### PR TITLE
Berserk game mode

### DIFF
--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -1101,6 +1101,26 @@ void G_Ticker (void)
 // also see P_SpawnPlayer in P_Mobj
 //
 
+CVAR_FUNC_IMPL(sv_berserk)
+{
+}
+
+CVAR_FUNC_IMPL(sv_berserk_pickups)
+{
+}
+
+CVAR_FUNC_IMPL(sv_berserk_radius)
+{
+}
+
+CVAR_FUNC_IMPL(sv_berserk_damage_mult)
+{
+}
+
+CVAR_FUNC_IMPL(sv_berserk_pistol_ammo)
+{
+}
+
 //
 // G_PlayerFinishLevel
 // Call when a player completes a level.
@@ -1121,8 +1141,17 @@ void G_PlayerFinishLevel (player_t &player)
 	p->fixedcolormap = 0;				// cancel ir goggles
 	p->damagecount = 0; 				// no palette changes
 	p->bonuscount = 0;
-}
 
+	if (sv_berserk) {
+		// [jsd] berserk mode
+		for (int i = 0; i < NUMAMMO; i++)
+		{
+			p->ammo[i] = 0;
+		}
+		p->ammo[am_clip] = sv_berserk_pistol_ammo.asInt();
+		p->powers[pw_strength] = 1;
+	}
+}
 
 //
 // G_PlayerReborn
@@ -1155,10 +1184,19 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 	p.health = deh.StartHealth;		// [RH] Used to be MAXHEALTH
 	p.armortype = 0;
 	p.armorpoints = 0;
-	p.readyweapon = p.pendingweapon = wp_pistol;
-	p.weaponowned[wp_fist] = true;
-	p.weaponowned[wp_pistol] = true;
-	p.ammo[am_clip] = deh.StartBullets; // [RH] Used to be 50
+	if (sv_berserk) {
+		// [jsd] berserk mode
+		p.readyweapon = p.pendingweapon = wp_fist;
+		p.weaponowned[wp_fist] = true;
+		p.weaponowned[wp_pistol] = true;
+		p.ammo[am_clip] = sv_berserk_pistol_ammo.asInt();
+		p.powers[pw_strength] = 1;
+	} else {
+		p.readyweapon = p.pendingweapon = wp_pistol;
+		p.weaponowned[wp_fist] = true;
+		p.weaponowned[wp_pistol] = true;
+		p.ammo[am_clip] = deh.StartBullets; // [RH] Used to be 50
+	}
 	p.cheats = 0;						// Reset cheat flags
 
 	p.death_time = 0;

--- a/client/src/v_palette.cpp
+++ b/client/src/v_palette.cpp
@@ -1092,6 +1092,8 @@ BEGIN_COMMAND (testcolor)
 }
 END_COMMAND (testcolor)
 
+EXTERN_CVAR(sv_berserk)
+
 //
 // V_DoPaletteEffects
 //
@@ -1112,9 +1114,11 @@ void V_DoPaletteEffects()
 		if (!multiplayer || sv_allowredscreen)
 			red_count *= r_painintensity;
 
-		// slowly fade the berzerk out
-		if (plyr->powers[pw_strength])
-			red_count = MAX(red_count, 12.0f - float(plyr->powers[pw_strength] >> 6));
+		if (!sv_berserk) {
+			// slowly fade the berzerk out
+			if (plyr->powers[pw_strength])
+				red_count = MAX(red_count, 12.0f - float(plyr->powers[pw_strength] >> 6));
+		}
 
 		if (red_count > 0.0f)
 		{
@@ -1175,9 +1179,11 @@ void V_DoPaletteEffects()
 			if (!multiplayer || sv_allowredscreen)
 				red_amount *= r_painintensity;
 
-			// slowly fade the berzerk out
-			if (plyr->powers[pw_strength])
-				red_amount = MAX(red_amount, 12.0f - float(plyr->powers[pw_strength]) / 64.0f);
+			if (!sv_berserk) {
+				// slowly fade the berzerk out
+				if (plyr->powers[pw_strength])
+					red_amount = MAX(red_amount, 12.0f - float(plyr->powers[pw_strength]) / 64.0f);
+			}
 
 			if (red_amount > 0.0f)
 			{

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -35,6 +35,26 @@ CVAR_RANGE(			sv_gametype, "0", "Sets the game mode, values are:\n" \
 					CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH | CVAR_NOENABLEDISABLE,
 					0.0f, 3.0f)
 
+CVAR(				sv_berserk, "0", "Berserk fists only mode",
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
+
+CVAR_FUNC_DECL(		sv_berserk_pickups, "health", "Berserk mode weapons,ammo,backpacks pickup transformation mode: " \
+					"'health' -> pickups replaced with health bonuses, " \
+					"'remove' -> pickups removed",
+					CVARTYPE_STRING, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE | CVAR_LATCH)
+
+CVAR_RANGE_FUNC_DECL(sv_berserk_radius, "64", "Berserk mode - fist punch radius in map units; normal is 64",
+					CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE,
+					32.0f, 32768.0f)
+
+CVAR_RANGE_FUNC_DECL(sv_berserk_damage_mult, "10", "Berserk mode - fist damage multiplier; normal is 10",
+					CVARTYPE_FLOAT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE,
+					0.0625f, 10000.0f)
+
+CVAR_RANGE_FUNC_DECL(sv_berserk_pistol_ammo, "1", "Berserk mode - pistol start ammo",
+					CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE,
+					0.0f, 255.0f)
+
 CVAR(				sv_friendlyfire, "1", "When set, players can injure others on the same team, " \
 					"it is ignored in deathmatch",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
@@ -178,7 +198,7 @@ CVAR(				sv_coopunassignedvoodoodolls, "1", "",
 					
 CVAR(				sv_coopunassignedvoodoodollsfornplayers, "255", "", 
 					CVARTYPE_WORD, CVAR_SERVERINFO | CVAR_LATCH)
-	
+
 
 // Compatibility options
 // ---------------------------------

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -377,6 +377,8 @@ ItemEquipVal P_GiveCard(player_t *player, card_t card)
 	return IEV_EquipRemove;
 }
 
+EXTERN_CVAR(sv_berserk)
+
 //
 // P_GivePower
 //
@@ -409,9 +411,14 @@ ItemEquipVal P_GivePower(player_t *player, int /*powertype_t*/ power)
 
 	if (power == pw_strength)
 	{
-		P_GiveBody(player, 100);
 		player->powers[power] = 1;
-		return IEV_EquipRemove;
+		if (sv_berserk) {
+			// [jsd] don't destroy the pickup in berserk mode if we already have >= 100% health:
+			return P_GiveBody(player, 100);
+		} else {
+			P_GiveBody(player, 100);
+			return IEV_EquipRemove;
+		}
 	}
 
 	if (player->powers[power])
@@ -883,6 +890,8 @@ void SexMessage (const char *from, char *to, int gender, const char *victim, con
 	} while (*from++);
 }
 
+EXTERN_CVAR(sv_berserk)
+
 //
 // P_KillMobj
 //
@@ -1122,6 +1131,12 @@ void P_KillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill
     {
 		return;
     }
+
+	// [jsd] in berserk mode, monsters don't drop ammo or weapons.
+	if (sv_berserk)
+	{
+		return;
+	}
 
 	// Drop stuff.
 	// This determines the kind of object spawned

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -624,6 +624,10 @@ void A_GunFlash(AActor* mo)
 // WEAPON ATTACKS
 //
 
+EXTERN_CVAR(sv_berserk)
+EXTERN_CVAR(sv_berserk_radius)
+EXTERN_CVAR(sv_berserk_damage_mult)
+
 //
 // A_Punch
 //
@@ -632,13 +636,24 @@ void A_Punch(AActor* mo)
 	angle_t 	angle;
 	int 		damage;
 	int 		slope;
+	fixed_t		distance;
+	int 		mult;
 
     player_t *player = mo->player;
 
 	damage = (P_Random (player->mo)%10+1)<<1;
 
-	if (player->powers[pw_strength])
-		damage *= 10;
+	if (sv_berserk) {
+		distance = sv_berserk_radius.asInt() << FRACBITS;
+		mult = sv_berserk_damage_mult.asInt();
+	} else {
+		distance = MELEERANGE;
+		mult = 10;
+	}
+
+	if (player->powers[pw_strength]) {
+		damage *= mult;
+	}
 
 	angle = player->mo->angle;
 	angle += P_RandomDiff(player->mo) << 18;
@@ -647,8 +662,8 @@ void A_Punch(AActor* mo)
 	// this player hit the fire button clientside.
 	Unlag::getInstance().reconcile(player->id);
 
-	slope = P_AimLineAttack (player->mo, angle, MELEERANGE);
-	P_LineAttack (player->mo, angle, MELEERANGE, slope, damage);
+	slope = P_AimLineAttack (player->mo, angle, distance);
+	P_LineAttack (player->mo, angle, distance, slope, damage);
 
 	// [SL] 2011-07-12 - Restore players and sectors to their current position
 	// according to the server.


### PR DESCRIPTION
berserk: sv_berserk cvar to set berserk mode; no ammo or weapon pickups; start with berserk mode on and maintain across level changes; reset clip ammo to 1 on each map; no monster drops.

added new cvars to control fist punch radius, fist damage multiplier, and pistol start ammo amount.
disable red tint when sv_berserk mode.
cvar changes notify players.
changing sv_berserk_pistol_ammo downgrades current ammo amount to new value for all players.
dont pick up berserk powerups if health >= 100.
new cvar sv_berserk_pickups with values [health,remove]. health replaces weapons, ammo, backpacks with health pickups.
make sure item respawns have same pickup translation logic as initial spawns.