### PR TITLE
Fix the vanilla sound bug when closing blazing doors if co_zdoomsound…

### DIFF
--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -35,6 +35,8 @@
 
 #include "p_spec.h"
 
+EXTERN_CVAR(co_zdoomsound)
+
 extern bool predicting;
 
 void P_SetDoorDestroy(DDoor *door)
@@ -283,7 +285,7 @@ void DDoor::PlayDoorSound ()
 		// [SL] 2011-06-10 - emulate vanilla Doom bug that plays the
 		// blazing-door sound twice: when the door begins to close
 		// and when the door finishes closing.
-		if (!IsBlazingDoor(this))
+		if (!IsBlazingDoor(this) || co_zdoomsound)
 			return;
 		snd = "doors/dr2_clos";
 		break;


### PR DESCRIPTION
… is enabled