### PR TITLE
send net id instead of player id for svc_damageplayer

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2577,29 +2577,28 @@ void CL_RemoveMobj(void)
 //
 void CL_DamagePlayer(void)
 {
-	player_t *p;
-	int       health;
-	int       damage;
+	int netid = MSG_ReadShort();
+	int healthDamage = MSG_ReadShort();
+	int armorDamage = MSG_ReadByte();
 
-	p = &idplayer(MSG_ReadByte());
+	AActor* actor = P_FindThingById(netid);
 
-	p->armorpoints = MSG_ReadByte();
-	health         = MSG_ReadShort();
-
-	if(!p->mo)
+	if (!actor || !actor->player)
 		return;
 
-	damage = p->health - health;
-	p->mo->health = p->health = health;
+	player_t *p = actor->player;
+	p->health -= healthDamage;
+	p->mo->health = p->health;
+	p->armorpoints -= armorDamage;
 
 	if (p->health < 0)
 		p->health = 0;
+	if (p->armorpoints < 0)
+		p->armorpoints = 0;
 
-	if (damage < 0)  // can't be!
-		return;
-
-	if (damage > 0) {
-		p->damagecount += damage;
+	if (healthDamage > 0)
+	{
+		p->damagecount += healthDamage;
 
 		if (p->damagecount > 100)
 			p->damagecount = 100;

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -45,7 +45,7 @@ void SV_TouchSpecial(AActor *special, player_t *player) {}
 ItemEquipVal SV_FlagTouch (player_t &player, flag_t f, bool firstgrab) { return IEV_NotEquipped; }
 void SV_SocketTouch (player_t &player, flag_t f) {}
 void SV_SendKillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill) {}
-void SV_SendDamagePlayer(player_t *player, int pain) {}
+void SV_SendDamagePlayer(player_t *player, int healthDamage, int armorDamage) {}
 void SV_SendDamageMobj(AActor *target, int pain) {}
 void SV_CTFEvent(flag_t f, flag_score_t event, player_t &who) {}
 void SV_UpdateFrags(player_t &player) {}

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -5081,16 +5081,16 @@ void ClientObituary(AActor* self, AActor* inflictor, AActor* attacker)
 	SV_BroadcastPrintf(PRINT_MEDIUM, "%s\n", gendermessage);
 }
 
-void SV_SendDamagePlayer(player_t *player, int damage)
+void SV_SendDamagePlayer(player_t *player, int healthDamage, int armorDamage)
 {
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{
 		client_t *cl = &(it->client);
 
 		MSG_WriteMarker(&cl->reliablebuf, svc_damageplayer);
-		MSG_WriteByte(&cl->reliablebuf, player->id);
-		MSG_WriteByte(&cl->reliablebuf, player->armorpoints);
-		MSG_WriteShort(&cl->reliablebuf, damage);
+		MSG_WriteShort(&cl->reliablebuf, player->mo->netid);
+		MSG_WriteShort(&cl->reliablebuf, healthDamage);
+		MSG_WriteByte(&cl->reliablebuf, armorDamage);
 	}
 }
 

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -93,7 +93,7 @@ extern std::vector<std::string> wadnames;
 void MSG_WriteMarker (buf_t *b, svc_t c);
 
 void SV_SendKillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill);
-void SV_SendDamagePlayer(player_t *player, int pain);
+void SV_SendDamagePlayer(player_t *player, int healthDamage, int armorDamage);
 void SV_SendDamageMobj(AActor *target, int pain);
 // Tells clients to remove an actor from the world as it doesn't exist anymore
 void SV_SendDestroyActor(AActor *mo);


### PR DESCRIPTION
If the svc_damageplayer packet was resent after a player respawned then that player would be damaged on the client but not the server.

This update sends the player mobj's netid instead, so if they respawn and receive the svc_damageplayer command out of order it will fail to find the player.

This update also sends the health/armor damage amounts so the client can subtract them rather the player's health/armor. This will prevent desyncs where the client can get an older damage message after a newer one, which would incorrectly increase the players health/armor.