### PR TITLE
Server controls ACS execution

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2446,7 +2446,7 @@ void CL_PlayerInfo(void)
 	p->armortype = MSG_ReadByte();
 
 	weapontype_t newweapon = static_cast<weapontype_t>(MSG_ReadByte());
-	if (newweapon >= NUMWEAPONS)	// bad weapon number, choose something else
+	if (newweapon > NUMWEAPONS)	// bad weapon number, choose something else
 		newweapon = wp_fist;
 
 	if (newweapon != p->readyweapon)
@@ -4247,12 +4247,10 @@ void CL_ACSExecuteSpecial()
 		break;
 
 	case DLevelScript::PCD_FADERANGE:
-		// TODO test
 		DLevelScript::ACS_FadeRange(activator, acsArgs, count);
 		break;
 
 	case DLevelScript::PCD_CANCELFADE:
-		// TODO test
 		DLevelScript::ACS_CancelFade(activator);
 		break;
 
@@ -4262,7 +4260,6 @@ void CL_ACSExecuteSpecial()
 		break;
 
 	case DLevelScript::PCD_SOUNDSEQUENCE:
-		// TODO test
 		DLevelScript::ACS_SoundSequence(acsArgs, count);
 		break;
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -4164,16 +4164,16 @@ void CL_ExecuteLineSpecial()
 	byte special = MSG_ReadByte();
 	short lineid = MSG_ReadShort();
 	AActor* activator = P_FindThingById(MSG_ReadShort());
+	byte arg0 = MSG_ReadByte();
 	byte arg1 = MSG_ReadByte();
 	byte arg2 = MSG_ReadByte();
 	byte arg3 = MSG_ReadByte();
 	byte arg4 = MSG_ReadByte();
-	byte arg5 = MSG_ReadByte();
 
 	if (lineid > numlines)
 		return;
 
-	LineSpecials[special](&lines[lineid], activator, arg1, arg2, arg3, arg4, arg5);
+	LineSpecials[special](&lines[lineid], activator, arg0, arg1, arg2, arg3, arg4);
 }
 
 void CL_ACSExecuteSpecial()

--- a/client/src/cl_main.h
+++ b/client/src/cl_main.h
@@ -58,6 +58,9 @@ void CL_MoveThing(AActor *mobj, fixed_t x, fixed_t y, fixed_t z);
 void CL_PredictWorld(void);
 void CL_SendUserInfo(void);
 bool CL_Connect(void);
+void CL_UpdatePlayerQueuePos();
+void CL_ExecuteLineSpecial();
+void CL_ACSExecuteSpecial();
 
 void CL_DisplayTics();
 void CL_RunTics();

--- a/client/src/cl_maplist.h
+++ b/client/src/cl_maplist.h
@@ -87,7 +87,6 @@ public:
 void CL_Maplist(void);
 void CL_MaplistIndex(void);
 void CL_MaplistUpdate(void);
-void CL_UpdatePlayerQueuePos();
 
 void Maplist_Runtic(void);
 

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -62,6 +62,9 @@ void CTF_SpawnFlag(flag_t f) {}
 bool SV_AwarenessUpdate(player_t &pl, AActor* mo) { return true; }
 void SV_SendPackets(void) {}
 void SV_SetWinPlayer(byte playerId) {}
+void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, int arg0 = -1, int arg1 = -1, int arg2 = -1, int arg3 = -1,
+	int arg4 = -1, int arg5 = -1, int arg6 = -1, int arg7 = -1, int arg8 = -1) {}
+void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg1, byte arg2, byte arg3, byte arg4, byte arg5) {}
 
 VERSION_CONTROL (cl_stubs_cpp, "$Id$")
 

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -62,9 +62,9 @@ void CTF_SpawnFlag(flag_t f) {}
 bool SV_AwarenessUpdate(player_t &pl, AActor* mo) { return true; }
 void SV_SendPackets(void) {}
 void SV_SetWinPlayer(byte playerId) {}
-void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, int arg0 = -1, int arg1 = -1, int arg2 = -1, int arg3 = -1,
+void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, bool playerOnly, int arg0 = -1, int arg1 = -1, int arg2 = -1, int arg3 = -1,
 	int arg4 = -1, int arg5 = -1, int arg6 = -1, int arg7 = -1, int arg8 = -1) {}
-void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg1, byte arg2, byte arg3, byte arg4, byte arg5) {}
+void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg0, byte arg1, byte arg2, byte arg3, byte arg4) {}
 
 VERSION_CONTROL (cl_stubs_cpp, "$Id$")
 

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -624,6 +624,44 @@ void MSG_WriteChunk (buf_t *b, const void *p, unsigned l)
 	b->WriteChunk((const char *)p, l);
 }
 
+int MSG_WriteVarInt(byte* buf, unsigned int value)
+{
+	int i = 0;
+
+	while (value >= 0x80)
+	{
+		buf[i] = value | 0x80;
+		value >>= 7;
+		i++;
+	}
+
+	buf[i] = value;
+	return i + 1;
+}
+
+int MSG_ReadVarInt(byte* buf, int bufLen, int& bytesRead)
+{
+	int x = 0;
+	int s = 0;
+
+	for (int i = 0; i < bufLen; i++)
+	{
+		if (buf[i] < 0x80)
+		{
+			if (i > 5 || i == 5 && buf[i] > 1)
+				return 0;
+
+			bytesRead += i + 1;
+			return x | buf[i] << s;
+		}
+
+		x |= (buf[i] & 0x7f) << s;
+		s += 7;
+	}
+
+	bytesRead = -1;
+	return 0;
+}
 
 void MSG_WriteShort (buf_t *b, short c)
 {

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -125,13 +125,13 @@ enum svc_t
 	svc_resetmap,			// [AM] Server is resetting the map
 	svc_playerqueuepos,     // Notify clients of player queue postion
 	svc_fullupdatestart,	// Inform client the full update has started
-
-	// for co-op
 	svc_mobjstate = 70,
 	svc_actor_movedir,
 	svc_actor_target,
 	svc_actor_tracer,
 	svc_damagemobj,
+	svc_executelinespecial,
+	svc_executeacsspecial,
 
 	// for downloading
 	svc_wadinfo,			// denis - [ulong:filesize]
@@ -557,6 +557,9 @@ void MSG_WriteFloat(buf_t *b, float);
 void MSG_WriteString (buf_t *b, const char *s);
 void MSG_WriteHexString(buf_t *b, const char *s);
 void MSG_WriteChunk (buf_t *b, const void *p, unsigned l);
+
+int MSG_WriteVarInt(byte* buf, unsigned int value);
+int MSG_ReadVarInt(byte* buf, int buflen, int& bytesRead);
 
 int MSG_BytesLeft(void);
 int MSG_NextByte (void);

--- a/common/p_acs.h
+++ b/common/p_acs.h
@@ -472,7 +472,7 @@ protected:
 	static void SetLineBlocking(int lineid, int flags);
 	static void SetLineMonsterBlocking(int lineid, int toggle);
 	static void SetLineSpecial(int lineid, int special, int arg1, int arg2, int arg3, int arg4, int arg5);
-	static void ActivateLineSpecial(byte special, line_t* line, AActor* activator, byte arg1, byte arg2, byte arg3, byte arg4, byte arg5);
+	static void ActivateLineSpecial(byte special, line_t* line, AActor* activator, byte arg0, byte arg1, byte arg2, byte arg3, byte arg4);
 	static void ChangeMusic(byte pcd, AActor* activator, int index, int loop);
 	static void StartSound(byte pcd, AActor* activator, int channel, int index, int volume, int attenuation);
 	static void StartSectorSound(byte pcd, sector_t* sector, int channel, int index, int volume, int attenuation);

--- a/common/p_acs.h
+++ b/common/p_acs.h
@@ -368,6 +368,21 @@ public:
 		PCODE_COMMAND_COUNT
 	};
 
+
+	static void ACS_SetLineTexture(int* args, byte argCount);
+	static void ACS_ClearInventory(AActor* actor);
+	static void ACS_Print(byte pcd, AActor* actor, const char* print);
+	static void ACS_ChangeMusic(byte pcd, AActor* activator, int* args, byte argCount);
+	static void ACS_StartSound(byte pcd, AActor* activator, int* args, byte argCount);
+	static void ACS_SetLineBlocking(int* args, byte argCount);
+	static void ACS_SetLineMonsterBlocking(int* args, byte argCount);
+	static void ACS_SetLineSpecial(int* args, byte argCount);
+	static void ACS_SetThingSpecial(int* args, byte argCount);
+	static void ACS_FadeRange(AActor* activator, int* args, byte argCount);
+	static void ACS_CancelFade(AActor* activator);
+	static void ACS_ChangeFlat(byte pcd, int* args, byte argCount);
+	static void ACS_SoundSequence(int* args, byte argCount);
+
 	// Some constants used by ACS scripts
 	enum {
 		LINE_FRONT =			0,
@@ -454,11 +469,20 @@ protected:
 	static void ChangeFlat (int tag, int name, bool floorOrCeiling);
 	static int CountPlayers ();
 	static void SetLineTexture (int lineid, int side, int position, int name);
-	// static int DoSpawn (int type, fixed_t x, fixed_t y, fixed_t z, int tid, int angle);
-	// static int DoSpawnSpot (int type, int spot, int tid, int angle);
+	static void SetLineBlocking(int lineid, int flags);
+	static void SetLineMonsterBlocking(int lineid, int toggle);
+	static void SetLineSpecial(int lineid, int special, int arg1, int arg2, int arg3, int arg4, int arg5);
+	static void ActivateLineSpecial(byte special, line_t* line, AActor* activator, byte arg1, byte arg2, byte arg3, byte arg4, byte arg5);
+	static void ChangeMusic(byte pcd, AActor* activator, int index, int loop);
+	static void StartSound(byte pcd, AActor* activator, int channel, int index, int volume, int attenuation);
+	static void StartSectorSound(byte pcd, sector_t* sector, int channel, int index, int volume, int attenuation);
+	static void StartThingSound(byte pcd, AActor* actor, int channel, int index, int volume, int attenuation);
+	static void SetThingSpecial(AActor* actor, int special, int arg1, int arg2, int arg3, int arg4, int arg5);
+	static void CancelFade(AActor* actor);
+	static void StartSoundSequence(sector_t* sec, int index);
 
-	void DoFadeTo (int r, int g, int b, int a, fixed_t time);
-	void DoFadeRange (int r1, int g1, int b1, int a1,
+	static void DoFadeTo (AActor* who, int r, int g, int b, int a, fixed_t time);
+	static void DoFadeRange (AActor* who, int r1, int g1, int b1, int a1,
 		int r2, int g2, int b2, int a2, fixed_t time);
 
 private:

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -1042,7 +1042,7 @@ FUNC(LS_Thing_SetGoal)
 FUNC(LS_ACS_Execute)
 // ACS_Execute (script, map, s_arg1, s_arg2, s_arg3)
 {
-	if (!serverside && s_SpecialFromServer)
+	if (!serverside)
 		return false;
 
 	level_info_t *info;
@@ -1056,7 +1056,7 @@ FUNC(LS_ACS_Execute)
 FUNC(LS_ACS_ExecuteAlways)
 // ACS_ExecuteAlways (script, map, s_arg1, s_arg2, s_arg3)
 {
-	if (!serverside && s_SpecialFromServer)
+	if (!serverside)
 		return false;
 
 	level_info_t *info;
@@ -1070,7 +1070,7 @@ FUNC(LS_ACS_ExecuteAlways)
 FUNC(LS_ACS_LockedExecute)
 // ACS_LockedExecute (script, map, s_arg1, s_arg2, lock)
 {
-	if (!serverside && s_SpecialFromServer)
+	if (!serverside)
 		return false;
 
 	if (arg4 && !P_CheckKeys (it->player, (card_t)arg4, 1))
@@ -1082,7 +1082,7 @@ FUNC(LS_ACS_LockedExecute)
 FUNC(LS_ACS_Suspend)
 // ACS_Suspend (script, map)
 {
-	if (!serverside && s_SpecialFromServer)
+	if (!serverside)
 		return false;
 
 	level_info_t *info;
@@ -1098,7 +1098,7 @@ FUNC(LS_ACS_Suspend)
 FUNC(LS_ACS_Terminate)
 // ACS_Terminate (script, map)
 {
-	if (!serverside && s_SpecialFromServer)
+	if (!serverside)
 		return false;
 
 	level_info_t *info;

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -90,7 +90,7 @@ std::list<movingsector_t>::iterator P_FindMovingSector(sector_t *sector)
 //
 void P_AddMovingCeiling(sector_t *sector)
 {
-	if (!sector)
+	if (!sector || consoleplayer().spectator)
 		return;
 
 	movingsector_t *movesec;
@@ -125,7 +125,7 @@ void P_AddMovingCeiling(sector_t *sector)
 //
 void P_AddMovingFloor(sector_t *sector)
 {
-	if (!sector)
+	if (!sector || consoleplayer().spectator)
 		return;
 
 	movingsector_t *movesec;

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -90,7 +90,7 @@ std::list<movingsector_t>::iterator P_FindMovingSector(sector_t *sector)
 //
 void P_AddMovingCeiling(sector_t *sector)
 {
-	if (!sector || consoleplayer().spectator)
+	if (!sector || (clientside && consoleplayer().spectator))
 		return;
 
 	movingsector_t *movesec;
@@ -125,7 +125,7 @@ void P_AddMovingCeiling(sector_t *sector)
 //
 void P_AddMovingFloor(sector_t *sector)
 {
-	if (!sector || consoleplayer().spectator)
+	if (!sector || (clientside && consoleplayer().spectator))
 		return;
 
 	movingsector_t *movesec;

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -5413,7 +5413,7 @@ void SV_ClearPlayerQueue()
 		SV_SendPlayerQueuePositions(&(*it), false);
 }
 
-void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg1, byte arg2, byte arg3, byte arg4, byte arg5)
+void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg0, byte arg1, byte arg2, byte arg3, byte arg4)
 {
 	for (Players::iterator it = players.begin(); it != players.end(); ++it)
 	{
@@ -5426,22 +5426,22 @@ void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, by
 		MSG_WriteByte(&cl->reliablebuf, special);
 		MSG_WriteShort(&cl->reliablebuf, lines - line);
 		MSG_WriteShort(&cl->reliablebuf, activator ? activator->netid : 0);
+		MSG_WriteByte(&cl->reliablebuf, arg0);
 		MSG_WriteByte(&cl->reliablebuf, arg1);
 		MSG_WriteByte(&cl->reliablebuf, arg2);
 		MSG_WriteByte(&cl->reliablebuf, arg3);
 		MSG_WriteByte(&cl->reliablebuf, arg4);
-		MSG_WriteByte(&cl->reliablebuf, arg5);
 	}
 }
 
-// If the activator is not null and a player then this activation will be sent to that player only.
-// Do not pass along the activating player if this message needs to be sent to all players.
-void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8)
+// If playerOnly is true and the activator is a player, then it will only be sent to the activating player
+void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, bool playerOnly,
+	int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8)
 {
 	int length = 0;
 	static byte argBuffer[64];
 	player_s* sendPlayer = NULL;
-	if (activator != NULL && activator->player != NULL)
+	if (playerOnly && activator != NULL && activator->player != NULL)
 		sendPlayer = activator->player;
 
 	if (arg0 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg0);

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1566,6 +1566,7 @@ void SV_SendGametic(client_t* cl)
 }
 
 short P_GetButtonTexture(line_t* line);
+
 //
 // SV_ClientFullUpdate
 //
@@ -1582,10 +1583,8 @@ void SV_ClientFullUpdate(player_t &pl)
 			SV_AwarenessUpdate(pl, it->mo);
 
 		SV_SendUserInfo(*it, cl);
-
-		if (cl->reliablebuf.cursize >= 600)
-			if (!SV_SendPacket(pl))
-				return;
+		if (cl->reliablebuf.cursize >= MaxPacketSize && !SV_SendPacket(pl))
+			return;
 	}
 
 	// update warmup state
@@ -1626,31 +1625,13 @@ void SV_ClientFullUpdate(player_t &pl)
 	if (sv_gametype == GM_CTF)
 		CTF_Connect(pl);
 
-	// update sectors
 	SV_UpdateSectors(cl);
-	if (cl->reliablebuf.cursize >= 600)
-		if(!SV_SendPacket(pl))
-			return;
+	if (cl->reliablebuf.cursize >= MaxPacketSize && !SV_SendPacket(pl))
+		return;
 
-	// update switches
-#if 0
-	for (int l=0; l<numlines; l++)
-	{
-		unsigned state = 0, time = 0;
-		if(P_GetButtonInfo(&lines[l], state, time) || lines[l].wastoggled)
-		{
-			MSG_WriteMarker(&cl->reliablebuf, svc_switch);
-			MSG_WriteLong(&cl->reliablebuf, l);
-			MSG_WriteByte(&cl->reliablebuf, lines[l].switchactive);
-			MSG_WriteByte(&cl->reliablebuf, lines[l].special);
-			MSG_WriteByte(&cl->reliablebuf, state);
-			MSG_WriteShort(&cl->reliablebuf, P_GetButtonTexture(&lines[l]));
-			MSG_WriteLong(&cl->reliablebuf, time);
-		}
-	}
-#else
 	P_UpdateButtons(cl);
-#endif
+	if (cl->reliablebuf.cursize >= MaxPacketSize && !SV_SendPacket(pl))
+		return;
 
 	MSG_WriteMarker(&cl->reliablebuf, svc_fullupdatedone);
 
@@ -5424,6 +5405,61 @@ void SV_ClearPlayerQueue()
 
 	for (Players::iterator it = players.begin(); it != players.end(); ++it)
 		SV_SendPlayerQueuePositions(&(*it), false);
+}
+
+void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg1, byte arg2, byte arg3, byte arg4, byte arg5)
+{
+	for (Players::iterator it = players.begin(); it != players.end(); ++it)
+	{
+		if (!(it->ingame()))
+			continue;
+
+		client_t* cl = &it->client;
+
+		MSG_WriteMarker(&cl->reliablebuf, svc_executelinespecial);
+		MSG_WriteByte(&cl->reliablebuf, special);
+		MSG_WriteShort(&cl->reliablebuf, lines - line);
+		MSG_WriteShort(&cl->reliablebuf, activator ? activator->netid : 0);
+		MSG_WriteByte(&cl->reliablebuf, arg1);
+		MSG_WriteByte(&cl->reliablebuf, arg2);
+		MSG_WriteByte(&cl->reliablebuf, arg3);
+		MSG_WriteByte(&cl->reliablebuf, arg4);
+		MSG_WriteByte(&cl->reliablebuf, arg5);
+	}
+}
+
+void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8)
+{
+	int length = 0;
+	static byte argBuffer[64];
+
+	if (arg0 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg0);
+	if (arg1 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg1);
+	if (arg2 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg2);
+	if (arg3 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg3);
+	if (arg4 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg4);
+	if (arg5 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg5);
+	if (arg6 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg6);
+	if (arg7 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg7);
+	if (arg8 != -1)	length += MSG_WriteVarInt(argBuffer + length, arg8);
+
+	for (Players::iterator it = players.begin(); it != players.end(); ++it)
+	{
+		if (!(it->ingame()))
+			continue;
+
+		client_t* cl = &it->client;
+
+		MSG_WriteMarker(&cl->reliablebuf, svc_executeacsspecial);
+		MSG_WriteByte(&cl->reliablebuf, special);
+		MSG_WriteShort(&cl->reliablebuf, activator ? activator->netid : 0);
+		MSG_WriteByte(&cl->reliablebuf, length);
+		MSG_WriteChunk(&cl->reliablebuf, argBuffer, length);
+		if (print)
+			MSG_WriteString(&cl->reliablebuf, print);
+		else
+			MSG_WriteString(&cl->reliablebuf, "");
+	}
 }
 
 VERSION_CONTROL (sv_main_cpp, "$Id$")

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -35,6 +35,8 @@
 #define GAME_TEAMPLAY	2
 #define GAME_CTF		3
 
+static const int MaxPacketSize = 600;
+
 #include <json/json.h>
 
 extern int shotclock;
@@ -127,6 +129,10 @@ void SV_SendPlayerQueuePositions(player_t* dest, bool initConnect);
 void SV_SendPlayerQueuePosition(player_t* source, player_t* dest);
 void SV_SetWinPlayer(byte playerId);
 void SV_ClearPlayerQueue();
+
+void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg1, byte arg2, byte arg3, byte arg4, byte arg5);
+void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, int arg0 = -1, int arg1 = -1, int arg2 = -1, int arg3 = -1,
+	int arg4 = -1, int arg5 = -1, int arg6 = -1, int arg7 = -1, int arg8 = -1);
 
 bool CompareQueuePosition(const player_t* p1, const player_t* p2);
 

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -130,8 +130,8 @@ void SV_SendPlayerQueuePosition(player_t* source, player_t* dest);
 void SV_SetWinPlayer(byte playerId);
 void SV_ClearPlayerQueue();
 
-void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg1, byte arg2, byte arg3, byte arg4, byte arg5);
-void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, int arg0 = -1, int arg1 = -1, int arg2 = -1, int arg3 = -1,
+void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg0, byte arg1, byte arg2, byte arg3, byte arg4);
+void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, bool playerOnly, int arg0 = -1, int arg1 = -1, int arg2 = -1, int arg3 = -1,
 	int arg4 = -1, int arg5 = -1, int arg6 = -1, int arg7 = -1, int arg8 = -1);
 
 bool CompareQueuePosition(const player_t* p1, const player_t* p2);

--- a/server/src/sv_rproto.cpp
+++ b/server/src/sv_rproto.cpp
@@ -280,7 +280,7 @@ void SV_AcknowledgePacket(player_t &player)
 				return;
 			}
 
-			if (cl->reliablebuf.cursize > 600)
+			if (cl->reliablebuf.cursize > MaxPacketSize)
 				SV_SendPacket(player);
 
 		}


### PR DESCRIPTION
The server now controls all ACS execution and sends commands to client(s) via svc_executelinespecial and svc_executeacsspecial.

svc_executeacsspecial is expandable and allows for a variable number of int parameters and an optional string for printing functions. The variable int parameters are packed to take up the least amount of bytes (e.g an integer value of 64 will only take one byte).

This also includes some minor fixes for ACS functions found along the way for inventory functions and DPlaneWatcher.