### PR TITLE
Client: fix NET_SendMessage message too long error

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -383,6 +383,7 @@ void CL_QuitNetGame(void)
 {
 	if(connected)
 	{
+		SZ_Clear(&net_buffer);
 		MSG_WriteMarker(&net_buffer, clc_disconnect);
 		NET_SendPacket(net_buffer, serveraddr);
 		SZ_Clear(&net_buffer);


### PR DESCRIPTION
client: fix NET_SendMessage message too long error