### PR TITLE
Server: performance fixes for O(n^2) loops

### DIFF
--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -1130,10 +1130,11 @@ void D_RunTics(void (*sim_func)(), void(*display_func)())
 	dtime_t simulation_wake_time = simulation_scheduler->getNextTime();
 	dtime_t display_wake_time = display_scheduler->getNextTime();
 
-	do
-	{
-		I_Yield();
-	} while (I_GetTime() < MIN(simulation_wake_time, display_wake_time));			
+	dtime_t now = I_GetTime();
+	dtime_t waketime = MIN(simulation_wake_time, display_wake_time);
+	if (waketime > now) {
+		I_Sleep(waketime - now);
+	}
 }
 
 VERSION_CONTROL (d_main_cpp, "$Id$")

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -435,6 +435,7 @@ void	P_ProcessSwitchDef ();
 bool	P_GetButtonInfo (line_t *line, unsigned &state, unsigned &time);
 bool	P_SetButtonInfo (line_t *line, unsigned state, unsigned time);
 
+void	P_UpdateButtons (client_t *cl);
 
 //
 // P_PLATS

--- a/common/p_switch.cpp
+++ b/common/p_switch.cpp
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <map>
 
 #include "i_system.h"
 #include "doomdef.h"
@@ -240,6 +241,51 @@ bool P_SetButtonInfo (line_t *line, unsigned state, unsigned time)
 	}
 
 	return false;
+}
+
+void P_UpdateButtons(client_t *cl)
+{
+	DActiveButton *button;
+	TThinkerIterator<DActiveButton> iterator;
+	std::map<unsigned, bool> actedlines;
+
+	// See if button is already pressed
+	while ( (button = iterator.Next ()) )
+	{
+		if (button->m_Line == NULL) continue;
+
+		unsigned l = button->m_Line - lines;
+		unsigned state = 0, timer = 0;
+
+		state = button->m_Where;
+		timer = button->m_Timer;
+
+		// record that we acted on this line:
+		actedlines[l] = true;
+
+		MSG_WriteMarker(&cl->reliablebuf, svc_switch);
+		MSG_WriteLong(&cl->reliablebuf, l);
+		MSG_WriteByte(&cl->reliablebuf, lines[l].switchactive);
+		MSG_WriteByte(&cl->reliablebuf, lines[l].special);
+		MSG_WriteByte(&cl->reliablebuf, state);
+		MSG_WriteShort(&cl->reliablebuf, P_GetButtonTexture(&lines[l]));
+		MSG_WriteLong(&cl->reliablebuf, timer);
+	}
+
+	for (int l=0; l<numlines; l++)
+	{
+		// update all button state except those that have actors assigned:
+		if (!actedlines[l] && lines[l].wastoggled)
+		{
+			MSG_WriteMarker(&cl->reliablebuf, svc_switch);
+			MSG_WriteLong(&cl->reliablebuf, l);
+			MSG_WriteByte(&cl->reliablebuf, lines[l].switchactive);
+			MSG_WriteByte(&cl->reliablebuf, lines[l].special);
+			MSG_WriteByte(&cl->reliablebuf, 0);
+			MSG_WriteShort(&cl->reliablebuf, P_GetButtonTexture(&lines[l]));
+			MSG_WriteLong(&cl->reliablebuf, 0);
+		}
+	}
 }
 
 //

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1636,6 +1636,7 @@ void SV_ClientFullUpdate(player_t &pl)
 			return;
 
 	// update switches
+#if 0
 	for (int l=0; l<numlines; l++)
 	{
 		unsigned state = 0, time = 0;
@@ -1650,6 +1651,9 @@ void SV_ClientFullUpdate(player_t &pl)
 			MSG_WriteLong(&cl->reliablebuf, time);
 		}
 	}
+#else
+	P_UpdateButtons(cl);
+#endif
 
 	MSG_WriteMarker(&cl->reliablebuf, svc_fullupdatedone);
 
@@ -3349,8 +3353,6 @@ void SV_WriteCommands(void)
 		if (validplayer(*target) && &(*it) != target && P_CanSpy(*it, *target))
 			SV_SendPlayerStateUpdate(&(it->client), target);
 
-		SV_UpdateHiddenMobj();
-
 		SV_UpdateConsolePlayer(*it);
 
 		SV_UpdateMissiles(*it);
@@ -3361,6 +3363,8 @@ void SV_WriteCommands(void)
 
 		SV_UpdatePing(cl);          // send the ping value of all cients to this client
 	}
+
+	SV_UpdateHiddenMobj();
 
 	SV_UpdateDeadPlayers(); // Update dying players.
 }
@@ -3378,8 +3382,8 @@ void SV_PlayerTriedToCheat(player_t &player)
 //
 void SV_FlushPlayerCmds(player_t &player)
 {
-	while (!player.cmdqueue.empty())
-		player.cmdqueue.pop();
+	std::queue<NetCommand> empty;
+	std::swap(player.cmdqueue, empty);
 }
 
 //


### PR DESCRIPTION
SV_WriteCommands() was calling SV_UpdateHiddenMobj() from a foreach player loop; SV_UpdateHiddenMobj() has its own foreach player loop; moved the SV_UpdateHiddenMobj() function out of the foreach player loop in SV_WriteCommands() which drastically reduces server CPU utilization according to playtesting.

Replaced I_Yield() call in D_RunTics() for SERVER_APP with explicit I_Sleep() and calculated sleep duration. This reduces unnecessary CPU utilization because I_Yield() simply loops and sleeps for 1ms each loop iteration.

optimized poor performance of SV_ClientFullUpdate() updating switch/button state: introduced new P_UpdateButtons() function to iterate efficiently through all switch objects.

More efficient std::queue clearing by swapping with empty instance instead of while(!empty){pop()} loop.