### PR TITLE
netcode: odasrv: fix O(n^2) loop in SV_WriteCommands()

### DIFF
--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -1127,10 +1127,11 @@ void D_RunTics(void (*sim_func)(), void(*display_func)())
 	dtime_t simulation_wake_time = simulation_scheduler->getNextTime();
 	dtime_t display_wake_time = display_scheduler->getNextTime();
 
-	do
-	{
-		I_Yield();
-	} while (I_GetTime() < MIN(simulation_wake_time, display_wake_time));			
+	dtime_t now = I_GetTime();
+	dtime_t waketime = MIN(simulation_wake_time, display_wake_time);
+	if (waketime > now) {
+		I_Sleep(waketime - now);
+	}
 }
 
 VERSION_CONTROL (d_main_cpp, "$Id$")

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -590,7 +590,8 @@ Players::iterator SV_RemoveDisconnectedPlayer(Players::iterator it)
 //
 void SV_GetPackets()
 {
-	while (NET_GetPacket())
+	int count = 256;
+	while (NET_GetPacket() && --count >= 0)
 	{
 		player_t &player = SV_FindPlayerByAddr();
 
@@ -3344,8 +3345,6 @@ void SV_WriteCommands(void)
 		if (validplayer(*target) && &(*it) != target && P_CanSpy(*it, *target))
 			SV_SendPlayerStateUpdate(&(it->client), target);
 
-		SV_UpdateHiddenMobj();
-
 		SV_UpdateConsolePlayer(*it);
 
 		SV_UpdateMissiles(*it);
@@ -3356,6 +3355,8 @@ void SV_WriteCommands(void)
 
 		SV_UpdatePing(cl);          // send the ping value of all cients to this client
 	}
+
+	SV_UpdateHiddenMobj();
 
 	SV_UpdateDeadPlayers(); // Update dying players.
 }
@@ -3373,8 +3374,8 @@ void SV_PlayerTriedToCheat(player_t &player)
 //
 void SV_FlushPlayerCmds(player_t &player)
 {
-	while (!player.cmdqueue.empty())
-		player.cmdqueue.pop();
+	std::queue<NetCommand> empty;
+	std::swap(player.cmdqueue, empty);
 }
 
 //


### PR DESCRIPTION
netcode: odasrv: fix O(n^2) loop in SV_WriteCommands() which was calling SV_UpdateHiddenMobj() for every player when that function already loops for every player; this change drastically reduces server CPU utilization according to playtesting.

Limiting SV_GetPackets() loop iteration count to see if too many NET_GetPackets() is causing a bottleneck for a large number of players.
More efficient std::queue clearing by swapping with empty instance instead of while(!empty){pop()} loop.
Replace I_Yield() spin loop in D_RunTics() for SERVER_APP with explicit I_Sleep() and calculated sleep duration.