### PR TITLE
Add /usr/share/doom search path

### DIFF
--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -455,6 +455,7 @@ static void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 	D_AddSearchDir(dirs, INSTALL_PREFIX "/" INSTALL_DATADIR "/games/odamex", separator);
 	#endif
 
+	D_AddSearchDir(dirs, "/usr/share/doom", separator);
 	D_AddSearchDir(dirs, "/usr/share/games/doom", separator);
 	D_AddSearchDir(dirs, "/usr/local/share/games/doom", separator);
 	D_AddSearchDir(dirs, "/usr/local/share/doom", separator);


### PR DESCRIPTION
Some Linux distributions such as Gentoo keep their WAD files under the
/usr/share/doom directory by default. Let's add that location to the
search paths too.