### PR TITLE
Bug/crash on wad change

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -1696,7 +1696,7 @@ void AM_Drawer()
 
 	AM_drawMarks();
 
-	if (!(viewactive && am_overlay < 2))
+	if (!(viewactive && am_overlay < 2) && hu_font[0] != NULL)
 	{
 		char line[64+10];
 		int time = level.time / TICRATE;

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -270,6 +270,10 @@ extern patch_t *hu_font[HU_FONTSIZE];
 
 void F_TextWrite (void)
 {
+	// Don't draw text without a working font.
+	if (::hu_font[0] == NULL)
+		return;
+
 	// erase the entire screen to a tiled background
 	IWindowSurface* primary_surface = I_GetPrimarySurface();
 	primary_surface->clear();		// ensure black background in matted modes

--- a/client/src/hu_drawers.cpp
+++ b/client/src/hu_drawers.cpp
@@ -194,6 +194,9 @@ void DrawPatch(int x, int y, const float scale,
                const patch_t* patch, const bool force_opaque,
                const bool use_patch_offsets)
 {
+	if (patch == NULL)
+		return;
+
 	// Calculate width and height of patch
 	unsigned short w = patch->width();
 	unsigned short h = patch->height();
@@ -222,6 +225,9 @@ void DrawTranslatedPatch(int x, int y, const float scale,
                          const patch_t* patch, byte* translation,
                          const bool force_opaque, const bool use_patch_offsets)
 {
+	if (patch == NULL)
+		return;
+
 	// Calculate width and height of patch
 	unsigned short w = patch->width();
 	unsigned short h = patch->height();
@@ -255,6 +261,9 @@ void DrawPatchStretched(int x, int y,
                         const patch_t* patch, const bool force_opaque,
                         const bool use_patch_offsets)
 {
+	if (patch == NULL)
+		return;
+
 	// Turn our scaled coordinates into real coordinates.
 	int x_scale, y_scale;
 	calculateOrigin(x, y, w, h, scale, x_scale, y_scale, x_align, y_align, x_origin, y_origin);
@@ -281,6 +290,9 @@ void DrawPatchScaled(const int x, const int y,
                      const patch_t* patch, const bool force_opaque,
                      const bool use_patch_offsets)
 {
+	if (patch == NULL)
+		return;
+
 	// Calculate aspect ratios of patch and destination.
 	float patch_aspect = patch->width() / (float)patch->height();
 	float dest_aspect = w / (float)h;

--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -219,8 +219,14 @@ void HU_Init()
 //
 void STACK_ARGS HU_Shutdown()
 {
-	Z_Free(sbline);
+	Z_ChangeTag(sbline, PU_CACHE);
 	sbline = NULL;
+
+	for (int i = 0; i < HU_FONTSIZE; i++)
+	{
+		Z_ChangeTag(hu_font[i], PU_CACHE);
+		hu_font[i] = NULL;
+	}
 }
 
 
@@ -402,6 +408,10 @@ static void HU_DrawCrosshair()
 
 static void HU_DrawChatPrompt()
 {
+	// Don't draw the chat prompt without a valid font.
+	if (::hu_font[0] == NULL)
+		return;
+
 	int surface_width = I_GetSurfaceWidth(), surface_height = I_GetSurfaceHeight();
 
 	// Set up text scaling
@@ -1845,5 +1855,3 @@ BEGIN_COMMAND (displayscores)
 END_COMMAND (displayscores)
 
 VERSION_CONTROL (hu_stuff_cpp, "$Id$")
-
-

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1656,6 +1656,10 @@ void M_StopMessage (void)
 //
 int M_StringHeight(char* string)
 {
+	// Default height without a working font is 8.
+	if (::hu_font[0] == NULL)
+		return 8;
+
 	int h;
 	int height = hu_font[0]->height();
 
@@ -1979,7 +1983,7 @@ void M_StartControlPanel (void)
 //
 void M_Drawer()
 {
-	if (messageToPrint)
+	if (messageToPrint && ::hu_font[0] != NULL)
 	{
 		// Horiz. & Vertically center string and print it.
 		brokenlines_t *lines = V_BreakLines (320, messageString);

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -47,34 +47,33 @@
 #include "p_ctf.h"
 #include "cl_vote.h"
 
-static int		widestnum, numheight;
-static const patch_t	*medi[2];
-static const patch_t	*armors[2];
-static const patch_t	*ammos[4];
-static const patch_t	*bigammos[4];
-static const patch_t	*flagiconteam;
-static const patch_t	*flagiconbhome;
-static const patch_t	*flagiconrhome;
-static const patch_t	*flagiconbtakenbyb;
-static const patch_t	*flagiconbtakenbyr;
-static const patch_t	*flagiconrtakenbyb;
-static const patch_t	*flagiconrtakenbyr;
-static const patch_t	*flagicongtakenbyb;
-static const patch_t	*flagicongtakenbyr;
-static const patch_t	*flagiconbdropped;
-static const patch_t	*flagiconrdropped;
-static const patch_t *line_leftempty;
-static const patch_t *line_leftfull;
-static const patch_t *line_centerempty;
-static const patch_t *line_centerleft;
-static const patch_t *line_centerright;
-static const patch_t *line_centerfull;
-static const patch_t *line_rightempty;
-static const patch_t *line_rightfull;
+static const char* medipatches[] = {"MEDIA0", "PSTRA0"};
+static const char* armorpatches[] = {"ARM1A0", "ARM2A0"};
+static const char* ammopatches[] = {"CLIPA0", "SHELA0", "CELLA0", "ROCKA0"};
+static const char* bigammopatches[] = {"AMMOA0", "SBOXA0", "CELPA0", "BROKA0"};
 
-static const char medipatches[2][8] = { "MEDIA0", "PSTRA0" };
-static const char ammopatches[4][8] = {"CLIPA0", "SHELA0", "CELLA0", "ROCKA0"};
-static const char bigammopatches[4][8] = {"AMMOA0", "SBOXA0", "CELPA0", "BROKA0"};
+static int widest_num, num_height;
+static const patch_t* medi[ARRAY_LENGTH(::medipatches)];
+static const patch_t* armors[ARRAY_LENGTH(::armorpatches)];
+static const patch_t* ammos[ARRAY_LENGTH(::ammopatches)];
+static const patch_t* bigammos[ARRAY_LENGTH(::bigammopatches)];
+static const patch_t* flagiconteam;
+static const patch_t* flagiconbhome;
+static const patch_t* flagiconrhome;
+static const patch_t* flagiconbtakenbyb;
+static const patch_t* flagiconbtakenbyr;
+static const patch_t* flagiconrtakenbyb;
+static const patch_t* flagiconrtakenbyr;
+static const patch_t* flagiconbdropped;
+static const patch_t* flagiconrdropped;
+static const patch_t* line_leftempty;
+static const patch_t* line_leftfull;
+static const patch_t* line_centerempty;
+static const patch_t* line_centerleft;
+static const patch_t* line_centerright;
+static const patch_t* line_centerfull;
+static const patch_t* line_rightempty;
+static const patch_t* line_rightfull;
 
 static int		NameUp = -1;
 
@@ -88,6 +87,13 @@ extern flagdata CTFdata[NUMFLAGS];
 
 extern NetDemo netdemo;
 
+typedef std::vector<const patch_t**> PathFreeList;
+
+/**
+ * @brief Stores pointers to status bar objects that should be freed on shutdown. 
+ */
+PathFreeList freelist;
+
 int V_TextScaleXAmount();
 int V_TextScaleYAmount();
 
@@ -97,100 +103,93 @@ EXTERN_CVAR (hud_targetcount)
 EXTERN_CVAR (hud_demobar)
 EXTERN_CVAR (sv_fraglimit)
 
-void ST_unloadNew (void)
+/**
+ * @brief Caches a patch, while also adding to a freelist, where it can be
+ *        cleaned up in one fell swoop. 
+ * 
+ * @param patch Destination pointer to write to.
+ * @param lump Lump name to cache.
+ */
+static void CacheHUDPatch(const patch_t** patch, const char* lump)
 {
-	int i;
-
-	Z_ChangeTag (flagiconteam, PU_CACHE);
-	Z_ChangeTag (flagiconbhome, PU_CACHE);
-	Z_ChangeTag (flagiconrhome, PU_CACHE);
-	Z_ChangeTag (flagiconbtakenbyb, PU_CACHE);
-	Z_ChangeTag (flagiconbtakenbyr, PU_CACHE);
-	Z_ChangeTag (flagiconrtakenbyb, PU_CACHE);
-	Z_ChangeTag (flagiconrtakenbyr, PU_CACHE);
-	Z_ChangeTag (flagicongtakenbyb, PU_CACHE);
-	Z_ChangeTag (flagicongtakenbyr, PU_CACHE);
-	Z_ChangeTag (flagiconbdropped, PU_CACHE);
-	Z_ChangeTag (flagiconrdropped, PU_CACHE);
-	Z_ChangeTag (line_leftempty, PU_CACHE);
-	Z_ChangeTag (line_leftfull, PU_CACHE);
-	Z_ChangeTag (line_centerempty, PU_CACHE);
-	Z_ChangeTag (line_centerleft, PU_CACHE);
-	Z_ChangeTag (line_centerright, PU_CACHE);
-	Z_ChangeTag (line_centerfull, PU_CACHE);
-	Z_ChangeTag (line_rightempty, PU_CACHE);
-	Z_ChangeTag (line_rightfull, PU_CACHE);
-
-	for (i = 0; i < 2; i++)
-	{
-		Z_ChangeTag(medi[i], PU_CACHE);
-		Z_ChangeTag(armors[i], PU_CACHE);
-	}
-
-	for (i = 0; i < 4; i++)
-		Z_ChangeTag (ammos[i], PU_CACHE);
+	*patch = W_CachePatch(lump, PU_STATIC);
+	::freelist.push_back(patch);
 }
 
-void ST_initNew (void)
+/**
+ * @brief Cache a patch from a sprite, which needs a special lookup.
+ * 
+ * @param patch Destination pointer to write to.
+ * @param lump Lump name to cache.
+ */
+static void CacheHUDSprite(const patch_t** patch, const char* lump)
 {
-	int i;
+	*patch = W_CachePatch(W_GetNumForName(lump, ns_sprites), PU_STATIC);
+	::freelist.push_back(patch);
+}
+
+/**
+ * @brief All of our patches will be freed when zone memory gets reset, but
+ *        we need to ensure all our pointers are NULL too so we don't
+ *        dereference a stale patch address by accident.
+ */
+void ST_unloadNew()
+{
+	PathFreeList::iterator it = ::freelist.begin();
+	for (; it != ::freelist.end(); ++it)
+		**it = NULL;
+}
+
+void ST_initNew()
+{
 	int widest = 0;
-	char name[8];
-	int lump;
 
 	// denis - todo - security - these patches have unchecked dimensions
 	// ie, if a patch has a 0 width/height, it may cause a divide by zero
 	// somewhere else in the code. we download wads, so this is an issue!
 
-	for (i = 0; i < 10; i++) {
-		if (tallnum[i]->width() > widest)
-			widest = tallnum[i]->width();
-	}
-
-	strcpy (name, "ARM1A0");
-	for (i = 0; i < 2; i++) {
-		name[3] = i + '1';
-		if ((lump = W_CheckNumForName (name, ns_sprites)) != -1)
-			armors[i] = W_CachePatch (lump, PU_STATIC);
-	}
-
-	for (i = 0; i < 4; i++) {
-		if ((lump = W_CheckNumForName (ammopatches[i], ns_sprites)) != -1)
-			ammos[i] = W_CachePatch (lump, PU_STATIC);
-		if ((lump = W_CheckNumForName (bigammopatches[i], ns_sprites)) != -1)
-			bigammos[i] = W_CachePatch (lump, PU_STATIC);
-	}
-
-	for (i = 0; i < 2; i++)
+	for (size_t i = 0; i < ARRAY_LENGTH(::tallnum); i++)
 	{
-		if ((lump = W_CheckNumForName(medipatches[i], ns_sprites)) != -1)
-			medi[i] = W_CachePatch(lump, PU_STATIC);
+		if (::tallnum[i]->width() > widest)
+			widest = ::tallnum[i]->width();
 	}
 
-	flagiconteam = W_CachePatch ("FLAGIT", PU_STATIC);
-	flagiconbhome = W_CachePatch ("FLAGIC2B", PU_STATIC);
-	flagiconrhome = W_CachePatch ("FLAGIC2R", PU_STATIC);
-	flagiconbtakenbyb = W_CachePatch ("FLAGI3BB", PU_STATIC);
-	flagiconbtakenbyr = W_CachePatch ("FLAGI3BR", PU_STATIC);
-	flagiconrtakenbyb = W_CachePatch ("FLAGI3RB", PU_STATIC);
-	flagiconrtakenbyr = W_CachePatch ("FLAGI3RR", PU_STATIC);
-	flagiconbdropped = W_CachePatch ("FLAGIC4B", PU_STATIC);
-	flagiconrdropped = W_CachePatch ("FLAGIC4R", PU_STATIC);
+	for (size_t i = 0; i < ARRAY_LENGTH(::medipatches); i++)
+		CacheHUDSprite(&::medi[i], ::medipatches[i]);
 
-	widestnum = widest;
-	numheight = tallnum[0]->height();
+	for (size_t i = 0; i < ARRAY_LENGTH(::armorpatches); i++)
+		CacheHUDSprite(&::armors[i], ::armorpatches[i]);
+
+	for (size_t i = 0; i < ARRAY_LENGTH(::ammopatches); i++)
+	{
+		CacheHUDSprite(&::ammos[i], ::ammopatches[i]);
+		CacheHUDSprite(&::bigammos[i], ::bigammopatches[i]);
+	}
+
+	CacheHUDPatch(&::flagiconteam, "FLAGIT");
+	CacheHUDPatch(&::flagiconbhome, "FLAGIC2B");
+	CacheHUDPatch(&::flagiconrhome, "FLAGIC2R");
+	CacheHUDPatch(&::flagiconbtakenbyb, "FLAGI3BB");
+	CacheHUDPatch(&::flagiconbtakenbyr, "FLAGI3BR");
+	CacheHUDPatch(&::flagiconrtakenbyb, "FLAGI3RB");
+	CacheHUDPatch(&::flagiconrtakenbyr, "FLAGI3RR");
+	CacheHUDPatch(&::flagiconbdropped, "FLAGIC4B");
+	CacheHUDPatch(&::flagiconrdropped, "FLAGIC4R");
+
+	::widest_num = widest;
+	::num_height = ::tallnum[0]->height();
 
 	if (multiplayer && (sv_gametype == GM_COOP || demoplayback) && level.time)
-		NameUp = level.time + 2*TICRATE;
+		NameUp = level.time + 2 * TICRATE;
 
-	line_leftempty = W_CachePatch ("ODABARLE", PU_STATIC);
-	line_leftfull = W_CachePatch ("ODABARLF", PU_STATIC);
-	line_centerempty = W_CachePatch ("ODABARCE", PU_STATIC);
-	line_centerleft = W_CachePatch ("ODABARCL", PU_STATIC);
-	line_centerright = W_CachePatch ("ODABARCR", PU_STATIC);
-	line_centerfull = W_CachePatch ("ODABARCF", PU_STATIC);
-	line_rightempty = W_CachePatch ("ODABARRE", PU_STATIC);
-	line_rightfull = W_CachePatch ("ODABARRF", PU_STATIC);
+	CacheHUDPatch(&::line_leftempty, "ODABARLE");
+	CacheHUDPatch(&::line_leftfull, "ODABARLF");
+	CacheHUDPatch(&::line_centerempty, "ODABARCE");
+	CacheHUDPatch(&::line_centerleft, "ODABARCL");
+	CacheHUDPatch(&::line_centerright, "ODABARCR");
+	CacheHUDPatch(&::line_centerfull, "ODABARCF");
+	CacheHUDPatch(&::line_rightempty, "ODABARRE");
+	CacheHUDPatch(&::line_rightfull, "ODABARRF");
 }
 
 void ST_DrawNum (int x, int y, DCanvas *scrn, int num)
@@ -569,7 +568,7 @@ void OdamexHUD() {
 	unsigned int y, xscale, yscale;
 	xscale = hud_scale ? CleanXfac : 1;
 	yscale = hud_scale ? CleanYfac : 1;
-	y = I_GetSurfaceHeight() - (numheight + 4) * yscale;
+	y = I_GetSurfaceHeight() - (num_height + 4) * yscale;
 
 	// Draw Armor if the player has any
 	if (plyr->armortype && plyr->armorpoints) {
@@ -742,7 +741,7 @@ void ZDoomHUD() {
 	int xscale = hud_scale ? CleanXfac : 1;
 	int yscale = hud_scale ? CleanYfac : 1;
 
-	y = I_GetSurfaceHeight() - (numheight + 4) * yscale;
+	y = I_GetSurfaceHeight() - (num_height + 4) * yscale;
 
 	// Draw health
 	{

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -129,15 +129,19 @@ static void CacheHUDSprite(const patch_t** patch, const char* lump)
 }
 
 /**
- * @brief All of our patches will be freed when zone memory gets reset, but
- *        we need to ensure all our pointers are NULL too so we don't
- *        dereference a stale patch address by accident.
+ * @brief In addition to unloading our patches we need to ensure the pointers
+ *        are NULL, so we don't dereference a stale patch on WAD change by
+ *        accident.
  */
 void ST_unloadNew()
 {
 	PathFreeList::iterator it = ::freelist.begin();
 	for (; it != ::freelist.end(); ++it)
+	{
+		if (**it != NULL)
+			Z_ChangeTag(**it, PU_CACHE);
 		**it = NULL;
+	}
 }
 
 void ST_initNew()

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -70,9 +70,7 @@ IWindowSurface* stnum_surface;
 
 // functions in st_new.c
 void ST_initNew();
-void ST_unloadNew (void);
-void ST_newDraw (void);
-void ST_newDrawCTF (void);
+void ST_unloadNew();
 
 extern bool simulated_connection;
 
@@ -1340,7 +1338,7 @@ static patch_t *LoadFaceGraphic (char *name, int namespc)
 	return W_CachePatch (lump, PU_STATIC);
 }
 
-void ST_loadGraphics(void)
+static void ST_loadGraphics()
 {
 	int i, j;
 	int namespc;
@@ -1432,13 +1430,13 @@ void ST_loadGraphics(void)
 	faces[facenum++] = LoadFaceGraphic (namebuf, namespc);
 }
 
-void ST_loadData()
+static void ST_loadData()
 {
     lu_palette = W_GetNumForName("PLAYPAL");
 	ST_loadGraphics();
 }
 
-void ST_unloadGraphics (void)
+static void ST_unloadGraphics()
 {
 
 	int i;
@@ -1478,7 +1476,7 @@ void ST_unloadGraphics (void)
 
 }
 
-void ST_unloadData(void)
+static void ST_unloadData()
 {
 	ST_unloadGraphics();
 	ST_unloadNew();
@@ -1682,6 +1680,8 @@ void ST_Init()
 
 void STACK_ARGS ST_Shutdown()
 {
+	ST_unloadData();
+
 	I_FreeSurface(stbar_surface);
 	I_FreeSurface(stnum_surface);
 }

--- a/client/src/v_draw.cpp
+++ b/client/src/v_draw.cpp
@@ -518,12 +518,19 @@ void DCanvas::DrawColorLucentPatchD (const byte *source, byte *dest, int count, 
 /*							  */
 /******************************/
 
-//
-// V_DrawWrapper
-// Masks a column based masked pic to the screen.
-//
-void DCanvas::DrawWrapper(EWrapperCode drawer, const patch_t *patch, int x, int y) const
+/**
+ * @brief Masks a column based masked pic to the screen.
+ * 
+ * @param drawer Draw code to use.
+ * @param patch Patch to draw.  Attempting to draw a NULL patch will have no effect.
+ * @param x X coordinate of patch.
+ * @param y Y coordinate of patch.
+ */
+void DCanvas::DrawWrapper(EWrapperCode drawer, const patch_t* patch, int x, int y) const
 {
+	if (patch == NULL)
+		return;
+
 	int surface_width = mSurface->getWidth(), surface_height = mSurface->getHeight();
 	int surface_pitch = mSurface->getPitch();
 	int colstep = mSurface->getBytesPerPixel();
@@ -569,15 +576,21 @@ void DCanvas::DrawWrapper(EWrapperCode drawer, const patch_t *patch, int x, int 
 	}
 }
 
-//
-// V_DrawSWrapper
-// Masks a column based masked pic to the screen
-// stretching it to fit the given dimensions.
-//
+
+/**
+ * @brief Masks a column based masked pic to the screen stretching it to fit the given dimensions.
+ * 
+ * @param drawer Draw code to use.
+ * @param patch 
+ * @param x0 
+ * @param y0 
+ * @param destwidth 
+ * @param destheight 
+ */
 void DCanvas::DrawSWrapper(EWrapperCode drawer, const patch_t* patch, int x0, int y0,
                            const int destwidth, const int destheight) const
 {
-	if (!patch)
+	if (patch == NULL)
 		return;
 
 	if (patch->width() <= 0 || patch->height() <= 0 ||
@@ -659,6 +672,9 @@ void DCanvas::DrawSWrapper(EWrapperCode drawer, const patch_t* patch, int x0, in
 //
 void DCanvas::DrawIWrapper(EWrapperCode drawer, const patch_t *patch, int x0, int y0) const
 {
+	if (patch == NULL)
+		return;
+
 	int surface_width = mSurface->getWidth(), surface_height = mSurface->getHeight();
 
 	if (surface_width == 320 && surface_height == 200)
@@ -675,6 +691,9 @@ void DCanvas::DrawIWrapper(EWrapperCode drawer, const patch_t *patch, int x0, in
 //
 void DCanvas::DrawCWrapper(EWrapperCode drawer, const patch_t *patch, int x0, int y0) const
 {
+	if (patch == NULL)
+		return;
+
 	int surface_width = mSurface->getWidth(), surface_height = mSurface->getHeight();
 
 	if (CleanXfac == 1 && CleanYfac == 1)
@@ -691,6 +710,9 @@ void DCanvas::DrawCWrapper(EWrapperCode drawer, const patch_t *patch, int x0, in
 //
 void DCanvas::DrawCNMWrapper(EWrapperCode drawer, const patch_t *patch, int x0, int y0) const
 {
+	if (patch == NULL)
+		return;
+
 	if (CleanXfac == 1 && CleanYfac == 1)
 		DrawWrapper(drawer, patch, x0, y0);
 	else
@@ -717,6 +739,9 @@ void DCanvas::DrawCNMWrapper(EWrapperCode drawer, const patch_t *patch, int x0, 
 //
 void DCanvas::DrawPatchFlipped(const patch_t *patch, int x0, int y0) const
 {
+	if (patch == NULL)
+		return;
+
 	int surface_width = mSurface->getWidth(), surface_height = mSurface->getHeight();
 	int surface_pitch = mSurface->getPitch();
 	int colstep = mSurface->getBytesPerPixel();
@@ -876,4 +901,3 @@ void DCanvas::GetTransposedBlock(int x, int y, int width, int height, byte* dest
 }
 
 VERSION_CONTROL (v_draw_cpp, "$Id$")
-

--- a/client/src/v_text.cpp
+++ b/client/src/v_text.cpp
@@ -235,6 +235,9 @@ void DCanvas::TextSWrapper (EWrapperCode drawer, int normalcolor, int x, int y, 
 void DCanvas::TextSWrapper (EWrapperCode drawer, int normalcolor, int x, int y, 
 							const byte *string, int scalex, int scaley) const
 {
+	if (::hu_font[0] == NULL)
+		return;
+
 	if (normalcolor < 0 || normalcolor > NUM_TEXT_COLORS)
 		normalcolor = CR_RED;
 
@@ -292,6 +295,10 @@ void DCanvas::TextSWrapper (EWrapperCode drawer, int normalcolor, int x, int y,
 //
 int V_StringWidth(const byte* str)
 {
+	// Default width without a font loaded is 8.
+	if (::hu_font[0] == NULL)
+		return 8;
+
 	int width = 0;
 	
 	while (*str)
@@ -336,6 +343,9 @@ static void breakit(brokenlines_t* line, const byte* start, const byte* string, 
 
 brokenlines_t* V_BreakLines(int maxwidth, const byte* str)
 {
+	if (::hu_font[0] == NULL)
+		return NULL;
+
 	brokenlines_t lines[128];	// Support up to 128 lines (should be plenty)
 
 	const byte* space = NULL;
@@ -449,4 +459,3 @@ void V_FreeBrokenLines(brokenlines_t* lines)
 
 
 VERSION_CONTROL (v_text_cpp, "$Id$")
-

--- a/common/st_stuff.h
+++ b/common/st_stuff.h
@@ -66,12 +66,6 @@ void ST_Init();
 
 void STACK_ARGS ST_Shutdown();
 
-// Draw the HUD (only if old status bar is not drawn)
-void ST_newDraw (void);
-
-// Called on init
-void ST_loadGraphics (void);
-
 // [ML] HUDified status bar
 void ST_drawStatusBar (void);
 
@@ -105,5 +99,3 @@ bool ST_Responder(event_t* ev);
 
 
 #endif
-
-

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -560,11 +560,9 @@ int W_CheckNumForName(const char *name, int namespc)
 // W_GetNumForName
 // Calls W_CheckNumForName, but bombs out if not found.
 //
-int W_GetNumForName (const char* name)
+int W_GetNumForName(const char* name, int namespc)
 {
-	int	i;
-
-	i = W_CheckNumForName (name);
+	int i = W_CheckNumForName(name, namespc);
 
 	if (i == -1)
 		I_Error ("W_GetNumForName: %s not found!", name);
@@ -815,4 +813,3 @@ void W_Close ()
 }
 
 VERSION_CONTROL (w_wad_cpp, "$Id$")
-

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -93,7 +93,7 @@ std::string W_MD5(std::string filename);
 std::vector<std::string> W_InitMultipleFiles (std::vector<std::string> &filenames);
 
 int		W_CheckNumForName (const char *name, int ns = ns_global);
-int		W_GetNumForName (const char *name);
+int		W_GetNumForName (const char *name, int ns = ns_global);
 
 unsigned	W_LumpLength (unsigned lump);
 void		W_ReadLump (unsigned lump, void *dest);
@@ -129,6 +129,3 @@ int W_GetLumpFile (unsigned lump);
 //void W_SetLumpNamespace (unsigned lump, int nmspace);
 
 #endif
-
-
-


### PR DESCRIPTION
Got this crash on WAD change in ASan, and I believe I also got a crashdump containing this same bug as well.

Essentially, when the game switches WAD files, there were some wild patch pointers hanging out in some of the HUD drawing functions that were being held onto too long.  I fixed that specific one, and decided to take care of a few other potential trouble spots I noticed as well.  Certainly not all of them, but there's only so much time in the day. :smile: 

```
=================================================================
==9038==ERROR: AddressSanitizer: heap-use-after-free on address 0x7fd95be6fe08 at pc 0x556364f21209 bp 0x7ffd93987ec0 sp 0x7ffd93987eb0
READ of size 2 at 0x7fd95be6fe08 thread T0
    #0 0x556364f21208 in patch_s::width() const ../common/./r_defs.h:533
    #1 0x556364f21208 in hud::DrawPatch(int, int, float, hud::x_align_t, hud::y_align_t, hud::x_align_t, hud::y_align_t, patch_s const*, bool, bool) ../client/src/hu_drawers.cpp:207
    #2 0x556365005a83 in hud::drawCTF() ../client/src/st_new.cpp:503
    #3 0x556365007d6d in hud::SpectatorHUD() ../client/src/st_new.cpp:731
    #4 0x556364f5c6cd in HU_Drawer() ../client/src/hu_stuff.cpp:489
    #5 0x556364ef0c4c in D_Display() ../client/src/d_main.cpp:268
    #6 0x556364e83dca in CL_DisplayTics() ../client/src/cl_main.cpp:689
    #7 0x556365095d66 in CappedTaskScheduler::run() ../common/d_main.cpp:1007
    #8 0x556365086058 in D_RunTics(void (*)(), void (*)()) ../common/d_main.cpp:1117
    #9 0x556364ef1bea in D_DoomLoop() ../client/src/d_main.cpp:337
    #10 0x556364ef347e in D_DoomMain() ../client/src/d_main.cpp:961
    #11 0x556364dcc372 in main ../client/sdl/i_main.cpp:245
    #12 0x7fd9a06b10b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #13 0x556364db40ad in _start (/home/alexmax/Documents/Workspace/odamex/build/client/odamex+0x16f0ad)

0x7fd95be6fe08 is located 73934344 bytes inside of 134217728-byte region [0x7fd9577ed800,0x7fd95f7ed800)
freed by thread T0 here:
    #0 0x7fd9a0fe87cf in __interceptor_free (/lib/x86_64-linux-gnu/libasan.so.5+0x10d7cf)
    #1 0x5563650d811f in M_Free2(void**) ../common/m_alloc.cpp:84
    #2 0x5563652b597b in Z_Close() ../common/z_zone.cpp:145
    #3 0x556364ef03bf in D_Shutdown() ../client/src/d_main.cpp:698
    #4 0x556365093d9c in D_DoomWadReboot(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) ../common/d_main.cpp:867
    #5 0x5563650a7669 in G_LoadWad(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../common/g_level.cpp:1334
    #6 0x556364e919e9 in CL_LoadMap() ../client/src/cl_main.cpp:3361
    #7 0x556364ea644f in CL_ParseCommands() ../client/src/cl_main.cpp:3722
    #8 0x556364f171be in G_Ticker() ../client/src/g_game.cpp:881
    #9 0x556364e855fb in CL_StepTics(unsigned int) ../client/src/cl_main.cpp:675
    #10 0x556364e86e45 in CL_RunTics() ../client/src/cl_main.cpp:732
    #11 0x556365095d66 in CappedTaskScheduler::run() ../common/d_main.cpp:1007
    #12 0x556365085e57 in D_RunTics(void (*)(), void (*)()) ../common/d_main.cpp:1102
    #13 0x556364ef1bea in D_DoomLoop() ../client/src/d_main.cpp:337
    #14 0x556364ef347e in D_DoomMain() ../client/src/d_main.cpp:961
    #15 0x556364dcc372 in main ../client/sdl/i_main.cpp:245
    #16 0x7fd9a06b10b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

previously allocated by thread T0 here:
    #0 0x7fd9a0fe8bc8 in malloc (/lib/x86_64-linux-gnu/libasan.so.5+0x10dbc8)
    #1 0x556364e03a09 in I_ZoneBase(unsigned long*) ../client/sdl/i_system.cpp:182
    #2 0x5563652b60f5 in Z_Init(bool) ../common/z_zone.cpp:163
    #3 0x556364ef189a in D_Init() ../client/src/d_main.cpp:574
    #4 0x556365093e43 in D_DoomWadReboot(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) ../common/d_main.cpp:878
    #5 0x556364e957e5 in CL_PrepareConnect() ../client/src/cl_main.cpp:1676
    #6 0x556364f176d6 in G_Ticker() ../client/src/g_game.cpp:919
    #7 0x556364e855fb in CL_StepTics(unsigned int) ../client/src/cl_main.cpp:675
    #8 0x556364e86e45 in CL_RunTics() ../client/src/cl_main.cpp:732
    #9 0x556365095d66 in CappedTaskScheduler::run() ../common/d_main.cpp:1007
    #10 0x556365085e57 in D_RunTics(void (*)(), void (*)()) ../common/d_main.cpp:1102
    #11 0x556364ef1bea in D_DoomLoop() ../client/src/d_main.cpp:337
    #12 0x556364ef347e in D_DoomMain() ../client/src/d_main.cpp:961
    #13 0x556364dcc372 in main ../client/sdl/i_main.cpp:245
    #14 0x7fd9a06b10b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)

SUMMARY: AddressSanitizer: heap-use-after-free ../common/./r_defs.h:533 in patch_s::width() const
Shadow bytes around the buggy address:
  0x0ffbab7c5f70: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c5f80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c5f90: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c5fa0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c5fb0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0ffbab7c5fc0: fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c5fd0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c5fe0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c5ff0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c6000: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0ffbab7c6010: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==9038==ABORTING
```