### PR TITLE
Several various minor to major fixes 

### DIFF
--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -199,7 +199,7 @@ void P_SetPsprite(player_t* player, int position, statenum_t stnum)
 		// Modified handling.
 		if (psp->state->action)
 		{
-			if (!player->spectator)
+			if (!player->spectator && player->mo != NULL)
 				psp->state->action(player->mo);
 
 			if (!psp->state)

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1306,11 +1306,6 @@ BOOL P_CheckKeys (player_t *p, card_t lock, BOOL remote)
 		C_MidPrint (GStrings(msg), p);
 	}
 
-	if (serverside && network_game && msg)
-	{
-		C_MidPrint (GStrings(msg), p);
-	}
-
 	return false;
 }
 

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -267,10 +267,7 @@ void D_DoomMain()
 	// Always log by default
     if (!LOG.is_open())
     	C_DoCommand("logfile");
-
-	M_LoadDefaults();			// load before initing other systems
-	C_ExecCmdLineParams(true, false);	// [RH] do all +set commands on the command line
-
+	
 	std::vector<std::string> newwadfiles, newpatchfiles;
 
 	const char* iwad_filename_cstr = Args.CheckValue("-iwad");
@@ -285,6 +282,10 @@ void D_DoomMain()
 	D_AddDehCommandLineFiles(newpatchfiles);
 
 	D_LoadResourceFiles(newwadfiles, newpatchfiles);
+
+	// Ch0wW: Loading the config here fixes the "addmap" issue.
+	M_LoadDefaults();					// load before initing other systems
+	C_ExecCmdLineParams(true, false);	// [RH] do all +set commands on the command line
 
 	Printf(PRINT_HIGH, "I_Init: Init hardware.\n");
 	I_Init();

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -756,6 +756,9 @@ BEGIN_COMMAND(clearmaplist) {
 	if (!Maplist::instance().clear()) {
 		Printf(PRINT_HIGH, "%s\n", Maplist::instance().get_error().c_str());
 	}
+	else {
+		Printf(PRINT_HIGH, "Maplist cleared.\n");
+	}
 } END_COMMAND(clearmaplist)
 
 CVAR_FUNC_IMPL(sv_shufflemaplist)


### PR DESCRIPTION
> Removes the double localized "You need a XXX key" from the server.

This is a fix that disables the message spread from the server to the client. Besides, I don't get why that part of code was created. So, I just assume it was for testing purposes, but is troublesome otherwise, if the PWAD uses custom messages.

For some reason, that said message is also spread from the server's locale (check PR #31 to also remove that). So for instance, it'll be displayed in French even if the user's language is in english.