### PR TITLE
Appveyor enable parallel builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ configuration: RelWithDebInfo
 build:
   project: build\Odamex.sln
   verbosity: minimal
+  parallel: true
 before_build:
   - ps: .\appveyor_before_build.ps1
 after_build:


### PR DESCRIPTION
Shaves about 50-60 seconds off the build times compared to non-parallel.

![image](https://user-images.githubusercontent.com/538152/73126094-2eabf900-3f74-11ea-8c79-cc092e385676.png)
