### PR TITLE
Use Mix_OpenAudioDevice on SDL2

### DIFF
--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -426,7 +426,17 @@ void I_InitSound()
 
 	Printf(PRINT_HIGH, "I_InitSound: Initializing SDL_mixer\n");
 
-    if (Mix_OpenAudio((int)snd_samplerate, AUDIO_S16SYS, 2, 1024) < 0)
+#if SDL_MIXER_VERSION_ATLEAST(2, 0, 2)
+    // Apparently, when Mix_OpenAudio requests a certain number of channels
+    // and the device claims to not support that number of channels, instead
+    // of handling it automatically behind the scenes, Mixer might initialize
+    // with a broken audio buffer instead.  Using this function instead works
+    // around the problem.
+	if (Mix_OpenAudioDevice((int)snd_samplerate, AUDIO_S16SYS, 2, 1024, NULL,
+	                        SDL_AUDIO_ALLOW_FREQUENCY_CHANGE) < 0)
+#else
+	if (Mix_OpenAudio((int)snd_samplerate, AUDIO_S16SYS, 2, 1024) < 0)
+#endif
 	{
 		Printf(PRINT_HIGH, 
                "I_InitSound: Error initializing SDL_mixer: %s\n", 
@@ -434,7 +444,7 @@ void I_InitSound()
 		return;
 	}
 
-    if(!Mix_QuerySpec(&mixer_freq, &mixer_format, &mixer_channels))
+	if(!Mix_QuerySpec(&mixer_freq, &mixer_format, &mixer_channels))
 	{
 		Printf(PRINT_HIGH, 
                "I_InitSound: Error initializing SDL_mixer: %s\n", 
@@ -476,4 +486,3 @@ void STACK_ARGS I_ShutdownSound (void)
 
 
 VERSION_CONTROL (i_sound_cpp, "$Id$")
-

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -426,7 +426,7 @@ void I_InitSound()
 
 	Printf(PRINT_HIGH, "I_InitSound: Initializing SDL_mixer\n");
 
-#if SDL_MIXER_VERSION_ATLEAST(2, 0, 2)
+#ifdef SDL20
     // Apparently, when Mix_OpenAudio requests a certain number of channels
     // and the device claims to not support that number of channels, instead
     // of handling it automatically behind the scenes, Mixer might initialize
@@ -444,7 +444,7 @@ void I_InitSound()
 		return;
 	}
 
-	if(!Mix_QuerySpec(&mixer_freq, &mixer_format, &mixer_channels))
+    if(!Mix_QuerySpec(&mixer_freq, &mixer_format, &mixer_channels))
 	{
 		Printf(PRINT_HIGH, 
                "I_InitSound: Error initializing SDL_mixer: %s\n", 


### PR DESCRIPTION
The short version is contained in the comment:

```
// Apparently, when Mix_OpenAudio requests a certain number of channels
// and the device claims to not support that number of channels, instead
// of handling it automatically behind the scenes, Mixer might initialize
// with a broken audio buffer instead.  Using this function instead works
// around the problem.
```

The long version is here: https://github.com/chocolate-doom/chocolate-doom/pull/1309  Thanks to Edward850 for hipping me to this issue.