### PR TITLE
Fix GCC6 compilation errors.

### DIFF
--- a/common/cmdlib.cpp
+++ b/common/cmdlib.cpp
@@ -733,7 +733,7 @@ uint32_t CRC32(const uint8_t* buf, uint32_t len)
 uint32_t Log2(uint32_t n)
 {
 	#define LT(n) n, n, n, n, n, n, n, n, n, n, n, n, n, n, n, n
-	static const char LogTable256[256] = 
+	static const signed char LogTable256[256] = 
 	{
 		-1, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
 		LT(4), LT(5), LT(5), LT(6), LT(6), LT(6), LT(6),

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1973,7 +1973,7 @@ void P_SpawnSpecials (void)
 			if ((sector->special & 0xff) >= Scroll_North_Slow &&
 				(sector->special & 0xff) <= Scroll_SouthWest_Fast)
 			{
-				static char hexenScrollies[24][2] =
+				static signed char hexenScrollies[24][2] =
 				{
 					{  0,  1 }, {  0,  2 }, {  0,  4 },
 					{ -1,  0 }, { -2,  0 }, { -4,  0 },


### PR DESCRIPTION
GCC 6.X detects narrowing conversions from negative numbers to chars. Fixing them by signing these chars.