### PR TITLE
Fixed more bad cases of "simulated connection"

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -403,6 +403,7 @@ void CL_QuitNetGame(void)
 
 	serverside = clientside = true;
 	network_game = false;
+	simulated_connection = false;	// Ch0wW : don't block people connect to a server after playing a demo
 
 	sv_freelook = 1;
 	sv_allowjump = 1;
@@ -459,6 +460,7 @@ void CL_Reconnect(void)
 		serveraddr = lastconaddr;
 	}
 
+	simulated_connection = false;	// Ch0wW : don't block people connect to a server after playing a demo
 	connecttimeout = 0;
 }
 


### PR DESCRIPTION
When playing a demo AFTER JOINING a server, if you want to reconnect, or disconnect and try to reconnect, it'll loop forever.

This PR fixes more of it.