### PR TITLE
Client: enable Windows XP compatibility

### DIFF
--- a/appveyor_after_build.ps1
+++ b/appveyor_after_build.ps1
@@ -1,5 +1,5 @@
 cd build
-7z a odamex.zip ".\client\RelWithDebInfo\odamex.exe" ".\client\RelWithDebInfo\odamex.pdb" "..\wad\odamex.wad" ".\SDL2-2.0.5\lib\x86\*.dll" ".\SDL2_mixer-2.0.1\lib\x86\*.dll"
+7z a odamex.zip ".\client\RelWithDebInfo\odamex.exe" ".\client\RelWithDebInfo\odamex.pdb" "..\wad\odamex.wad" ".\SDL2-2.0.5\lib\x86\*.dll" ".\SDL2_mixer-2.0.1\lib\x86\*.dll" "C:\Windows\SysWOW64\MSVCP140.dll" "C:\Windows\SysWOW64\VCRUNTIME140.dll"
 mv odamex.zip ..
 7z a odasrv.zip ".\server\RelWithDebInfo\odasrv.exe" ".\server\RelWithDebInfo\odasrv.pdb" "..\wad\odamex.wad"
 mv odasrv.zip ..

--- a/appveyor_before_build.ps1
+++ b/appveyor_before_build.ps1
@@ -4,5 +4,5 @@ Start-FileDownload "https://www.libsdl.org/release/SDL2-devel-2.0.5-VC.zip"
 7z x "SDL2-devel-2.0.5-VC.zip"
 Start-FileDownload "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.1-VC.zip"
 7z x "SDL2_mixer-devel-2.0.1-VC.zip"
-& "C:\Program Files (x86)\cmake\bin\cmake.exe" .. -G "Visual Studio 14 2015" -DUSE_MINIUPNP=False -DSDL2_INCLUDE_DIR="./SDL2-2.0.5/include/" -DSDL2_LIBRARY="./SDL2-2.0.5/lib/x86/SDL2.lib" -DSDL2MAIN_LIBRARY="./lib/x86/SDL2main.lib" -DSDL2_MIXER_INCLUDE_DIR="./SDL2_mixer-2.0.1/include/" -DSDL2_MIXER_LIBRARY="./SDL2_mixer-2.0.1/lib/x86/SDL2_mixer.lib"
+& "C:\Program Files (x86)\cmake\bin\cmake.exe" .. -G "Visual Studio 14 2015" -T v140_xp -DUSE_MINIUPNP=False -DSDL2_INCLUDE_DIR="./SDL2-2.0.5/include/" -DSDL2_LIBRARY="./SDL2-2.0.5/lib/x86/SDL2.lib" -DSDL2MAIN_LIBRARY="./lib/x86/SDL2main.lib" -DSDL2_MIXER_INCLUDE_DIR="./SDL2_mixer-2.0.1/include/" -DSDL2_MIXER_LIBRARY="./SDL2_mixer-2.0.1/lib/x86/SDL2_mixer.lib"
 cd ..


### PR DESCRIPTION
Enabled Windows XP (winxp) build compatibility for appyveyor builds.

include MSVC runtime DLLs for x86 winxp compatibility.