### PR TITLE
Fix the ability to override clientside compatibility settings

### DIFF
--- a/client/src/m_menu.h
+++ b/client/src/m_menu.h
@@ -95,6 +95,7 @@ typedef enum {
 	greenslider,
 	discrete,
 	cdiscrete,
+	svdiscrete,
 	control,
 	screenres,
 	bitflag,

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -119,6 +119,7 @@ EXTERN_CVAR (co_realactorheight)
 EXTERN_CVAR (wi_newintermission)
 EXTERN_CVAR (co_zdoomphys)
 EXTERN_CVAR (co_zdoomsound)
+EXTERN_CVAR (co_globalsound)
 EXTERN_CVAR (co_fixweaponimpacts)
 EXTERN_CVAR (cl_deathcam)
 EXTERN_CVAR (co_fineautoaim)
@@ -617,7 +618,6 @@ menu_t SoundMenu = {
  *=======================================*/
 static menuitem_t CompatItems[] ={
 	{bricktext, "Gameplay",                        {NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{discrete,  "Camera follows killer on death",  {&cl_deathcam},          {2.0}, {0.0}, {0.0}, {OnOff}},
 	{svdiscrete,  "Finer-precision Autoaim",         {&co_fineautoaim},       {2.0}, {0.0}, {0.0}, {OnOff}},
 	{svdiscrete,  "Fix hit detection at grid edges", {&co_blockmapfix},       {2.0}, {0.0}, {0.0}, {OnOff}},
 	{redtext,   " ",                               {NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
@@ -631,8 +631,9 @@ static menuitem_t CompatItems[] ={
 	{svdiscrete,  "ZDOOM 1.23 physics",              {&co_zdoomphys},         {2.0}, {0.0}, {0.0}, {OnOff}},
 	{redtext,   " ",                               {NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
 	{bricktext, "Sound",                           {NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{svdiscrete,  "Fix silent west spawns",          {&co_nosilentspawns},    {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete,  "ZDoom Sound Response",        		{&co_zdoomsound},     {2.0}, {0.0}, {0.0}, {OnOff}},
+	{svdiscrete,  "Fix silent west spawns",        {&co_nosilentspawns},    {2.0}, {0.0}, {0.0}, {OnOff}},
+	{svdiscrete,  "ZDoom Sound Response",        	{&co_zdoomsound},     {2.0}, {0.0}, {0.0}, {OnOff}},
+	{svdiscrete,  "Global Pickup Sounds",        	{&co_globalsound},     {2.0}, {0.0}, {0.0}, {OnOff}},
 };
 
 menu_t CompatMenu = {
@@ -878,11 +879,13 @@ static menuitem_t VideoItems[] = {
 	{ slider,   "UI Background Visibility", {&ui_dimamount},        {0.0}, {1.0},   {0.1},  {NULL} },
 	{ redtext,	" ",					    {NULL},					{0.0}, {0.0},	{0.0},  {NULL} },
 	{ discrete, "Show Scores on Death",		{&hud_show_scoreboard_ondeath},	{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Show Netdemo infos",		{&hud_demobar},	{2.0}, {0.0},	{0.0},	{OnOff} },
+	{ discrete, "Enable DeathCam",			{&cl_deathcam},         {2.0}, {0.0}, {0.0}, {OnOff}},
 	{ discrete, "Stretch short skies",	    {&r_stretchsky},	   	{3.0}, {0.0},	{0.0},  {OnOffAuto} },
 	{ discrete, "Invuln changes skies",		{&r_skypalette},		{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Screen wipe style",	    {&r_wipetype},			{4.0}, {0.0},	{0.0},  {Wipes} },
 	{ discrete, "Multiplayer Intermissions",{&wi_newintermission},	{2.0}, {0.0},	{0.0},  {DoomOrOdamex} },
+	{ redtext,	" ",					    {NULL},					{0.0}, {0.0},	{0.0},  {NULL} },
+	{ discrete, "Show Netdemo infos",		{&hud_demobar},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Show loading disk icon",	{&r_loadicon},			{2.0}, {0.0},	{0.0},	{OnOff} },
     { discrete,	"Show DOS ending screen" ,  {&r_showendoom},		{2.0}, {0.0},	{0.0},  {OnOff} },
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -126,6 +126,7 @@ EXTERN_CVAR (co_fineautoaim)
 EXTERN_CVAR (co_nosilentspawns)
 EXTERN_CVAR (co_boomphys)			// [ML] Roll-up of various compat options
 EXTERN_CVAR (co_blockmapfix)
+EXTERN_CVAR (co_lostsoulsfix)
 
 // [Toke - Menu] New Menu Stuff.
 void MouseSetup (void);
@@ -620,6 +621,7 @@ static menuitem_t CompatItems[] ={
 	{bricktext, "Gameplay",                        {NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
 	{svdiscrete,  "Finer-precision Autoaim",         {&co_fineautoaim},       {2.0}, {0.0}, {0.0}, {OnOff}},
 	{svdiscrete,  "Fix hit detection at grid edges", {&co_blockmapfix},       {2.0}, {0.0}, {0.0}, {OnOff}},
+	{svdiscrete,  "Bypass Pain Elemental spawn limit",	 {&co_lostsoulsfix},       {2.0}, {0.0}, {0.0}, {OnOff}},
 	{redtext,   " ",                               {NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
 	{bricktext, "Items and Decoration",            {NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
 	{svdiscrete,  "Fix invisible puffs under skies", {&co_fixweaponimpacts},  {2.0}, {0.0}, {0.0}, {OnOff}},

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -196,6 +196,9 @@ CVAR(				sv_coopunassignedvoodoodollsfornplayers, "255", "",
 	CVAR(			co_blockmapfix, "0", "Fix the blockmap collision bug",
 					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 
+	CVAR(			co_lostsoulsfix, "0", "Allows/Disallows the Pain Elemental spawning lost souls if there are already 21 on the map.",
+					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO)
+
 
 	// Boom-compatibility changes
 	//------------------------------

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -46,6 +46,7 @@ EXTERN_CVAR (sv_allowexit)
 EXTERN_CVAR (sv_fastmonsters)
 EXTERN_CVAR (co_realactorheight)
 EXTERN_CVAR (co_zdoomphys)
+EXTERN_CVAR (co_lostsoulsfix)
 
 enum dirtype_t
 {
@@ -1720,7 +1721,7 @@ void A_PainShootSkull (AActor *actor, angle_t angle)
 
 	// if there are already 20 skulls on the level,
 	// don't spit another one
-	if (count > 20)
+	if (count > 20 && !co_lostsoulsfix)
 		return;
 
 	// okay, there's room for another one


### PR DESCRIPTION
Added a new slider type (svdiscrete), so that :
- When playing online, this doesn't override the server settings
- It isn't enabled when "multiplayer" is checked, when playbacking|recording a vanilla or odamex demo.

When playing on singleplayer, these compatibility flags can be toggled.

EDIT : also contains co_lostsoulsfix, making the pain elemental being able to spawn more than 21 lost souls.