### PR TITLE
Add cvar for resetting the PRNG on map reload

### DIFF
--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -66,6 +66,7 @@ EXTERN_CVAR (sv_nextmap)
 EXTERN_CVAR (sv_loopepisode)
 EXTERN_CVAR (sv_intermissionlimit)
 EXTERN_CVAR (sv_warmup)
+EXTERN_CVAR (sv_resetprng)
 EXTERN_CVAR (sv_timelimit)
 
 extern int mapchange;
@@ -631,8 +632,10 @@ void G_DoResetLevel(bool full_reset)
 			if (sv_warmup)
 				it->ready = false;
 		}
+
 		// For predictable first spawns.
-		M_ClearRandom();
+		if (sv_resetprng)
+			M_ClearRandom();
 	}
 
 	// [SL] always reset the time (for now at least)

--- a/server/src/sv_cvarlist.cpp
+++ b/server/src/sv_cvarlist.cpp
@@ -154,6 +154,8 @@ CVAR(			sv_ticbuffer, "1", "Buffer controller input from players experiencing su
 				"latency spikes for smoother movement",
 				CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
 
+CVAR(			sv_resetprng, "1", "Reset the PRNG when the map resets, which makes initial spawns predictable like Vanilla.",
+				CVARTYPE_BOOL, CVAR_SERVERARCHIVE)
 
 // Ban settings
 // ============
@@ -253,4 +255,3 @@ CVAR(sv_download_test, "0", "Experimental download optimization testing",
 // None currently
 
 VERSION_CONTROL (sv_cvarlist_cpp, "$Id$")
-


### PR DESCRIPTION
Turning this off makes initial spawns less predictable.

Pretty much what it says on the tin.  Just thought i'd squeeze this in for upcoming tournaments.