### PR TITLE
Improve selection of SDL2 renderer drivers. 

### DIFF
--- a/client/sdl/i_sdlvideo.h
+++ b/client/sdl/i_sdlvideo.h
@@ -347,6 +347,8 @@ private:
 
 	bool mDrawLogicalRect;
 	SDL_Rect mLogicalRect;
+
+	SDL_Renderer* createRenderer(bool vsync) const;
 };
 
 
@@ -433,6 +435,7 @@ private:
 	void discoverNativePixelFormat();
 	PixelFormat buildSurfacePixelFormat(uint8_t bpp);
 	void setRendererDriver();
+	bool isRendererDriverAvailable(const char* driver) const;
 	const char* getRendererDriver() const;
 	void getEvents();
 


### PR DESCRIPTION
Select the most preferred driver that is actually supported by the user's system. Additionally, if the most preferred driver is OpenGL, include the SDL_WINDOW_OPENGL flag when creating the SDL Window. This was already the case on Win32 but was omitted in Linux systems, resulting in crashes when creating the SDL Renderer instance.