### PR TITLE
fix an "connecting to" infinite loop

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -738,6 +738,7 @@ BEGIN_COMMAND (connect)
 	    return;
 	}
 
+	simulated_connection = false;	// Ch0wW : don't block people connect to a server after playing a demo
 	C_FullConsole();
 	gamestate = GS_CONNECTING;
 


### PR DESCRIPTION
Whenever Odamex plays their own demoformat, it sets "simulated_connection" to true.

However, whenever this variable is true, it makes packet sending/receiving impossible, thus making an infinite "conn,ecting to..." loop. 

This PR fixes that issue, by resetting this value to "false" whenever the connect CMD is used.