### PR TITLE
Introduce PRIuSIZE and related defines

### DIFF
--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -89,24 +89,24 @@
 #endif
 
 #if (defined _XBOX || defined _MSC_VER)
-    typedef signed   __int8   int8_t;
-    typedef signed   __int16  int16_t;
-    typedef signed   __int32  int32_t;
-    typedef signed   __int64  int64_t;
-    typedef unsigned __int8   uint8_t;
-    typedef unsigned __int16  uint16_t;
-    typedef unsigned __int32  uint32_t;
-    typedef unsigned __int64  uint64_t;
+	typedef signed __int8 int8_t;
+	typedef signed __int16 int16_t;
+	typedef signed __int32 int32_t;
+	typedef signed __int64 int64_t;
+	typedef unsigned __int8 uint8_t;
+	typedef unsigned __int16 uint16_t;
+	typedef unsigned __int32 uint32_t;
+	typedef unsigned __int64 uint64_t;
 
-    #define PRI_SIZE_PREFIX "I"
+	#define PRI_SIZE_PREFIX "I"
 #else
-    #include <stdint.h>
-    #include <inttypes.h>
+	#include <inttypes.h>
+	#include <stdint.h>
 
-    #define PRI_SIZE_PREFIX "z"
+	#define PRI_SIZE_PREFIX "z"
 #endif
 
-// Format constants for ssize_t/size_t.
+    // Format constants for ssize_t/size_t.
 
 #define PRIdSIZE PRI_SIZE_PREFIX "d"
 #define PRIiSIZE PRI_SIZE_PREFIX "i"

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -89,17 +89,31 @@
 #endif
 
 #if (defined _XBOX || defined _MSC_VER)
-	typedef signed   __int8   int8_t;
-	typedef signed   __int16  int16_t;
-	typedef signed   __int32  int32_t;
-	typedef signed   __int64  int64_t;
-	typedef unsigned __int8   uint8_t;
-	typedef unsigned __int16  uint16_t;
-	typedef unsigned __int32  uint32_t;
-	typedef unsigned __int64  uint64_t;
+    typedef signed   __int8   int8_t;
+    typedef signed   __int16  int16_t;
+    typedef signed   __int32  int32_t;
+    typedef signed   __int64  int64_t;
+    typedef unsigned __int8   uint8_t;
+    typedef unsigned __int16  uint16_t;
+    typedef unsigned __int32  uint32_t;
+    typedef unsigned __int64  uint64_t;
+
+    #define PRI_SIZE_PREFIX "I"
 #else
-	#include <stdint.h>
+    #include <stdint.h>
+    #include <inttypes.h>
+
+    #define PRI_SIZE_PREFIX "z"
 #endif
+
+// Format constants for ssize_t/size_t.
+
+#define PRIdSIZE PRI_SIZE_PREFIX "d"
+#define PRIiSIZE PRI_SIZE_PREFIX "i"
+#define PRIuSIZE PRI_SIZE_PREFIX "u"
+#define PRIoSIZE PRI_SIZE_PREFIX "o"
+#define PRIxSIZE PRI_SIZE_PREFIX "x"
+#define PRIXSIZE PRI_SIZE_PREFIX "X"
 
 #ifdef UNIX
 	#define stricmp strcasecmp

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -100,7 +100,6 @@
 
 	#define PRI_SIZE_PREFIX "I"
 #else
-	#include <inttypes.h>
 	#include <stdint.h>
 
 	#define PRI_SIZE_PREFIX "z"

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -105,7 +105,7 @@
 	#define PRI_SIZE_PREFIX "z"
 #endif
 
-    // Format constants for ssize_t/size_t.
+// Format constants for ssize_t/size_t.
 
 #define PRIdSIZE PRI_SIZE_PREFIX "d"
 #define PRIiSIZE PRI_SIZE_PREFIX "i"

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -531,13 +531,15 @@ void Z_DumpHeap(int lowtag, int hightag)
 
 	Z_FreeMemory();
     memblock_t*	block;
-	
-    Printf(PRINT_HIGH, "zone size: %i  location: %p\n", mainzone->size, mainzone);
-	Printf(PRINT_HIGH, "used: %i  free: %i\n", pfree+lsize, efree);
-    Printf(PRINT_HIGH, "tag range: %i to %i\n", lowtag, hightag);
-	
-    for (block = mainzone->blocklist.next ; ; block = block->next)
-    {
+
+	Printf(PRINT_HIGH, "zone size: %" PRIuSIZE "  location: %p\n", mainzone->size,
+	       mainzone);
+	Printf(PRINT_HIGH, "used: %" PRIuSIZE "  free: %" PRIuSIZE "\n", pfree + lsize,
+	       efree);
+	Printf(PRINT_HIGH, "tag range: %i to %i\n", lowtag, hightag);
+
+	for (block = mainzone->blocklist.next;; block = block->next)
+	{
 		char user[30];
 		if (block->user == NULL || block->tag == PU_FREE)
 			sprintf(user, "---");
@@ -565,9 +567,10 @@ void Z_DumpHeap(int lowtag, int hightag)
 			sprintf(tag, "UNKNOWN");
 
 		if (block->tag >= lowtag && block->tag <= hightag)
-			Printf(PRINT_HIGH, "block:%p    size:%9i    user:%-9s    tag:%-s\n",
-				block, block->size, user, tag);
-		
+			Printf(PRINT_HIGH,
+			       "block:%p    size:%9" PRIuSIZE "    user:%-9s    tag:%-s\n", block,
+			       block->size, user, tag);
+
 		if (block->next == &mainzone->blocklist)
 			break;		// all blocks have been hit
 	
@@ -603,23 +606,18 @@ BEGIN_COMMAND (mem)
 	Z_FreeMemory();
 
 	Printf(PRINT_HIGH,
-			"%u blocks:\n"
-			"% 5u used      (%u, %u)\n"
-			" % 5u purgable (%u, %u)\n"
-			" % 5u locked   (%u, %u)\n"
-			"% 5u unused    (%u, %u)\n"
-			"% 5u p-free    (%u, %u)\n",
-			numblocks,
-			usedpblocks+usedlblocks, pfree+lsize,
-			largestpfree > largestlsize ? largestpfree : largestlsize,
-			usedpblocks, pfree, largestpfree,
-			usedlblocks, lsize, largestlsize,
-			usedeblocks, efree, largestefree,
-			usedpblocks + usedeblocks, pfree + efree,
-			largestpfree > largestefree ? largestpfree : largestefree
-			);
+	       "%" PRIuSIZE " blocks:\n"
+	       "%5" PRIuSIZE " used      (%" PRIuSIZE ", %" PRIuSIZE ")\n"
+	       " %5" PRIuSIZE " purgable (%" PRIuSIZE ", %" PRIuSIZE ")\n"
+	       " %5" PRIuSIZE " locked   (%" PRIuSIZE ", %" PRIuSIZE ")\n"
+	       "%5" PRIuSIZE " unused    (%" PRIuSIZE ", %" PRIuSIZE ")\n"
+	       "%5" PRIuSIZE " p-free    (%" PRIuSIZE ", %" PRIuSIZE ")\n",
+	       numblocks, usedpblocks + usedlblocks, pfree + lsize,
+	       largestpfree > largestlsize ? largestpfree : largestlsize, usedpblocks, pfree,
+	       largestpfree, usedlblocks, lsize, largestlsize, usedeblocks, efree,
+	       largestefree, usedpblocks + usedeblocks, pfree + efree,
+	       largestpfree > largestefree ? largestpfree : largestefree);
 }
 END_COMMAND (mem)
 
 VERSION_CONTROL (z_zone_cpp, "$Id$")
-


### PR DESCRIPTION
`inttypes.h` has several PRI* defines used to print format specifiers, and keeping with this convention I introduced a format define specifically for size_t.  It uses `I` on MSVC and `z` elsewhere.

Hopefully this means we can finally nix some format specifier warnings.  I nixed all of them in `z_zone.cpp` as an example.