### PR TITLE
Fix for bug 1262

### DIFF
--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -611,6 +611,8 @@ void C_ReleaseKeys()
 			(*binding)[achar] = '+';
 		}
 	}
+
+	HU_ReleaseKeyStates();
 }
 
 void C_ArchiveBindings (FILE *f)

--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -238,6 +238,10 @@ void HU_Ticker()
 		HU_UnsetChatMode();
 }
 
+void HU_ReleaseKeyStates()
+{
+	altdown = false;
+}
 
 //
 // HU_Responder

--- a/client/src/hu_stuff.h
+++ b/client/src/hu_stuff.h
@@ -55,7 +55,7 @@ chatmode_t HU_ChatMode();
 void HU_SetChatMode();
 void HU_SetTeamChatMode();
 void HU_UnsetChatMode();
-
+void HU_ReleaseKeyStates();
 
 void OdamexEffect (int xa, int ya, int xb, int yb);
 


### PR DESCRIPTION
Added HU_ReleaseKeyStates to release the alt key when the windows gains focus back. This fixes the alt+tab chat bug for when pressing numbers: I'm not looking to good!