### PR TITLE
use c11 in cmake to fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,8 @@ cmake_minimum_required(VERSION 3.1)
 set(PROJECT_VERSION 0.8.3)
 set(PROJECT_COPYRIGHT "2006-2020")
 
-# Use C++ 98/03 for all targets
-set(CMAKE_CXX_STANDARD 98)
+# Use C++ 11 for all targets
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # identify the target CPU


### PR DESCRIPTION
Currently, the latest code (and 0.8.3 release) fails to compile on Linux/gcc due to C++11 code being used:
```
[ 94%] Building CXX object odalaunch/CMakeFiles/odalaunch.dir/src/ctrl_infobar.cpp.o
In file included from /usr/include/c++/10.1.0/type_traits:35,
                 from /usr/include/wx-3.0/wx/strvararg.h:25,
                 from /usr/include/wx-3.0/wx/string.h:46,
                 from /usr/include/wx-3.0/wx/memory.h:15,
                 from /usr/include/wx-3.0/wx/object.h:19,
                 from /usr/include/wx-3.0/wx/event.h:16,
                 from /usr/include/wx-3.0/wx/window.h:18,
                 from /home/lukas/odamex/odalaunch/src/ctrl_infobar.h:27,
                 from /home/lukas/odamex/odalaunch/src/ctrl_infobar.cpp:24:
/usr/include/c++/10.1.0/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
   32 | #error This file requires compiler and library support \
      |  ^~~~~
In file included from /usr/include/wx-3.0/wx/string.h:46,
                 from /usr/include/wx-3.0/wx/memory.h:15,
                 from /usr/include/wx-3.0/wx/object.h:19,
                 from /usr/include/wx-3.0/wx/event.h:16,
                 from /usr/include/wx-3.0/wx/window.h:18,
                 from /home/lukas/odamex/odalaunch/src/ctrl_infobar.h:27,
                 from /home/lukas/odamex/odalaunch/src/ctrl_infobar.cpp:24:
/usr/include/wx-3.0/wx/strvararg.h:350:18: error: ‘is_enum’ in namespace ‘std’ does not name a template type; did you mean ‘isalnum’?
  350 |     typedef std::is_enum<T> is_enum;
      |                  ^~~~~~~
      |                  isalnum
/usr/include/wx-3.0/wx/strvararg.h:354:54: error: ‘is_enum’ was not declared in this scope; did you mean ‘isalnum’?
  354 |     enum { value = wxFormatStringSpecifierNonPodType<is_enum::value>::value };
      |                                                      ^~~~~~~
      |                                                      isalnum
/usr/include/wx-3.0/wx/strvararg.h:354:68: error: template argument 1 is invalid
  354 |     enum { value = wxFormatStringSpecifierNonPodType<is_enum::value>::value };
      |                                                                    ^
make[2]: *** [odalaunch/CMakeFiles/odalaunch.dir/build.make:152: odalaunch/CMakeFiles/odalaunch.dir/src/ctrl_infobar.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:427: odalaunch/CMakeFiles/odalaunch.dir/all] Error 2
make: *** [Makefile:172: all] Error 2
```

This patch bumps the required C++ version.  If the maintainers want to retain compatibility with C++98, then the C++11 code will need to be rewritten.