### PR TITLE
do not destroy specials while predicting

### DIFF
--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -38,7 +38,7 @@ extern bool predicting;
 
 void P_SetDoorDestroy(DDoor *door)
 {
-	if (!door)
+	if (!door || predicting)
 		return;
 
 	door->m_Status = DDoor::destroy;

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -40,7 +40,7 @@ extern bool predicting;
 
 void P_SetFloorDestroy(DFloor *floor)
 {
-	if (!floor)
+	if (!floor || predicting)
 		return;
 
 	floor->m_Status = DFloor::destroy;
@@ -832,7 +832,7 @@ int EV_DoDonut (int tag, fixed_t pillarspeed, fixed_t slimespeed)
 
 void P_SetElevatorDestroy(DElevator *elevator)
 {
-	if (!elevator)
+	if (!elevator || predicting)
 		return;
 
 	elevator->m_Status = DElevator::destroy;

--- a/common/p_pillar.cpp
+++ b/common/p_pillar.cpp
@@ -31,7 +31,7 @@ extern bool predicting;
 
 void P_SetPillarDestroy(DPillar *pillar)
 {
-	if (!pillar)
+	if (!pillar || predicting)
 		return;
 
 	pillar->m_Status = DPillar::destroy;

--- a/common/p_plats.cpp
+++ b/common/p_plats.cpp
@@ -241,7 +241,8 @@ void DPlat::RunThink ()
 	if (m_Status == finished)
 	{
 		PlayPlatSound();
-		m_Status = destroy;
+		if (!predicting)
+			m_Status = destroy;
 	}
 
 	if (m_Status == destroy)


### PR DESCRIPTION
Resolves bug caused by specials with looping sounds never stopping. This happened because the sector prediction would destroy the special but predicting sectors wouldn't stop the sound. This fix prevents the special from being destroyed so the next run think can stop the sound.