### PR TITLE
Fixing a netplay demos not being read properly.

### DIFF
--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -1867,9 +1867,13 @@ bool G_RecordDemo(const std::string& mapname, const std::string& basedemoname)
 
 std::string defdemoname;
 
-void G_DeferedPlayDemo (const char *name)
+void G_DeferedPlayDemo (const char *name, bool bIsSingleDemo)
 {
 	defdemoname = name;
+
+	if (bIsSingleDemo)
+		singledemo = true;
+
 	gameaction = ga_playdemo;
 }
 
@@ -1930,7 +1934,7 @@ BEGIN_COMMAND(playdemo)
 		extern bool lastWadRebootSuccess;
 		if(lastWadRebootSuccess)
 		{
-			G_DeferedPlayDemo(argv[1]);
+			G_DeferedPlayDemo(argv[1], true);
 		}
 		else
 		{
@@ -2251,10 +2255,13 @@ BOOL G_CheckDemoStatus (void)
 			else
 				Printf (PRINT_HIGH, "Demo ended.\n");
 
+			demoplayback = false;
+			democlassic = false;
 			gameaction = ga_fullconsole;
 			timingdemo = false;
 			return false;
 		}
+
 
 		D_AdvanceDemo ();
 		return true;

--- a/common/g_game.h
+++ b/common/g_game.h
@@ -36,7 +36,7 @@
 void G_DeathMatchSpawnPlayer(player_t &player);
 void G_DoReborn(player_t &player);
 
-void G_DeferedPlayDemo(const char* demo);
+void G_DeferedPlayDemo(const char* demo, bool bIsSingleDemo = false);
 
 // Can be called by the startup code or M_Responder,
 // calls P_SetupLevel or W_EnterWorld.


### PR DESCRIPTION
The problem lies in the G_CheckDemoStatus function, where Odamex doesn't differenciate a single demo read by using the "playdemo" command from the demoscreen loop.

This PR fixes it.