### PR TITLE
Fix for forced colors after switching teams (Bug #1234)

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -999,7 +999,6 @@ BEGIN_COMMAND (changeteams)
 		cl_team.Set("RED");
 	else if (consoleplayer().userinfo.team == TEAM_RED)
 		cl_team.Set("BLUE");
-	CL_RebuildAllPlayerTranslations();
 }
 END_COMMAND (changeteams)
 
@@ -1361,6 +1360,8 @@ void CL_SendUserInfo(void)
 	{
 		MSG_WriteByte (&net_buffer, coninfo->weapon_prefs[i]);
 	}
+
+	CL_RebuildAllPlayerTranslations();	// Refresh Player Translations AFTER sending the new status to the client.
 }
 
 //

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1361,7 +1361,7 @@ void CL_SendUserInfo(void)
 		MSG_WriteByte (&net_buffer, coninfo->weapon_prefs[i]);
 	}
 
-	CL_RebuildAllPlayerTranslations();	// Refresh Player Translations AFTER sending the new status to the client.
+	CL_RebuildAllPlayerTranslations();	// Refresh Player Translations AFTER sending the new status to the server.
 }
 
 //


### PR DESCRIPTION
I fixed the teams wrongly translated after changing a team.

When you do switch teams, you're sending the command after changing the CVAR, but BEFORE the server acknoledges you're switching teams. As a result, colors are messed up.

Fixes bug 1234 : https://odamex.net/bugs/show_bug.cgi?id=1234