### PR TITLE
Add sv_respawnsuper CVAR.

### DIFF
--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -99,6 +99,7 @@ EXTERN_CVAR (sv_skill)
 EXTERN_CVAR (novert)
 EXTERN_CVAR (sv_monstersrespawn)
 EXTERN_CVAR (sv_itemsrespawn)
+EXTERN_CVAR (sv_itemsrespawn_powerups)
 EXTERN_CVAR (sv_weaponstay)
 EXTERN_CVAR (sv_keepkeys)
 EXTERN_CVAR (co_nosilentspawns)
@@ -2107,6 +2108,7 @@ void G_DoPlayDemo(bool justStreamInput)
 				sv_itemsrespawn.Set(0.0f);
 			}
 
+			sv_itemsrespawn_powerups.Set(0.0f);
 			G_InitNew(mapname);
 
 			usergame = false;

--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -99,7 +99,7 @@ EXTERN_CVAR (sv_skill)
 EXTERN_CVAR (novert)
 EXTERN_CVAR (sv_monstersrespawn)
 EXTERN_CVAR (sv_itemsrespawn)
-EXTERN_CVAR (sv_itemsrespawn_powerups)
+EXTERN_CVAR (sv_respawnsuper)
 EXTERN_CVAR (sv_weaponstay)
 EXTERN_CVAR (sv_keepkeys)
 EXTERN_CVAR (co_nosilentspawns)
@@ -2108,7 +2108,7 @@ void G_DoPlayDemo(bool justStreamInput)
 				sv_itemsrespawn.Set(0.0f);
 			}
 
-			sv_itemsrespawn_powerups.Set(0.0f);
+			sv_respawnsuper.Set(0.0f);
 			G_InitNew(mapname);
 
 			usergame = false;

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -93,6 +93,9 @@ CVAR(				sv_infiniteammo, "0", "Infinite ammo for all players",
 CVAR(				sv_itemsrespawn, "0", "Items will respawn after a fixed period, see sv_itemrespawntime",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 
+CVAR(				sv_itemsrespawn_powerups, "0", "Allows Invisibility/Invulnerability spheres from respawning (need sv_itemsrespawn set to 1)",
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
+
 CVAR_RANGE(			sv_itemrespawntime, "30", "If sv_itemsrespawn is set, items will respawn after this " \
 					"time (in seconds)",
 					CVARTYPE_WORD, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE, 0.0f, 500.0f)
@@ -142,7 +145,7 @@ CVAR(				sv_allowmovebob, "0", "Allow weapon & view bob changing",
 CVAR(				sv_allowredscreen, "0","Allow clients to adjust amount of red pain screen intensity",
 					CVARTYPE_BOOL, CVAR_SERVERINFO | CVAR_SERVERARCHIVE)
 
-CVAR(				sv_allowpwo, "0", "Allow clients to set their preferences for automatic weapon swithching",
+CVAR(				sv_allowpwo, "0", "Allow clients to set their preferences for automatic weapon switching",
 					CVARTYPE_BOOL, CVAR_SERVERINFO | CVAR_SERVERARCHIVE)
 
 CVAR_FUNC_DECL(		sv_allowwidescreen, "1", "Allow clients to use true widescreen",

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -93,7 +93,7 @@ CVAR(				sv_infiniteammo, "0", "Infinite ammo for all players",
 CVAR(				sv_itemsrespawn, "0", "Items will respawn after a fixed period, see sv_itemrespawntime",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 
-CVAR(				sv_itemsrespawn_powerups, "0", "Allows Invisibility/Invulnerability spheres from respawning (need sv_itemsrespawn set to 1)",
+CVAR(				sv_respawnsuper, "0", "Allows Invisibility/Invulnerability spheres from respawning (need sv_itemsrespawn set to 1)",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 
 CVAR_RANGE(			sv_itemrespawntime, "30", "If sv_itemsrespawn is set, items will respawn after this " \

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -58,7 +58,7 @@ void SV_ExplodeMissile(AActor *);
 
 EXTERN_CVAR(sv_freelook)
 EXTERN_CVAR(sv_itemsrespawn) 
-EXTERN_CVAR(sv_itemsrespawn_powerups)
+EXTERN_CVAR(sv_respawnsuper)
 EXTERN_CVAR(sv_itemrespawntime)
 EXTERN_CVAR(co_zdoomphys)
 EXTERN_CVAR(co_realactorheight)
@@ -2166,8 +2166,8 @@ void P_RespawnSpecials (void)
 	{
 		if (mthing->type == mobjinfo[i].doomednum)
 		{
-			// Disallow Partial Invisibility & Invulnerability from respawning
-			if (!sv_itemsrespawn_powerups && (mthing->type == 2022 || mthing->type == 2024))
+			// Allow or not Partial Invisibility & Invulnerability from respawning 
+			if (!sv_respawnsuper && (mthing->type == 2022 || mthing->type == 2024))
 			{
 				iquetail = (iquetail + 1)&(ITEMQUESIZE - 1);
 				return;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -57,7 +57,8 @@ void SV_SendDestroyActor(AActor *);
 void SV_ExplodeMissile(AActor *);
 
 EXTERN_CVAR(sv_freelook)
-EXTERN_CVAR(sv_itemsrespawn)
+EXTERN_CVAR(sv_itemsrespawn) 
+EXTERN_CVAR(sv_itemsrespawn_powerups)
 EXTERN_CVAR(sv_itemrespawntime)
 EXTERN_CVAR(co_zdoomphys)
 EXTERN_CVAR(co_realactorheight)
@@ -386,8 +387,7 @@ void AActor::Destroy ()
     // Add special to item respawn queue if it is destined to be respawned
 	if ((flags & MF_SPECIAL) && !(flags & MF_DROPPED))
 	{
-		if (type != MT_INV && type != MT_INS &&
-            (type < MT_BSOK || type > MT_RDWN))
+		if (type < MT_BSOK || type > MT_RDWN)
 		{
 			itemrespawnque[iquehead] = spawnpoint;
 			itemrespawntime[iquehead] = level.time;
@@ -2165,7 +2165,16 @@ void P_RespawnSpecials (void)
 	for (i=0 ; i< NUMMOBJTYPES ; i++)
 	{
 		if (mthing->type == mobjinfo[i].doomednum)
-			break;
+		{
+			// Disallow Partial Invisibility & Invulnerability from respawning
+			if (!sv_itemsrespawn_powerups && (mthing->type == 2022 || mthing->type == 2024))
+			{
+				iquetail = (iquetail + 1)&(ITEMQUESIZE - 1);
+				return;
+			} else {
+				break;
+			}
+		}
 	}
 
 	// [Fly] crashes sometimes without it


### PR DESCRIPTION
Initially, Odamex doesn't respawn Invulnerability and partial invisibility. This commit fixes it by adding a new CVAR.

Also, fixes a small grammatical mistake in a CVAR.