### PR TITLE
Fixes flying spectators being able to play locally the grunt1 sound. 

### DIFF
--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -1500,10 +1500,13 @@ END_COMMAND (changemus)
 
 //
 // UV_SoundAvoidCl
-// Sends a sound to clients, but doesn't send it to client 'player'.
+// Sends a sound to clients, but doesn't send it to client 'player' and spectators.
 //
 void UV_SoundAvoidPlayer (AActor *mo, byte channel, const char *name, byte attenuation)
 {
+	if (mo->player->spectator)
+		return;
+
 	S_Sound(mo, channel, name, 1, attenuation);
 }
 


### PR DESCRIPTION
You can reproduce it easily on moo2d while flying on some sectors. (like the window near the Rocket Launcher)