### PR TITLE
Fix for decino's client crash and Edward850's client crash

### DIFF
--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -349,7 +349,7 @@ void R_BlastSpriteColumn(void (*drawfunc)())
 {
 	tallpost_t* post = dcol.post;
 
-	while (!post->end())
+	while (post && !post->end())
 	{
 		// calculate unclipped screen coordinates for post
 		int topscreen = sprtopscreen + spryscale * post->topdelta + 1;

--- a/common/p_ceiling.cpp
+++ b/common/p_ceiling.cpp
@@ -421,13 +421,13 @@ manual_ceiling:
 
 		case DCeiling::ceilLowerByTexture:
 			targheight = ceiling->m_BottomHeight =
-				ceilingheight - P_FindShortestUpperAround (secnum);
+				ceilingheight - P_FindShortestUpperAround (sec);
 			ceiling->m_Direction = -1;
 			break;
 
 		case DCeiling::ceilRaiseByTexture:
 			targheight = ceiling->m_TopHeight =
-				ceilingheight + P_FindShortestUpperAround (secnum);
+				ceilingheight + P_FindShortestUpperAround (sec);
 			ceiling->m_Direction = 1;
 			break;
 
@@ -453,8 +453,8 @@ manual_ceiling:
 					   type == DCeiling::ceilRaiseToFloor ||
 					   type == DCeiling::ceilLowerToHighest ||
 					   type == DCeiling::ceilLowerToFloor) ?
-					P_FindModelFloorSector (targheight, secnum) :
-					P_FindModelCeilingSector (targheight, secnum);
+					P_FindModelFloorSector (targheight, sec) :
+					P_FindModelCeilingSector (targheight, sec);
 				if (sec)
 				{
 					ceiling->m_Texture = sec->ceilingpic;

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -241,8 +241,6 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 			   fixed_t speed, fixed_t height, bool crush, int change)
 	: DMovingFloor (sec), m_Status(init)
 {
-	int secnum = sec - sectors;
-
 	fixed_t floorheight = P_FloorHeight(sec);
 	fixed_t ceilingheight = P_CeilingHeight(sec);
 
@@ -339,7 +337,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 	case DFloor::floorLowerByTexture:
 		m_Direction = -1;
 		m_FloorDestHeight = floorheight -
-			P_FindShortestTextureAround (secnum);
+			P_FindShortestTextureAround (sec);
 		break;
 
 	case DFloor::floorLowerToCeiling:
@@ -355,7 +353,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 		//		enough, BOOM preserved the code here even though it
 		//		also had this function.)
 		m_FloorDestHeight = floorheight +
-			P_FindShortestTextureAround (secnum);
+			P_FindShortestTextureAround (sec);
 		break;
 
 	case DFloor::floorRaiseAndChange:
@@ -379,7 +377,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 		m_NewSpecial = sec->special;
 
 		//jff 5/23/98 use model subroutine to unify fixes and handling
-		sec = P_FindModelFloorSector (m_FloorDestHeight,sec-sectors);
+		sec = P_FindModelFloorSector (m_FloorDestHeight,sec);
 		if (sec)
 		{
 			m_Texture = sec->floorpic;
@@ -402,24 +400,24 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 		if (change & 4)
 		{
 			// Numeric model change
-			sector_t *sec;
+			sector_t *tmpsec;
 
-			sec = (floortype == DFloor::floorRaiseToLowestCeiling ||
+			tmpsec = (floortype == DFloor::floorRaiseToLowestCeiling ||
 				   floortype == DFloor::floorLowerToLowestCeiling ||
 				   floortype == DFloor::floorRaiseToCeiling ||
 				   floortype == DFloor::floorLowerToCeiling) ?
-				  P_FindModelCeilingSector (m_FloorDestHeight, secnum) :
-				  P_FindModelFloorSector (m_FloorDestHeight, secnum);
+					 P_FindModelCeilingSector (m_FloorDestHeight, sec) :
+					 P_FindModelFloorSector (m_FloorDestHeight, sec);
 
-			if (sec) {
-				m_Texture = sec->floorpic;
+			if (tmpsec) {
+				m_Texture = tmpsec->floorpic;
 				switch (change & 3) {
 					case 1:
 						m_NewSpecial = 0;
 						m_Type = DFloor::genFloorChg0;
 						break;
 					case 2:
-						m_NewSpecial = sec->special;
+						m_NewSpecial = tmpsec->special;
 						m_Type = DFloor::genFloorChgT;
 						break;
 					case 3:
@@ -547,7 +545,7 @@ BOOL EV_DoChange (line_t *line, EChange changetype, int tag)
 			}
 			break;
 		case numChangeOnly:
-			secm = P_FindModelFloorSector(P_FloorHeight(sec), secnum);
+			secm = P_FindModelFloorSector(P_FloorHeight(sec), sec);
 			if (secm) // if no model, no change
 			{
 				sec->floorpic = secm->floorpic;

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -996,22 +996,21 @@ fixed_t P_FindHighestCeilingSurrounding (sector_t *sec)
 //
 // jff 02/03/98 Add routine to find shortest lower texture
 //
-fixed_t P_FindShortestTextureAround (int secnum)
+fixed_t P_FindShortestTextureAround (sector_t *sec)
 {
 	int minsize = MAXINT;
 	side_t *side;
 	int i;
-	sector_t *sec = &sectors[secnum];
 
 	for (i = 0; i < sec->linecount; i++)
 	{
-		if (twoSided (secnum, i))
+		if (twoSided (sec, i))
 		{
-			side = getSide (secnum, i, 0);
+			side = getSide (sec, i, 0);
 			if (side->bottomtexture >= 0)
 				if (textureheight[side->bottomtexture] < minsize)
 					minsize = textureheight[side->bottomtexture];
-			side = getSide (secnum, i, 1);
+			side = getSide (sec, i, 1);
 			if (side->bottomtexture >= 0)
 				if (textureheight[side->bottomtexture] < minsize)
 					minsize = textureheight[side->bottomtexture];
@@ -1032,22 +1031,21 @@ fixed_t P_FindShortestTextureAround (int secnum)
 //
 // jff 03/20/98 Add routine to find shortest upper texture
 //
-fixed_t P_FindShortestUpperAround (int secnum)
+fixed_t P_FindShortestUpperAround (sector_t *sec)
 {
 	int minsize = MAXINT;
 	side_t *side;
 	int i;
-	sector_t *sec = &sectors[secnum];
 
 	for (i = 0; i < sec->linecount; i++)
 	{
-		if (twoSided (secnum, i))
+		if (twoSided (sec, i))
 		{
-			side = getSide (secnum,i,0);
+			side = getSide (sec,i,0);
 			if (side->toptexture >= 0)
 				if (textureheight[side->toptexture] < minsize)
 					minsize = textureheight[side->toptexture];
-			side = getSide (secnum,i,1);
+			side = getSide (sec,i,1);
 			if (side->toptexture >= 0)
 				if (textureheight[side->toptexture] < minsize)
 					minsize = textureheight[side->toptexture];
@@ -1073,9 +1071,9 @@ fixed_t P_FindShortestUpperAround (int secnum)
 // [SL] Changed to use ZDoom 1.23's version of this function to account
 // for sloped sectors.
 //
-sector_t *P_FindModelFloorSector (fixed_t floordestheight, int secnum)
+sector_t *P_FindModelFloorSector (fixed_t floordestheight, sector_t *sec)
 {
-	sector_t *other, *sec = &sectors[secnum];
+	sector_t *other;
 
     //jff 5/23/98 don't disturb sec->linecount while searching
     // but allow early exit in old demos
@@ -1110,9 +1108,9 @@ sector_t *P_FindModelFloorSector (fixed_t floordestheight, int secnum)
 // [SL] Changed to use ZDoom 1.23's version of this function to account
 // for sloped sectors.
 //
-sector_t *P_FindModelCeilingSector (fixed_t ceildestheight, int secnum)
+sector_t *P_FindModelCeilingSector (fixed_t ceildestheight, sector_t *sec)
 {
-	sector_t *other, *sec = &sectors[secnum];
+	sector_t *other;
 
     //jff 5/23/98 don't disturb sec->linecount while searching
     // but allow early exit in old demos

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -198,9 +198,9 @@ void    P_PlayerInSpecialSector (player_t *player);
 //	given the number of the current sector,
 //	the line number, and the side (0/1) that you want.
 //
-inline side_t *getSide (int currentSector, int line, int side)
+inline side_t *getSide (sector_t *sec, int line, int side)
 {
-	return &sides[ (sectors[currentSector].lines[line])->sidenum[side] ];
+	return &sides[ (sec->lines[line])->sidenum[side] ];
 }
 
 //
@@ -220,9 +220,9 @@ inline sector_t *getSector (int currentSector, int line, int side)
 // Given the sector number and the line number,
 //	it will tell you whether the line is two-sided or not.
 //
-inline int twoSided (int sector, int line)
+inline int twoSided (sector_t *sec, int line)
 {
-	return (sectors[sector].lines[line])->flags & ML_TWOSIDED;
+	return (sec->lines[line])->flags & ML_TWOSIDED;
 }
 
 //
@@ -253,11 +253,11 @@ fixed_t	P_FindHighestCeilingSurrounding (sector_t *sec);	// jff 2/04/98
 fixed_t P_FindNextLowestCeiling (sector_t *sec);		// jff 2/04/98
 fixed_t P_FindNextHighestCeiling (sector_t *sec);	// jff 2/04/98
 
-fixed_t P_FindShortestTextureAround (int secnum);	// jff 2/04/98
-fixed_t P_FindShortestUpperAround (int secnum);		// jff 2/04/98
+fixed_t P_FindShortestTextureAround (sector_t *sec);	// jff 2/04/98
+fixed_t P_FindShortestUpperAround (sector_t *sec);		// jff 2/04/98
 
-sector_t* P_FindModelFloorSector (fixed_t floordestheight, int secnum);	//jff 02/04/98
-sector_t* P_FindModelCeilingSector (fixed_t ceildestheight, int secnum);	//jff 02/04/98
+sector_t* P_FindModelFloorSector (fixed_t floordestheight, sector_t *sec);	//jff 02/04/98
+sector_t* P_FindModelCeilingSector (fixed_t ceildestheight, sector_t *sec);	//jff 02/04/98
 
 int		P_FindSectorFromTag (int tag, int start);
 int		P_FindLineFromID (int id, int start);


### PR DESCRIPTION
Simple fix for null pointer dereference in `client\src\r_things.cpp : 352`.

Crash dump from WinDbg:
```
0:000> !analyze -v
FAULTING_IP: 
odamex!R_BlastSpriteColumn+20 [x:\odamex-0.8.1\client\src\r_things.cpp @ 352]
00007ff6`c642f950 0fb703          movzx   eax,word ptr [rbx]

EXCEPTION_RECORD:  ffffffffffffffff -- (.exr 0xffffffffffffffff)
ExceptionAddress: 00007ff6c642f950 (odamex!tallpost_s::end+0x0000000000000009)
   ExceptionCode: c0000005 (Access violation)
  ExceptionFlags: 00000000
NumberParameters: 2
   Parameter[0]: 0000000000000000
   Parameter[1]: 000001bc84d7f648
Attempt to read from address 000001bc84d7f648

DEFAULT_BUCKET_ID:  WRONG_SYMBOLS

PROCESS_NAME:  odamex.exe

ADDITIONAL_DEBUG_TEXT:  
You can run '.symfix; .reload' to try to fix the symbol path and load symbols.

MODULE_NAME: odamex

FAULTING_MODULE: 00007ffac2580000 ntdll

DEBUG_FLR_IMAGE_TIMESTAMP:  5d35f8cf

ERROR_CODE: (NTSTATUS) 0xc0000005 - The instruction at 0x%p referenced memory at 0x%p. The memory could not be %s.

EXCEPTION_CODE: (NTSTATUS) 0xc0000005 - The instruction at 0x%p referenced memory at 0x%p. The memory could not be %s.

EXCEPTION_PARAMETER1:  0000000000000000

EXCEPTION_PARAMETER2:  000001bc84d7f648

READ_ADDRESS:  000001bc84d7f648 

FOLLOWUP_IP: 
odamex!R_BlastSpriteColumn+20 [x:\odamex-0.8.1\client\src\r_things.cpp @ 352]
00007ff6`c642f950 0fb703          movzx   eax,word ptr [rbx]

APP:  odamex.exe

PRIMARY_PROBLEM_CLASS:  WRONG_SYMBOLS

BUGCHECK_STR:  APPLICATION_FAULT_WRONG_SYMBOLS

LAST_CONTROL_TRANSFER:  from 00007ff6c642c708 to 00007ff6c642f950

STACK_TEXT:  
000000bb`762f15a0 00007ff6`c642c708 : 00007ff6`c62f1a37 00000000`0000077f 00007ff6`c62f1a37 00000000`0000077f : odamex!R_BlastSpriteColumn+0x20
000000bb`762f15d0 00007ff6`c6430e74 : 000001bc`00000000 00007ff6`0000077f 00007ff6`c6646610 00007ff6`c6649310 : odamex!R_RenderColumnRange+0x158
000000bb`762f1690 00007ff6`c6430bec : 00007ff6`c6695ba0 000001bc`0d4f3650 00000000`00000534 00000000`0000077f : odamex!R_DrawVisSprite+0x1d4
000000bb`762f16f0 00007ff6`c64300ba : 00007ff6`c66bffe8 000001bc`1a421dd0 00000000`00401400 000001bc`0d4975d0 : odamex!R_DrawSprite+0x23c
000000bb`762f1730 00007ff6`c64287a5 : 00000000`00401400 000000bb`762f17c8 00000000`00000000 00000000`00000000 : odamex!R_DrawMasked+0x3a
000000bb`762f1760 00007ff6`c6455a6a : 00000000`00000000 00000000`00000000 000001bc`0d53db50 00007ff6`c64515b2 : odamex!R_RenderPlayerView+0x1d5
000000bb`762f17e0 00007ff6`c645135d : 00000000`00000000 00000000`00000000 000001bc`00000000 00000000`00000000 : odamex!D_Display+0x15a
000000bb`762f1830 00007ff6`c6456163 : 00000000`00000000 00000000`00000000 00000000`00000000 00007ff6`c66bffe8 : odamex!D_RunTics+0xad
000000bb`762f1860 00007ff6`c6456e50 : 00007ff6`c64e48d0 00007ff6`c64aae30 000001bc`0ac41500 00000000`00008000 : odamex!D_DoomLoop+0x33
000000bb`762f18d0 00007ff6`c63ab6bc : 00007ffa`c06cf050 00000000`00000000 00000000`00000005 00000000`00000000 : odamex!D_DoomMain+0xcd0
000000bb`762ffc40 00007ff6`c64851b9 : 00000000`00000000 00000000`00000000 00007ffa`bf76b570 00000000`00000000 : odamex!main+0x36c
000000bb`762ffcd0 00007ffa`c0687974 : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : odamex!__scrt_common_main_seh+0x11d
000000bb`762ffd10 00007ffa`c25ea271 : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : kernel32!BaseThreadInitThunk+0x14
000000bb`762ffd40 00000000`00000000 : 00000000`00000000 00000000`00000000 00000000`00000000 00000000`00000000 : ntdll!RtlUserThreadStart+0x21


STACK_COMMAND:  ~0s; .ecxr ; kb

FAULTING_SOURCE_LINE:  x:\odamex-0.8.1\client\src\r_things.cpp

FAULTING_SOURCE_FILE:  x:\odamex-0.8.1\client\src\r_things.cpp

FAULTING_SOURCE_LINE_NUMBER:  352

SYMBOL_STACK_INDEX:  0

SYMBOL_NAME:  odamex!R_BlastSpriteColumn+20

FOLLOWUP_NAME:  MachineOwner

IMAGE_NAME:  odamex.exe

BUCKET_ID:  WRONG_SYMBOLS

FAILURE_BUCKET_ID:  WRONG_SYMBOLS_c0000005_odamex.exe!R_BlastSpriteColumn
```

Simplified stack trace:
```
odamex!R_BlastSpriteColumn+0x20
odamex!R_RenderColumnRange+0x158
odamex!R_DrawVisSprite+0x1d4
odamex!R_DrawSprite+0x23c
odamex!R_DrawMasked+0x3a
odamex!R_RenderPlayerView+0x1d5
odamex!D_Display+0x15a
odamex!D_RunTics+0xad
odamex!D_DoomLoop+0x33
odamex!D_DoomMain+0xcd0
odamex!main+0x36c
odamex!__scrt_common_main_seh+0x11d
kernel32!BaseThreadInitThunk+0x14
ntdll!RtlUserThreadStart+0x21
```
