### PR TITLE
Delete linelist_t with delete and not delete[] in P_CreateBlockMap

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1361,7 +1361,7 @@ void P_CreateBlockMap()
 		{
 			linelist_t *tmp = bl->next;
 			blockmaplump[offs++] = bl->num;
-			delete[] bl;
+			delete bl;
 			bl = tmp;
 		}
 	}


### PR DESCRIPTION
While testing the new duel queue, I was running the server with Address Sanitizer and it caught a pretty nasty bug in `P_CreateBlockMap()`.  The stack trace should be self-explanatory.

```
[18:47:47] ========== Odamex Server Initialized ==========
[18:47:48] --- MAP00: "START" ---
=================================================================
==7328==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new vs operator delete []) on 0x6020000156b0
    #0 0x7f151543ac40 in operator delete[](void*) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xebc40)
    #1 0x55cc18fdb6ed in P_CreateBlockMap() ../common/p_setup.cpp:1364
    #2 0x55cc18fdbbc3 in P_LoadBlockMap(int) ../common/p_setup.cpp:1388
    #3 0x55cc18fde152 in P_SetupLevel(char*, int) ../common/p_setup.cpp:1752
    #4 0x55cc190c619a in G_DoLoadLevel(int) ../server/src/g_level.cpp:771
    #5 0x55cc190c770c in G_InitNew(char const*) ../server/src/g_level.cpp:423
    #6 0x55cc190c7dd9 in G_DoNewGame() ../server/src/g_level.cpp:283
    #7 0x55cc190c1d5a in G_Ticker() ../server/src/g_game.cpp:144
    #8 0x55cc1913414a in SV_StepTics(unsigned long long) ../server/src/sv_main.cpp:4697
    #9 0x55cc19143162 in SV_RunTics() ../server/src/sv_main.cpp:4758
    #10 0x55cc18ecbed4 in CappedTaskScheduler::run() ../common/d_main.cpp:1010
    #11 0x55cc18eb8b02 in D_RunTics(void (*)(), void (*)()) ../common/d_main.cpp:1105
    #12 0x55cc190bcab4 in D_DoomLoop() ../server/src/d_main.cpp:116
    #13 0x55cc190bde3f in D_DoomMain() ../server/src/d_main.cpp:391
    #14 0x55cc190ce856 in main ../server/src/i_main.cpp:274
    #15 0x7f15148e909a in __libc_start_main ../csu/libc-start.c:308
    #16 0x55cc18e4b099 in _start (/opt/odamex/bin/dev/odasrv+0xc9099)

0x6020000156b0 is located 0 bytes inside of 16-byte region [0x6020000156b0,0x6020000156c0)
allocated by thread T0 here:
    #0 0x7f1515439d30 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xead30)
    #1 0x55cc18fd4bb5 in AddBlockLine ../common/p_setup.cpp:1093
    #2 0x55cc18fdb689 in P_CreateBlockMap() ../common/p_setup.cpp:1325
    #3 0x55cc18fdbbc3 in P_LoadBlockMap(int) ../common/p_setup.cpp:1388
    #4 0x55cc18fde152 in P_SetupLevel(char*, int) ../common/p_setup.cpp:1752
    #5 0x55cc190c619a in G_DoLoadLevel(int) ../server/src/g_level.cpp:771
    #6 0x55cc190c770c in G_InitNew(char const*) ../server/src/g_level.cpp:423
    #7 0x55cc190c7dd9 in G_DoNewGame() ../server/src/g_level.cpp:283
    #8 0x55cc190c1d5a in G_Ticker() ../server/src/g_game.cpp:144
    #9 0x55cc1913414a in SV_StepTics(unsigned long long) ../server/src/sv_main.cpp:4697
    #10 0x55cc19143162 in SV_RunTics() ../server/src/sv_main.cpp:4758
    #11 0x55cc18ecbed4 in CappedTaskScheduler::run() ../common/d_main.cpp:1010
    #12 0x55cc18eb8b02 in D_RunTics(void (*)(), void (*)()) ../common/d_main.cpp:1105
    #13 0x55cc190bcab4 in D_DoomLoop() ../server/src/d_main.cpp:116
    #14 0x55cc190bde3f in D_DoomMain() ../server/src/d_main.cpp:391
    #15 0x55cc190ce856 in main ../server/src/i_main.cpp:274
    #16 0x7f15148e909a in __libc_start_main ../csu/libc-start.c:308
```