### PR TITLE
(RE)Keys are now shown when spying on Coop.

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2048,6 +2048,12 @@ void CL_UpdatePlayerState(void)
 
 	for (int i = 0; i < NUMPSPRITES; i++)
 		P_SetPsprite(&player, i, stnum[i]);
+
+	// Receive the keys from a spied player
+	if (sv_gametype == GM_COOP) {
+		for (int i = 0; i < NUMCARDS; i++)
+			player.cards[i] = MSG_ReadByte();
+	}
 }
 
 //

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3226,6 +3226,11 @@ void SV_SendPlayerStateUpdate(client_t *client, player_t *player)
 		else
 			MSG_WriteByte(buf, 0xFF);
 	}
+
+	if (sv_gametype == GM_COOP) {
+		for (int i = 0; i < NUMCARDS; i++)
+			MSG_WriteByte(buf, player->cards[i]);
+	}
 }
 
 void SV_SpyPlayer(player_t &viewer)


### PR DESCRIPTION
Since no action has been done (was merged in protobreak), I'm redoing a pull request, this time on the development branch for 0.8.1 .