### PR TITLE
Sector/switch client/server desync fixes.

### DIFF
--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1489,7 +1489,7 @@ P_ShootSpecialLine
 
 	if(serverside)
 	{
-		P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
+		P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL, true);
 		OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
 	}
 }
@@ -1566,7 +1566,7 @@ P_UseSpecialLine
 
 		if(serverside && GET_SPAC(line->flags) != SPAC_PUSH)
 		{
-			P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
+			P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL, true);
 			OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
 		}
 	}
@@ -1632,7 +1632,7 @@ P_PushSpecialLine
 
 		if(serverside)
 		{
-			P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
+			P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL, true);
 			OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
 		}
 	}

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -426,7 +426,7 @@ typedef struct
 // 1 second, in ticks.
 #define BUTTONTIME		TICRATE
 
-void	P_ChangeSwitchTexture (line_t *line, int useAgain);
+void	P_ChangeSwitchTexture (line_t *line, int useAgain, bool playsound);
 
 void	P_InitSwitchList ();
 

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -320,9 +320,8 @@ struct line_s
 							//		note that these are shorts in order to support
 							//		the tag parameter from DOOM.
 	int			firstid, nextid;
-
-	// denis - has this switch ever been pressed?
 	bool wastoggled;
+	bool switchactive;
 };
 typedef struct line_s line_t;
 

--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -617,6 +617,10 @@ void G_DoResetLevel(bool full_reset)
 		}
 	}
 
+	//reset switch activation
+	for (int i = 0; i < numlines; i++)
+		lines[i].switchactive = false;
+
 	// Clear the item respawn queue, otherwise all those actors we just
 	// destroyed and replaced with the serialized items will start respawning.
 	iquehead = iquetail = 0;


### PR DESCRIPTION
Destroy sector move and sound effects when resetting on client.

Fixed svc_switch to include special, switchactive, and button texture if
applicable so the client syncs properly with the server.

Client will no longer play switch sound when initially syncing with
server.

Fixes bugs:
https://odamex.net/bugs/show_bug.cgi?id=1281
https://odamex.net/bugs/show_bug.cgi?id=1205
https://odamex.net/bugs/show_bug.cgi?id=1102
https://odamex.net/bugs/show_bug.cgi?id=1267