### PR TITLE
Prevent ACS from executing client side when connected to server

### DIFF
--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -42,6 +42,7 @@
 // activated by walking across the backside of a line.
 int TeleportSide;
 extern bool HasBehavior;
+extern bool s_SpecialFromServer;
 
 // Set true if this special was activated from inside a script.
 BOOL InScript;
@@ -1041,6 +1042,9 @@ FUNC(LS_Thing_SetGoal)
 FUNC(LS_ACS_Execute)
 // ACS_Execute (script, map, s_arg1, s_arg2, s_arg3)
 {
+	if (!serverside && s_SpecialFromServer)
+		return false;
+
 	level_info_t *info;
 
 	if ( (arg1 == 0) || !(info = FindLevelByNum (arg1)) )
@@ -1052,6 +1056,9 @@ FUNC(LS_ACS_Execute)
 FUNC(LS_ACS_ExecuteAlways)
 // ACS_ExecuteAlways (script, map, s_arg1, s_arg2, s_arg3)
 {
+	if (!serverside && s_SpecialFromServer)
+		return false;
+
 	level_info_t *info;
 
 	if ( (arg1 == 0) || !(info = FindLevelByNum (arg1)) )
@@ -1063,6 +1070,9 @@ FUNC(LS_ACS_ExecuteAlways)
 FUNC(LS_ACS_LockedExecute)
 // ACS_LockedExecute (script, map, s_arg1, s_arg2, lock)
 {
+	if (!serverside && s_SpecialFromServer)
+		return false;
+
 	if (arg4 && !P_CheckKeys (it->player, (card_t)arg4, 1))
 		return false;
 	else
@@ -1072,6 +1082,9 @@ FUNC(LS_ACS_LockedExecute)
 FUNC(LS_ACS_Suspend)
 // ACS_Suspend (script, map)
 {
+	if (!serverside && s_SpecialFromServer)
+		return false;
+
 	level_info_t *info;
 
 	if ( (arg1 == 0) || !(info = FindLevelByNum (arg1)) )
@@ -1085,6 +1098,9 @@ FUNC(LS_ACS_Suspend)
 FUNC(LS_ACS_Terminate)
 // ACS_Terminate (script, map)
 {
+	if (!serverside && s_SpecialFromServer)
+		return false;
+
 	level_info_t *info;
 
 	if ( (arg1 == 0) || !(info = FindLevelByNum (arg1)) )

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -66,6 +66,7 @@ EXTERN_CVAR(sv_allowexit)
 EXTERN_CVAR(sv_fragexitswitch)
 
 std::list<movingsector_t> movingsectors;
+bool s_SpecialFromServer = false;
 
 //
 // P_FindMovingSector
@@ -1412,6 +1413,8 @@ P_CrossSpecialLine
 
 	TeleportSide = side;
 
+	s_SpecialFromServer = FromServer;
+
 	LineSpecials[line->special] (line, thing, line->args[0],
 					line->args[1], line->args[2],
 					line->args[3], line->args[4]);
@@ -1419,6 +1422,8 @@ P_CrossSpecialLine
 	P_HandleSpecialRepeat(line);
 
 	OnActivatedLine(line, thing, side, 0);
+
+	s_SpecialFromServer = false;
 }
 
 //
@@ -1446,6 +1451,8 @@ P_ShootSpecialLine
 			return;
 	}
 
+	s_SpecialFromServer = FromServer;
+
 	//TeleportSide = side;
 
 	LineSpecials[line->special] (line, thing, line->args[0],
@@ -1461,6 +1468,8 @@ P_ShootSpecialLine
 		P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL, true);
 		OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
 	}
+
+	s_SpecialFromServer = false;
 }
 
 
@@ -1523,6 +1532,8 @@ P_UseSpecialLine
 		}
 	}
 
+	s_SpecialFromServer = FromServer;
+
     TeleportSide = side;
 
 	if(LineSpecials[line->special] (line, thing, line->args[0],
@@ -1539,6 +1550,8 @@ P_UseSpecialLine
 			OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
 		}
 	}
+
+	s_SpecialFromServer = false;
 
     return true;
 }
@@ -1591,6 +1604,8 @@ P_PushSpecialLine
 
     TeleportSide = side;
 
+	s_SpecialFromServer = FromServer;
+
 	if(LineSpecials[line->special] (line, thing, line->args[0],
 					line->args[1], line->args[2],
 					line->args[3], line->args[4]))
@@ -1605,6 +1620,8 @@ P_PushSpecialLine
 			OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
 		}
 	}
+
+	s_SpecialFromServer = false;
 
     return true;
 }


### PR DESCRIPTION
Prevent ACS from executing client side when connected to server. Previously scrips would execute on the client and then again when the client receives the line special activation from the server. This would cause scripts with print messages to double print, but has much worse de-sync potential depending on what specials the script would activate.