### PR TITLE
Fixing classic demo desyncs.

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -420,6 +420,9 @@ void CL_QuitNetGame(void)
 	if (demorecording && democlassic)
 		G_CleanupDemo();
 
+	democlassic = false;
+	demoplayback = false;
+
 	// Reset the palette to default
 	V_ResetPalette();
 
@@ -737,6 +740,7 @@ BEGIN_COMMAND (connect)
 	}
 
 	simulated_connection = false;	// Ch0wW : don't block people connect to a server after playing a demo
+
 	C_FullConsole();
 	gamestate = GS_CONNECTING;
 

--- a/client/src/cl_mobj.cpp
+++ b/client/src/cl_mobj.cpp
@@ -164,9 +164,15 @@ std::vector<AActor*> spawnfountains;
 
 /**
  * Show spawn points as particle fountains
+ * ToDo: Make an independant spawning loop to handle these.
  */
 void P_ShowSpawns(mapthing2_t* mthing)
 {
+	// Ch0wW: DO NOT add new spawns to a DOOM2 demo !
+	// It'll immediately desync in DM!
+	if (democlassic)
+		return;
+
 	if (clientside && cl_showspawns)
 	{
 		AActor* spawn = 0;

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -369,7 +369,7 @@ bool P_CheckSwitchWeapon(player_t *player, weapontype_t weapon)
 	// Always switch - vanilla Doom behavior
 	if ((multiplayer && !sv_allowpwo) ||
 		player->userinfo.switchweapon == WPSW_ALWAYS ||
-		demoplayback || demorecording)
+		democlassic || demoplayback || demorecording)
 	{
 		return true;
 	}


### PR DESCRIPTION
As pointed out in the Bug Tracker here ( https://odamex.net/bugs/show_bug.cgi?id=1245 ) , Odamex actually desyncs during a few deathmatch demos.

This PR partially fixes them.