### PR TITLE
Server: fix double-callback on cvar Set

### DIFF
--- a/common/c_cvars.cpp
+++ b/common/c_cvars.cpp
@@ -206,7 +206,7 @@ void cvar_t::ForceSet(const char* valstr)
 
 		if (m_Flags & CVAR_USERINFO)
 			D_UserInfoChanged(this);
-		if (m_Flags & CVAR_SERVERINFO)
+		if (m_Flags & CVAR_SERVERINFO && !serverside)
 			D_SendServerInfoChange(this, m_String.c_str());
 	}
 


### PR DESCRIPTION
cvars: do not call Set and Callback twice serverside when unlatching cvars.