### PR TITLE
Fix for bug 1265

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -280,9 +280,6 @@ CVAR_RANGE_FUNC_DECL(rate, "200", "Rate of client updates in multiplayer mode",
 CVAR(				cl_unlag, "1", "client opt-in/out for server unlagging",
 					CVARTYPE_BOOL, CVAR_USERINFO | CVAR_CLIENTARCHIVE)
 
-CVAR_RANGE(			cl_updaterate, "1",	"Update players every N tics",
-					CVARTYPE_BYTE, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 1.0f, 3.0f)
-
 CVAR_RANGE_FUNC_DECL(cl_interp, "1", "Interpolate enemy player positions",
 					CVARTYPE_INT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 4.0f)
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -152,7 +152,6 @@ EXTERN_CVAR (mute_enemies)
 
 EXTERN_CVAR (cl_autoaim)
 
-EXTERN_CVAR (cl_updaterate)
 EXTERN_CVAR (cl_interp)
 EXTERN_CVAR (cl_serverdownload)
 EXTERN_CVAR (cl_forcedownload)

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1336,7 +1336,6 @@ void CL_SendUserInfo(void)
 	MSG_WriteLong	(&net_buffer, coninfo->aimdist);
 	MSG_WriteBool	(&net_buffer, coninfo->unlag);  // [SL] 2011-05-11
 	MSG_WriteBool	(&net_buffer, coninfo->predict_weapons);
-	MSG_WriteByte	(&net_buffer, (char)coninfo->update_rate);
 	MSG_WriteByte	(&net_buffer, (char)coninfo->switchweapon);
 	for (size_t i = 0; i < NUMWEAPONS; i++)
 	{

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -211,8 +211,10 @@ FArchive &operator<< (FArchive &arc, UserInfo &info)
 
 	// [SL] place holder for deprecated skins
 	unsigned int skin = 0;
+	byte update_rate = 0;
 	arc << skin;
 	arc << info.unlag;
+	arc << update_rate; //update_rate was removed, still read/write so that old saves continue to function
 
 	arc.Write(&info.switchweapon, sizeof(info.switchweapon));
 	arc.Write(info.weapon_prefs, sizeof(info.weapon_prefs));
@@ -237,8 +239,10 @@ FArchive &operator>> (FArchive &arc, UserInfo &info)
 
 	// [SL] place holder for deprecated skins
 	unsigned int skin;
+	byte update_rate;
 	arc >> skin;
 	arc >> info.unlag;
+	arc >> update_rate; //update_rate was removed, still read/write so that old saves continue to function
 
 	arc.Read(&info.switchweapon, sizeof(info.switchweapon));
 	arc.Read(info.weapon_prefs, sizeof(info.weapon_prefs));

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -63,7 +63,6 @@ EXTERN_CVAR (cl_color)
 EXTERN_CVAR (cl_gender)
 EXTERN_CVAR (cl_team)
 EXTERN_CVAR (cl_unlag)
-EXTERN_CVAR (cl_updaterate)
 EXTERN_CVAR (cl_switchweapon)
 EXTERN_CVAR (cl_weaponpref_fst)
 EXTERN_CVAR (cl_weaponpref_csw)
@@ -166,7 +165,7 @@ void D_SetupUserInfo(void)
 	coninfo->gender				= D_GenderByName (cl_gender.cstring());
 	coninfo->aimdist			= (fixed_t)(cl_autoaim * 16384.0);
 	coninfo->unlag				= (cl_unlag != 0);
-	coninfo->update_rate		= cl_updaterate;
+	coninfo->update_rate		= 1; //Update every tic
 	coninfo->predict_weapons	= (cl_predictweapons != 0);
 
 	// sanitize the weapon switching choice

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -165,7 +165,6 @@ void D_SetupUserInfo(void)
 	coninfo->gender				= D_GenderByName (cl_gender.cstring());
 	coninfo->aimdist			= (fixed_t)(cl_autoaim * 16384.0);
 	coninfo->unlag				= (cl_unlag != 0);
-	coninfo->update_rate		= 1; //Update every tic
 	coninfo->predict_weapons	= (cl_predictweapons != 0);
 
 	// sanitize the weapon switching choice
@@ -213,8 +212,7 @@ FArchive &operator<< (FArchive &arc, UserInfo &info)
 	// [SL] place holder for deprecated skins
 	unsigned int skin = 0;
 	arc << skin;
-
-	arc << info.unlag << info.update_rate;
+	arc << info.unlag;
 
 	arc.Write(&info.switchweapon, sizeof(info.switchweapon));
 	arc.Write(info.weapon_prefs, sizeof(info.weapon_prefs));
@@ -240,8 +238,7 @@ FArchive &operator>> (FArchive &arc, UserInfo &info)
 	// [SL] place holder for deprecated skins
 	unsigned int skin;
 	arc >> skin;
-
-	arc >> info.unlag >> info.update_rate;
+	arc >> info.unlag;
 
 	arc.Read(&info.switchweapon, sizeof(info.switchweapon));
 	arc.Read(info.weapon_prefs, sizeof(info.weapon_prefs));

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -159,7 +159,6 @@ EXTERN_CVAR (joy_freelook)
 // Network Options
 EXTERN_CVAR (rate)
 EXTERN_CVAR (cl_unlag)
-EXTERN_CVAR (cl_updaterate)
 EXTERN_CVAR (cl_interp)
 EXTERN_CVAR (cl_prednudge)
 EXTERN_CVAR (cl_predictpickup)
@@ -635,12 +634,6 @@ static value_t BandwidthLevels[] = {
 	{ 750.0,		"6.0Mbps" }
 };
 
-static value_t UpdateRate[] = {
-	{ 1.0,			"Every tic" },
-	{ 2.0,			"Every 2nd tic" },
-	{ 3.0,			"Every 3rd tic" }
-};
-
 static value_t PredictSectors[] = {
 	{ 0.0, "None" },
 	{ 1.0, "All" },
@@ -651,7 +644,6 @@ static menuitem_t NetworkItems[] = {
     { redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
 	{ bricktext,	"Adjust Network Settings",		{NULL},				{0.0},		{0.0},		{0.0},		{NULL} },
 	{ discrete,		"Bandwidth",					{&rate},			{4.0},		{0.0},		{0.0},		{BandwidthLevels} },
-	{ discrete,		"Position update freq",			{&cl_updaterate},	{3.0},		{0.0},		{0.0},		{UpdateRate} },
 	{ slider,		"Interpolation time",			{&cl_interp},		{0.0},		{4.0},		{1.0},		{NULL} },
 	{ slider,		"Smooth collisions",			{&cl_prednudge},	{1.0},		{0.1},		{-0.1},		{NULL} },
 	{ discrete,		"Adjust weapons for lag",		{&cl_unlag},		{2.0},		{0.0},		{0.0},		{OnOff} },

--- a/common/d_netinf.h
+++ b/common/d_netinf.h
@@ -67,7 +67,6 @@ struct UserInfo
 	fixed_t			aimdist;
 	bool			unlag;
 	bool			predict_weapons;
-	byte			update_rate;
 	byte			color[4];
 	gender_t		gender;
 	weaponswitch_t	switchweapon;
@@ -76,7 +75,7 @@ struct UserInfo
 	static const byte weapon_prefs_default[NUMWEAPONS];
 
 	UserInfo() : team(TEAM_NONE), aimdist(0),
-	             unlag(true), predict_weapons(true), update_rate(2),
+	             unlag(true), predict_weapons(true),
 	             gender(GENDER_MALE), switchweapon(WPSW_ALWAYS)
 	{
 		// default doom weapon ordering when player runs out of ammo

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4541,11 +4541,7 @@ void SV_StepTics(QWORD count)
 		SV_SendPackets();
 		SV_ClearClientsBPS();
 		SV_CheckTimeouts();
-
-		// Since clients are only sent sector updates every 3rd tic, don't destroy
-		// the finished moving sectors until we've sent the clients the update
-		if (P_AtInterval(3))
-			SV_DestroyFinishedMovingSectors();
+		SV_DestroyFinishedMovingSectors();
 
 		// increment player_t::GameTime for all players once a second
 		static int TicCount = 0;


### PR DESCRIPTION
Removed obsolete P_AtInterval(3) for destroying moving sectors.

Removed any code relating cl_updaterate and the update_rate variable in the player structure. The clients can no longer change the tic interval they are updated.