### PR TITLE
Appveyor optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ macro(global_compile_options)
   endif()
 endmacro(global_compile_options)
 
+# jsd: hide warnings about using insecure crt functions:
+if(MSVC)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES SunOS )
   set(SOLARIS 1)
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,19 @@
 
 image: Visual Studio 2015
 
+# jsd: cuts down about 10 seconds of build
+clone_depth: 1
+
 ### build config ###
 version: 0.7.{build}
 pull_requests:
   do_not_increment_build_number: true
 configuration: RelWithDebInfo
+cache:
+  - build\SDL2-devel-2.0.5-VC.zip
+  - build\SDL2-2.0.5
+  - build\SDL2_mixer-devel-2.0.1-VC.zip
+  - build\SDL2_mixer-2.0.1
 build:
   project: build\Odamex.sln
   verbosity: minimal

--- a/appveyor_before_build.ps1
+++ b/appveyor_before_build.ps1
@@ -1,8 +1,19 @@
 mkdir build | Out-Null
 cd build
-Start-FileDownload "https://www.libsdl.org/release/SDL2-devel-2.0.5-VC.zip"
-7z x "SDL2-devel-2.0.5-VC.zip"
-Start-FileDownload "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.1-VC.zip"
-7z x "SDL2_mixer-devel-2.0.1-VC.zip"
+
+if (!(Test-Path -Path "SDL2-devel-2.0.5-VC.zip" -PathType leaf)) {
+    Start-FileDownload "https://www.libsdl.org/release/SDL2-devel-2.0.5-VC.zip"
+}
+if (!(Test-Path -Path "SDL2-2.0.5")) {
+    7z x "SDL2-devel-2.0.5-VC.zip"
+}
+
+if (!(Test-Path -Path "SDL2_mixer-devel-2.0.1-VC.zip" -PathType leaf)) {
+    Start-FileDownload "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.1-VC.zip"
+}
+if (!(Test-Path -Path "SDL2_mixer-2.0.1")) {
+    7z x "SDL2_mixer-devel-2.0.1-VC.zip"
+}
+
 & "C:\Program Files (x86)\cmake\bin\cmake.exe" .. -G "Visual Studio 14 2015" -T v140_xp -DUSE_MINIUPNP=False -DSDL2_INCLUDE_DIR="./SDL2-2.0.5/include/" -DSDL2_LIBRARY="./SDL2-2.0.5/lib/x86/SDL2.lib" -DSDL2MAIN_LIBRARY="./lib/x86/SDL2main.lib" -DSDL2_MIXER_INCLUDE_DIR="./SDL2_mixer-2.0.1/include/" -DSDL2_MIXER_LIBRARY="./SDL2_mixer-2.0.1/lib/x86/SDL2_mixer.lib"
 cd ..

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -332,7 +332,7 @@ public:
 	{	seta(_a); setr(_r); setg(_g); setb(_b);	}
 
 	inline operator argb_t () const
-	{	return argb_t(a * 255.0f, r * 255.0f, g * 255.0f, b * 255.0f);	}
+	{	return argb_t((uint8_t)(a * 255.0f), (uint8_t)(r * 255.0f), (uint8_t)(g * 255.0f), (uint8_t)(b * 255.0f));	}
 
 	inline float geta() const
 	{	return a;	}


### PR DESCRIPTION
cmake: define _CRT_SECURE_NO_WARNINGS for MSVC compilers
appveyor: cache SDL2 downloads and extraction
Remove redundant compiler warnings (270 of them all the same).