### PR TITLE
Ensure special 24576 is considered a floor special

### DIFF
--- a/common/p_xlat.cpp
+++ b/common/p_xlat.cpp
@@ -642,11 +642,19 @@ void P_TranslateLineDef (line_t *ld, maplinedef_t *mld)
 		{
 			// Generalized ceiling (tag, speed, height, target, change/model/direct/crush)
 			// Generalized floor (tag, speed, height, target, change/model/direct/crush)
-			if (special <= GenFloorBase)
-				ld->special = Generic_Ceiling;
-			else
+			if ((unsigned)special >= GenFloorBase)
+			{
 				ld->special = Generic_Floor;
-			
+			}
+			else if ((unsigned)special >= GenCeilingBase)
+			{
+				ld->special = Generic_Ceiling;
+			}
+			else
+			{
+				Printf(PRINT_HIGH, "Unknown special %u\n", (unsigned)special);
+			}
+
 			switch (special & 0x0018)
 			{
 				case 0x0000:	ld->args[1] = F_SLOW;	break;
@@ -760,4 +768,3 @@ int P_TranslateSectorSpecial (int special)
 }
 
 VERSION_CONTROL (p_xlat_cpp, "$Id$")
-


### PR DESCRIPTION
This is something I noticed in Valiant MAP01 - some of the lifts that make hidden monsters appear don't work.  After looking into it, this is a simple oversight in the existing code that incorrectly classifies a floor special as a ceiling special.

This is technically backwards incompatible, as it is possible for clients and servers to disagree on the position of the floor.  However, in my testing between mismatched client and server, nothing crashes, there's just possibilities for mispredictions, and considering that the prior behavior was straight up broken I don't really consider said mispredictions a problem, so I think that it is safe to merge into `development`.

Considering that getting Valiant working without crashes requires a protobreak patch, here is a test WAD you can use to see the before/after behavior:
https://mega.nz/file/sFYwEKZL#qkY6Yd9rMrBkXFKLSQfizgXr11lPEY1usmHYTg1zWCw