### PR TITLE
Add GCC attributes to functions

### DIFF
--- a/client/sdl/i_system.cpp
+++ b/client/sdl/i_system.cpp
@@ -728,7 +728,7 @@ NORETURN void STACK_ARGS I_FatalError (const char *error, ...)
 	va_start(argptr, error);
 	fprintf(stderr, "Recursive I_FatalError detected!\r\nError = ");
 	vfprintf(stderr, error, argptr);
-	fprintf(stderr, "\r\nnSDL_GetError = %s\r\n", SDL_GetError());
+	fprintf(stderr, "\r\nSDL_GetError = %s\r\n", SDL_GetError());
 	va_end(argptr);
 
 	abort();

--- a/client/sdl/i_system.cpp
+++ b/client/sdl/i_system.cpp
@@ -696,15 +696,15 @@ BOOL gameisdead;
 
 void STACK_ARGS call_terms (void);
 
-void STACK_ARGS I_FatalError (const char *error, ...)
+NORETURN void STACK_ARGS I_FatalError (const char *error, ...)
 {
+	char errortext[MAX_ERRORTEXT];
 	static BOOL alreadyThrown = false;
 	gameisdead = true;
 
 	if (!alreadyThrown)		// ignore all but the first message -- killough
 	{
 		alreadyThrown = true;
-		char errortext[MAX_ERRORTEXT];
 		va_list argptr;
 		va_start (argptr, error);
 		int index = vsprintf (errortext, error, argptr);
@@ -722,6 +722,16 @@ void STACK_ARGS I_FatalError (const char *error, ...)
 
 		exit(EXIT_FAILURE);
 	}
+
+	// Something has seriously gone sideways.
+	va_list argptr;
+	va_start(argptr, error);
+	fprintf(stderr, "Recursive I_FatalError detected!\r\nError = ");
+	vfprintf(stderr, error, argptr);
+	fprintf(stderr, "\r\nnSDL_GetError = %s\r\n", SDL_GetError());
+	va_end(argptr);
+
+	abort();
 }
 
 void STACK_ARGS I_Error (const char *error, ...)

--- a/client/sdl/i_system.h
+++ b/client/sdl/i_system.h
@@ -98,7 +98,7 @@ void STACK_ARGS I_Quit (void);
 
 void STACK_ARGS I_Warning(const char *warning, ...);
 void STACK_ARGS I_Error (const char *error, ...);
-void STACK_ARGS I_FatalError (const char *error, ...);
+NORETURN void STACK_ARGS I_FatalError(const char *error, ...);
 
 void addterm (void (STACK_ARGS *func)(void), const char *name);
 #define atterm(t) addterm (t, #t)

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1197,7 +1197,7 @@ static int VPrintf(int printlevel, const char* color_code, const char* format, v
 	return len;
 }
 
-int STACK_ARGS Printf(int printlevel, const char *format, ...)
+FORMAT_PRINTF(2, 3) int STACK_ARGS Printf(int printlevel, const char* format, ...)
 {
 	va_list argptr;
 
@@ -1208,7 +1208,7 @@ int STACK_ARGS Printf(int printlevel, const char *format, ...)
 	return count;
 }
 
-int STACK_ARGS Printf_Bold(const char *format, ...)
+FORMAT_PRINTF(1, 2) int STACK_ARGS Printf_Bold(const char* format, ...)
 {
 	va_list argptr;
 
@@ -1219,7 +1219,7 @@ int STACK_ARGS Printf_Bold(const char *format, ...)
 	return count;
 }
 
-int STACK_ARGS DPrintf(const char *format, ...)
+FORMAT_PRINTF(1, 2) int STACK_ARGS DPrintf(const char* format, ...)
 {
 	if (developer || devparm)
 	{

--- a/common/c_cvars.cpp
+++ b/common/c_cvars.cpp
@@ -782,6 +782,13 @@ BEGIN_COMMAND (help)
 END_COMMAND (help)
 
 // [AM] Crash Odamex on purpose - with no survivors.  Used for testing crash handlers.
+BEGIN_COMMAND(errorout)
+{
+	I_FatalError("errorout was run from the console");
+}
+END_COMMAND(errorout)
+
+// [AM] Crash Odamex on purpose - with no survivors.  Used for testing crash handlers.
 BEGIN_COMMAND(crashout)
 {
 	std::terminate();

--- a/common/cmdlib.cpp
+++ b/common/cmdlib.cpp
@@ -353,7 +353,7 @@ StringTokens TokenizeString(const std::string& str, const std::string& delim) {
 //
 // A quick and dirty std::string formatting that uses snprintf under the covers.
 //
-void STACK_ARGS StrFormat(std::string& out, const char* fmt, ...)
+FORMAT_PRINTF(2, 3) void STACK_ARGS StrFormat(std::string& out, const char* fmt, ...)
 {
 	va_list va;
 	va_start(va, fmt);

--- a/common/cmdlib.h
+++ b/common/cmdlib.h
@@ -94,7 +94,7 @@ std::string JoinStrings(const std::vector<std::string> &pieces, const std::strin
 typedef std::vector<std::string> StringTokens;
 StringTokens TokenizeString(const std::string& str, const std::string& delim);
 
-void STACK_ARGS StrFormat(std::string& out, const char* fmt, ...);
+FORMAT_PRINTF(2, 3) void STACK_ARGS StrFormat(std::string& out, const char* fmt, ...);
 void STACK_ARGS VStrFormat(std::string& out, const char* fmt, va_list va);
 
 bool StrFormatISOTime(std::string& s, const tm* utc_tm);

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -35,6 +35,18 @@
 	#include <gctypes.h>
 #endif
 
+#ifdef _MSC_VER
+	#define FORMAT_PRINTF(index, first_arg)
+#else
+	#define FORMAT_PRINTF(index, first_arg) __attribute__ ((format(printf, index, first_arg)))
+#endif
+
+#ifdef _MSC_VER
+	#define NORETURN __declspec(noreturn)
+#else
+	#define NORETURN __attribute__ ((noreturn))
+#endif
+
 #ifndef __BYTEBOOL__
 	#define __BYTEBOOL__
 	// [RH] Some windows includes already define this
@@ -167,11 +179,11 @@ typedef uint64_t			dtime_t;
 #endif
 
 // [RH] This gets used all over; define it here:
-int STACK_ARGS Printf (int printlevel, const char *, ...);
+FORMAT_PRINTF(2, 3) int STACK_ARGS Printf(int printlevel, const char* format, ...);
 // [Russell] Prints a bold green message to the console
-int STACK_ARGS Printf_Bold (const char *format, ...);
+FORMAT_PRINTF(1, 2) int STACK_ARGS Printf_Bold(const char* format, ...);
 // [RH] Same here:
-int STACK_ARGS DPrintf (const char *, ...);
+FORMAT_PRINTF(1, 2) int STACK_ARGS DPrintf(const char* format, ...);
 
 // Simple log file
 #include <fstream>

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -144,7 +144,7 @@ int VPrintf(int printlevel, const char* format, va_list parms)
 	return PrintString(printlevel, str.c_str());
 }
 
-int STACK_ARGS Printf (int printlevel, const char *format, ...)
+FORMAT_PRINTF(2, 3) int STACK_ARGS Printf(int printlevel, const char* format, ...)
 {
 	va_list argptr;
 	int count;
@@ -156,7 +156,7 @@ int STACK_ARGS Printf (int printlevel, const char *format, ...)
 	return count;
 }
 
-int STACK_ARGS Printf_Bold (const char *format, ...)
+FORMAT_PRINTF(1, 2) int STACK_ARGS Printf_Bold(const char* format, ...)
 {
 	va_list argptr;
 	int count;
@@ -169,7 +169,7 @@ int STACK_ARGS Printf_Bold (const char *format, ...)
 	return count;
 }
 
-int STACK_ARGS DPrintf (const char *format, ...)
+FORMAT_PRINTF(1, 2) int STACK_ARGS DPrintf(const char* format, ...)
 {
 	va_list argptr;
 	int count;

--- a/server/src/i_system.h
+++ b/server/src/i_system.h
@@ -84,7 +84,7 @@ ticcmd_t *I_BaseTiccmd (void);
 void STACK_ARGS I_Quit (void);
 
 void STACK_ARGS I_Error (const char *error, ...);
-void STACK_ARGS I_FatalError (const char *error, ...);
+NORETURN void STACK_ARGS I_FatalError(const char *error, ...);
 
 void addterm (void (STACK_ARGS *func)(void), const char *name);
 #define atterm(t) addterm (t, #t)
@@ -130,6 +130,3 @@ int I_FindAttr (findstate_t *fileinfo);
 #define FA_ARCH		16
 
 #endif
-
-
-


### PR DESCRIPTION
This patch introduces wrapper defines for two GCC "attributes".  One of them checks the formatting of printf-style functions, and the other annotates a function as not returning, which should squelch warnings that arise from the compiler incorrectly assuming it can advance past a noreturn function call.

`FORMAT_PRINTF` was applied to the three print functions and `StrFormat`.  `NORETURN` was applied to `I_FatalError`.  MSVC has an equivalent for noreturn, but not for format, and the define accounts for this.