### PR TITLE
Fix drawing "hud_heldflag" border around the view window

### DIFF
--- a/client/src/cl_ctf.cpp
+++ b/client/src/cl_ctf.cpp
@@ -274,51 +274,26 @@ void CTF_MoveFlags ()
 
 static void TintScreen(argb_t color)
 {
+	int surface_width = I_GetSurfaceWidth(), surface_height = I_GetSurfaceHeight();
+	int thickness = std::min(surface_height / 100, surface_width / 100);
+
 	// draw border around the screen excluding the status bar
 	// NOTE: status bar is not currently drawn when spectating
 	if (R_StatusBarVisible())
+		surface_height = ST_StatusBarY(surface_width, surface_height);
+
+	if (hud_heldflag == 1)
 	{
-		if (hud_heldflag == 1) {
-			screen->Clear(0, 0,
-				I_GetSurfaceWidth() / 100, I_GetSurfaceHeight() - ST_HEIGHT,
-				color);
-
-			screen->Clear(0, 0,
-				I_GetSurfaceWidth(), I_GetSurfaceHeight() / 100,
-				color);
-
-			screen->Clear(I_GetSurfaceWidth() - (I_GetSurfaceWidth() / 100), 0,
-				I_GetSurfaceWidth(), I_GetSurfaceHeight() - ST_HEIGHT,
-				color);
-		}
-			screen->Clear (0, (I_GetSurfaceHeight() - ST_HEIGHT) - (I_GetSurfaceHeight() / 100),
-						   I_GetSurfaceWidth(), I_GetSurfaceHeight() - ST_HEIGHT,
-						   color);
+		screen->Clear(0, 0, thickness, surface_height, color);
+		screen->Clear(0, 0, surface_width, thickness, color);
+		screen->Clear(surface_width - thickness, 0, surface_width, surface_height, color);
 	}
-
-	// if there's no status bar, draw border around the full screen
-	else
+	if (hud_heldflag > 0)
 	{
-		if (hud_heldflag == 1)
-		{
-			screen->Clear(0, 0,
-				I_GetSurfaceWidth() / 100, I_GetSurfaceHeight(),
-				color);
-
-			screen->Clear(0, 0,
-				I_GetSurfaceWidth(), I_GetSurfaceHeight() / 100,
-				color);
-
-			screen->Clear(I_GetSurfaceWidth() - (I_GetSurfaceWidth() / 100), 0,
-				I_GetSurfaceWidth(), I_GetSurfaceHeight(),
-				color);
-
-		}
-			screen->Clear (0, (I_GetSurfaceHeight()) - (I_GetSurfaceHeight() / 100),
-						   I_GetSurfaceWidth(), I_GetSurfaceHeight(),
-						   color);
+		screen->Clear (0, surface_height - thickness, surface_width, surface_height, color);
 	}
 }
+
 
 //
 //	[Toke - CTF] CTF_RunTics
@@ -377,10 +352,7 @@ void CTF_DrawHud (void)
 		}
 	}
 
-	if (!hud_heldflag)
-		return;
-
-	if (hasflag)
+	if (hasflag && hud_heldflag > 0)
 	{
 		if (hud_heldflag_flash == 1)
 		{


### PR DESCRIPTION
Fix drawing "hud_heldflag" border around the view window when the status bar is visible and vid_320x200 or vid_640x400 is enabled.