### PR TITLE
Fix odamex.wad build flow

### DIFF
--- a/wad/CMakeLists.txt
+++ b/wad/CMakeLists.txt
@@ -4,28 +4,32 @@ find_program(DEUTEX deutex)
 if(DEUTEX)
 	message("Found DeuTex: ${DEUTEX}")
 
-	file(REMOVE odamex.wad)
-	add_custom_command(OUTPUT odamex.wad
-		COMMAND ${DEUTEX} -overwrite -rgb 0 255 255 -doom2 bootstrap -build wadinfo.txt odamex.wad
+	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/odamex.wad
+		COMMAND ${DEUTEX} -rgb 0 255 255 -doom2 bootstrap -build wadinfo.txt ${CMAKE_CURRENT_BINARY_DIR}/odamex.wad
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/odamex.wad
 		VERBATIM)
 
-	add_custom_target(odawad DEPENDS odamex.wad)
+	add_custom_target(odawad ALL
+		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/odamex.wad)
 
-	if(BUILD_CLIENT)
-	  add_dependencies(odamex odawad)
+	if(WIN32)
+		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/odamex.wad
+			DESTINATION .
+			COMPONENT common)
+	else()
+		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/odamex.wad
+			DESTINATION ${CMAKE_INSTALL_DATADIR}/odamex
+			COMPONENT common)
 	endif()
-	if(BUILD_SERVER)
-	  add_dependencies(odasrv odawad)
-	endif()
-endif()
-
-if(WIN32)
-	install(FILES odamex.wad
-		DESTINATION .
-		COMPONENT common)
 else()
-	install(FILES odamex.wad
-		DESTINATION ${CMAKE_INSTALL_DATADIR}/odamex
-		COMPONENT common)
+	if(WIN32)
+		install(FILES odamex.wad
+			DESTINATION .
+			COMPONENT common)
+	else()
+		install(FILES odamex.wad
+			DESTINATION ${CMAKE_INSTALL_DATADIR}/odamex
+			COMPONENT common)
+	endif()
 endif()


### PR DESCRIPTION
The odamex.wad file should be built in the proper build directory;
building in the source tree confuses CMake and causes it to attempt to
rebuild a second time.