### PR TITLE
Client: spyname command

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1078,27 +1078,6 @@ END_COMMAND (spyprev)
 
 BEGIN_COMMAND (spy)
 {
-	byte id = consoleplayer_id;
-
-	if (argc > 1)
-		id = atoi(argv[1]);
-
-	if (id == 0)
-	{
-		Printf(PRINT_HIGH, "Expecting player ID.  Try 'players' to list all of the player IDs.\n");
-		return;
-	}
-
-	displayplayer_id = id;
-	CL_CheckDisplayPlayer();
-
-	if (displayplayer_id != id)
-		Printf(PRINT_HIGH, "Unable to spy player ID %i!\n", id);
-}
-END_COMMAND (spy)
-
-BEGIN_COMMAND (spyname)
-{
 	if (argc <= 1) {
 		if (spyplayername.length() > 0) {
 			Printf(PRINT_HIGH, "Unfollowing player '%s'.\n", spyplayername.c_str());
@@ -1115,13 +1094,13 @@ BEGIN_COMMAND (spyname)
 		// remember player name in case of disconnect/reconnect e.g. level change:
 		spyplayername = argv[1];
 
-		Printf(PRINT_HIGH, "Following player '%s'. Use 'spyname' with no player name to unfollow.\n",
+		Printf(PRINT_HIGH, "Following player '%s'. Use 'spy' with no player name to unfollow.\n",
 			   spyplayername.c_str());
 	}
 
 	CL_CheckDisplayPlayer();
 }
-END_COMMAND (spyname)
+END_COMMAND (spy)
 
 void STACK_ARGS call_terms (void);
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -461,12 +461,17 @@ void CL_Reconnect(void)
 	connecttimeout = 0;
 }
 
+std::string spyplayername;
+void CL_CheckDisplayPlayer(void);
+
 //
 // CL_ConnectClient
 //
 void CL_ConnectClient(void)
 {
 	player_t &player = idplayer(MSG_ReadByte());
+
+	CL_CheckDisplayPlayer();
 
 	if (!cl_connectalert)
 		return;
@@ -484,10 +489,18 @@ void CL_ConnectClient(void)
 // Perfoms validation on the value of displayplayer_id based on the current
 // game state and status of the consoleplayer.
 //
-void CL_CheckDisplayPlayer()
+void CL_CheckDisplayPlayer(void)
 {
 	static byte previd = consoleplayer_id;
 	byte newid = 0;
+
+	// [jsd]: try to spy on player by name when connected if spyplayername is set:
+	if (spyplayername.length() > 0) {
+		player_t &spyplayer = nameplayer(spyplayername);
+		if (validplayer(spyplayer)) {
+			displayplayer_id = spyplayer.id;
+		}
+	}
 
 	if (displayplayer_id != previd)
 		newid = displayplayer_id;
@@ -1083,6 +1096,32 @@ BEGIN_COMMAND (spy)
 		Printf(PRINT_HIGH, "Unable to spy player ID %i!\n", id);
 }
 END_COMMAND (spy)
+
+BEGIN_COMMAND (spyname)
+{
+	if (argc <= 1) {
+		if (spyplayername.length() > 0) {
+			Printf(PRINT_HIGH, "Unfollowing player '%s'.\n", spyplayername.c_str());
+
+			// revert to not spying:
+			displayplayer_id = consoleplayer_id;
+		} else {
+			Printf(PRINT_HIGH, "Expecting player name.  Try 'players' to list all player names.\n");
+		}
+
+		// clear last player name:
+		spyplayername = "";
+	} else {
+		// remember player name in case of disconnect/reconnect e.g. level change:
+		spyplayername = argv[1];
+
+		Printf(PRINT_HIGH, "Following player '%s'. Use 'spyname' with no player name to unfollow.\n",
+			   spyplayername.c_str());
+	}
+
+	CL_CheckDisplayPlayer();
+}
+END_COMMAND (spyname)
 
 void STACK_ARGS call_terms (void);
 


### PR DESCRIPTION
Added `spyname` command for convenience of spying players by name instead of id.

try to actively spy on named player when they reconnect, e.g. level changes.

spyname with no args unfollows player and will disable spy mode