### PR TITLE
Client: fix msg cvar to not be a boolean

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -511,7 +511,7 @@ static ConsoleHistory History;
 static void setmsgcolor(int index, const char *color);
 
 
-cvar_t msglevel("msg", "0", "", CVARTYPE_STRING, CVAR_ARCHIVE);
+cvar_t msglevel("msg", "0", "", CVARTYPE_INT, CVAR_ARCHIVE | CVAR_NOENABLEDISABLE);
 
 CVAR_FUNC_IMPL(msg0color)
 {


### PR DESCRIPTION
Fix "msg" cvar to not be a boolean to fix message level filtering.

This now enables the third option in the message filtering menu option which was previously inaccessible due to the absence of the CVAR_NOENABLEDISABLE flag, forcing the value to a boolean 0 or 1 case.