### PR TITLE
Sync map state

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -3267,32 +3267,34 @@ void ActivateLine(AActor* mo, line_s* line, byte side, LineActivationType activa
 	if (line && P_LineSpecialMovesSector(line->special))
 		return;
 
+	s_SpecialFromServer = true;
+
 	switch (activationType)
 	{
 	case LineCross:
 		if (line)
-			P_CrossSpecialLine(line - lines, side, mo, true);
+			P_CrossSpecialLine(line - lines, side, mo);
 		break;
 	case LineUse:
 		if (line)
-			P_UseSpecialLine(mo, line, side, true);
+			P_UseSpecialLine(mo, line, side);
 		break;
 	case LineShoot:
 		if (line)
-			P_ShootSpecialLine(mo, line, true);
+			P_ShootSpecialLine(mo, line);
 		break;
 	case LinePush:
 		if (line)
-			P_PushSpecialLine(mo, line, side, true);
+			P_PushSpecialLine(mo, line, side);
 		break;
 	case LineACS:
-		s_SpecialFromServer = true;
 		LineSpecials[special](line, mo, arg0, arg1, arg2, arg3, arg4);
-		s_SpecialFromServer = false;
 		break;
 	default:
 		break;
 	}
+
+	s_SpecialFromServer = false;
 }
 
 void CL_ActivateLine(void)

--- a/client/src/cl_main.h
+++ b/client/src/cl_main.h
@@ -61,6 +61,10 @@ bool CL_Connect(void);
 void CL_UpdatePlayerQueuePos();
 void CL_ExecuteLineSpecial();
 void CL_ACSExecuteSpecial();
+void CL_LineUpdate();
+void CL_LineSideUpdate();
+void CL_SectorSectorPropertiesUpdate();
+void CL_ThinkerUpdate();
 
 void CL_DisplayTics();
 void CL_RunTics();

--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -758,11 +758,13 @@ BOOL R_AlignFlat (int linenum, int side, int fc)
 	{
 		sec->base_ceiling_angle = 0-angle;
 		sec->base_ceiling_yoffs = dist & ((1<<(FRACBITS+8))-1);
+		sec->SectorChanges |= SPC_AlignBase;
 	}
 	else
 	{
 		sec->base_floor_angle = 0-angle;
 		sec->base_floor_yoffs = dist & ((1<<(FRACBITS+8))-1);
+		sec->SectorChanges |= SPC_AlignBase;
 	}
 
 	return true;

--- a/common/dsectoreffect.h
+++ b/common/dsectoreffect.h
@@ -49,6 +49,7 @@ public:
 	~DSectorEffect ();
 	virtual DSectorEffect* Clone(sector_t *sector) const;
 	virtual void Destroy();
+	sector_t* GetSector() const { return m_Sector; }
 protected:
 	DSectorEffect ();
 	sector_t	*m_Sector;

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -125,13 +125,18 @@ enum svc_t
 	svc_resetmap,			// [AM] Server is resetting the map
 	svc_playerqueuepos,     // Notify clients of player queue postion
 	svc_fullupdatestart,	// Inform client the full update has started
-	svc_mobjstate = 70,
+	svc_lineupdate,			// Sync client with any line property changes - e.g. SetLineTexture, SetLineBlocking, SetLineSpecial, etc.
+	svc_sectorproperties,
+	svc_linesideupdate,
+	svc_mobjstate,
 	svc_actor_movedir,
 	svc_actor_target,
 	svc_actor_tracer,
 	svc_damagemobj,
 	svc_executelinespecial,
 	svc_executeacsspecial,
+	svc_actorspecialupdate,
+	svc_thinkerupdate,
 
 	// for downloading
 	svc_wadinfo,			// denis - [ulong:filesize]
@@ -154,6 +159,18 @@ enum svc_t
 	svc_launcher_challenge = 212,
 	svc_challenge = 163,
 	svc_max = 255
+};
+
+enum ThinkerType
+{
+	TT_Scroller,
+	TT_FireFlicker,
+	TT_Flicker,
+	TT_LightFlash,
+	TT_Strobe,
+	TT_Glow,
+	TT_Glow2,
+	TT_Phased,
 };
 
 // network messages

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -135,7 +135,6 @@ enum svc_t
 	svc_damagemobj,
 	svc_executelinespecial,
 	svc_executeacsspecial,
-	svc_actorspecialupdate,
 	svc_thinkerupdate,
 
 	// for downloading

--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -1591,14 +1591,17 @@ void DLevelScript::SetLineBlocking(int lineid, int flags)
 		{
 		case BLOCK_NOTHING:
 			lines[line].flags &= ~(ML_BLOCKING | ML_BLOCKEVERYTHING);
+			lines[line].PropertiesChanged = true;
 			break;
 		case BLOCK_CREATURES:
 		default:
 			lines[line].flags &= ~ML_BLOCKEVERYTHING;
 			lines[line].flags |= ML_BLOCKING;
+			lines[line].PropertiesChanged = true;
 			break;
 		case BLOCK_EVERYTHING:
 			lines[line].flags |= ML_BLOCKING | ML_BLOCKEVERYTHING;
+			lines[line].PropertiesChanged = true;
 			break;
 		}
 	}
@@ -1641,7 +1644,6 @@ void DLevelScript::SetLineSpecial(int lineid, int special, int arg1, int arg2, i
 		line->args[2] = arg3;
 		line->args[3] = arg4;
 		line->args[4] = arg5;
-		line->PropertiesChanged = true;
 	}
 
 	if (serverside)
@@ -2697,10 +2699,7 @@ void DLevelScript::RunScript ()
 
 		case PCD_CLEARLINESPECIAL:
 			if (activationline)
-			{
 				activationline->special = 0;
-				activationline->PropertiesChanged = true;
-			}
 			break;
 
 		case PCD_CASEGOTO:

--- a/common/p_lights.cpp
+++ b/common/p_lights.cpp
@@ -158,6 +158,9 @@ DFlicker::DFlicker (sector_t *sector, int upper, int lower)
 
 void EV_StartLightFlickering (int tag, int upper, int lower)
 {
+	if (IgnoreSpecial)
+		return;
+
 	int secnum;
 		
 	secnum = -1;
@@ -312,6 +315,9 @@ DStrobe::DStrobe (sector_t *sector, int utics, int ltics, bool inSync)
 //
 void EV_StartLightStrobing (int tag, int upper, int lower, int utics, int ltics)
 {
+	if (IgnoreSpecial)
+		return;
+
 	int secnum;
 		
 	secnum = -1;
@@ -327,6 +333,9 @@ void EV_StartLightStrobing (int tag, int upper, int lower, int utics, int ltics)
 
 void EV_StartLightStrobing (int tag, int utics, int ltics)
 {
+	if (IgnoreSpecial)
+		return;
+
 	int secnum;
 		
 	secnum = -1;
@@ -365,6 +374,7 @@ void EV_TurnTagLightsOff (int tag)
 				min = tsec->lightlevel;
 		}
 		sector->lightlevel = min;
+		sector->SectorChanges |= SPC_LightLevel;
 	}
 }
 
@@ -402,6 +412,7 @@ void EV_LightTurnOn (int tag, int bright)
 			}
 		}
 		sector->lightlevel = CLIPLIGHT(bright);
+		sector->SectorChanges |= SPC_LightLevel;
 	}
 }
 
@@ -456,6 +467,7 @@ int EV_LightTurnOnPartway(int tag, int level)
         // Set level in-between extremes
         sector->lightlevel =
             (level * bright + (FRACUNIT-level) * min) >> FRACBITS;
+		sector->SectorChanges |= SPC_LightLevel;
     }
     return 1;
 }
@@ -473,6 +485,7 @@ void EV_LightChange (int tag, int value)
 	while ((secnum = P_FindSectorFromTag (tag, secnum)) >= 0) {
 		int newlight = sectors[secnum].lightlevel + value;
 		sectors[secnum].lightlevel = CLIPLIGHT(newlight);
+		sectors[secnum].SectorChanges |= SPC_LightLevel;
 	}
 }
 
@@ -583,6 +596,9 @@ DGlow2::DGlow2 (sector_t *sector, int start, int end, int tics, bool oneshot)
 
 void EV_StartLightGlowing (int tag, int upper, int lower, int tics)
 {
+	if (IgnoreSpecial)
+		return;
+
 	int secnum;
 
 	if (upper < lower) {
@@ -597,13 +613,15 @@ void EV_StartLightGlowing (int tag, int upper, int lower, int tics)
 		sector_t *sec = &sectors[secnum];
 		if (sec->lightingdata)
 			continue;
-		
 		new DGlow2 (sec, upper, lower, tics, false);
 	}
 }
 
 void EV_StartLightFading (int tag, int value, int tics)
 {
+	if (IgnoreSpecial)
+		return;
+
 	int secnum;
 		
 	secnum = -1;

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -60,11 +60,8 @@ BOOL EV_RotatePoly (line_t *line, int polyNum, int speed, int byteAngle, int dir
 // Returns true if the special for line will cause a DMovingFloor or
 // DMovingCeiling object to be created.
 //
-bool P_LineSpecialMovesSector(line_t *line)
+bool P_LineSpecialMovesSector(byte special)
 {
-	if (!line)
-		return false;
-
 	static bool initialized = false;
 	static bool specials[256];
 
@@ -150,7 +147,7 @@ bool P_LineSpecialMovesSector(line_t *line)
 		specials[Ceiling_CrushRaiseAndStaySilA]	= true;		// 255
 	}
 
-	return specials[line->special];
+	return specials[special];
 }
 
 EXTERN_CVAR (cl_predictsectors)
@@ -171,7 +168,7 @@ bool P_CanActivateSpecials(AActor* mo, line_t* line)
 	}
 
 	// Predict sectors that don't actually create floor or ceiling thinkers.
-	if (!P_LineSpecialMovesSector(line))
+	if (line && !P_LineSpecialMovesSector(line->special))
 		return true;
 
 	return false;
@@ -1748,13 +1745,14 @@ FUNC(LS_SetPlayerProperty)
 FUNC(LS_TranslucentLine)
 // TranslucentLine (id, amount)
 {
-	if (ln)
+	if (IgnoreSpecial)
 		return false;
 
 	int linenum = -1;
 	while ((linenum = P_FindLineFromID (arg0, linenum)) >= 0)
 	{
 		lines[linenum].lucency = arg1 & 255;
+		lines[linenum].PropertiesChanged = true;
 	}
 
 	return true;

--- a/common/p_lnspec.h
+++ b/common/p_lnspec.h
@@ -345,7 +345,7 @@ BOOL EV_CeilingCrushStop (int tag);
 int EV_DoDonut (int tag, fixed_t pillarspeed, fixed_t slimespeed);
 void EV_StopPlat (int tag);
 
-bool P_LineSpecialMovesSector(line_t *line);
+bool P_LineSpecialMovesSector(byte special);
 bool P_CanActivateSpecials(AActor* mo, line_t* line);
 
 extern int TeleportSide;

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1884,67 +1884,91 @@ void P_SpawnSpecials (void)
 
 		case dLight_Flicker:
 			// FLICKERING LIGHTS
+			if (IgnoreSpecial)
+				break;
 			new DLightFlash (sector);
 			sector->special &= 0xff00;
 			break;
 
 		case dLight_StrobeFast:
 			// STROBE FAST
+			if (IgnoreSpecial)
+				break;
 			new DStrobe (sector, STROBEBRIGHT, FASTDARK, false);
 			sector->special &= 0xff00;
 			break;
 
 		case dLight_StrobeSlow:
 			// STROBE SLOW
+			if (IgnoreSpecial)
+				break;
 			new DStrobe (sector, STROBEBRIGHT, SLOWDARK, false);
 			sector->special &= 0xff00;
 			break;
 
 		case dLight_Strobe_Hurt:
 			// STROBE FAST/DEATH SLIME
+			if (IgnoreSpecial)
+				break;
 			new DStrobe (sector, STROBEBRIGHT, FASTDARK, false);
 			break;
 
 		case dLight_Glow:
 			// GLOWING LIGHT
+			if (IgnoreSpecial)
+				break;
 			new DGlow (sector);
 			sector->special &= 0xff00;
 			break;
 
 		case dSector_DoorCloseIn30:
+			if (!serverside)
+				break;
 			// DOOR CLOSE IN 30 SECONDS
 			P_SpawnDoorCloseIn30 (sector);
 			break;
 
 		case dLight_StrobeSlowSync:
 			// SYNC STROBE SLOW
+			if (IgnoreSpecial)
+				break;
 			new DStrobe (sector, STROBEBRIGHT, SLOWDARK, true);
 			sector->special &= 0xff00;
 			break;
 
 		case dLight_StrobeFastSync:
 			// SYNC STROBE FAST
+			if (IgnoreSpecial)
+				break;
 			new DStrobe (sector, STROBEBRIGHT, FASTDARK, true);
 			sector->special &= 0xff00;
 			break;
 
 		case dSector_DoorRaiseIn5Mins:
+			if (!serverside)
+				break;
 			// DOOR RAISE IN 5 MINUTES
 			P_SpawnDoorRaiseIn5Mins (sector);
 			break;
 
 		case dLight_FireFlicker:
 			// fire flickering
+			if (IgnoreSpecial)
+				break;
 			new DFireFlicker (sector);
 			sector->special &= 0xff00;
 			break;
 
 		  // [RH] Hexen-like phased lighting
 		case LightSequenceStart:
+			if (IgnoreSpecial)
+				break;
 			new DPhased (sector);
 			break;
 
 		case Light_Phased:
+			if (IgnoreSpecial)
+				break;
 			new DPhased (sector, 48, 63 - (sector->lightlevel & 63));
 			break;
 
@@ -1953,6 +1977,8 @@ void P_SpawnSpecials (void)
 			break;
 
 		default:
+			if (IgnoreSpecial)
+				break;
 			// [RH] Try for normal Hexen scroller
 			if ((sector->special & 0xff) >= Scroll_North_Slow &&
 				(sector->special & 0xff) <= Scroll_SouthWest_Fast)
@@ -2063,6 +2089,8 @@ void P_SpawnSpecials (void)
 			{
 			case Init_Gravity:
 				{
+				if (IgnoreSpecial)
+					break;
 				float grav = ((float)P_AproxDistance (lines[i].dx, lines[i].dy)) / (FRACUNIT * 100.0f);
 				for (s = -1; (s = P_FindSectorFromTag(lines[i].args[0],s)) >= 0;)
 					sectors[s].gravity = grav;
@@ -2074,6 +2102,9 @@ void P_SpawnSpecials (void)
 
 			case Init_Damage:
 				{
+					if (IgnoreSpecial)
+						break;
+
 					int damage = P_AproxDistance (lines[i].dx, lines[i].dy) >> FRACBITS;
 					for (s = -1; (s = P_FindSectorFromTag(lines[i].args[0],s)) >= 0;)
 					{
@@ -2331,11 +2362,17 @@ static void P_SpawnScrollers(void)
 			register int s;
 
 			case Scroll_Ceiling:
+				if (IgnoreSpecial)
+					break;
+
 				for (s=-1; (s = P_FindSectorFromTag (l->args[0],s)) >= 0;)
 					new DScroller (DScroller::sc_ceiling, -dx, dy, control, s, accel);
 				break;
 
 			case Scroll_Floor:
+				if (IgnoreSpecial)
+					break;
+
 				if (l->args[2] != 1)
 					// scroll the floor
 					for (s=-1; (s = P_FindSectorFromTag (l->args[0],s)) >= 0;)
@@ -2353,12 +2390,18 @@ static void P_SpawnScrollers(void)
 			// killough 3/1/98: scroll wall according to linedef
 			// (same direction and speed as scrolling floors)
 			case Scroll_Texture_Model:
+				if (IgnoreSpecial)
+					break;
+
 				for (s=-1; (s = P_FindLineFromID (l->args[0],s)) >= 0;)
 					if (s != i)
 						new DScroller (dx, dy, lines+s, control, accel);
 				break;
 
 			case Scroll_Texture_Offsets:
+				if (IgnoreSpecial)
+					break;
+
 				// killough 3/2/98: scroll according to sidedef offsets
 				s = lines[i].sidenum[0];
 				new DScroller (DScroller::sc_side, -sides[s].textureoffset,
@@ -2366,26 +2409,41 @@ static void P_SpawnScrollers(void)
 				break;
 
 			case Scroll_Texture_Left:
+				if (IgnoreSpecial)
+					break;
+
 				new DScroller (DScroller::sc_side, l->args[0] * (FRACUNIT/64), 0,
 							   -1, lines[i].sidenum[0], accel);
 				break;
 
 			case Scroll_Texture_Right:
+				if (IgnoreSpecial)
+					break;
+
 				new DScroller (DScroller::sc_side, l->args[0] * (-FRACUNIT/64), 0,
 							   -1, lines[i].sidenum[0], accel);
 				break;
 
 			case Scroll_Texture_Up:
+				if (IgnoreSpecial)
+					break;
+
 				new DScroller (DScroller::sc_side, 0, l->args[0] * (FRACUNIT/64),
 							   -1, lines[i].sidenum[0], accel);
 				break;
 
 			case Scroll_Texture_Down:
+				if (IgnoreSpecial)
+					break;
+
 				new DScroller (DScroller::sc_side, 0, l->args[0] * (-FRACUNIT/64),
 							   -1, lines[i].sidenum[0], accel);
 				break;
 
 			case Scroll_Texture_Both:
+				if (IgnoreSpecial)
+					break;
+
 				if (l->args[0] == 0) {
 					dx = (l->args[1] - l->args[2]) * (FRACUNIT/64);
 					dy = (l->args[4] - l->args[3]) * (FRACUNIT/64);

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1280,7 +1280,7 @@ BOOL P_CheckKeys (player_t *p, card_t lock, BOOL remote)
 }
 
 void OnChangedSwitchTexture (line_t *line, int useAgain);
-void OnActivatedLine (line_t *line, AActor *mo, int side, int activationType);
+void OnActivatedLine (line_t *line, AActor *mo, int side, LineActivationType activationType);
 
 //
 // EVENTS
@@ -1421,7 +1421,7 @@ P_CrossSpecialLine
 
 	P_HandleSpecialRepeat(line);
 
-	OnActivatedLine(line, thing, side, 0);
+	OnActivatedLine(line, thing, side, LineCross);
 
 	s_SpecialFromServer = false;
 }
@@ -1461,7 +1461,7 @@ P_ShootSpecialLine
 
 	P_HandleSpecialRepeat(line);
 
-	OnActivatedLine(line, thing, 0, 2);
+	OnActivatedLine(line, thing, 0, LineShoot);
 
 	if(serverside)
 	{
@@ -1542,7 +1542,7 @@ P_UseSpecialLine
 	{
 		P_HandleSpecialRepeat(line);
 
-		OnActivatedLine(line, thing, side, 1);
+		OnActivatedLine(line, thing, side, LineUse);
 
 		if(serverside && GET_SPAC(line->flags) != SPAC_PUSH)
 		{
@@ -1612,7 +1612,7 @@ P_PushSpecialLine
 	{
 		P_HandleSpecialRepeat(line);
 
-		OnActivatedLine(line, thing, side, 3);
+		OnActivatedLine(line, thing, side, LinePush);
 
 		if(serverside)
 		{

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -66,7 +66,7 @@ EXTERN_CVAR(sv_allowexit)
 EXTERN_CVAR(sv_fragexitswitch)
 
 std::list<movingsector_t> movingsectors;
-bool s_SpecialFromServer = false;
+bool s_SpecialFromServer;
 
 //
 // P_FindMovingSector
@@ -1314,12 +1314,7 @@ void P_HandleSpecialRepeat(line_t* line)
 // Called every time a thing origin is about
 //  to cross a line with a non 0 special.
 //
-void
-P_CrossSpecialLine
-( int		linenum,
-  int		side,
-  AActor*	thing,
-  bool      FromServer)
+void P_CrossSpecialLine(int	linenum, int side, AActor*	thing)
 {
     line_t*	line = &lines[linenum];
 
@@ -1413,8 +1408,6 @@ P_CrossSpecialLine
 
 	TeleportSide = side;
 
-	s_SpecialFromServer = FromServer;
-
 	LineSpecials[line->special] (line, thing, line->args[0],
 					line->args[1], line->args[2],
 					line->args[3], line->args[4]);
@@ -1422,19 +1415,13 @@ P_CrossSpecialLine
 	P_HandleSpecialRepeat(line);
 
 	OnActivatedLine(line, thing, side, LineCross);
-
-	s_SpecialFromServer = false;
 }
 
 //
 // P_ShootSpecialLine - IMPACT SPECIALS
 // Called when a thing shoots a special line.
 //
-void
-P_ShootSpecialLine
-( AActor*	thing,
-  line_t*	line,
-  bool      FromServer)
+void P_ShootSpecialLine(AActor*	thing, line_t* line)
 {
 	if (!P_CanActivateSpecials(thing, line))
 		return;
@@ -1451,8 +1438,6 @@ P_ShootSpecialLine
 			return;
 	}
 
-	s_SpecialFromServer = FromServer;
-
 	//TeleportSide = side;
 
 	LineSpecials[line->special] (line, thing, line->args[0],
@@ -1468,8 +1453,6 @@ P_ShootSpecialLine
 		P_ChangeSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL, true);
 		OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
 	}
-
-	s_SpecialFromServer = false;
 }
 
 
@@ -1478,12 +1461,7 @@ P_ShootSpecialLine
 // Called when a thing uses a special line.
 // Only the front sides of lines are usable.
 //
-bool
-P_UseSpecialLine
-( AActor*	thing,
-  line_t*	line,
-  int		side,
-  bool      FromServer)
+bool P_UseSpecialLine(AActor* thing, line_t* line, int side)
 {
 	if (!P_CanActivateSpecials(thing, line))
 		return false;
@@ -1532,8 +1510,6 @@ P_UseSpecialLine
 		}
 	}
 
-	s_SpecialFromServer = FromServer;
-
     TeleportSide = side;
 
 	if(LineSpecials[line->special] (line, thing, line->args[0],
@@ -1551,8 +1527,6 @@ P_UseSpecialLine
 		}
 	}
 
-	s_SpecialFromServer = false;
-
     return true;
 }
 
@@ -1562,12 +1536,7 @@ P_UseSpecialLine
 // Called when a thing pushes a special line, only in advanced map format
 // Only the front sides of lines are pushable.
 //
-bool
-P_PushSpecialLine
-( AActor*	thing,
-  line_t*	line,
-  int		side,
-  bool      FromServer)
+bool P_PushSpecialLine(AActor* thing, line_t* line, int side)
 {
 	if (!P_CanActivateSpecials(thing, line))
 		return false;
@@ -1604,8 +1573,6 @@ P_PushSpecialLine
 
     TeleportSide = side;
 
-	s_SpecialFromServer = FromServer;
-
 	if(LineSpecials[line->special] (line, thing, line->args[0],
 					line->args[1], line->args[2],
 					line->args[3], line->args[4]))
@@ -1620,8 +1587,6 @@ P_PushSpecialLine
 			OnChangedSwitchTexture (line, line->flags & ML_REPEAT_SPECIAL);
 		}
 	}
-
-	s_SpecialFromServer = false;
 
     return true;
 }

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -64,6 +64,15 @@ typedef enum
 	lighting_special
 } special_e;
 
+enum LineActivationType
+{
+	LineCross,
+	LineUse,
+	LineShoot,
+	LinePush,
+	LineACS,
+};
+
 // killough 3/7/98: Add generalized scroll effects
 
 class DScroller : public DThinker

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -43,6 +43,9 @@ typedef struct movingsector_s
 } movingsector_t;
 
 extern std::list<movingsector_t> movingsectors;
+extern bool s_SpecialFromServer;
+
+#define IgnoreSpecial !serverside && !s_SpecialFromServer
 
 std::list<movingsector_t>::iterator P_FindMovingSector(sector_t *sector);
 void P_AddMovingCeiling(sector_t *sector);
@@ -87,6 +90,10 @@ public:
 	void SetRate (fixed_t dx, fixed_t dy) { m_dx = dx; m_dy = dy; }
 	bool IsType(EScrollType type) const { return type == m_Type; }
 	int GetAffectee() const { return m_Affectee; }
+
+	EScrollType GetType() const { return m_Type; }
+	fixed_t GetScrollX() const { return m_dx; }
+	fixed_t GetScrollY() const { return m_dy; }
 
 protected:
 	EScrollType m_Type;		// Type of scroll effect
@@ -290,6 +297,8 @@ public:
 	DFireFlicker (sector_t *sector);
 	DFireFlicker (sector_t *sector, int upper, int lower);
 	void		RunThink ();
+	int GetMaxLight() const { return m_MaxLight; }
+	int GetMinLight() const { return m_MinLight; }
 protected:
 	int 		m_Count;
 	int 		m_MaxLight;
@@ -304,6 +313,8 @@ class DFlicker : public DLighting
 public:
 	DFlicker (sector_t *sector, int upper, int lower);
 	void		RunThink ();
+	int GetMaxLight() const { return m_MaxLight; }
+	int GetMinLight() const { return m_MinLight; }
 protected:
 	int 		m_Count;
 	int 		m_MaxLight;
@@ -319,6 +330,8 @@ public:
 	DLightFlash (sector_t *sector);
 	DLightFlash (sector_t *sector, int min, int max);
 	void		RunThink ();
+	int GetMaxLight() const { return m_MaxLight; }
+	int GetMinLight() const { return m_MinLight; }
 protected:
 	int 		m_Count;
 	int 		m_MaxLight;
@@ -336,6 +349,12 @@ public:
 	DStrobe (sector_t *sector, int utics, int ltics, bool inSync);
 	DStrobe (sector_t *sector, int upper, int lower, int utics, int ltics);
 	void		RunThink ();
+	int GetMaxLight() const { return m_MaxLight; }
+	int GetMinLight() const { return m_MinLight; }
+	int GetDarkTime() const { return m_DarkTime; }
+	int GetBrightTime() const { return m_BrightTime; }
+	int GetCount() const { return m_Count; }
+	void SetCount(int count) { m_Count = count; }
 protected:
 	int 		m_Count;
 	int 		m_MinLight;
@@ -367,6 +386,10 @@ class DGlow2 : public DLighting
 public:
 	DGlow2 (sector_t *sector, int start, int end, int tics, bool oneshot);
 	void		RunThink ();
+	int GetStart() const { return m_Start; }
+	int GetEnd() const { return m_End; }
+	int GetMaxTics() const { return m_MaxTics; }
+	bool GetOneShot() const { return m_OneShot; }
 protected:
 	int			m_Start;
 	int			m_End;
@@ -385,6 +408,8 @@ public:
 	DPhased (sector_t *sector);
 	DPhased (sector_t *sector, int baselevel, int phase);
 	void		RunThink ();
+	byte GetBaseLevel() const { return m_BaseLevel; }
+	byte GetPhase() const { return m_Phase; }
 protected:
 	byte		m_BaseLevel;
 	byte		m_Phase;

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -203,10 +203,10 @@ void	P_SpawnSpecials (void);
 void	P_UpdateSpecials (void);
 
 // when needed
-void    P_CrossSpecialLine (int linenum, int side, AActor*	thing, bool FromServer = false);
-void    P_ShootSpecialLine (AActor* thing, line_t*	line, bool FromServer = false);
-bool    P_UseSpecialLine (AActor* thing, line_t* line, int	side, bool FromServer = false);
-bool    P_PushSpecialLine (AActor* thing, line_t* line, int	side, bool FromServer = false);
+void    P_CrossSpecialLine (int linenum, int side, AActor* thing);
+void    P_ShootSpecialLine (AActor* thing, line_t* line);
+bool    P_UseSpecialLine (AActor* thing, line_t* line, int side);
+bool    P_PushSpecialLine (AActor* thing, line_t* line, int	side);
 
 void    P_PlayerInSpecialSector (player_t *player);
 

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -117,6 +117,28 @@ enum
 	FAKED_AboveCeiling
 };
 
+enum SectorPropChanges
+{
+	SPC_FlatPic = 1,
+	SPC_LightLevel = 2,
+	SPC_Color = 4,
+	SPC_Fade = 8,
+	SPC_Gravity = 16,
+	SPC_Panning = 32,
+	SPC_Scale = 64,
+	SPC_Rotation = 128,
+	SPC_AlignBase = 256,
+	SPC_Max = 512,
+};
+
+enum SideDefPropChanges
+{
+	SDPC_TexTop = 1,
+	SDPC_TexMid = 2,
+	SDPC_TexBottom = 4,
+	SDPC_Max = 8,
+};
+
 //
 // Plane
 //
@@ -234,6 +256,7 @@ struct sector_s
 
 	// [SL] 2012-01-16 - planes for sloping ceilings/floors
 	plane_t floorplane, ceilingplane;
+	int SectorChanges;
 };
 typedef struct sector_s sector_t;
 
@@ -264,6 +287,7 @@ struct side_s
 	short		linenum;
 	short		special;
 	short		tag;
+	int SidedefChanges;
 };
 typedef struct side_s side_t;
 
@@ -322,6 +346,8 @@ struct line_s
 	int			firstid, nextid;
 	bool wastoggled;
 	bool switchactive;
+	bool PropertiesChanged;
+	bool SidedefChanged;
 };
 typedef struct line_s line_t;
 

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -142,6 +142,7 @@ void D_DoomLoop (void)
 //
 void D_Init()
 {
+	argb_t::setChannels(3, 2, 1, 0);
 	// only print init messages during startup, not when changing WADs
 	static bool first_time = true;
 

--- a/server/src/r_plane.cpp
+++ b/server/src/r_plane.cpp
@@ -49,11 +49,13 @@ BOOL R_AlignFlat (int linenum, int side, int fc)
 	{
 		sec->base_ceiling_angle = 0-angle;
 		sec->base_ceiling_yoffs = dist & ((1<<(FRACBITS+8))-1);
+		sec->SectorChanges |= SPC_AlignBase;
 	}
 	else
 	{
 		sec->base_floor_angle = 0-angle;
 		sec->base_floor_yoffs = dist & ((1<<(FRACBITS+8))-1);
+		sec->SectorChanges |= SPC_AlignBase;
 	}
 
 	return true;


### PR DESCRIPTION
Sync server map state with client on connection.

Client will not execute sector, line, and sidedef changes unless instructed by the server. This includes light thinkers and scrollers.

Server keeps track of sector, line, and sidedef changes.

This change is mostly required for ACS changing map state. However, this does fix certain vanilla cases. For example, connecting after the light change special E1M3 would cause the client to have the wrong sector brightness.

svc_sectorproperties, svc_linesideupdate, and svc_thinkerupdate use sub-types so we do not need to eat all the svc_* commands for every property that changed.

For example, svc_sectorproperties writes the flags in the next short of what properties changed in the sector. This allows all sector property changes to be written in the same message and the client can iterate through the flags and read the properties case by case.