### PR TITLE
Client: fix scaling factor for DCanvas::DrawSWrapper

### DIFF
--- a/client/src/v_draw.cpp
+++ b/client/src/v_draw.cpp
@@ -602,8 +602,15 @@ void DCanvas::DrawSWrapper(EWrapperCode drawer, const patch_t* patch, int x0, in
 	// [AM] Adding 1 to the inc variables leads to fewer weird scaling
 	//      artifacts since it forces col to roll over to the next real number
 	//      a column-of-real-pixels sooner.
-	int xinc = (patch->width() << FRACBITS) / destwidth + 1;
-	int yinc = (patch->height() << FRACBITS) / destheight + 1;
+	int xinc = (patch->width() << FRACBITS) / destwidth;
+	int yinc = (patch->height() << FRACBITS) / destheight;
+	// [jsd] only adding 1 in cases where scaling is non-integral:
+	if (xinc & (FRACUNIT-1)) {
+		xinc++;
+	}
+	if (yinc & (FRACUNIT-1)) {
+		yinc++;
+	}
 	int xmul = (destwidth << FRACBITS) / patch->width();
 	int ymul = (destheight << FRACBITS) / patch->height();
 


### PR DESCRIPTION
client: adjust scaling factor by +1 only in non-integral cases; fixes console font rendering to be 1:1 pixels when scaling is not needed.