### PR TITLE
Fix for bug 1067

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -3441,6 +3441,7 @@ void CL_Spectate()
 			player.playerstate = PST_LIVE; // resurrect dead spectators
 			// GhostlyDeath -- Sometimes if the player spectates while he is falling down he squats
 			player.deltaviewheight = 1000 << FRACBITS;
+			movingsectors.clear(); //clear all moving sectors, otherwise client side prediction will not move active sectors
 		}
 		else
 		{


### PR DESCRIPTION
Clear the moving sectors when going from in game back to spectator so that moving sectors do not appear stuck.