### PR TITLE
Clear the freelist after tagging it as cachable

### DIFF
--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -150,6 +150,7 @@ void ST_unloadNew()
 			Z_ChangeTag(**it, PU_CACHE);
 		**it = NULL;
 	}
+	::freelist.clear();
 }
 
 void ST_initNew()


### PR DESCRIPTION
Should fix instances of Z_ChangeTag errors on quit.