### PR TITLE
Vibranium doors

### DIFF
--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -35,6 +35,9 @@ CVAR_RANGE(			sv_gametype, "0", "Sets the game mode, values are:\n" \
 					CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH | CVAR_NOENABLEDISABLE,
 					0.0f, 3.0f)
 
+CVAR(				sv_activation_rate, "0", "Door/lift activation rate limit in tics; 0 disables.",
+					CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
 CVAR(				sv_friendlyfire, "1", "When set, players can injure others on the same team, " \
 					"it is ignored in deathmatch",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -478,6 +478,11 @@ BOOL EV_DoFloor (DFloor::EFloor floortype, line_t *line, int tag,
 	{
 		if (!line || !(sec = line->backsector))
 			return rtn;
+
+		// rate limit sector activation:
+		if (P_CheckSectorRateLimit(sec, NULL))
+			return false;
+
 		secnum = sec-sectors;
 		manual = true;
 		goto manual_floor;

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -474,6 +474,7 @@ BOOL PO_Busy (int polyobj);
 //
 #include "p_spec.h"
 
+bool P_CheckSectorRateLimit(sector_t *sec, AActor *thing);
 
 #endif	// __P_LOCAL__
 

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -359,6 +359,9 @@ void P_LoadSectors (int lump)
 		P_SetupLevelFloorPlane(ss);
 		P_SetupLevelCeilingPlane(ss);
 
+		// [jsd] reset last_activation_tic for rate limiting:
+		ss->last_activation_tic = -TICRATE;
+
 		ss->gravity = 1.0f;	// [RH] Default sector gravity of 1.0
 
 		// [RH] Sectors default to white light with the default fade.

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -234,6 +234,9 @@ struct sector_s
 
 	// [SL] 2012-01-16 - planes for sloping ceilings/floors
 	plane_t floorplane, ceilingplane;
+
+	// [jsd] record last gametic sector was activated to rate limit on serverside for doors, lifts, etc.
+	int last_activation_tic;
 };
 typedef struct sector_s sector_t;
 


### PR DESCRIPTION
doors: added sv_activation_rate default to 35 tics to rate limit linedef activations for untagged doors and lifts.