### PR TITLE
snd_cubic: cubic interpolation for sound effects

### DIFF
--- a/client/sdl/i_sound.h
+++ b/client/sdl/i_sound.h
@@ -73,4 +73,7 @@ int I_SoundIsPlaying(int handle);
 //	and pitch of a sound channel.
 void I_UpdateSoundParams(int handle, float vol, int sep, int pitch);
 
+// Clears all cached sound samples
+void I_ClearSoundCache(void);
+
 #endif

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -540,6 +540,8 @@ CVAR_RANGE_FUNC_DECL(snd_samplerate, "44100", "Audio samplerate",
 CVAR_RANGE_FUNC_DECL(snd_channels, "12", "Number of channels for sound effects",
 				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 4.0f, 32.0f)
 
+CVAR_FUNC_DECL(	snd_cubic, "0", "Cubic resampling",	CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 //
 // C_GetDefaultMuiscSystem()
 //

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -140,6 +140,7 @@ EXTERN_CVAR (snd_musicvolume)
 EXTERN_CVAR (snd_announcervolume)
 EXTERN_CVAR (snd_sfxvolume)
 EXTERN_CVAR (snd_crossover)
+EXTERN_CVAR (snd_cubic)
 EXTERN_CVAR (snd_gamesfx)
 EXTERN_CVAR (snd_voxtype)
 EXTERN_CVAR (cl_connectalert)
@@ -576,6 +577,11 @@ static value_t VoxType[] = {
 	{ 2.0,			"Possessive" }
 };
 
+static value_t SndInterp[] = {
+	{ 0.0,					"Off" },
+	{ 1.0,					"Cubic" },
+};
+
 static float num_mussys = static_cast<float>(STACKARRAY_LENGTH(MusSys));
 
 static menuitem_t SoundItems[] = {
@@ -585,6 +591,7 @@ static menuitem_t SoundItems[] = {
 	{ slider    ,	"Sound Volume"                      , {&snd_sfxvolume},		{0.0},      	{1.0},	    {0.1},      {NULL} },
 	{ slider    ,	"Announcer Volume"             		, {&snd_announcervolume},	{0.0},      {1.0},	    {0.1},      {NULL} },
 	{ discrete  ,   "Stereo Switch"                     , {&snd_crossover},	    {2.0},			{0.0},		{0.0},		{OnOff} },
+	{ discrete  ,   "Interpolation"                     , {&snd_cubic},	    	{2.0},			{1.0},		{0.0},		{SndInterp} },
 	{ redtext   ,	" "                                 , {NULL},	            {0.0},      	{0.0},      {0.0},      {NULL} },
 	{ discrete	,	"Music System Backend"				, {&snd_musicsystem},	{num_mussys},	{0.0},		{0.0},		{MusSys} },
 	{ redtext   ,	" "                                 , {NULL},	            {0.0},      	{0.0},      {0.0},      {NULL} },

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -247,6 +247,8 @@ static void S_StopChannel (unsigned int cnum);
 //
 void S_Init (float sfxVolume, float musicVolume)
 {
+	I_ClearSoundCache();
+
 	SoundCurve = (byte *)W_CacheLumpNum(W_GetNumForName("SNDCURVE"), PU_STATIC);
 
 	// [RH] Read in sound sequences


### PR DESCRIPTION
Cubic interpolation resampling method for sound chunks. Only resamples sounds on load and caches them. Avoids nasty aliasing that occurs from current zero-order-hold implementation.

New cvar: `snd_cubic` boolean with new sound options menu item to enable/disable.