### PR TITLE
switch desync fixes

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -157,6 +157,7 @@ EXTERN_CVAR (r_forceteamcolor)
 static argb_t enemycolor, teamcolor;
 
 void P_PlayerLeavesGame(player_s* player);
+void P_DestroyButtonThinkers();
 
 //
 // CL_ShadePlayerColor
@@ -3123,6 +3124,11 @@ void CL_FinishedFullUpdate()
 		netdemo.writeMapChange();
 }
 
+void CL_StartFullUpdate()
+{
+	recv_full_update = false;
+}
+
 //
 // CL_SetMobjState
 //
@@ -3414,8 +3420,6 @@ void CL_LoadMap(void)
 		netdemo.writeMapChange();
 }
 
-void P_ResetSwitch(line_t* line);
-
 void CL_ResetMap()
 {
 	// Destroy every actor with a netid that isn't a player.  We're going to
@@ -3445,6 +3449,8 @@ void CL_ResetMap()
 			sectors[i].ceilingdata->Destroy();
 		}
 	}
+
+	P_DestroyButtonThinkers();
 
 	// write the map index to the netdemo
 	if (netdemo.isRecording() && recv_full_update)
@@ -3653,6 +3659,7 @@ void CL_InitCommands(void)
 	cmds[svc_netdemostop]       = &CL_NetDemoStop;
 	cmds[svc_netdemoloadsnap]	= &CL_NetDemoLoadSnap;
 	cmds[svc_fullupdatedone]	= &CL_FinishedFullUpdate;
+	cmds[svc_fullupdatestart]	= &CL_StartFullUpdate;
 
 	cmds[svc_vote_update] = &CL_VoteUpdate;
 	cmds[svc_maplist] = &CL_Maplist;

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -123,7 +123,8 @@ enum svc_t
 	svc_playerstate,		// [SL] Health, armor, and weapon of a player
 	svc_warmupstate,		// [AM] Broadcast warmup state to client
 	svc_resetmap,			// [AM] Server is resetting the map
-	svc_playerqueuepos,        // Notify clients of player queue postion
+	svc_playerqueuepos,     // Notify clients of player queue postion
+	svc_fullupdatestart,	// Inform client the full update has started
 
 	// for co-op
 	svc_mobjstate = 70,

--- a/common/p_switch.cpp
+++ b/common/p_switch.cpp
@@ -122,6 +122,15 @@ void P_InitSwitchList(void)
 	Z_Free (alphSwitchList);
 }
 
+void P_DestroyButtonThinkers()
+{
+	DActiveButton *button;
+	TThinkerIterator<DActiveButton> iterator;
+
+	while ((button = iterator.Next()))
+		button->Destroy();
+}
+
 //
 // Start a button counting down till it turns off.
 // [RH] Rewritten to remove MAXBUTTONS limit and use temporary soundorgs.

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1573,6 +1573,8 @@ void SV_ClientFullUpdate(player_t &pl)
 {
 	client_t *cl = &pl.client;
 
+	MSG_WriteMarker(&cl->reliablebuf, svc_fullupdatestart);
+
 	// send player's info to the client
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{


### PR DESCRIPTION
Destroy switch thinkers on CL_ResetMap, otherwise active switches set during a map reset will be stuck. Also prevent repeat switches from playing the switch sound on destroy.

Send svc_fullupdatestart so the client can correctly reset the recv_full_update variable, so single use switches are set to the appropriate texture.