### PR TITLE
Bug #1236, plus additional stubs

### DIFF
--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -348,9 +348,16 @@ void A_SpawnSound(AActor*);
 void A_SpawnFly(AActor*);
 void A_BrainExplode(AActor*);
 void A_MonsterRail(AActor*);
-void A_Die(AActor*);
 void A_Detonate(AActor*);
 void A_Mushroom(AActor*);
+void A_Die(AActor*);
+void A_Spawn(AActor*);
+void A_Turn(AActor*);
+void A_Face(AActor*);
+void A_Scratch(AActor*);
+void A_PlaySound(AActor*);
+void A_RandomJump(AActor*);
+void A_LineEffect(AActor*);
 
 struct CodePtr {
 	const char *name;
@@ -438,9 +445,16 @@ static const struct CodePtr CodePtrs[] = {
 	{ "SpawnSound",		A_SpawnSound },
 	{ "SpawnFly",		A_SpawnFly },
 	{ "BrainExplode",	A_BrainExplode },
-	{ "Die",	        A_Die },
-	{ "Detonate",	    A_Detonate },
-    { "Mushroom",	    A_Mushroom },
+	{ "Detonate",		A_Detonate },       // killough 8/9/98
+	{ "Mushroom",		A_Mushroom },       // killough 10/98
+	{ "Die",		A_Die },            // killough 11/98
+	{ "Spawn",		A_Spawn },          // killough 11/98
+	{ "Turn",		A_Turn },           // killough 11/98
+	{ "Face",		A_Face },           // killough 11/98
+	{ "Scratch",		A_Scratch },        // killough 11/98
+	{ "PlaySound",		A_PlaySound },      // killough 11/98
+	{ "RandomJump",		A_RandomJump },     // killough 11/98
+	{ "LineEffect",		A_LineEffect },     // killough 11/98
 	{ NULL, NULL }
 };
 

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -240,6 +240,25 @@ forceinline T clamp (const T in, const T min, const T max)
 	return in <= min ? min : in >= max ? max : in;
 }
 
+//
+// COUNTOF
+//
+// Safely counts the number of items in an C array.
+// 
+// https://www.drdobbs.com/cpp/counting-array-elements-at-compile-time/197800525?pgno=1
+//
+#define COUNTOF(arr) ( \
+	0 * sizeof(reinterpret_cast<const ::Bad_arg_to_COUNTOF*>(arr)) + \
+	0 * sizeof(::Bad_arg_to_COUNTOF::check_type((arr), &(arr))) + \
+	sizeof(arr) / sizeof((arr)[0]) )
+
+struct Bad_arg_to_COUNTOF {
+	class Is_pointer; // incomplete
+	class Is_array {};
+	template <typename T>
+	static Is_pointer check_type(const T*, const T* const*);
+	static Is_array check_type(const void*, const void*);
+};
 
 
 // ----------------------------------------------------------------------------

--- a/common/info.cpp
+++ b/common/info.cpp
@@ -5393,6 +5393,223 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 	"MT_MISC86"
 	},
 
+	// For use with wind and current effects
+	{		// MT_PUSH	// phares
+	5001,		// doomednum	//   |    //jff 5/11/98 deconflict
+	S_TNT1,		// spawnstate	//   V    // with DOSDoom
+	1000,		// spawnhealth
+	S_NULL,		// seestate
+	NULL,		// seesound
+	8,		// reactiontime
+	NULL,		// attacksound
+	S_NULL,		// painstate
+	0,		// painchance
+	NULL,		// painsound
+	S_NULL,		// meleestate
+	S_NULL,		// missilestate
+	S_NULL,		// deathstate
+	S_NULL,		// xdeathstate
+	NULL,		// deathsound
+	0,		// speed
+	8,		// radius
+	8,		// height
+	8,		// cdheight
+	10,		// mass
+	0,		// damage
+	NULL,		// activesound
+	MF_NOBLOCKMAP,	// flags
+	MF2_DONTDRAW,	// flags2
+	S_NULL,		// raisestate
+	0x10000,	// translucency
+	"MT_PUSH"	// name
+	},
+
+	// For use with wind and current effects
+	{		// MT_PULL
+	5002,		// doomednum                   //jff 5/11/98 deconflict
+	S_TNT1,		// spawnstate                  // with DOSDoom
+	1000,		// spawnhealth
+	S_NULL,		// seestate
+	NULL,		// seesound
+	8,		// reactiontime
+	NULL,		// attacksound
+	S_NULL,		// painstate
+	0,		// painchance
+	NULL,		// painsound
+	S_NULL,		// meleestate
+	S_NULL,		// missilestate
+	S_NULL,		// deathstate
+	S_NULL,		// xdeathstate
+	NULL,		// deathsound
+	0,		// speed
+	8,		// radius
+	8,		// height
+	8,		// cdheight
+	10,		// mass
+	0,		// damage
+	NULL,		// activesound
+	MF_NOBLOCKMAP,	// flags
+	MF2_DONTDRAW,	// flags2
+	S_NULL,		// raisestate
+	0x10000,	// translucency
+	"MT_PULL"	// name
+	},
+
+	// Marine's best friend :)      // killough 7/19/98
+	{		// MT_DOGS
+	888,		// doomednum
+	S_DOGS_STND,	// spawnstate
+	500,		// spawnhealth
+	S_DOGS_RUN1,	// seestate
+	"dog/sight",	// seesound
+	8,		// reactiontime
+	"dog/attack",	// attacksound
+	S_DOGS_PAIN,	// painstate
+	180,		// painchance
+	"dog/pain",	// painsound
+	S_DOGS_ATK1,	// meleestate
+	S_NULL,		// missilestate
+	S_DOGS_DIE1,	// deathstate
+	S_NULL,		// xdeathstate
+	"dog/death",	// deathsound
+	10,		// speed
+	12*FRACUNIT,	// radius
+	28*FRACUNIT,	// height
+	28*FRACUNIT,	// cdheight
+	100,		// mass
+	0,		// damage
+	"dog/active",	// activesound
+	MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,   // flags
+	MF2_MCROSS|MF2_PASSMOBJ|MF2_PUSHWALL, // flags2
+	S_DOGS_RAISE1,	// raisestate
+	0x10000,	// translucency
+	"MT_DOGS"	// name
+	},
+
+	// killough 7/11/98: this is the first of two plasma fireballs in the beta
+	{		// MT_PLASMA1
+	-1,		// doomednum
+	S_PLS1BALL,	// spawnstate
+	1000,		// spawnhealth
+	S_NULL,		// seestate
+	"weapons/plasmaf", // seesound
+	8,		// reactiontime
+	NULL,		// attacksound
+	S_NULL,		// painstate
+	0,		// painchance
+	NULL,		// painsound
+	S_NULL,		// meleestate
+	S_NULL,		// missilestate
+	S_PLS1EXP,	// deathstate
+	S_NULL,		// xdeathstate
+	"weapons/plasmax", // deathsound
+	25*FRACUNIT,	// speed
+	13*FRACUNIT,	// radius
+	8*FRACUNIT,	// height
+	8*FRACUNIT,	// cdheight
+	100,		// mass
+	4,		// damage
+	NULL,		// activesound
+	MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY, // flags [AM] MF_BOUNCES not implemented
+	MF2_PCROSS|MF2_IMPACT, // flags2
+	S_NULL,		// raisestate
+	FRACUNIT,	// translucency
+	"MT_PLASMA1"	// name
+	},
+
+	// killough 7/11/98: this is the second of two plasma fireballs in the beta
+	{		// MT_PLASMA2
+	-1,		// doomednum
+	S_PLS2BALL,	// spawnstate
+	1000,		// spawnhealth
+	S_NULL,		// seestate
+	"weapons/plasmaf", // seesound
+	8,		// reactiontime
+	NULL,		// attacksound
+	S_NULL,		// painstate
+	0,		// painchance
+	NULL,		// painsound
+	S_NULL,		// meleestate
+	S_NULL,		// missilestate
+	S_PLS2BALLX1,	// deathstate
+	S_NULL,		// xdeathstate
+	"weapons/plasmax", // deathsound
+	25*FRACUNIT,	// speed
+	6*FRACUNIT,	// radius
+	8*FRACUNIT,	// height
+	8*FRACUNIT,	// cdheight
+	100,		// mass
+	4,		// damage
+	NULL,		// activesound
+	MF_NOBLOCKMAP|MF_MISSILE|MF_DROPOFF|MF_NOGRAVITY, // flags [AM] MF_BOUNCES not implemented
+	MF2_PCROSS|MF2_IMPACT, // flags2
+	S_NULL,		// raisestate
+	FRACUNIT,	// translucency
+	"MT_PLASMA2"	// name
+	},
+
+	// killough 7/11/98: this is the evil sceptre in the beta version
+	{		// MT_SCEPTRE
+	2016,		// doomednum
+	S_BON3,		// spawnstate
+	1000,		// spawnhealth
+	S_NULL,		// seestate
+	NULL,		// seesound
+	8,		// reactiontime
+	NULL,		// attacksound
+	S_NULL,		// painstate
+	0,		// painchance
+	NULL,		// painsound
+	S_NULL,		// meleestate
+	S_NULL,		// missilestate
+	S_NULL,		// deathstate
+	S_NULL,		// xdeathstate
+	NULL,		// deathsound
+	0,		// speed
+	10*FRACUNIT,	// radius
+	16*FRACUNIT,	// height
+	16*FRACUNIT,	// cdheight
+	100,		// mass
+	0,		// damage
+	NULL,		// activesound
+	MF_SPECIAL|MF_COUNTITEM, // flags
+	0,		// flags2
+	S_NULL,		// raisestate
+	0x10000,	// translucency
+	"MT_SCEPTRE"	// name
+	},
+
+	// killough 7/11/98: this is the unholy bible in the beta version
+	{		// MT_BIBLE
+	2017,		// doomednum
+	S_BON4,		// spawnstate
+	1000,		// spawnhealth
+	S_NULL,		// seestate
+	NULL,		// seesound
+	8,		// reactiontime
+	NULL,		// attacksound
+	S_NULL,		// painstate
+	0,		// painchance
+	NULL,		// painsound
+	S_NULL,		// meleestate
+	S_NULL,		// missilestate
+	S_NULL,		// deathstate
+	S_NULL,		// xdeathstate
+	NULL,		// deathsound
+	0,		// speed
+	20*FRACUNIT,	// radius
+	10*FRACUNIT,	// height
+	10*FRACUNIT,	// cdheight
+	100,		// mass
+	0,		// damage
+	NULL,		// activesound
+	MF_SPECIAL|MF_COUNTITEM, // flags
+	0,		// flags2
+	S_NULL,		// raisestate
+	0x10000,	// translucency
+	"MT_BIBLE"	// name
+	},
+
 	{		// MT_GIB0
 	-1,		// doomednum
 	S_GIB0,		// spawnstate
@@ -5661,68 +5878,6 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 	S_NULL,		// raisestate
 	0x10000,
 	"MT_UNKNOWNTHING"
-	},
-
-	// For use with wind and current effects
-	{		// MT_PUSH				// phares
-	5001,		// doomednum		//   |		//jff 5/11/98 deconflict
-	S_TNT1,		// spawnstate		//   V		// with DOSDoom
-	1000,		// spawnhealth
-	S_NULL,		// seestate
-	NULL,		// seesound
-	8,		// reactiontime
-	NULL,		// attacksound
-	S_NULL,		// painstate
-	0,		// painchance
-	NULL,		// painsound
-	S_NULL,		// meleestate
-	S_NULL,		// missilestate
-	S_NULL,		// deathstate
-	S_NULL,		// xdeathstate
-	NULL,		// deathsound
-	0,		// speed
-	8,		// radius
-	8,		// height
-	8*FRACUNIT,	// cdheight
-	10,		// mass
-	0,		// damage
-	NULL,		// activesound
-	MF_NOBLOCKMAP,		// flags
-	MF2_DONTDRAW,		// flags2
-	S_NULL,		// raisestate
-	0x10000,
-	"MT_PUSH"				// phares
-	},
-
-	// For use with wind and current effects
-	{		// MT_PULL
-	5002,		// doomednum					//jff 5/11/98 deconflict
-	S_TNT1,		// spawnstate					// with DOSDoom
-	1000,		// spawnhealth
-	S_NULL,		// seestate
-	NULL,		// seesound
-	8,		// reactiontime
-	NULL,		// attacksound
-	S_NULL,		// painstate
-	0,		// painchance
-	NULL,		// painsound
-	S_NULL,		// meleestate
-	S_NULL,		// missilestate
-	S_NULL,		// deathstate
-	S_NULL,		// xdeathstate
-	NULL,		// deathsound
-	0,		// speed
-	8,		// radius
-	8,		// height
-	8*FRACUNIT,	// cdheight
-	10,		// mass
-	0,		// damage
-	NULL,		// activesound
-	MF_NOBLOCKMAP,		// flags
-	MF2_DONTDRAW,		// flags2
-	S_NULL,		// raisestate
-	0x10000,
-	"MT_PULL"
 	},
 
 	{		// [RH] MT_PATHNODE -- used for monster patrols

--- a/common/info.cpp
+++ b/common/info.cpp
@@ -44,8 +44,18 @@ const char *sprnames[NUMSPRITES+1] = {
 	"POL3","POL1","POL6","GOR2","GOR3","GOR4","GOR5","SMIT","COL1","COL2",
 	"COL3","COL4","CAND","CBRA","COL6","TRE1","TRE2","ELEC","CEYE","FSKU",
 	"COL5","TBLU","TGRN","TRED","SMBT","SMGT","SMRT","HDB1","HDB2","HDB3",
-	"HDB4","HDB5","HDB6","POB1","POB2","BRS1","TLMP","TLP2","TNT1","GIB0",
-	"GIB1","GIB2","GIB3","GIB4","GIB5","GIB6","GIB7","UNKN",
+	"HDB4","HDB5","HDB6","POB1","POB2","BRS1","TLMP","TLP2",
+
+	"TNT1", // invisible sprite                                 phares 3/9/98
+
+	"DOGS", // killough 7/19/98: Marine's best friend :)
+
+	"PLS1", // killough 7/19/98: first  of two plasma fireballs in the beta
+	"PLS2", // killough 7/19/98: second of two plasma fireballs in the beta
+	"BON3", // killough 7/11/98: evil sceptre in the beta version
+	"BON4", // killough 7/11/98: unholy bible in the beta version
+
+	"GIB0","GIB1","GIB2","GIB3","GIB4","GIB5","GIB6","GIB7","UNKN",
 
 	//	[Toke - CTF]
 	"BSOK","RSOK","BFLG","RFLG","BDWN","RDWN","BCAR","RCAR","TLGL",
@@ -85,12 +95,14 @@ void A_Explode(AActor*);
 void A_Pain(AActor*);
 void A_PlayerScream(AActor*);
 void A_Fall(AActor*);
+void A_Stop(AActor*);
 void A_XScream(AActor*);
 void A_Look(AActor*);
 void A_Chase(AActor*);
 void A_FaceTarget(AActor*);
 void A_PosAttack(AActor*);
 void A_Scream(AActor*);
+void A_Die(AActor*);
 void A_SPosAttack(AActor*);
 void A_VileChase(AActor*);
 void A_VileStart(AActor*);
@@ -132,6 +144,10 @@ void A_BrainSpit(AActor*);
 void A_SpawnSound(AActor*);
 void A_SpawnFly(AActor*);
 void A_BrainExplode(AActor*);
+void A_FireOldBFG(AActor*);      // killough 7/19/98: classic BFG firing function
+void A_Detonate(AActor*);        // killough 8/9/98: detonate a bomb or other device
+void A_Mushroom(AActor*);        // killough 10/98: mushroom effect
+void A_BetaSkullAttack(AActor*); // killough 10/98: beta lost souls attacked different
 void A_Ambient(AActor*);		// [RH] Play ambient sound
 void A_Gibify(AActor*); // denis - squash thing
 
@@ -1103,8 +1119,126 @@ state_t	states[NUMSTATES] = {
 	{SPR_TLP2,32769,4,NULL,S_TECH2LAMP3,0,0},	// S_TECH2LAMP2
 	{SPR_TLP2,32770,4,NULL,S_TECH2LAMP4,0,0},	// S_TECH2LAMP3
 	{SPR_TLP2,32771,4,NULL,S_TECH2LAMP,0,0},	// S_TECH2LAMP4
-	// END of vanilla DOOM things
-	{SPR_TNT1,0,-1,NULL,S_NULL,0,0},	// S_TNT1
+
+	// Boom/MBF stuff starts here
+
+	{SPR_TNT1,0,-1,NULL,S_TNT1},          // S_TNT1    // phares 3/8/98
+
+	// killough 8/9/98: grenade
+	{SPR_MISL,32768,1000,A_Die,S_GRENADE},      // S_GRENADE
+
+	// killough 8/10/98: variable damage explosion
+	{SPR_MISL,32769,4,A_Scream,S_DETONATE2},    // S_DETONATE
+	{SPR_MISL,32770,6,A_Detonate,S_DETONATE3},  // S_DETONATE2
+	{SPR_MISL,32771,10,NULL,S_NULL},            // S_DETONATE3
+
+	// killough 7/19/98: Marine's best friend :)
+	{SPR_DOGS,0,10,A_Look,S_DOGS_STND2},  // S_DOGS_STND
+	{SPR_DOGS,1,10,A_Look,S_DOGS_STND}, // S_DOGS_STND2
+	{SPR_DOGS,0,2,A_Chase,S_DOGS_RUN2}, // S_DOGS_RUN1
+	{SPR_DOGS,0,2,A_Chase,S_DOGS_RUN3}, // S_DOGS_RUN2
+	{SPR_DOGS,1,2,A_Chase,S_DOGS_RUN4}, // S_DOGS_RUN3
+	{SPR_DOGS,1,2,A_Chase,S_DOGS_RUN5}, // S_DOGS_RUN4
+	{SPR_DOGS,2,2,A_Chase,S_DOGS_RUN6}, // S_DOGS_RUN5
+	{SPR_DOGS,2,2,A_Chase,S_DOGS_RUN7}, // S_DOGS_RUN6
+	{SPR_DOGS,3,2,A_Chase,S_DOGS_RUN8}, // S_DOGS_RUN7
+	{SPR_DOGS,3,2,A_Chase,S_DOGS_RUN1}, // S_DOGS_RUN8
+	{SPR_DOGS,4,8,A_FaceTarget,S_DOGS_ATK2},  // S_DOGS_ATK1
+	{SPR_DOGS,5,8,A_FaceTarget,S_DOGS_ATK3},  // S_DOGS_ATK2
+	{SPR_DOGS,6,8,A_SargAttack,S_DOGS_RUN1},  // S_DOGS_ATK3
+	{SPR_DOGS,7,2,NULL,S_DOGS_PAIN2}, // S_DOGS_PAIN
+	{SPR_DOGS,7,2,A_Pain,S_DOGS_RUN1},  // S_DOGS_PAIN2
+	{SPR_DOGS,8,8,NULL,S_DOGS_DIE2},  // S_DOGS_DIE1
+	{SPR_DOGS,9,8,A_Scream,S_DOGS_DIE3},  // S_DOGS_DIE2
+	{SPR_DOGS,10,4,NULL,S_DOGS_DIE4}, // S_DOGS_DIE3
+	{SPR_DOGS,11,4,A_Fall,S_DOGS_DIE5}, // S_DOGS_DIE4
+	{SPR_DOGS,12,4,NULL,S_DOGS_DIE6}, // S_DOGS_DIE5
+	{SPR_DOGS,13,-1,NULL,S_NULL}, // S_DOGS_DIE6
+	{SPR_DOGS,13,5,NULL,S_DOGS_RAISE2}, // S_DOGS_RAISE1
+	{SPR_DOGS,12,5,NULL,S_DOGS_RAISE3}, // S_DOGS_RAISE2
+	{SPR_DOGS,11,5,NULL,S_DOGS_RAISE4}, // S_DOGS_RAISE3
+	{SPR_DOGS,10,5,NULL,S_DOGS_RAISE5}, // S_DOGS_RAISE4
+	{SPR_DOGS,9,5,NULL,S_DOGS_RAISE6},  // S_DOGS_RAISE5
+	{SPR_DOGS,8,5,NULL,S_DOGS_RUN1},  // S_DOGS_RAISE6
+
+	// killough 7/11/98: beta BFG begins here
+	// S_OLDBFG1
+
+#define BFGDELAY 1
+#define OLDBFG_1FRAMES(x) {SPR_BFGG,1,BFGDELAY,A_FireOldBFG,static_cast<statenum_t>(x+S_OLDBFG1+2)},
+#define OLDBFG_2FRAMES(x) OLDBFG_1FRAMES(x) OLDBFG_1FRAMES(x+1)
+#define OLDBFG_4FRAMES(x) OLDBFG_2FRAMES(x) OLDBFG_2FRAMES(x+2)
+#define OLDBFG_8FRAMES(x) OLDBFG_4FRAMES(x) OLDBFG_4FRAMES(x+4)
+	{SPR_BFGG,0,10,A_BFGsound,static_cast<statenum_t>(S_OLDBFG1+1)},  // S_OLDBFG1
+
+	OLDBFG_8FRAMES(0)
+	OLDBFG_8FRAMES(8)
+	OLDBFG_8FRAMES(16) 
+	OLDBFG_8FRAMES(24)
+	OLDBFG_8FRAMES(32)
+
+	{SPR_BFGG,1,0,A_Light0,S_OLDBFG43}, // S_OLDBFG42
+	{SPR_BFGG,1,20,A_ReFire,S_BFG},   // S_OLDBFG43
+
+	// killough 7/11/98: end of beta BFG
+
+	// killough 7/19/98: First plasma fireball in the beta:
+	{SPR_PLS1,32768,6,NULL,S_PLS1BALL2},  // S_PLS1BALL
+	{SPR_PLS1,32769,6,NULL,S_PLS1BALL}, // S_PLS1BALL2
+	{SPR_PLS1,32770,4,NULL,S_PLS1EXP2}, // S_PLS1EXP
+	{SPR_PLS1,32771,4,NULL,S_PLS1EXP3}, // S_PLS1EXP2
+	{SPR_PLS1,32772,4,NULL,S_PLS1EXP4}, // S_PLS1EXP3
+	{SPR_PLS1,32773,4,NULL,S_PLS1EXP5}, // S_PLS1EXP4
+	{SPR_PLS1,32774,4,NULL,S_NULL}, // S_PLS1EXP5
+
+	// killough 7/19/98: Second plasma fireball in the beta:
+	{SPR_PLS2,32768,4,NULL,S_PLS2BALL2}, // S_PLS2BALL
+	{SPR_PLS2,32769,4,NULL,S_PLS2BALL},  // S_PLS2BALL2
+	{SPR_PLS2,32770,6,NULL,S_PLS2BALLX2},  // S_PLS2BALLX1
+	{SPR_PLS2,32771,6,NULL,S_PLS2BALLX3},  // S_PLS2BALLX2
+	{SPR_PLS2,32772,6,NULL,S_NULL}, // S_PLS2BALLX3
+
+	{SPR_BON3,0,6,NULL,S_BON3},           // S_BON3  // killough 7/11/98:
+	{SPR_BON4,0,6,NULL,S_BON4},           // S_BON4  // beta bonus items
+
+	// killough 10/98: beta lost souls attacked from a distance, 
+	// animated with colors, and stayed in the air when killed.
+	// This is an approximation, but I'm sure it can be improved.
+
+	// spawnstate
+	{SPR_SKUL,0,10,A_Look,S_BSKUL_STND},  // S_BSKUL_STND
+
+	// chasestate
+	{SPR_SKUL,1,5,A_Chase,S_BSKUL_RUN2},  // S_BSKUL_RUN1
+	{SPR_SKUL,2,5,A_Chase,S_BSKUL_RUN3},  // S_BSKUL_RUN2
+	{SPR_SKUL,3,5,A_Chase,S_BSKUL_RUN4},  // S_BSKUL_RUN3
+	{SPR_SKUL,0,5,A_Chase,S_BSKUL_RUN1},  // S_BSKUL_RUN4
+
+	// missilestate
+	{SPR_SKUL,4,4,A_FaceTarget,S_BSKUL_ATK2},     // S_BSKUL_ATK1
+	{SPR_SKUL,5,5,A_BetaSkullAttack,S_BSKUL_ATK3}, // S_BSKUL_ATK2
+	{SPR_SKUL,5,4,NULL,S_BSKUL_RUN1},              // S_BSKUL_ATK3
+
+	// painstate
+	{SPR_SKUL,6,4,NULL,S_BSKUL_PAIN2},     // S_BSKUL_PAIN1
+	{SPR_SKUL,7,2,A_Pain,S_BSKUL_RUN1},   // S_BSKUL_PAIN2
+	{SPR_SKUL,8,4,NULL,S_BSKUL_RUN1},      // S_BSKUL_PAIN3
+
+	// deathstate
+	{SPR_SKUL, 9,5,NULL,S_BSKUL_DIE2},     // S_BSKUL_DIE1
+	{SPR_SKUL,10,5,NULL,S_BSKUL_DIE3},     // S_BSKUL_DIE2
+	{SPR_SKUL,11,5,NULL,S_BSKUL_DIE4},     // S_BSKUL_DIE3
+	{SPR_SKUL,12,5,NULL,S_BSKUL_DIE5},     // S_BSKUL_DIE4
+	{SPR_SKUL,13,5,A_Scream,S_BSKUL_DIE6}, // S_BSKUL_DIE5
+	{SPR_SKUL,14,5,NULL,S_BSKUL_DIE7},     // S_BSKUL_DIE6
+	{SPR_SKUL,15,5,A_Fall,S_BSKUL_DIE8},   // S_BSKUL_DIE7
+	{SPR_SKUL,16,5,A_Stop,S_BSKUL_DIE8},   // S_BSKUL_DIE8
+
+	// killough 10/98: mushroom effect
+	{SPR_MISL,32769,8,A_Mushroom,S_EXPLODE2},  // S_MUSHROOM
+
+	// ZDoom/Odamex stuff starts here
+
 	{SPR_GIB0,0,-1,NULL,S_NULL,0,0},	// S_GIB0
 	{SPR_GIB1,0,-1,NULL,S_NULL,0,0},	// S_GIB1
 	{SPR_GIB2,0,-1,NULL,S_NULL,0,0},	// S_GIB2

--- a/common/info.h
+++ b/common/info.h
@@ -1490,6 +1490,16 @@ typedef enum {
 	MT_MISC84,
 	MT_MISC85,
 	MT_MISC86,
+	MT_PUSH,    // controls push source                     // phares
+	MT_PULL,    // controls pull source                     // phares 3/20/98
+
+	MT_DOGS,    // killough 7/19/98: Marine's best friend
+
+	MT_PLASMA1, // killough 7/11/98: first  of alternating beta plasma fireballs
+	MT_PLASMA2, // killough 7/11/98: second of alternating beta plasma fireballs
+	MT_SCEPTRE, // killough 7/11/98: evil sceptre in beta version
+	MT_BIBLE,   // killough 7/11/98: unholy bible in beta version
+
 	// [RH] Gibs (code is disabled)
 	MT_GIB0,
 	MT_GIB1,
@@ -1501,8 +1511,6 @@ typedef enum {
 	MT_GIB7,
 	// [RH] Miscellaneous things
 	MT_UNKNOWNTHING,
-	MT_PUSH,		// Boom's push thing
-	MT_PULL,		// Boom's pull thing
 	MT_PATHNODE,
 	MT_AMBIENT,		// Ambient sounds
 	MT_TELEPORTMAN2,// Teleport destination that pays attention to its height

--- a/common/info.h
+++ b/common/info.h
@@ -173,6 +173,14 @@ typedef enum
 	SPR_TLMP,
 	SPR_TLP2,
 	SPR_TNT1,
+
+	SPR_DOGS, // killough 7/19/98: Marine's best friend :)
+
+	SPR_PLS1, // killough 7/19/98: first  of two plasma fireballs in the beta
+	SPR_PLS2, // killough 7/19/98: second of two plasma fireballs in the beta
+	SPR_BON3, // killough 7/11/98: evil sceptre in beta version
+	SPR_BON4, // killough 7/11/98: unholy bible in beta version
+
 	// [RH] Gibs
 	SPR_GIB0,
 	SPR_GIB1,
@@ -1173,7 +1181,85 @@ typedef enum
 	S_TECH2LAMP2,
 	S_TECH2LAMP3,
 	S_TECH2LAMP4,
-	S_TNT1,
+
+	S_TNT1, // add state for invisible sprite         // phares 3/8/98 
+
+	S_GRENADE,   // killough 8/9/98: grenade launcher
+	S_DETONATE,  // killough 8/9/98: detonation of objects
+	S_DETONATE2,
+	S_DETONATE3,
+
+	S_DOGS_STND,      // killough 7/19/98: Marine's best friend :)
+	S_DOGS_STND2,
+	S_DOGS_RUN1,
+	S_DOGS_RUN2,
+	S_DOGS_RUN3,
+	S_DOGS_RUN4,
+	S_DOGS_RUN5,
+	S_DOGS_RUN6,
+	S_DOGS_RUN7,
+	S_DOGS_RUN8,
+	S_DOGS_ATK1,
+	S_DOGS_ATK2,
+	S_DOGS_ATK3,
+	S_DOGS_PAIN,
+	S_DOGS_PAIN2,
+	S_DOGS_DIE1,
+	S_DOGS_DIE2,
+	S_DOGS_DIE3,
+	S_DOGS_DIE4,
+	S_DOGS_DIE5,
+	S_DOGS_DIE6,
+	S_DOGS_RAISE1,
+	S_DOGS_RAISE2,
+	S_DOGS_RAISE3,
+	S_DOGS_RAISE4,
+	S_DOGS_RAISE5,
+	S_DOGS_RAISE6,
+
+	S_OLDBFG1,  // killough 7/11/98: the old BFG's 43 firing frames
+	S_OLDBFG42 = S_OLDBFG1 + 41,
+	S_OLDBFG43,
+
+	S_PLS1BALL,      // killough 7/19/98: first plasma fireball in the beta
+	S_PLS1BALL2,
+	S_PLS1EXP,
+	S_PLS1EXP2,
+	S_PLS1EXP3,
+	S_PLS1EXP4,
+	S_PLS1EXP5,
+
+	S_PLS2BALL,     // killough 7/19/98: second plasma fireball in the beta
+	S_PLS2BALL2,
+	S_PLS2BALLX1,
+	S_PLS2BALLX2,
+	S_PLS2BALLX3,
+	S_BON3, // killough 7/11/98: evil sceptre in beta version
+	S_BON4, // killough 7/11/98: unholy bible in beta version
+
+	// killough 10/98: beta lost souls were different from their modern cousins
+	S_BSKUL_STND,
+	S_BSKUL_RUN1,
+	S_BSKUL_RUN2,
+	S_BSKUL_RUN3,
+	S_BSKUL_RUN4,
+	S_BSKUL_ATK1,
+	S_BSKUL_ATK2,
+	S_BSKUL_ATK3,
+	S_BSKUL_PAIN1,
+	S_BSKUL_PAIN2,
+	S_BSKUL_PAIN3,
+	S_BSKUL_DIE1,
+	S_BSKUL_DIE2,
+	S_BSKUL_DIE3,
+	S_BSKUL_DIE4,
+	S_BSKUL_DIE5,
+	S_BSKUL_DIE6,
+	S_BSKUL_DIE7,
+	S_BSKUL_DIE8,
+
+	S_MUSHROOM,  // killough 10/98: mushroom explosion effect
+
 	// [RH] gibs
 	S_GIB0,
 	S_GIB1,

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -1687,6 +1687,30 @@ void A_SkullAttack (AActor *actor)
 	actor->momz = (dest->z+(dest->height>>1) - actor->z) / dist;
 }
 
+//
+// A_BetaSkullAttack()
+// killough 10/98: this emulates the beta version's lost soul attacks
+//
+
+void A_BetaSkullAttack(AActor* actor)
+{
+	if (!actor->target || actor->target->type == MT_SKULL)
+		return;
+
+	// [FG] fix crash when attack sound is missing
+	if (actor->info->attacksound)
+	{
+		S_Sound(actor, CHAN_VOICE, actor->info->attacksound, 1, ATTN_NORM);
+	}
+	A_FaceTarget(actor);
+	int damage = (P_Random(actor) % 8 + 1) * actor->info->damage;
+	P_DamageMobj(actor->target, actor, actor, damage);
+}
+
+void A_Stop(AActor* actor)
+{
+	actor->momx = actor->momy = actor->momz = 0;
+}
 
 //
 // A_PainShootSkull
@@ -2261,6 +2285,90 @@ void A_Gibify(AActor *mo) // denis - squash thing
 	mo->flags &= ~MF_SOLID;
 	mo->height = 0;
 	mo->radius = 0;
+}
+
+//
+// killough 11/98
+//
+// The following were inspired by Len Pitre
+//
+// A small set of highly-sought-after code pointers
+//
+
+void A_Spawn(AActor* mo)
+{
+	/* [AM] Not implemented...yet.
+	if (mo->state->misc1)
+	{
+		AActor* newmobj = P_SpawnMobj(
+			mo->x, mo->y, (mo->state->misc2 << FRACBITS) + mo->z,
+			mo->state->misc1 - 1
+		);
+		newmobj->flags = (newmobj->flags & ~MF_FRIEND) | (mo->flags & MF_FRIEND);
+	}
+	*/
+}
+
+void A_Turn(AActor* mo)
+{
+	mo->angle += (angle_t)(((uint64_t)mo->state->misc1 << 32) / 360);
+}
+
+void A_Face(AActor* mo)
+{
+	mo->angle = (angle_t)(((uint64_t)mo->state->misc1 << 32) / 360);
+}
+
+void A_Scratch(AActor* mo)
+{
+	/* [AM] Not implemented...yet.
+	mo->target && (A_FaceTarget(mo), P_CheckMeleeRange(mo)) ?
+		mo->state->misc2 ? S_StartSound(mo, mo->state->misc2) : (void)0,
+		P_DamageMobj(mo->target, mo, mo, mo->state->misc1) : (void)0;
+	*/
+}
+
+void A_PlaySound(AActor* mo)
+{
+	/* [AM] Not implemented...yet.
+	S_StartSound(mo->state->misc2 ? NULL : mo, mo->state->misc1);
+	*/
+}
+
+void A_RandomJump(AActor* mo)
+{
+	/* [AM] Not implemented...yet.
+	if (P_Random(mo) < mo->state->misc2)
+		P_SetMobjState(mo, mo->state->misc1);
+	*/
+}
+
+//
+// This allows linedef effects to be activated inside deh frames.
+//
+
+void A_LineEffect(AActor* mo)
+{
+	/* [AM] Not implemented...yet.
+	if (!(mo->intflags & MIF_LINEDONE))                // Unless already used up
+	{
+		line_t junk = *lines;                          // Fake linedef set to 1st
+		if ((junk.special = (short)mo->state->misc1))  // Linedef type
+		{
+			// [FG] made static
+			static player_t player;                    // Remember player status
+			player_t* oldplayer = mo->player;          // Remember player status
+			mo->player = &player;                      // Fake player
+			player.health = 100;                       // Alive player
+			junk.tag = (short)mo->state->misc2;        // Sector tag for linedef
+			if (!P_UseSpecialLine(mo, &junk, 0))       // Try using it
+			    P_CrossSpecialLine(&junk, 0, mo);        // Try crossing it
+			if (!junk.special)                         // If type cleared,
+			    mo->intflags |= MIF_LINEDONE;            // no more for this thing
+			mo->player = oldplayer;                    // Restore player status
+		}
+	}
+	*/
 }
 
 VERSION_CONTROL (p_enemy_cpp, "$Id$")

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -245,6 +245,7 @@ AActor::AActor (fixed_t ix, fixed_t iy, fixed_t iz, mobjtype_t itype) :
 	y = iy;
 	radius = info->radius;
 	height = P_ThingInfoHeight(info);
+	damage = info->damage;
 	flags = info->flags;
 	flags2 = info->flags2;
 	health = info->spawnhealth;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -925,6 +925,11 @@ bool P_SetMobjState(AActor *mobj, statenum_t state, bool cl_update)
 
 	do
 	{
+		if (state >= COUNTOF(states) || state < 0)
+		{
+			I_Error("P_SetMobjState: State %d does not exist in state table.", state);
+		}
+
 		if (state == S_NULL)
 		{
 			mobj->state = (state_t *) S_NULL;

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -764,7 +764,7 @@ void A_FireBFG(AActor* mo)
 // This code may not be used in other mods without appropriate credit given.
 // Code leeches will be telefragged.
 
-void A_FireOldBFG(player_t* player, pspdef_t* psp)
+void A_FireOldBFG(AActor* mo)
 {
     /* [AM] Not implemented...yet.
     int type = MT_PLASMA1;

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -755,7 +755,67 @@ void A_FireBFG(AActor* mo)
 	player->userinfo.aimdist = storedaimdist;
 }
 
+//
+// A_FireOldBFG
+//
+// This function emulates Doom's Pre-Beta BFG
+// By Lee Killough 6/6/98, 7/11/98, 7/19/98, 8/20/98
+//
+// This code may not be used in other mods without appropriate credit given.
+// Code leeches will be telefragged.
 
+void A_FireOldBFG(player_t* player, pspdef_t* psp)
+{
+    /* [AM] Not implemented...yet.
+    int type = MT_PLASMA1;
+
+    if (weapon_recoil && !(player->mo->flags & MF_NOCLIP))
+	P_Thrust(player, ANG180 + player->mo->angle,
+	    512 * recoil_values[wp_plasma]);
+
+    player->ammo[weaponinfo[player->readyweapon].ammo]--;
+
+    player->extralight = 2;
+
+    do
+    {
+	mobj_t* th, * mo = player->mo;
+	angle_t an = mo->angle;
+	angle_t an1 = ((P_Random(pr_bfg) & 127) - 64) * (ANG90 / 768) + an;
+	angle_t an2 = ((P_Random(pr_bfg) & 127) - 64) * (ANG90 / 640) + ANG90;
+	extern int autoaim;
+
+	if (autoaim || !beta_emulation)
+	{
+	    // killough 8/2/98: make autoaiming prefer enemies
+	    int mask = MF_FRIEND;
+	    fixed_t slope;
+	    do
+	    {
+		slope = P_AimLineAttack(mo, an, 16 * 64 * FRACUNIT, mask);
+		if (!linetarget)
+		    slope = P_AimLineAttack(mo, an += 1 << 26, 16 * 64 * FRACUNIT, mask);
+		if (!linetarget)
+		    slope = P_AimLineAttack(mo, an -= 2 << 26, 16 * 64 * FRACUNIT, mask);
+		if (!linetarget)
+		    slope = 0, an = mo->angle;
+	    } while (mask && (mask = 0, !linetarget));     // killough 8/2/98
+	    an1 += an - mo->angle;
+	    an2 += tantoangle[slope >> DBITS];
+	}
+
+	th = P_SpawnMobj(mo->x, mo->y,
+	    mo->z + 62 * FRACUNIT - player->psprites[ps_weapon].sy,
+	    type);
+	P_SetTarget(&th->target, mo);
+	th->angle = an1;
+	th->momx = finecosine[an1 >> ANGLETOFINESHIFT] * 25;
+	th->momy = finesine[an1 >> ANGLETOFINESHIFT] * 25;
+	th->momz = finetangent[an2 >> ANGLETOFINESHIFT] * 25;
+	P_CheckMissileSpawn(th);
+    } while ((type != MT_PLASMA2) && (type = MT_PLASMA2)); //killough: obfuscated!
+    */
+}
 
 //
 // A_FirePlasma


### PR DESCRIPTION
This is an attempt to fix the custom pinkie crash in Valiant, but the scope got a little wider past that.

Essentially, the custom pinkie uses a state index that Odamex simply does not have.  In theory, this change could be fixed by adding a bunch of blank states, like what happened in Woof and Graf's fork of prBoom+.  However, I decided to go a little bit above and beyond and stub out the missing MBF codepointers and mobj types as well.  This ensures that the final boss of Valiant, which uses the helper dog mobj, works as well.

Most of the other MBF code pointers are stubbed out, because the important ones that ZDoom gives first class support for already exist.  I also did not add any default graphics or sounds for the mobjs to the WAD either, since that might give the impression that these features are fully supported and not just a shim (although if such resources were desired, Woof has some under a usable license).  I also imagine that the Beta BFG would be a gigantic drain of network resources anyway.

Note that in order to get this stuff working, I moved the position of MBF mobj definitions and state frames to after Vanilla but before ZDoom/Odamex.  The reason I did this is because I wanted the mobj definition array and state table to line up with MBF's state table, just in case there were ever any compatibility subtleties that could arise from the different orders.  However, I suspect doing this also implies a protocol breakage, since mobj ids and frame indexes wouldn't be compatible (but that's going to be the case no matter where I put the mobjs and state frames).

This pull request also comes with some extra code that prevents a crash when trying to go to a state index outside the state table.  To implement this, I also added an extra `COUNTOF` macro that counts the size of a static C array, which should be useful elsewhere.