### PR TITLE
GOD mode won't make us drown anymore.

### DIFF
--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -786,7 +786,7 @@ void P_PlayerThink (player_t *player)
 		player->fixedcolormap = 0;
 
 	// Handle air supply
-	if (player->mo->waterlevel < 3 || player->powers[pw_ironfeet])
+	if (player->mo->waterlevel < 3 || player->powers[pw_ironfeet] || player->cheats & CF_GODMODE)
 	{
 		player->air_finished = level.time + 10*TICRATE;
 	}


### PR DESCRIPTION
When using GOD mode, you can still drown in deepwater.

This PR fixes it.