### PR TITLE
Adds con_autohide CVAR.

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1150,7 +1150,13 @@ void C_AdjustBottom()
 	else if (ConsoleState == c_up)
 		ConBottom = 0;
 	else if (ConsoleState == c_down || ConBottom > surface_height / 2)
+	{
+		if (ConBottom > surface_height / 2)
+			C_HideConsole();
+
 		ConBottom = surface_height / 2;
+		
+	}
 
 	// don't adjust if the console is raising or lowering because C_Ticker
 	// handles that already

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -148,6 +148,9 @@ CVAR_RANGE(			con_scrlock, "1", "",
 CVAR_RANGE(			con_buffersize, "1024", "Size of console scroll-back buffer",
 					CVARTYPE_INT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 512.0f, 65536.0f)
 
+CVAR(				con_autohide, "1", "Automatically hides the console after loading a new map.",
+					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 CVAR_RANGE_FUNC_DECL(msg0color, "6", "",
 					CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 22.0f)
 

--- a/client/src/g_level.cpp
+++ b/client/src/g_level.cpp
@@ -149,6 +149,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 }
 END_COMMAND (wad)
 
+EXTERN_CVAR(con_autohide)
 EXTERN_CVAR(sv_allowexit)
 EXTERN_CVAR(sv_nomonsters)
 EXTERN_CVAR(sv_freelook)
@@ -481,10 +482,13 @@ void G_DoLoadLevel (int position)
 
 	gamestate = GS_LEVEL;
 
-	// [SL] Hide the console unless this is just part of the demo loop
-	// It's annoying to have the console close every time a new demo starts...
-	if (!demoscreen)
+	// Hide the console unless this is just part of the demo loop
+	// or, if there's con_autohide enabled.
+	if (!demoscreen && (gamestate == GS_LEVEL && con_autohide))
 		C_HideConsole();
+
+	// Ch0wW : Readjust the console so that when connecting, it doesn't go fullscreen
+	C_AdjustBottom();
 
 	// [SL] clear the saved sector data from the last level
 	R_ResetInterpolation();

--- a/client/src/g_level.cpp
+++ b/client/src/g_level.cpp
@@ -482,13 +482,15 @@ void G_DoLoadLevel (int position)
 
 	gamestate = GS_LEVEL;
 
+	// Ch0wW : Readjust the console so that when connecting, it doesn't go fullscreen
+	C_AdjustBottom();
+
 	// Hide the console unless this is just part of the demo loop
 	// or, if there's con_autohide enabled.
 	if (!demoscreen && (gamestate == GS_LEVEL && con_autohide))
 		C_HideConsole();
 
-	// Ch0wW : Readjust the console so that when connecting, it doesn't go fullscreen
-	C_AdjustBottom();
+
 
 	// [SL] clear the saved sector data from the last level
 	R_ResetInterpolation();


### PR DESCRIPTION
Con_autohide hides the console when entering a new map.
That is honestly quite a bit annoying to lose the message you were writing on the intermission, so this should make it at least a bit better.