### PR TITLE
Don't activate transparency lines

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -751,6 +751,7 @@ void P_FinishLoadingLineDefs (void)
 						if (lines[j].id == ld->args[0])
 							lines[j].lucency = (byte)ld->args[1];
 #endif
+				ld->special = 0;
 				break;
 		}
 	}


### PR DESCRIPTION
This was causing an amazing bug where crossing the line occupied by a transparent texture would cause all of the 2s lines on the map to become more transparent.

Funny bug, one line fix, what's not to love.