### PR TITLE
Skip when hitting invalid syntax, otherwise pointer addition is invalid.

### DIFF
--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -359,6 +359,9 @@ static void ParseMapInfoLower (MapInfoHandler *handlers,
 		}
 
 		int entry = SC_MustMatchString(strings);
+		if (entry == -1)
+			continue;
+
 		handler = handlers + entry;
 
 		switch (handler->type)


### PR DESCRIPTION
Fixes:
https://odamex.net/bugs/show_bug.cgi?id=1266