### PR TITLE
No V_Init on cvar changes

### DIFF
--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -898,6 +898,24 @@ bool I_IsProtectedResolution(const IWindowSurface* surface)
 	return I_IsProtectedResolution(surface->getWidth(), surface->getHeight());
 }
 
+//
+// I_IsWideResolution
+//
+bool I_IsWideResolution(int width, int height)
+{
+	if (I_IsProtectedResolution(width, height))
+		return false;
+
+	// consider the mode widescreen if it's width-to-height ratio is
+	// closer to 16:10 than it is to 4:3
+	return abs(15 * width - 20 * height) > abs(15 * width - 24 * height);
+}
+
+bool I_IsWideResolution(const IWindowSurface* surface)
+{
+	return I_IsWideResolution(surface->getWidth(), surface->getHeight());
+}
+
 
 //
 // I_LockAllSurfaces

--- a/client/sdl/i_video.h
+++ b/client/sdl/i_video.h
@@ -75,6 +75,8 @@ int I_GetSurfaceHeight();
 
 bool I_IsProtectedResolution(const IWindowSurface* surface = I_GetPrimarySurface());
 bool I_IsProtectedResolution(int width, int height);
+bool I_IsWideResolution(int width, int height);
+bool I_IsWideResolution(const IWindowSurface* surface = I_GetPrimarySurface());
 
 void I_SetPalette(const argb_t* palette);
 
@@ -176,12 +178,7 @@ public:
 
 	bool isWideScreen() const
 	{
-		if ((mWidth == 320 && mHeight == 200) || (mWidth == 640 && mHeight == 400))
-			return false;
-
-		// consider the mode widescreen if it's width-to-height ratio is
-		// closer to 16:10 than it is to 4:3
-		return abs(15 * (int)mWidth - 20 * (int)mHeight) > abs(15 * (int)mWidth - 24 * (int)mHeight);
+		return I_IsWideResolution(mWidth, mHeight);
 	}
 
 	float getAspectRatio() const

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -135,13 +135,13 @@ bool V_CheckModeAdjustment()
 {
 	const IWindow* window = I_GetWindow();
 
-	if (vid_defwidth.asInt() != window->getWidth())
+	if (vid_defwidth != window->getWidth())
 		return true;
 
-	if (vid_defheight.asInt() != window->getHeight())
+	if (vid_defheight != window->getHeight())
 		return true;
 
-	if (vid_32bpp != (window->getBitsPerPixel() == 32))
+	if (vid_32bpp != (window->getPrimarySurface()->getBitsPerPixel() == 32))
 		return true;
 
 	if (vid_fullscreen != window->isFullScreen())

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -123,12 +123,49 @@ void V_AdjustVideoMode()
 }
 
 
+EXTERN_CVAR(vid_defwidth)
+EXTERN_CVAR(vid_defheight)
+EXTERN_CVAR(vid_32bpp)
+EXTERN_CVAR(vid_fullscreen)
+EXTERN_CVAR(vid_widescreen)
+EXTERN_CVAR(sv_allowwidescreen)
+EXTERN_CVAR(vid_vsync)
+
+bool V_CheckModeAdjustment()
+{
+	const IWindow* window = I_GetWindow();
+
+	if (vid_defwidth.asInt() != window->getWidth())
+		return true;
+
+	if (vid_defheight.asInt() != window->getHeight())
+		return true;
+
+	if (vid_32bpp != (window->getBitsPerPixel() == 32))
+		return true;
+
+	if (vid_fullscreen != window->isFullScreen())
+		return true;
+
+	if (vid_vsync != window->usingVSync())
+		return true;
+
+	bool using_widescreen = I_IsWideResolution();
+	if (vid_widescreen && sv_allowwidescreen != using_widescreen)
+		return true;
+
+	if (vid_widescreen != using_widescreen)
+		return true;
+
+	return false;
+}
+
 CVAR_FUNC_IMPL(vid_defwidth)
 {
 	if (var < 320 || var > MAXWIDTH)
 		var.RestoreDefault();
 	
-	if (gamestate != GS_STARTUP)
+	if (gamestate != GS_STARTUP && V_CheckModeAdjustment())
         V_SetResolution(var, new_video_height);
 }
 
@@ -138,28 +175,28 @@ CVAR_FUNC_IMPL(vid_defheight)
 	if (var < 200 || var > MAXHEIGHT)
 		var.RestoreDefault();
 	
-	if (gamestate != GS_STARTUP)
+	if (gamestate != GS_STARTUP && V_CheckModeAdjustment())
         V_SetResolution(new_video_width, var);
 }
 
 
 CVAR_FUNC_IMPL(vid_fullscreen)
 {
-	if (gamestate != GS_STARTUP)
+	if (gamestate != GS_STARTUP && V_CheckModeAdjustment())
         V_ForceVideoModeAdjustment();
 }
 
 
 CVAR_FUNC_IMPL(vid_32bpp)
 {
-	if (gamestate != GS_STARTUP)
+	if (gamestate != GS_STARTUP && V_CheckModeAdjustment())
         V_ForceVideoModeAdjustment();
 }
 
 
 CVAR_FUNC_IMPL(vid_vsync)
 {
-	if (gamestate != GS_STARTUP)
+	if (gamestate != GS_STARTUP && V_CheckModeAdjustment())
         V_ForceVideoModeAdjustment();
 }
 
@@ -187,14 +224,14 @@ CVAR_FUNC_IMPL(vid_640x400)
 
 CVAR_FUNC_IMPL (vid_widescreen)
 {
-	if (gamestate != GS_STARTUP)
+	if (gamestate != GS_STARTUP && V_CheckModeAdjustment())
         V_ForceVideoModeAdjustment();
 }
 
 
 CVAR_FUNC_IMPL (sv_allowwidescreen)
 {
-	if (gamestate != GS_STARTUP)
+	if (gamestate != GS_STARTUP && V_CheckModeAdjustment())
         V_ForceVideoModeAdjustment();
 }
 


### PR DESCRIPTION
Only call V_Init to change video resolution / parameters if a parameter is actually changed. This fixes a V_Init flicker when sv_allowwidescreen is sent to clients.