### PR TITLE
Survival game mode

### DIFF
--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -62,5 +62,8 @@ void CTF_SpawnFlag(flag_t f) {}
 bool SV_AwarenessUpdate(player_t &pl, AActor* mo) { return true; }
 void SV_SendPackets(void) {}
 
+void SV_SurvivalRestartLevel(void) {}
+void SV_SurvivalCheck(void) {}
+
 VERSION_CONTROL (cl_stubs_cpp, "$Id$")
 

--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -102,6 +102,7 @@ EXTERN_CVAR (sv_itemsrespawn)
 EXTERN_CVAR (sv_respawnsuper)
 EXTERN_CVAR (sv_weaponstay)
 EXTERN_CVAR (sv_keepkeys)
+EXTERN_CVAR (sv_survival)
 EXTERN_CVAR (co_nosilentspawns)
 EXTERN_CVAR (co_allowdropoff)
 
@@ -1139,7 +1140,7 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 	}
 	for (i = 0; i < NUMWEAPONS; i++)
 		p.weaponowned[i] = false;
-	if (!sv_keepkeys)
+	if (sv_survival || !sv_keepkeys)
 	{
 		for (i = 0; i < NUMCARDS; i++)
 			p.cards[i] = false;

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -35,6 +35,15 @@ CVAR_RANGE(			sv_gametype, "0", "Sets the game mode, values are:\n" \
 					CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH | CVAR_NOENABLEDISABLE,
 					0.0f, 3.0f)
 
+CVAR(				sv_survival, "0", "Survival mode",
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
+
+CVAR(				sv_survival_join_timer, "15", "Survival mode join timer",
+					CVARTYPE_FLOAT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
+CVAR(				sv_maxlives, "1", "Survival mode number of lives",
+					CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
 CVAR(				sv_friendlyfire, "1", "When set, players can injure others on the same team, " \
 					"it is ignored in deathmatch",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
@@ -178,7 +187,7 @@ CVAR(				sv_coopunassignedvoodoodolls, "1", "",
 					
 CVAR(				sv_coopunassignedvoodoodollsfornplayers, "255", "", 
 					CVARTYPE_WORD, CVAR_SERVERINFO | CVAR_LATCH)
-	
+
 
 // Compatibility options
 // ---------------------------------

--- a/common/d_player.h
+++ b/common/d_player.h
@@ -248,6 +248,8 @@ public:
 	argb_t		blend_color;			// blend color for the sector the player is in
 	bool		doreborn;
 
+	int			survival_lives;			// number of remaining lives for sv_survival mode
+
 	// For flood protection
 	struct LastMessage_s
 	{

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -78,6 +78,9 @@ void SV_ActorTarget(AActor *actor);
 void PickupMessage(AActor *toucher, const char *message);
 void WeaponPickupMessage(AActor *toucher, weapontype_t &Weapon);
 
+void SV_SurvivalRestartLevel(void);
+void SV_SurvivalCheck(void);
+
 //
 // GET STUFF
 //
@@ -883,6 +886,8 @@ void SexMessage (const char *from, char *to, int gender, const char *victim, con
 	} while (*from++);
 }
 
+EXTERN_CVAR(sv_survival)
+
 //
 // P_KillMobj
 //
@@ -1014,6 +1019,16 @@ void P_KillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill
 		// [Toke - CTF]
 		if (sv_gametype == GM_CTF)
 			CTF_CheckFlags(*target->player);
+
+		// [jsd] survival mode
+		if (!joinkill && sv_survival) {
+			if (tplayer->ingame() && !tplayer->spectator) {
+				tplayer->survival_lives--;
+				DPrintf("%s was killed; now has %d lives left\n", tplayer->userinfo.netname.c_str(), tplayer->survival_lives);
+
+				SV_SurvivalCheck();
+			}
+		}
 
 		if (!joinkill && !shotclock)
 		{

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -2004,6 +2004,8 @@ EXTERN_CVAR (sv_fraglimit)
 EXTERN_CVAR (sv_allowexit)
 EXTERN_CVAR (sv_fragexitswitch)
 
+EXTERN_CVAR (sv_survival)
+
 BOOL CheckIfExitIsGood (AActor *self)
 {
 	if (self == NULL || !serverside)
@@ -2011,7 +2013,7 @@ BOOL CheckIfExitIsGood (AActor *self)
 
 	// Bypass the exit restrictions if we're on a lobby.
 	if (level.flags & LEVEL_LOBBYSPECIAL)
-		return true;	
+		return true;
 
 	// [Toke - dmflags] Old location of DF_NO_EXIT
 	if (sv_gametype != GM_COOP && self)
@@ -2022,7 +2024,11 @@ BOOL CheckIfExitIsGood (AActor *self)
 				P_DamageMobj(self, NULL, NULL, 10000, MOD_SUICIDE);
 
 			return false;
-		}
+		} else {
+			if (sv_survival) {
+				return false;
+			}
+        }
 	}
 
 	if (self->player && multiplayer)

--- a/server/src/g_game.cpp
+++ b/server/src/g_game.cpp
@@ -176,7 +176,7 @@ void G_Ticker (void)
 	case GS_INTERMISSION:
 	{
 		mapchange--; // denis - todo - check if all players are ready, proceed immediately
-		if (!mapchange || 
+		if (!mapchange ||
 			(level.flags & LEVEL_NOINTERMISSION && (level.flags & LEVEL_EPISODEENDHACK) == 0 ))
         {
 			G_ChangeMap ();
@@ -219,6 +219,8 @@ void G_PlayerFinishLevel (player_t &player)
 }
 
 
+EXTERN_CVAR(sv_survival)
+
 //
 // G_PlayerReborn
 // Called after a player dies
@@ -234,7 +236,7 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 	}
 	for (i = 0; i < NUMWEAPONS; i++)
 		p.weaponowned[i] = false;
-	if (!sv_keepkeys)
+	if (sv_survival || !sv_keepkeys)
 	{
 		for (i = 0; i < NUMCARDS; i++)
 			p.cards[i] = false;

--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -477,7 +477,7 @@ void G_ExitLevel (int position, int drawscores)
 
 	if (drawscores)
         SV_DrawScores();
-	
+
 	gamestate = GS_INTERMISSION;
 	shotclock = 0;
 	mapchange = TICRATE * sv_intermissionlimit;  // wait n seconds, default 10
@@ -497,7 +497,7 @@ void G_SecretExitLevel (int position, int drawscores)
 
     if (drawscores)
         SV_DrawScores();
-        
+
 	gamestate = GS_INTERMISSION;
 	shotclock = 0;
 	mapchange = TICRATE * sv_intermissionlimit;  // wait n seconds, defaults to 10
@@ -542,6 +542,9 @@ void G_DoSaveResetState()
 	arc << level.time;
 }
 
+EXTERN_CVAR(sv_survival)
+void SV_SurvivalStart(void);
+
 // [AM] - Reset the state of the level.  Second parameter is true if you want
 //        to zero-out gamestate as well (i.e. resetting scores, RNG, etc.).
 void G_DoResetLevel(bool full_reset)
@@ -568,6 +571,8 @@ void G_DoResetLevel(bool full_reset)
 			CTFdata[i].state = flag_home;
 		}
 	}
+
+	SV_SurvivalStart();
 
 	// Clear netids of every non-player actor so we don't spam the
 	// destruction message of actors to clients.
@@ -654,6 +659,8 @@ void G_DoResetLevel(bool full_reset)
 	level.time = 0;
 	level.timeleft = sv_timelimit * TICRATE * 60;
 	level.inttimeleft = mapchange / TICRATE;
+
+	SV_SurvivalStart();
 
 	// Send information about the newly reset map.
 	for (it = players.begin();it != players.end();++it)
@@ -764,6 +771,8 @@ void G_DoLoadLevel (int position)
 			}
 		}
 	}
+
+	SV_SurvivalStart();
 
 	// [deathz0r] It's a smart idea to reset the team points
 	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)


### PR DESCRIPTION
survival: sv_survival enables/disables survival mode. all players get 1 life on map start and once all players are dead the map restarts.

disallow rejoining after spectating.
disallow joining after join_timer expires (15 seconds).
override sv_keepkeys in survival mode
GM_COOP is normal survival mode; GM_DM is last man standing mode; GM_TEAMDM and GM_CTF are TODO.
proper join timer reset for LMS mode.
disallow map exits when not in COOP.
add cvar controls for sv_maxlives and sv_survival_join_timer.
added server command sv_survival_reset_timer to be able to reset join timer at any point if one wants players to join mid-round.
broadcast messages about remaining player counts.

new cvars:
sv_survival             - enables or disables survival mode
sv_survival_join_timer  - allowed time for players to join at start of level in seconds (default 15)
sv_maxlives             - number of initial lives given to each player when joining (default 1)

commands:
sv_survival_reset_timer - reset the join timer