### PR TITLE
Fix an error that pops up in CMake 3.10

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -3,6 +3,6 @@ file(GLOB COMMON_SOURCES *.cpp)
 
 configure_file(git_describe.h.in "${CMAKE_CURRENT_BINARY_DIR}/git_describe.h")
 
-add_library(odamex-common INTERFACE IMPORTED GLOBAL)
+add_library(odamex-common INTERFACE)
 target_sources(odamex-common INTERFACE ${COMMON_SOURCES} ${COMMON_HEADERS})
 target_include_directories(odamex-common INTERFACE . ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
```
CMake Error at common/CMakeLists.txt:7 (target_sources):
  Cannot specify sources for imported target "odamex-common".


CMake Error at common/CMakeLists.txt:8 (target_include_directories):
  Cannot specify include directories for imported target "odamex-common".
```

This PR fixes this bug in CMake 3.10.