### PR TITLE
Language fixes

### DIFF
--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -260,7 +260,7 @@ CVAR(				developer, "0", "Debugging mode",
 					CVARTYPE_BOOL, CVAR_NULL)
 
 CVAR_RANGE_FUNC_DECL(language, "0", "",
-					CVARTYPE_INT, CVAR_ARCHIVE, 0.0f, 256.0f)
+					CVARTYPE_INT, CVAR_ARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 256.0f)
 
 CVAR(				port, "0", "Display currently used network port number",
 					CVARTYPE_INT, CVAR_NOSET | CVAR_NOENABLEDISABLE)

--- a/server/src/i_system.cpp
+++ b/server/src/i_system.cpp
@@ -329,35 +329,19 @@ static const char *langids[] = {
 
 EXTERN_CVAR (language)
 
+// Force the language to English (default)
 void SetLanguageIDs ()
 {
-	unsigned int langid = language.asInt();
+	DWORD lang = 0;
+	const char *langtag = langids[1];	// Forces ENGLISH as language.
 
-	if (langid == 0 || langid > 3)
-	{
-    #ifdef _WIN32
-		memset (LanguageIDs, 0, sizeof(LanguageIDs));
-		SubsetLanguageIDs (LOCALE_USER_DEFAULT, LOCALE_ILANGUAGE, 0);
-		SubsetLanguageIDs (LOCALE_USER_DEFAULT, LOCALE_IDEFAULTLANGUAGE, 1);
-		SubsetLanguageIDs (LOCALE_SYSTEM_DEFAULT, LOCALE_ILANGUAGE, 2);
-		SubsetLanguageIDs (LOCALE_SYSTEM_DEFAULT, LOCALE_IDEFAULTLANGUAGE, 3);
-    #else
-        langid = 1;     // Default to US English on non-windows systems
-    #endif
-	}
-	else
-	{
-		DWORD lang = 0;
-		const char *langtag = langids[langid];
-
-		((BYTE *)&lang)[0] = (langtag)[0];
-		((BYTE *)&lang)[1] = (langtag)[1];
-		((BYTE *)&lang)[2] = (langtag)[2];
-		LanguageIDs[0] = lang;
-		LanguageIDs[1] = lang;
-		LanguageIDs[2] = lang;
-		LanguageIDs[3] = lang;
-	}
+	((BYTE *)&lang)[0] = (langtag)[0];
+	((BYTE *)&lang)[1] = (langtag)[1];
+	((BYTE *)&lang)[2] = (langtag)[2];
+	LanguageIDs[0] = lang;
+	LanguageIDs[1] = lang;
+	LanguageIDs[2] = lang;
+	LanguageIDs[3] = lang;
 }
 
 //


### PR DESCRIPTION
- Forces ENGLISH as the language of the server.
- Fixes `language` CVAR being seen as a boolean, while technically accepting up to 256 languages. (yet it doesn't though)