### PR TITLE
Bug/status bar asan fix

### DIFF
--- a/client/src/st_lib.cpp
+++ b/client/src/st_lib.cpp
@@ -155,7 +155,7 @@ void STlib_drawNum(st_number_t* n, bool force_refresh)
 	STlib_ClearRect(n->x - w * n->maxdigits, n->y, w * n->maxdigits, h);
 
 	// if non-number, do not draw it
-	if (num == 1994)
+	if (num == ST_DONT_DRAW_NUM)
 		return;
 
 	x = n->x;
@@ -268,4 +268,3 @@ void STlib_updateBinIcon(st_binicon_t* icon, bool force_refresh)
 }
 
 VERSION_CONTROL (st_lib_cpp, "$Id$")
-

--- a/client/src/st_lib.h
+++ b/client/src/st_lib.h
@@ -220,9 +220,9 @@ void
 STlib_updateBinIcon
 ( st_binicon_t* 		bi,
   bool				refresh );
-  
+
+#define ST_DONT_DRAW_NUM 1994 			// means "n/a"
 void STlib_drawNum(st_number_t *n, bool refresh);
 void ST_DrawNum(int x, int y, DCanvas *scrn, int num);
 
 #endif
-

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1113,14 +1113,12 @@ void ST_updateFaceWidget(void)
 
 void ST_updateWidgets(void)
 {
-	static int DONT_DRAW_NUM = 1994; 			// means "n/a"
-
 	player_t *plyr = &displayplayer();
 
 	if (weaponinfo[plyr->readyweapon].ammotype == am_noammo)
-		w_ready.num = &DONT_DRAW_NUM;
+		st_current_ammo = ST_DONT_DRAW_NUM;
 	else
-		w_ready.num = &plyr->ammo[weaponinfo[plyr->readyweapon].ammotype];
+		st_current_ammo = plyr->ammo[weaponinfo[plyr->readyweapon].ammotype];
 
 	w_ready.data = plyr->readyweapon;
 
@@ -1141,8 +1139,6 @@ void ST_updateWidgets(void)
 		else
 			st_weaponowned[i] = 0;
 	}
-
-	st_current_ammo = plyr->ammo[weaponinfo[plyr->readyweapon].ammotype];
 
 	// update keycard multiple widgets
 	for (int i = 0; i < 3; i++)
@@ -1692,5 +1688,3 @@ void STACK_ARGS ST_Shutdown()
 
 
 VERSION_CONTROL (st_stuff_cpp, "$Id$")
-
-


### PR DESCRIPTION
One of the status bar widgets held a pointer directly into the memory of a player struct instead of the value being copied out like most of the other widgets.  If that player struct went bye-bye, the result was a use-after-free.