### PR TITLE
Server: prevent DoS during WAD downloading

### DIFF
--- a/common/d_player.h
+++ b/common/d_player.h
@@ -298,11 +298,12 @@ public:
 		{
 		public:
 			std::string name;
+			std::string md5;
 			unsigned int next_offset;
 
-			download_t() : name(""), next_offset(0) {}
-			download_t(const download_t& other) : name(other.name), next_offset(other.next_offset) {}
-		}download;
+			download_t() : name(""), md5(""), next_offset(0) {}
+			download_t(const download_t& other) : name(other.name), md5(other.md5), next_offset(other.next_offset) {}
+		} download;
 
 		client_t()
 		{


### PR DESCRIPTION
server: short-cut clc_wantwad to resume download without expensive MD5 checks.

Without this short-cut, the server will constantly keep recomputing the MD5 hash of the requested WAD whenever the client misses a packet. This causes the CPU utilization to climb to 100% easily when packet loss is high.