### PR TITLE
Fix for z-teleports height not working

### DIFF
--- a/common/p_teleport.cpp
+++ b/common/p_teleport.cpp
@@ -187,7 +187,9 @@ BOOL EV_Teleport(int tid, int tag, int side, AActor *thing)
 	// problem between normal doom2 1.9 and final doom
 	// Note that although chex.exe is based on Final Doom,
 	// it does not have this quirk.
-	if (gamemission < pack_tnt || gamemission == chex)
+	// [AM] For z-teleports, the destination sets the height, don't
+	//      override it here.
+	if (m->type == MT_TELEPORTMAN && (gamemission < pack_tnt || gamemission == chex))
 		thing->z = thing->floorz;
 
 	if (player)


### PR DESCRIPTION
Pretty simple - the height-aware teleport broke at some point in the past and and this commit fixes it.