### PR TITLE
Server coop-completionist mode

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1074,6 +1074,7 @@ void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 	MSG_WriteBool	(netbuffer, false);	// sv_emptyreset
 	MSG_WriteBool	(netbuffer, false);	// sv_cleanmaps
 	MSG_WriteBool	(netbuffer, false);	// sv_fragexitswitch
+	// TODO(jsd): sync sv_coop_completionist
 	
 	for (Players::const_iterator it = players.begin();it != players.end();++it)
 	{

--- a/client/src/cl_vote.cpp
+++ b/client/src/cl_vote.cpp
@@ -187,6 +187,8 @@ BEGIN_COMMAND(callvote) {
 	case VOTE_FRAGLIMIT:
 	case VOTE_SCORELIMIT:
 	case VOTE_TIMELIMIT:
+	case VOTE_COOPCOMPLETIONISTKILLS:
+	case VOTE_COOPCOMPLETIONISTSECRETS:
 		// Only one argument is necessary.
 		arguments.resize(1);
 		break;

--- a/common/actor.h
+++ b/common/actor.h
@@ -461,6 +461,9 @@ public:
 	int             netid;          // every object has its own netid
 	short			tid;			// thing identifier
 
+	bool 			completionist_killable;
+	bool 			completionist_killed;
+
 private:
 	static const size_t TIDHashSize = 256;
 	static const size_t TIDHashMask = TIDHashSize - 1;

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -35,6 +35,26 @@ CVAR_RANGE(			sv_gametype, "0", "Sets the game mode, values are:\n" \
 					CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH | CVAR_NOENABLEDISABLE,
 					0.0f, 3.0f)
 
+CVAR(				sv_coop_completionist, "0", "EXPERIMENTAL: When enabled in COOP, all monsters must be killed " \
+                    "and secrets found to exit the map.",
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_LATCH | CVAR_SERVERINFO)
+
+CVAR(				sv_coop_completionist_kills, "-1", "Count of killable monsters for coop completionist mode " \
+					"for the current map.",
+					CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
+CVAR(				sv_coop_completionist_secrets, "-1", "Count of findable secrets for coop completionist mode " \
+					"for the current map.",
+					CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
+CVAR(				sv_coop_completionist_killed, "0", "Count of killed monsters for coop completionist mode " \
+					"for the current map.",
+					CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE | CVAR_NOSET)
+
+CVAR(				sv_coop_completionist_found, "0", "Count of found secrets for coop completionist mode " \
+					"for the current map.",
+					CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE | CVAR_NOSET)
+
 CVAR(				sv_friendlyfire, "1", "When set, players can injure others on the same team, " \
 					"it is ignored in deathmatch",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)

--- a/common/c_vote.cpp
+++ b/common/c_vote.cpp
@@ -20,10 +20,12 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "c_vote.h"
+
 /**
  * A string array used to associate vote types with command names.
  */
-const char* vote_type_cmd[] = {
+const char* vote_type_cmd[VOTE_MAX+1] = {
 	"???",
 	"kick",
 	"forcespec",
@@ -38,5 +40,7 @@ const char* vote_type_cmd[] = {
 	"scorelimit",
 	"timelimit",
 	"coinflip",
+	"kills",
+	"secrets",
 	"???"
 };

--- a/common/c_vote.h
+++ b/common/c_vote.h
@@ -53,9 +53,11 @@ typedef enum {
 	VOTE_SCORELIMIT,
 	VOTE_TIMELIMIT,
 	VOTE_COINFLIP,
+	VOTE_COOPCOMPLETIONISTKILLS,
+	VOTE_COOPCOMPLETIONISTSECRETS,
 	VOTE_MAX // Reserved
 } vote_type_t;
 
-extern const char* vote_type_cmd[];
+extern const char* vote_type_cmd[VOTE_MAX+1];
 
 #endif

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -54,6 +54,8 @@ EXTERN_CVAR(cl_predictpickup)
 EXTERN_CVAR(co_zdoomsound)
 EXTERN_CVAR(co_globalsound)
 
+EXTERN_CVAR(sv_coop_completionist_killed)
+
 int shotclock = 0;
 int MeansOfDeath;
 
@@ -923,8 +925,15 @@ void P_KillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill
 	// [RH] Also set the thing's tid to 0. [why?]
 	target->tid = 0;
 
-	if (serverside && target->flags & MF_COUNTKILL)
+	if (serverside && target->flags & MF_COUNTKILL) {
 		level.killed_monsters++;
+		if (target->completionist_killable && !target->completionist_killed) {
+			int killed = sv_coop_completionist_killed.asInt();
+			killed++;
+			sv_coop_completionist_killed.ForceSet(killed);
+			target->completionist_killed = true;
+		}
+	}
 
 	if (source)
 	{

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -33,6 +33,7 @@
 #include "v_palette.h"
 #include "tables.h"
 #include "i_system.h"
+#include "c_console.h"
 
 #define FUNC(a) static BOOL a (line_t *ln, AActor *it, int arg0, int arg1, \
 							   int arg2, int arg3, int arg4)
@@ -1949,17 +1950,69 @@ EXTERN_CVAR (sv_fraglimit)
 EXTERN_CVAR (sv_allowexit)
 EXTERN_CVAR (sv_fragexitswitch)
 
+EXTERN_CVAR (sv_coop_completionist)
+EXTERN_CVAR (sv_coop_completionist_kills)
+EXTERN_CVAR (sv_coop_completionist_secrets)
+EXTERN_CVAR (sv_coop_completionist_killed)
+EXTERN_CVAR (sv_coop_completionist_found)
+
 BOOL CheckIfExitIsGood (AActor *self)
 {
+	// must be server side:
 	if (self == NULL || !serverside)
 		return false;
 
 	// Bypass the exit restrictions if we're on a lobby.
 	if (level.flags & LEVEL_LOBBYSPECIAL)
-		return true;	
+		return true;
 
+	if (sv_gametype == GM_COOP) {
+		// COOP completionist mode:
+		if (sv_coop_completionist && self->player) {
+			// determine total number of killable monsters and findable secrets for the current level:
+			int killable_monsters = (sv_coop_completionist_kills < 0.0) ? level.total_monsters : (int)sv_coop_completionist_kills;
+			int findable_secrets = (sv_coop_completionist_secrets < 0.0) ? level.total_secrets : (int)sv_coop_completionist_secrets;
+
+			int unkilled_monsters = killable_monsters - sv_coop_completionist_killed.asInt();
+			int unfound_secrets = findable_secrets - level.found_secrets;
+
+			if (unkilled_monsters > 0 || unfound_secrets > 0) {
+				char reuse[100], *m;
+
+				m = reuse;
+				if (unkilled_monsters > 0) {
+					m += sprintf(m, " %d unkilled %s",
+							unkilled_monsters,
+							unkilled_monsters == 1 ? "monster" : "monsters");
+				}
+				if (unfound_secrets > 0) {
+					if (unkilled_monsters > 0) {
+						m += sprintf(m, " and");
+					}
+					m += sprintf(m, " %d unfound %s",
+							unfound_secrets,
+							unfound_secrets == 1 ? "secret" : "secrets");
+				}
+				m += sprintf(m, ".\n");
+
+				char plyrmsg[200];
+				strcpy(plyrmsg, "Cannot exit the level with");
+				strcat(plyrmsg, reuse);
+				C_MidPrint (plyrmsg, self->player, 5);
+
+				// write message to server:
+				char srvmsg[256 + 100];
+				sprintf(srvmsg, "%s attempted to exit the level with", self->player->userinfo.netname.c_str());
+				strcat(srvmsg, reuse);
+				Printf (PRINT_HIGH, srvmsg);
+
+				// don't allow exit:
+				return false;
+			}
+		}
+	}
 	// [Toke - dmflags] Old location of DF_NO_EXIT
-	if (sv_gametype != GM_COOP && self)
+	else if (sv_gametype != GM_COOP)
 	{
         if (!sv_allowexit)
         {

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -48,6 +48,11 @@
 
 #include "p_setup.h"
 
+EXTERN_CVAR(sv_coop_completionist_kills)
+EXTERN_CVAR(sv_coop_completionist_secrets)
+EXTERN_CVAR(sv_coop_completionist_killed)
+EXTERN_CVAR(sv_coop_completionist_found)
+
 void SV_PreservePlayer(player_t &player);
 void P_SpawnMapThing (mapthing2_t *mthing, int position);
 
@@ -1658,6 +1663,13 @@ void P_SetupLevel (char *lumpname, int position)
 		level.killed_monsters = level.found_items = level.found_secrets =
 		wminfo.maxfrags = 0;
 	wminfo.partime = 180;
+
+	// reset completionist counts to -1 which is translated to level.total_monsters and level.total_secrets in p_lnspec.cpp:
+	sv_coop_completionist_kills.ForceSet(-1.0f);
+	sv_coop_completionist_secrets.ForceSet(-1.0f);
+	// reset completionist counters to 0:
+	sv_coop_completionist_killed.ForceSet(0.0f);
+	sv_coop_completionist_found.ForceSet(0.0f);
 
 	if (!savegamerestore)
 	{

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1443,13 +1443,14 @@ P_CrossSpecialLine
 
 	TeleportSide = side;
 
-	LineSpecials[line->special] (line, thing, line->args[0],
+	if(LineSpecials[line->special] (line, thing, line->args[0],
 					line->args[1], line->args[2],
-					line->args[3], line->args[4]);
+					line->args[3], line->args[4]))
+	{
+		P_HandleSpecialRepeat(line);
 
-	P_HandleSpecialRepeat(line);
-
-	OnActivatedLine(line, thing, side, 0);
+		OnActivatedLine(line, thing, side, 0);
+	}
 }
 
 //
@@ -1479,18 +1480,19 @@ P_ShootSpecialLine
 
 	//TeleportSide = side;
 
-	LineSpecials[line->special] (line, thing, line->args[0],
+	if(LineSpecials[line->special] (line, thing, line->args[0],
 					line->args[1], line->args[2],
-					line->args[3], line->args[4]);
-
-	P_HandleSpecialRepeat(line);
-
-	OnActivatedLine(line, thing, 0, 2);
-
-	if(serverside)
+					line->args[3], line->args[4]))
 	{
-		P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL, true);
-		OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
+		P_HandleSpecialRepeat(line);
+
+		OnActivatedLine(line, thing, 0, 2);
+
+		if(serverside)
+		{
+			P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL, true);
+			OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
+		}
 	}
 }
 
@@ -1640,7 +1642,11 @@ P_PushSpecialLine
     return true;
 }
 
-
+#ifdef SERVER_APP
+EXTERN_CVAR(sv_coop_completionist)
+EXTERN_CVAR(sv_coop_completionist_secrets)
+EXTERN_CVAR(sv_coop_completionist_found)
+#endif
 
 //
 // P_PlayerInSpecialSector
@@ -1781,6 +1787,35 @@ void P_PlayerInSpecialSector (player_t *player)
 #ifdef CLIENT_APP
 			if (player->mo == consoleplayer().camera)
 				C_RevealSecret();
+#endif
+#ifdef SERVER_APP
+			if (serverside && sv_gametype == GM_COOP && sv_coop_completionist)
+			{
+				char msg[256 + 32];
+
+				// increase found secret count:
+				int found = sv_coop_completionist_found.asInt();
+				found++;
+				sv_coop_completionist_found.ForceSet(found);
+
+				// determine total number of killable monsters and findable secrets for the current level:
+				int findable_secrets = (sv_coop_completionist_secrets < 0.0) ? level.total_secrets : (int)sv_coop_completionist_secrets;
+
+				sprintf(msg, "%s revealed a secret!  %d/%d\n",
+						player->userinfo.netname.c_str(),
+						level.found_secrets,
+						findable_secrets);
+
+				for (Players::iterator itr = players.begin();itr != players.end();++itr)
+				{
+					if (!(itr->ingame()))
+						continue;
+
+					C_MidPrint(msg, &*itr, 5);
+				}
+
+				Printf(PRINT_HIGH, msg);
+			}
 #endif
 		}
 	}

--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -546,6 +546,9 @@ void G_DoSaveResetState()
 	arc << level.time;
 }
 
+EXTERN_CVAR(sv_coop_completionist_killed)
+EXTERN_CVAR(sv_coop_completionist_found)
+
 // [AM] - Reset the state of the level.  Second parameter is true if you want
 //        to zero-out gamestate as well (i.e. resetting scores, RNG, etc.).
 void G_DoResetLevel(bool full_reset)
@@ -602,6 +605,9 @@ void G_DoResetLevel(bool full_reset)
 	reset_snapshot->Reopen();
 	FArchive arc(*reset_snapshot);
 	G_SerializeLevel(arc, false, true);
+	sv_coop_completionist_killed.ForceSet(0.0f);
+	sv_coop_completionist_found.ForceSet(0.0f);
+
 	int level_time;
 	arc >> level_time;
 	reset_snapshot->Seek(0, FFile::ESeekSet);

--- a/server/src/sv_cvarlist.cpp
+++ b/server/src/sv_cvarlist.cpp
@@ -154,7 +154,6 @@ CVAR(			sv_ticbuffer, "1", "Buffer controller input from players experiencing su
 				"latency spikes for smoother movement",
 				CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
 
-
 // Ban settings
 // ============
 

--- a/server/src/sv_sqpold.cpp
+++ b/server/src/sv_sqpold.cpp
@@ -245,6 +245,7 @@ void SV_SendServerInfo()
 	MSG_WriteBool(&ml_message, (sv_emptyreset ? true : false));
 	MSG_WriteBool(&ml_message, false);		// used to be sv_cleanmaps
 	MSG_WriteBool(&ml_message, (sv_fragexitswitch ? true : false));
+	// TODO(jsd): sync sv_coop_completionist
 
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{

--- a/server/src/sv_vote.cpp
+++ b/server/src/sv_vote.cpp
@@ -50,6 +50,10 @@ EXTERN_CVAR(sv_vote_specvote)
 EXTERN_CVAR(sv_vote_timelimit)
 EXTERN_CVAR(sv_vote_timeout)
 
+EXTERN_CVAR(sv_coop_completionist)
+EXTERN_CVAR(sv_coop_completionist_kills)
+EXTERN_CVAR(sv_coop_completionist_secrets)
+
 EXTERN_CVAR(sv_callvote_coinflip)
 EXTERN_CVAR(sv_callvote_forcespec)
 EXTERN_CVAR(sv_callvote_forcestart)
@@ -63,6 +67,9 @@ EXTERN_CVAR(sv_callvote_restart)
 EXTERN_CVAR(sv_callvote_fraglimit)
 EXTERN_CVAR(sv_callvote_scorelimit)
 EXTERN_CVAR(sv_callvote_timelimit)
+
+EXTERN_CVAR(sv_callvote_kills)
+EXTERN_CVAR(sv_callvote_secrets)
 
 // Vote class goes here
 Vote *vote = 0;
@@ -650,6 +657,92 @@ public:
 	}
 };
 
+class CoopCompletionistKillsVote : public Vote
+{
+private:
+	float count;
+public:
+	CoopCompletionistKillsVote() : Vote("kills", NULL) { };
+	bool setup(const std::vector<std::string> &args, const player_t &player)
+	{
+		float count;
+
+		if (!sv_coop_completionist)
+			return false;
+
+		// Do we have at least one argument?
+		if (args.size() < 1)
+		{
+			this->error = "kills needs a second argument.";
+			return false;
+		}
+
+		// Is the count a numeric value?
+		std::istringstream buffer(args[0].c_str());
+		buffer >> count;
+		if (!buffer)
+		{
+			this->error = "kills must be a number.";
+			return false;
+		}
+
+		std::ostringstream vote_string;
+		vote_string << "kills " << count;
+		this->votestring = vote_string.str();
+
+		this->count = count;
+		return true;
+	}
+	bool exec(void)
+	{
+		sv_coop_completionist_kills.Set(count);
+		return true;
+	}
+};
+
+class CoopCompletionistSecretsVote : public Vote
+{
+private:
+	float count;
+public:
+	CoopCompletionistSecretsVote() : Vote("secrets", NULL) { };
+	bool setup(const std::vector<std::string> &args, const player_t &player)
+	{
+		float count;
+
+		if (!sv_coop_completionist)
+			return false;
+
+		// Do we have at least one argument?
+		if (args.size() < 1)
+		{
+			this->error = "secrets needs a second argument.";
+			return false;
+		}
+
+		// Is the count a numeric value?
+		std::istringstream buffer(args[0].c_str());
+		buffer >> count;
+		if (!buffer)
+		{
+			this->error = "secrets must be a number.";
+			return false;
+		}
+
+		std::ostringstream vote_string;
+		vote_string << "secrets " << count;
+		this->votestring = vote_string.str();
+
+		this->count = count;
+		return true;
+	}
+	bool exec(void)
+	{
+		sv_coop_completionist_secrets.Set(count);
+		return true;
+	}
+};
+
 //////// VOTING FUNCTIONS ////////
 
 // Returns if the result of a vote is a forgone conclusion.
@@ -1128,6 +1221,12 @@ void SV_Callvote(player_t &player)
 		break;
 	case VOTE_COINFLIP:
 		vote = new CoinflipVote;
+		break;
+	case VOTE_COOPCOMPLETIONISTKILLS:
+		vote = new CoopCompletionistKillsVote;
+		break;
+	case VOTE_COOPCOMPLETIONISTSECRETS:
+		vote = new CoopCompletionistSecretsVote;
 		break;
 	default:
 		return;


### PR DESCRIPTION
defined new sv_coop_completionist cvar to prevent exit unless all monsters killed and all secrets found.

count only original map spawned killable monsters as completionist kills.
move sv_coop_completionist cvar to common/c_cvarlist.cpp but left unsynced between server and client. switch Printf to C_MidPrint so player sees unfinished states for completionist.
singularize and pluralize parts of message for monster(s) and secret(s).
fix bug where crossing special exit linedefs did not reattempt to exit after first failure; same with shootable linedefs or pushable linedefs.
print server message as well as send client message when exit attempt fails.
send message to all players when each secret is revealed.
allow clients to vote on killable monster count and findable secret count. future enhancement should load these counts per wad per map from a json file ideally loaded from odamex.net.
callvotes are named "secrets" and "kills", and enable callvotes when sv_coop_completionist is enabled.