### PR TITLE
Spy mode now displays keys people have on COOP mode.

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2048,6 +2048,12 @@ void CL_UpdatePlayerState(void)
 
 	for (int i = 0; i < NUMPSPRITES; i++)
 		P_SetPsprite(&player, i, stnum[i]);
+
+	// Receive the keys from a spied player
+	if (sv_gametype == GM_COOP) {
+		for (int i = 0; i < NUMCARDS; i++)
+			player.cards[i] = MSG_ReadByte();
+	}
 }
 
 //

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3226,6 +3226,11 @@ void SV_SendPlayerStateUpdate(client_t *client, player_t *player)
 		else
 			MSG_WriteByte(buf, 0xFF);
 	}
+
+	if (sv_gametype == GM_COOP) {
+		for (int i = 0; i < NUMCARDS; i++)
+			MSG_WriteByte(buf, player->cards[i]);
+	}
 }
 
 void SV_SpyPlayer(player_t &viewer)


### PR DESCRIPTION
This PR fixes the issue at this link: https://odamex.net/bugs/show_bug.cgi?id=1108