### PR TITLE
Improve tab-completion

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1440,7 +1440,7 @@ void C_DrawConsole()
 			// Render an overflow message if necessary.
 			if (cOverflow)
 			{
-				snprintf(rowstring, ARRAY_LENGTH(rowstring), "...and %u more...",
+				snprintf(rowstring, ARRAY_LENGTH(rowstring), "...and %lu more...",
 				         ::Completions.size() - (cLines * cColumns));
 				screen->PrintStr(left, offset + (lines + cLines + 1) * 8, rowstring);
 			}

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -2024,6 +2024,7 @@ static void TabComplete()
 	{
 		// We found a single completion, use it.
 		::CmdLine.replaceString(::Completions.at(0));
+		::Completions.clear();
 	}
 }
 

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1640,7 +1640,8 @@ void C_DrawConsole()
 						rowstring[col - 1] = ' ';
 				}
 
-				screen->PrintStr(left, offset + (lines + l + 1) * 8, rowstring);
+				screen->PrintStr(left, offset + (lines + l + 1) * 8, rowstring,
+				                 CR_YELLOW);
 			}
 
 			// Render an overflow message if necessary.
@@ -1648,7 +1649,8 @@ void C_DrawConsole()
 			{
 				snprintf(rowstring, ARRAY_LENGTH(rowstring), "...and %lu more...",
 				         ::CmdCompletions.size() - (cLines * cColumns));
-				screen->PrintStr(left, offset + (lines + cLines + 1) * 8, rowstring);
+				screen->PrintStr(left, offset + (lines + cLines + 1) * 8, rowstring,
+				                 CR_YELLOW);
 			}
 		}
 

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -2004,6 +2004,10 @@ static void TabComplete()
 		tabEnd = ::CmdLine.text.length();
 	size_t tabLen = tabEnd - tabStart;
 
+	// Don't complete if the cursor is past the command.
+	if (::CmdLine.cursor_position >= tabEnd + 1)
+		return;
+
 	// Find all substrings.
 	std::string sTabPos = StdStringToLower(::CmdLine.text.substr(tabStart, tabLen));
 	const char* cTabPos = sTabPos.c_str();

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1588,6 +1588,8 @@ void C_DrawConsole()
 
 			// How many columns can we fit on the screen at one time?
 			size_t cColumns = ::ConCols / cTabLen;
+			if (cColumns == 0)
+				cColumns += 1;
 
 			// Given the number of columns, how many lines do we need?
 			size_t cLines = ::CmdCompletions.size() / cColumns;


### PR DESCRIPTION
This PR adds zsh-style tab-completion.

- Upon hitting tab while typing a partial command, the console will calculate all possible completions and complete up to the longest unambiguous sub-string.  It will then render a list of possible completions above the command line.
- The possible completions are presented in columns, and up to five lines worth of completions are printed.  If there are more, it will say so.
- At this point, hitting tab will insert a completion candidate.  Hitting tab again will cycle to the next completion candidate.  Hitting shift-tab will cycle back to the previous completion candidate.  If you move the cursor, this sort of tab-cycling state will cease.
- Note that these completions are presented in a sort of "buffer" between the normal console output and the command line.  It will grow and shrink to meet the current context, and the console output will grow and shrink above it.