### PR TITLE
Use C++11 on odalaunch target for wx 3.0.4 and up

### DIFF
--- a/odalaunch/CMakeLists.txt
+++ b/odalaunch/CMakeLists.txt
@@ -35,6 +35,11 @@ endif()
 
 # Odalaunch target
 if(wxWidgets_FOUND)
+  # wxWidgets 3.0.4 requires C++11
+  if(wxWidgets_VERSION_STRING VERSION_GREATER 3.0.3)
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
+
   file(MAKE_DIRECTORY "${XRCRES_BINARY_DIR}")
 
   # Attempt to compile all of the XRC files with custom commands.


### PR DESCRIPTION
This addresses bug #1311. wxWidgets 3.0.4 requires C++11 support.