### PR TITLE
[BUG #1248] sv_sharekeys CVAR

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -897,7 +897,7 @@ BEGIN_COMMAND (kill)
     if (sv_allowcheats || sv_gametype == GM_COOP)
         MSG_WriteMarker(&net_buffer, clc_kill);
     else
-        Printf (PRINT_HIGH, "You must run the server with '+set sv_allowcheats 1' or disable sv_keepkeys to enable this command.\n");
+        Printf (PRINT_HIGH, "You must run the server with '+set sv_allowcheats 1' to enable this command.\n");
 }
 END_COMMAND (kill)
 

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -62,5 +62,7 @@ void CTF_SpawnFlag(flag_t f) {}
 bool SV_AwarenessUpdate(player_t &pl, AActor* mo) { return true; }
 void SV_SendPackets(void) {}
 
+CVAR_FUNC_IMPL(sv_sharekeys) {}
+
 VERSION_CONTROL (cl_stubs_cpp, "$Id$")
 

--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -98,6 +98,7 @@ EXTERN_CVAR (sv_itemsrespawn)
 EXTERN_CVAR (sv_respawnsuper)
 EXTERN_CVAR (sv_weaponstay)
 EXTERN_CVAR (sv_keepkeys)
+EXTERN_CVAR (sv_sharekeys)
 EXTERN_CVAR (co_nosilentspawns)
 EXTERN_CVAR (co_allowdropoff)
 
@@ -1052,7 +1053,7 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 	}
 	for (i = 0; i < NUMWEAPONS; i++)
 		p.weaponowned[i] = false;
-	if (!sv_keepkeys)
+	if (!sv_keepkeys && !sv_sharekeys)
 	{
 		for (i = 0; i < NUMCARDS; i++)
 			p.cards[i] = false;

--- a/client/src/g_level.cpp
+++ b/client/src/g_level.cpp
@@ -514,7 +514,7 @@ void G_DoLoadLevel (int position)
 			it->playerstate = PST_ENTER;
 		}
 
-		// [AM] If sv_keepkeys is on, players might still be carrying keys, so
+		// [AM] If sv_keepkeys|sv_sharekeys is on, players might still be carrying keys, so
 		//      make sure they're gone.
 		for (size_t j = 0; j < NUMCARDS; j++)
 			it->cards[j] = false;

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -131,7 +131,10 @@ CVAR(				sv_weaponstay,    "1", "Weapons stay after pickup",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 
 CVAR(				sv_keepkeys, "0", "Keep keys on death",
-					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
+
+CVAR_FUNC_DECL(		sv_sharekeys, "0", "Share keys found to every player.",
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
 
 CVAR_RANGE(			sv_maxunlagtime, "1.0", "Cap the maxiumum time allowed for player reconciliation (in seconds)",
 					CVARTYPE_FLOAT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE, 0.0f, 1.0f)

--- a/common/d_items.cpp
+++ b/common/d_items.cpp
@@ -209,6 +209,19 @@ gitem_t	*FindItem (const char *pickup_name)
 	return NULL;
 }
 
+gitem_t* FindCardItem(card_t card)
+{
+	int		i;
+	gitem_t* it;
+
+	it = itemlist;
+	for (i = 0; i < num_items; i++, it++)
+		if (it->flags == IT_KEY && (card_t)it->offset == card)
+			return it;
+
+	return NULL;
+}
+
 
 // Item info
 // Used mainly by the give command. Hopefully will
@@ -535,8 +548,7 @@ gitem_t itemlist[] = {
 		0,
 		"Red Flag"
 	},
-
-	// end of list marker
+				// end of list marker
 	{
 	    "",
 	    NULL,

--- a/common/d_items.h
+++ b/common/d_items.h
@@ -83,6 +83,8 @@ gitem_t	*GetItemByIndex (int index);
 gitem_t	*FindItemByClassname (const char *classname);
 gitem_t *FindItem (const char *pickup_name);
 
+gitem_t* FindCardItem(card_t card);
+
 #define ITEM_INDEX(i)	((i)-itemlist)
 
 #endif //__D_ITEMS_H__

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -77,6 +77,10 @@ void SV_ActorTarget(AActor *actor);
 void PickupMessage(AActor *toucher, const char *message);
 void WeaponPickupMessage(AActor *toucher, weapontype_t &Weapon);
 
+#ifdef SERVER_APP
+void SV_ShareKeys(card_t card, player_t& player);
+#endif
+
 //
 // GET STUFF
 //
@@ -370,6 +374,12 @@ ItemEquipVal P_GiveCard(player_t *player, card_t card)
 
 	if (multiplayer)
 	{
+#ifdef SERVER_APP
+		// Register the key
+		SV_ShareKeys(card, *player);	
+#endif
+
+
 		return IEV_EquipStay;
 	}
 

--- a/server/src/g_game.cpp
+++ b/server/src/g_game.cpp
@@ -50,6 +50,7 @@ void	G_DoWorldDone (void);
 EXTERN_CVAR (sv_maxplayers)
 EXTERN_CVAR (sv_timelimit)
 EXTERN_CVAR (sv_keepkeys)
+EXTERN_CVAR (sv_sharekeys)
 EXTERN_CVAR (co_nosilentspawns)
 EXTERN_CVAR (sv_nomonsters)
 EXTERN_CVAR (sv_fastmonsters)
@@ -205,6 +206,7 @@ void G_PlayerFinishLevel (player_t &player)
 	p->bonuscount = 0;
 }
 
+void SV_SendPlayerInfo(player_t& player);
 
 //
 // G_PlayerReborn
@@ -221,11 +223,21 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 	}
 	for (i = 0; i < NUMWEAPONS; i++)
 		p.weaponowned[i] = false;
-	if (!sv_keepkeys)
+	if (!sv_keepkeys && !sv_sharekeys)
 	{
 		for (i = 0; i < NUMCARDS; i++)
 			p.cards[i] = false;
 	}
+
+	// That said, if keys are found between a player's death and respawn, resync them.
+	if (sv_sharekeys)
+	{
+		for (i = 0; i < NUMCARDS; i++)
+			p.cards[i] = keysfound[i];
+
+		SV_SendPlayerInfo(p);
+	}
+
 	for (i = 0; i < NUMPOWERS; i++)
 		p.powers[i] = false;
 	for (i = 0; i < NUMFLAGS; i++)

--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -698,6 +698,10 @@ void G_DoLoadLevel (int position)
 		wipegamestate = GS_FORCEWIPE;
 
 	gamestate = GS_LEVEL;
+	
+	// Reset all keys found
+	for (size_t j = 0; j < NUMCARDS; j++)
+		keysfound[j] = false;
 
 	// Set the sky map.
 	// First thing, we have a dummy sky texture name,
@@ -722,7 +726,7 @@ void G_DoLoadLevel (int position)
 		if (it->ingame() && it->playerstate == PST_DEAD)
 			it->playerstate = PST_REBORN;
 
-		// [AM] If sv_keepkeys is on, players might still be carrying keys, so
+		// [AM] If sv_keepkeys or sv_sharekeys is on, players might still be carrying keys, so
 		//      make sure they're gone.
 		for (size_t j = 0; j < NUMCARDS; j++)
 			it->cards[j] = false;

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -92,6 +92,8 @@ bool step_mode = false;
 
 std::set<byte> free_player_ids;
 
+bool keysfound[NUMCARDS];		// Ch0wW : Found keys
+
 // General server settings
 EXTERN_CVAR(sv_motd)
 EXTERN_CVAR(sv_hostname)
@@ -107,11 +109,14 @@ EXTERN_CVAR(sv_allowtargetnames)
 EXTERN_CVAR(sv_flooddelay)
 EXTERN_CVAR(sv_ticbuffer)
 EXTERN_CVAR(sv_warmup)
+EXTERN_CVAR(sv_sharekeys)
 
 void SexMessage (const char *from, char *to, int gender,
 	const char *victim, const char *killer);
 Players::iterator SV_RemoveDisconnectedPlayer(Players::iterator it);
 void P_PlayerLeavesGame(player_s* player);
+
+void SV_UpdateShareKeys(player_t& player);
 
 CVAR_FUNC_IMPL (sv_maxclients)
 {
@@ -213,7 +218,6 @@ EXTERN_CVAR (sv_fragexitswitch)
 EXTERN_CVAR (sv_allowjump)
 EXTERN_CVAR (sv_freelook)
 EXTERN_CVAR (sv_infiniteammo)
-EXTERN_CVAR (sv_keepkeys)
 
 // Teamplay/CTF
 EXTERN_CVAR (sv_scorelimit)
@@ -5256,6 +5260,65 @@ void SV_PreservePlayer(player_t &player)
 	G_DoReborn(player);
 
 	SV_SendPlayerInfo(player);
+}
+
+
+CVAR_FUNC_IMPL (sv_sharekeys)
+{
+	if (var == 1.0f)
+	{
+		// Refresh it to everyone
+		for (Players::iterator it = players.begin(); it != players.end(); ++it) {
+			SV_UpdateShareKeys(*it);
+		}
+	}
+}
+
+
+void SV_UpdateShareKeys(player_t& player)
+{
+	// Player needs to be valid.
+	if (!validplayer(player))
+		return;
+
+	// Disallow to spectators
+	if (player.spectator)
+		return;
+
+	// Don't send to dead players... Yet, since they'll get it upon respawning
+	if (player.health <= 0)
+		return;
+
+	// Update their keys informations
+	for (int i = 0; i < NUMCARDS; i++) {
+		player.cards[i] = keysfound[i];
+	}
+
+	// Refresh that new data to the client
+	SV_SendPlayerInfo(player);
+}
+
+void SV_ShareKeys(card_t card, player_t &player)
+{
+	// Add it to the KeysCheck array
+	keysfound[card] = true;
+
+	// If the server hasn't accepted to share keys yet, stop it.
+	if (!sv_sharekeys)
+		return;
+
+	// Broadcast the key shared to 
+	gitem_t* item;
+	if (item = FindCardItem(card))
+		SV_BroadcastPrintf(PRINT_HIGH, "%s found the %s!\n", player.userinfo.netname.c_str(), item->pickup_name);
+	else
+		SV_BroadcastPrintf(PRINT_HIGH, "%s found a key!\n", player.userinfo.netname.c_str());
+
+	// Refresh the inventory to everyone
+	// ToDo: If we're the player who picked it, don't refresh our own inventory
+	for (Players::iterator it = players.begin(); it != players.end(); ++it) {
+		SV_UpdateShareKeys(*it);
+	}
 }
 
 VERSION_CONTROL (sv_main_cpp, "$Id$")

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -38,6 +38,7 @@
 #include <json/json.h>
 
 extern int shotclock;
+extern bool keysfound[NUMCARDS];
 
 class client_c
 {


### PR DESCRIPTION
When a key has been found by a player, share that key to all players.

I'ved also removed the CVAR_LATCH property in sv_keepkeys, it has no reason to be there.

Original bug thread : https://odamex.net/bugs/show_bug.cgi?id=1248