### PR TITLE
Fix suicide spam

### DIFF
--- a/common/d_player.h
+++ b/common/d_player.h
@@ -217,6 +217,7 @@ public:
 	int			jumpTics;				// delay the next jump for a moment
 
 	int			death_time;				// [SL] Record time of death to enforce respawn delay if needed 
+	int			suicide_time;			// Ch0wW - Time between 2 suicides.
 	fixed_t		oldvelocity[3];			// [RH] Used for falling damage
 
 	AActor::AActorPtr camera;			// [RH] Whose eyes this player sees through

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -1043,6 +1043,7 @@ void P_KillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill
 		target->player->playerstate = PST_DEAD;
 		P_DropWeapon(target->player);
 
+		tplayer->suicide_time = level.time;
 		tplayer->death_time = level.time;
 
 		if (target == consoleplayer().camera)

--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -369,6 +369,8 @@ void G_InitNew (const char *mapname)
 			}
 			it->spectator = true;
 			it->playerstate = PST_LIVE;
+
+			it->suicide_time = 0;				// Ch0wW : Disallow suicide
 			it->joinafterspectatortime = -(TICRATE * 5);
 		}
 	}
@@ -444,6 +446,7 @@ void G_InitNew (const char *mapname)
 
 			it->playerstate = PST_ENTER; // [BC]
 
+			it->suicide_time = 0;				// Ch0wW : Disallow suicide
 			it->joinafterspectatortime = -(TICRATE * 5);
 		}
 	}

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3929,7 +3929,7 @@ void SV_Suicide(player_t &player)
 		return;
 
 	// WHY do you want to commit suicide in the intermission screen ?!?!
-	if (gamestate == GS_INTERMISSION)
+	if (gamestate != GS_LEVEL)
 		return;
 
 	// merry suicide!

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4194,7 +4194,7 @@ void SV_ParseCommands(player_t &player)
 
 		case clc_kill:
 			if(player.mo &&
-               level.time > player.death_time + TICRATE*10 &&
+               level.time > player.suicide_time + TICRATE*10 &&
                (sv_allowcheats || sv_gametype == GM_COOP))
             {
 				SV_Suicide (player);

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3928,6 +3928,10 @@ void SV_Suicide(player_t &player)
 	if (!player.mo)
 		return;
 
+	// WHY do you want to commit suicide in the intermission screen ?!?!
+	if (gamestate == GS_INTERMISSION)
+		return;
+
 	// merry suicide!
 	P_DamageMobj (player.mo, NULL, NULL, 10000, MOD_SUICIDE);
 	//player.mo->player = NULL;


### PR DESCRIPTION
death_time was reset after each respawn, making suicide spam entirely possible.

This PR fixes that issue by addressing a new variable specifically tailored for this purpose.