### PR TITLE
COUNTOF and STACKARRAY_LENGTH to ARRAY_LENGTH

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -912,7 +912,7 @@ static int VPrintf(int printlevel, const char* color_code, const char* format, v
 	if (gameisdead)
 		return 0;
 
-	vsnprintf(outline, STACKARRAY_LENGTH(outline), format, parms);
+	vsnprintf(outline, ARRAY_LENGTH(outline), format, parms);
 
 	// denis - 0x07 is a system beep, which can DoS the console (lol)
 	int len = strlen(outline);

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -956,7 +956,7 @@ BEGIN_COMMAND (rcon)
 	{
 		char  command[256];
 
-		strncpy(command, args, STACKARRAY_LENGTH(command) - 1);
+		strncpy(command, args, ARRAY_LENGTH(command) - 1);
 		command[255] = '\0';		
 
 		MSG_WriteMarker(&net_buffer, clc_rcon);

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -286,7 +286,7 @@ static menuitem_t OptionItems[] =
 menu_t OptionMenu = {
 	"M_OPTTTL",
 	0,
-	STACKARRAY_LENGTH(OptionItems),
+	ARRAY_LENGTH(OptionItems),
 	177,
 	OptionItems,
 	0,
@@ -381,7 +381,7 @@ static menuitem_t ControlsItems[] = {
 menu_t ControlsMenu = {
 	"M_CONTRO",
 	3,
-	STACKARRAY_LENGTH(ControlsItems),
+	ARRAY_LENGTH(ControlsItems),
 	0,
 	ControlsItems,
 	2,
@@ -429,7 +429,7 @@ static menuitem_t MouseItems[] =
 menu_t MouseMenu = {
     "M_MOUSET",
     0,
-    STACKARRAY_LENGTH(MouseItems),
+    ARRAY_LENGTH(MouseItems),
     177,
     MouseItems,
 	0,
@@ -464,7 +464,7 @@ static menuitem_t JoystickItems[] =
 menu_t JoystickMenu = {
     "M_JOYSTK",
     0,
-    STACKARRAY_LENGTH(JoystickItems),
+    ARRAY_LENGTH(JoystickItems),
     177,
     JoystickItems,
 	0,
@@ -495,7 +495,7 @@ static value_t VoxType[] = {
 	{ 2.0,			"Possessive" }
 };
 
-static float num_mussys = static_cast<float>(STACKARRAY_LENGTH(MusSys));
+static float num_mussys = static_cast<float>(ARRAY_LENGTH(MusSys));
 
 static menuitem_t SoundItems[] = {
     { redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
@@ -517,7 +517,7 @@ static menuitem_t SoundItems[] = {
 menu_t SoundMenu = {
 	"M_SOUND",
 	2,
-	STACKARRAY_LENGTH(SoundItems),
+	ARRAY_LENGTH(SoundItems),
 	177,
 	SoundItems,
 	0,
@@ -554,7 +554,7 @@ static menuitem_t CompatItems[] ={
 menu_t CompatMenu = {
 	"M_COMPAT",
 	1,
-	STACKARRAY_LENGTH(CompatItems),
+	ARRAY_LENGTH(CompatItems),
 	240,
 	CompatItems,
 	0,
@@ -602,7 +602,7 @@ static menuitem_t NetworkItems[] = {
 menu_t NetworkMenu = {
 	"M_NETWRK",
 	2,
-	STACKARRAY_LENGTH(NetworkItems),
+	ARRAY_LENGTH(NetworkItems),
 	177,
 	NetworkItems,
 	1,
@@ -647,7 +647,7 @@ static menuitem_t WeaponItems[] = {
 menu_t WeaponMenu = {
 	"M_WEAPON",
 	1,
-	STACKARRAY_LENGTH(WeaponItems),
+	ARRAY_LENGTH(WeaponItems),
 	177,
 	WeaponItems,
 	0,
@@ -798,7 +798,7 @@ static menuitem_t VideoItems[] = {
 
 static void M_UpdateDisplayOptions()
 {
-	const static size_t menu_length = STACKARRAY_LENGTH(VideoItems);
+	const static size_t menu_length = ARRAY_LENGTH(VideoItems);
 	const static size_t gamma_index = M_FindCvarInMenu(gammalevel, VideoItems, menu_length);
 
 	// update the parameters for gammalevel based on vid_gammatype (doom or zdoom gamma)
@@ -810,7 +810,7 @@ static void M_UpdateDisplayOptions()
 menu_t VideoMenu = {
 	"M_VIDEO",
 	0,
-	STACKARRAY_LENGTH(VideoItems),
+	ARRAY_LENGTH(VideoItems),
 	0,
 	VideoItems,
 	3,
@@ -891,7 +891,7 @@ static menuitem_t MessagesItems[] = {
 menu_t MessagesMenu = {
 	"M_MESS",
 	0,
-	STACKARRAY_LENGTH(MessagesItems),
+	ARRAY_LENGTH(MessagesItems),
 	0,
 	MessagesItems,
 	0,
@@ -928,7 +928,7 @@ static menuitem_t AutomapItems[] = {
 menu_t AutomapMenu = {
 	"M_MESS",
 	0,
-	STACKARRAY_LENGTH(AutomapItems),
+	ARRAY_LENGTH(AutomapItems),
 	0,
 	AutomapItems,
 	0,
@@ -1018,7 +1018,7 @@ static menuitem_t ModesItems[] = {
 menu_t ModesMenu = {
 	"M_VIDMOD",
 	0,
-	STACKARRAY_LENGTH(ModesItems),
+	ARRAY_LENGTH(ModesItems),
 	130,
 	ModesItems,
 	0,
@@ -2333,6 +2333,3 @@ BEGIN_COMMAND (menu_video)
 END_COMMAND (menu_video)
 
 VERSION_CONTROL (m_options_cpp, "$Id$")
-
-
-

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -241,18 +241,18 @@ forceinline T clamp (const T in, const T min, const T max)
 }
 
 //
-// COUNTOF
+// ARRAY_LENGTH
 //
 // Safely counts the number of items in an C array.
 // 
 // https://www.drdobbs.com/cpp/counting-array-elements-at-compile-time/197800525?pgno=1
 //
-#define COUNTOF(arr) ( \
-	0 * sizeof(reinterpret_cast<const ::Bad_arg_to_COUNTOF*>(arr)) + \
-	0 * sizeof(::Bad_arg_to_COUNTOF::check_type((arr), &(arr))) + \
+#define ARRAY_LENGTH(arr) ( \
+	0 * sizeof(reinterpret_cast<const ::Bad_arg_to_ARRAY_LENGTH*>(arr)) + \
+	0 * sizeof(::Bad_arg_to_ARRAY_LENGTH::check_type((arr), &(arr))) + \
 	sizeof(arr) / sizeof((arr)[0]) )
 
-struct Bad_arg_to_COUNTOF {
+struct Bad_arg_to_ARRAY_LENGTH {
 	class Is_pointer; // incomplete
 	class Is_array {};
 	template <typename T>

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -98,8 +98,6 @@ typedef int SOCKET;
 #include "upnpcommands.h"
 #endif
 
-#include "m_memio.h"	// for STACKARRAY_LENGTH
-
 unsigned int	inet_socket;
 int         	localport;
 netadr_t    	net_from;   // address of who sent the packet
@@ -705,7 +703,7 @@ void MSG_WriteHexString(buf_t *b, const char *s)
 
     const size_t numdigits = strlen(s) / 2;
 
-    if (numdigits > STACKARRAY_LENGTH(output))
+    if (numdigits > ARRAY_LENGTH(output))
     {
         Printf (PRINT_HIGH, "MSG_WriteHexString: too many digits\n");
         return;
@@ -1130,5 +1128,3 @@ void I_SetPort(netadr_t &addr, int port)
 }
 
 VERSION_CONTROL (i_net_cpp, "$Id$")
-
-

--- a/common/m_memio.h
+++ b/common/m_memio.h
@@ -28,9 +28,6 @@
 
 #include <stdio.h>
 
-// returns the length of an "c array" on the stack.
-#define STACKARRAY_LENGTH(a) ((sizeof(a) / sizeof(a[0])))
-
 typedef struct _MEMFILE MEMFILE;
 
 typedef enum 

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -926,7 +926,7 @@ bool P_SetMobjState(AActor *mobj, statenum_t state, bool cl_update)
 
 	do
 	{
-		if (state >= COUNTOF(states) || state < 0)
+		if (state >= ARRAY_LENGTH(states) || state < 0)
 		{
 			I_Error("P_SetMobjState: State %d does not exist in state table.", state);
 		}

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -108,7 +108,7 @@ int VPrintf(int printlevel, const char* format, va_list parms)
 	if (gameisdead)
 		return 0;
 
-	vsnprintf(outline, STACKARRAY_LENGTH(outline), format, parms);
+	vsnprintf(outline, ARRAY_LENGTH(outline), format, parms);
 
 	// denis - 0x07 is a system beep, which can DoS the console (lol)
 	size_t len = strlen(outline);
@@ -246,4 +246,3 @@ void C_RemoveTabCommand (const char *name)
 }
 
 VERSION_CONTROL (c_console_cpp, "$Id$")
-


### PR DESCRIPTION
This PR changes the name of my `COUNTOF` Array Length macro (that I contributed with my first MBF fix patch) to `ARRAY_LENGTH` to be more clear and gets rid of the old `STACKARRAY_LENGTH ` macro that was vulnerable to misuse.