### PR TITLE
Change a #if statement to #ifdef in i_sdlvideo

### DIFF
--- a/client/sdl/i_sdlvideo.cpp
+++ b/client/sdl/i_sdlvideo.cpp
@@ -1386,7 +1386,7 @@ void ISDL20Window::setWindowTitle(const std::string& str)
 //
 void ISDL20Window::setWindowIcon()
 {
-	#if WIN32 && !_XBOX
+	#if defined(_WIN32) && !defined(_XBOX)
 	// [SL] Use Win32-specific code to make use of multiple-icon sizes
 	// stored in the executable resources. SDL 1.2 only allows a fixed
 	// 32x32 px icon.


### PR DESCRIPTION
Apparently, I managed to make one of my compilations unsuccessful because of
that line.

Besides, every other statement to _XBOX has been stated under
define(_XBOX), except this one.

also, _WIN32 should be used instead of WIN32 alone.