### PR TITLE
Added a CVAR for removing mp-only items on coop.

### DIFF
--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -169,7 +169,7 @@ CVAR(				sv_unblockplayers, "0", "Allows players to walk through other players",
 CVAR(				sv_hostname, "Untitled Odamex Server", "Server name to appear on masters, clients and launchers",
 					CVARTYPE_STRING, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE | CVAR_SERVERINFO)
 
-CVAR(				sv_spawnmpthings, "1", "Spawn multiplayer-only entities in cooperative mode",
+CVAR(				sv_nompthings, "0", "Removes multiplayer-only entities in cooperative mode",
 					CVARTYPE_BOOL, CVAR_SERVERINFO | CVAR_LATCH)
 
 CVAR(				sv_coopspawnvoodoodolls, "1", "Spawn voodoo dolls in cooperative mode", 

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -169,7 +169,9 @@ CVAR(				sv_unblockplayers, "0", "Allows players to walk through other players",
 CVAR(				sv_hostname, "Untitled Odamex Server", "Server name to appear on masters, clients and launchers",
 					CVARTYPE_STRING, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE | CVAR_SERVERINFO)
 
-					
+CVAR(				sv_spawnmpthings, "1", "Spawn multiplayer-only entities in cooperative mode",
+					CVARTYPE_BOOL, CVAR_SERVERINFO | CVAR_LATCH)
+
 CVAR(				sv_coopspawnvoodoodolls, "1", "Spawn voodoo dolls in cooperative mode", 
 					CVARTYPE_BOOL, CVAR_SERVERINFO | CVAR_LATCH)
 					

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -63,7 +63,7 @@ void P_InvertPlane(plane_t *plane);
 extern dyncolormap_t NormalLight;
 extern AActor* shootthing;
 
-EXTERN_CVAR(sv_spawnmpthings)
+EXTERN_CVAR(sv_nompthings)
 
 //
 // MAP related Lookup tables.
@@ -597,7 +597,7 @@ void P_LoadThings (int lump)
 		mt2.flags = (short)((flags & 0xf) | 0x7e0);
 		if (flags & BTF_NOTSINGLE)
 		{
-			if (!sv_spawnmpthings && sv_gametype == GM_COOP)
+			if (sv_nompthings && sv_gametype == GM_COOP)
 				mt2.flags &= ~MTF_COOPERATIVE;
 			else
 				mt2.flags &= ~MTF_SINGLE;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -63,6 +63,8 @@ void P_InvertPlane(plane_t *plane);
 extern dyncolormap_t NormalLight;
 extern AActor* shootthing;
 
+EXTERN_CVAR(sv_spawnmpthings)
+
 //
 // MAP related Lookup tables.
 // Store VERTEXES, LINEDEFS, SIDEDEFS, etc.
@@ -593,7 +595,13 @@ void P_LoadThings (int lump)
 		// [RH] Need to translate the spawn flags to Hexen format.
 		short flags = LESHORT(mt->options);
 		mt2.flags = (short)((flags & 0xf) | 0x7e0);
-		if (flags & BTF_NOTSINGLE)			mt2.flags &= ~MTF_SINGLE;
+		if (flags & BTF_NOTSINGLE)
+		{
+			if (!sv_spawnmpthings && sv_gametype == GM_COOP)
+				mt2.flags &= ~MTF_COOPERATIVE;
+			else
+				mt2.flags &= ~MTF_SINGLE;
+		}
 		if (flags & BTF_NOTDEATHMATCH)		mt2.flags &= ~MTF_DEATHMATCH;
 		if (flags & BTF_NOTCOOPERATIVE)		mt2.flags &= ~MTF_COOPERATIVE;
 


### PR DESCRIPTION
Added sv_spawnmpthings to control the spawn of multiplayer-only items in cooperative modes.

This is an old request I've done years ago, but for some reason, it wasn't included in the builds aswell.