### PR TITLE
Lowercase all key arguments during bind commands

### DIFF
--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -365,7 +365,8 @@ BEGIN_COMMAND (unbind)
 
 	if (argc > 1)
 	{
-		if ( (i = GetKeyFromName (argv[1])) )
+		std::string strArg = StdStringToLower(argv[1]);
+		if ( (i = GetKeyFromName (strArg.c_str())) )
 			Bindings[i] = "";
 		else
 			Printf (PRINT_HIGH, "Unknown key %s\n", C_QuoteString(argv[1]).c_str());
@@ -378,13 +379,15 @@ BEGIN_COMMAND (bind)
 	int i;
 
 	if (argc > 1) {
-		i = GetKeyFromName (argv[1]);
+
+		std::string strArg = StdStringToLower(argv[1]);
+		i = GetKeyFromName (strArg.c_str());
 		if (!i) {
 			Printf (PRINT_HIGH, "Unknown key %s\n", C_QuoteString(argv[1]).c_str());
 			return;
 		}
 		if (argc == 2) {
-			Printf (PRINT_HIGH, "%s = %s\n", argv[1], C_QuoteString(Bindings[i]).c_str());
+			Printf (PRINT_HIGH, "%s = %s\n", strArg.c_str(), C_QuoteString(Bindings[i]).c_str());
 		} else {
 			Bindings[i] = argv[2];
 		}
@@ -405,7 +408,8 @@ BEGIN_COMMAND (undoublebind)
 
 	if (argc > 1)
 	{
-		if ( (i = GetKeyFromName (argv[1])) )
+		std::string strArg = StdStringToLower(argv[1]);
+		if ( (i = GetKeyFromName (strArg.c_str())) )
 			DoubleBindings[i] = "";
 		else
 			Printf (PRINT_HIGH, "Unknown key %s\n", C_QuoteString(argv[1]).c_str());
@@ -419,7 +423,8 @@ BEGIN_COMMAND (doublebind)
 
 	if (argc > 1)
 	{
-		i = GetKeyFromName (argv[1]);
+		std::string strArg = StdStringToLower(argv[1]);
+		i = GetKeyFromName (strArg.c_str());
 		if (!i)
 		{
 			Printf (PRINT_HIGH, "Unknown key %s\n", C_QuoteString(argv[1]).c_str());
@@ -427,7 +432,7 @@ BEGIN_COMMAND (doublebind)
 		}
 		if (argc == 2)
 		{
-			Printf (PRINT_HIGH, "%s = %s\n", argv[1], C_QuoteString(DoubleBindings[i]).c_str());
+			Printf (PRINT_HIGH, "%s = %s\n", strArg.c_str(), C_QuoteString(DoubleBindings[i]).c_str());
 		}
 		else
 		{


### PR DESCRIPTION
In earlier builds, all keys not in lowercase weren't recognized by the port.

This PR fixes it, by converting all argv[1] arguments to bind commands to lowercase.