### PR TITLE
Corrected a #if statement in i_sdlvideo

### DIFF
--- a/client/sdl/i_sdlvideo.cpp
+++ b/client/sdl/i_sdlvideo.cpp
@@ -1386,7 +1386,7 @@ void ISDL20Window::setWindowTitle(const std::string& str)
 //
 void ISDL20Window::setWindowIcon()
 {
-	#if WIN32 && !_XBOX
+	#if defined(WIN32) && !defined(_XBOX)
 	// [SL] Use Win32-specific code to make use of multiple-icon sizes
 	// stored in the executable resources. SDL 1.2 only allows a fixed
 	// 32x32 px icon.


### PR DESCRIPTION
Apparently, I managed to make my MSVC 2014 compilation unsuccessful because of that line.

Besides, every other statement to _XBOX has been stated under **#if define(_XBOX)**, except this one. 