### PR TITLE
Change source path of odamex.wad for macOS client

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -253,7 +253,7 @@ if(SDL_VERSION)
       POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/odamex.app/Contents/Resources
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/media/${MACOSX_BUNDLE_ICON_FILE} ${CMAKE_CURRENT_BINARY_DIR}/odamex.app/Contents/Resources
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/odamex.wad ${CMAKE_CURRENT_BINARY_DIR}/odamex.app/Contents/MacOS
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/wad/odamex.wad ${CMAKE_CURRENT_BINARY_DIR}/odamex.app/Contents/MacOS
     )
 
     set_directory_properties(


### PR DESCRIPTION
When compiling for macOS, CMake was looking for `odamex.wad` in the project root directory but it looks like it should be `wad/odamex.wad` instead.

I'm not sure how it is for other OS'es. I think I'm seeing another reference to a root-located `odamex.wad` in the Windows installer wizard script, but I cannot test it.