### PR TITLE
Fix Icon of Sin save game crash

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2168,6 +2168,11 @@ void A_SpawnFly (AActor *mo)
 		return;
 
 	targ = mo->target;
+	// When loading a save game, any in-flight cube will have lost its pointer to its target.
+	if (!targ) {
+		mo->Destroy ();
+		return;
+	}
 
 	// First spawn teleport fog.
 	fog = new AActor (targ->x, targ->y, targ->z, MT_SPAWNFIRE);


### PR DESCRIPTION
Duplicates how vanilla Doom II did it: just remove the spawning cube when it has an invalid target (which it has after loading)

Fixes https://odamex.net/bugs/show_bug.cgi?id=1302