### PR TITLE
Fix ASAN DeHackEd crash on UDMX

### DIFF
--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -1574,6 +1574,11 @@ donewithtext:
 	if (oldStr)
 		delete[] oldStr;
 
+	// Ensure that we've munched the entire line in the case of an incomplete
+	// substitution.
+	if (!(*PatchPt == '\0' || *PatchPt == '\n'))
+		igets();
+
 	// Fetch next identifier for main loop
 	while ((result = GetLine ()) == 1)
 		;
@@ -1834,4 +1839,3 @@ bool DoDehPatch (const char *patchfile, BOOL autoloading)
 }
 
 VERSION_CONTROL (d_dehacked_cpp, "$Id$")
-


### PR DESCRIPTION
One of the text substitutions asserted fewer characters than were actually there, which led to GetLine() bombing out because it tried to make sense of the end of the string substitution.

I solved the immediate problem by using `igets()` to munch the rest of the line safely.  However, GetLine really should be fixed-up to do bounds-checking and lay off some of the migraine-inducing post-increment stunts it does like`*line++ = 0;`.  I'd do it, but I'd rather wait until the `MAPINFO` and `LANGUAGE` improvements are in `development`, since there are some unfortunate interactions that happen between DeHackEd and `LANGUAGE` that makes debugging text substitutions difficult right now.