### PR TITLE
Fix co_realactorheights and player in-between collisions.

### DIFF
--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -678,6 +678,10 @@ BOOL PIT_CheckOnmobjZ (AActor *thing)
 	if (thing == tmthing)
 		return true;
 
+	// Don't clip against a player
+	if (tmthing->player && thing->player && sv_unblockplayers)
+		return true;
+
 	// over / under thing
 	if (tmthing->z > thing->z + thing->height)
 		return true;


### PR DESCRIPTION
With co_realactorheights , two players can still enter each other if there's a height difference.

This PR fixes it.