### PR TITLE
Add keys to the Warmup message

### DIFF
--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -727,14 +727,18 @@ std::string C_GetKeyStringsFromCommand(char *cmd, bool bTwoEntries)
 	C_GetKeysForCommand(cmd, &first, &second);
 
 	if (!first && !second)
-		return "<UNKNOWN>";
+		return "<???>";
 
 	if (bTwoEntries)
 		return C_NameKeys(first, second);
 	else
-		return KeyName(first);
-
-	return "<UNKNOWN>";
+	{
+		if (!first && second)
+			return KeyName(second);
+		else
+			return KeyName(first);
+	}
+	return "<???>";
 }
 
 

--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -714,4 +714,28 @@ const char *C_GetBinding (int key)
 	return Bindings[key].c_str();
 }
 
+/*
+C_GetKeyStringsFromCommand
+Finds binds from a command and returns it into a std::string .
+- If TRUE, second arg returns up to 2 keys. ("x OR y")
+*/
+std::string C_GetKeyStringsFromCommand(char *cmd, bool bTwoEntries)
+{
+	int first = -1;
+	int second = -1;
+
+	C_GetKeysForCommand(cmd, &first, &second);
+
+	if (!first && !second)
+		return "<UNKNOWN>";
+
+	if (bTwoEntries)
+		return C_NameKeys(first, second);
+	else
+		return KeyName(first);
+
+	return "<UNKNOWN>";
+}
+
+
 VERSION_CONTROL (c_bind_cpp, "$Id$")

--- a/client/src/c_bind.h
+++ b/client/src/c_bind.h
@@ -45,5 +45,7 @@ const char *C_GetBinding (int key);
 
 void C_ReleaseKeys();
 
+std::string C_GetKeyStringsFromCommand(char *cmd, bool bTwoEntries = false);
+
 #endif //__C_BINDINGS_H__
 

--- a/client/src/hu_elements.cpp
+++ b/client/src/hu_elements.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <sstream>
 
+#include "c_bind.h"
 #include "c_cvars.h"
 #include "cl_demo.h"
 #include "m_fixed.h" // This should probably go into d_netinf.h
@@ -216,7 +217,11 @@ std::string Warmup(int& color)
 		{
 			color = CR_RED;
 			if (dp == cp)
-				return "Warmup: You are not ready";
+			{
+				char strReady[64];
+				sprintf(strReady, "Warmup: Press %s to ready up", C_GetKeyStringsFromCommand("ready").c_str());
+				return strReady;
+			}
 			else
 				return "Warmup: This player is not ready";
 		}


### PR DESCRIPTION
This PR creates a new function in C_BIND.cpp (C_GetKeyStringsFromCommand) that tells you what buttons you use from a bind.

That created, I used it on the "Warmup: you are not ready" so that it says "Warmup: press <KEYBINDS> to ready up".