### PR TITLE
Framerate & console fixes.

### DIFF
--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -1108,7 +1108,11 @@ void D_RunTics(void (*sim_func)(), void(*display_func)())
 #ifdef CLIENT_APP
 	// Use linear interpolation for rendering entities if the display
 	// framerate is not synced with the simulation frequency.
-	if ((maxfps == TICRATE && capfps) || timingdemo || paused || step_mode || (menuactive && !network_game))
+	// Ch0wW : if you experience a spinning effect while trying to pause the frame, 
+	// don't forget to add your condition here.
+	if ((maxfps == TICRATE && capfps)
+		|| timingdemo || paused || step_mode
+		|| ((menuactive || ConsoleState == c_down || ConsoleState == c_falling) && !network_game && !demoplayback))
 		render_lerp_amount = FRACUNIT;
 	else
 		render_lerp_amount = simulation_scheduler->getRemainder() * FRACUNIT;

--- a/common/p_tick.cpp
+++ b/common/p_tick.cpp
@@ -52,7 +52,10 @@ void P_Ticker (void)
 
 #ifdef CLIENT_APP
 	// Game pauses when in the menu and not online/demo
-	if (!multiplayer && !demoplayback && menuactive && players.begin()->viewz != 1)
+	if (!multiplayer
+		&& !demoplayback 
+		&& (menuactive || ConsoleState == c_down || ConsoleState == c_falling)
+		&& players.begin()->viewz != 1)
 		return;
 #endif
 


### PR DESCRIPTION
- Odamex now pauses in Singleplayer if you bring down the console.
- Odamex's framelimit is perfectly uncapped while playing a demo and after bringing down the console (or open the menu).