### PR TITLE
Fix the weapon's sprite's offset.

### DIFF
--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -1002,7 +1002,7 @@ void R_DrawPlayerSprites (void)
 	{
 		int centerhack = centery;
 
-		centery = viewheight >> 1;
+		centery = (viewheight >> 1) + 1;	// Ch0wW : Fix for the weapon sprite's offset.
 		centeryfrac = centery << FRACBITS;
 
 		// add all active psprites


### PR DESCRIPTION
The weapon was shown one pixel higher. This PR fixes it.