### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,13 +168,14 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 # git describe
 #
-# Grabs the branch we're on, plus a short hash.
+# Grabs the git hash and branch a few different ways.
 include(GetGitRevisionDescription)
-git_describe(GIT_DESCRIBE --all --long)
+get_git_head_revision(HEAD GIT_HASH)
+git_describe(GIT_DESCRIBE --all --long --abbrev=4)
 string(REGEX REPLACE "^(heads\/|tags\/)(.+)(-0-g)([0-9a-f]+)"
   "\\2" GIT_BRANCH "${GIT_DESCRIBE}")
 string(REGEX REPLACE "^(heads\/|tags\/)(.+)(-0-g)([0-9a-f]+)"
-  "\\4" GIT_HASH "${GIT_DESCRIBE}")
+  "\\4" GIT_SHORT_HASH "${GIT_DESCRIBE}")
 
 # Libraries
 add_subdirectory(libraries)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ cmake_dependent_option( USE_MINIUPNP "Build with UPnP support" 1 BUILD_SERVER 0 
 project(Odamex)
 cmake_minimum_required(VERSION 3.1)
 
-set(PROJECT_VERSION 0.8.3)
+set(PROJECT_VERSION 0.9.0)
 set(PROJECT_COPYRIGHT "2006-2020")
 
 # Use C++ 98/03 for all targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,8 +167,13 @@ endmacro(define_platform)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 # git describe
+#
+# Grabs the branch we're on, plus a short hash.  We also do a little massaging
+# of the output to make it look better in a version string.
 include(GetGitRevisionDescription)
-git_describe(GIT_DESCRIBE --tags --always)
+git_describe(GIT_DESCRIBE --all --long --abbrev=4)
+string(REGEX REPLACE "^(heads\/|tags\/)(.+)(-0-g)([0-9a-f]+)"
+  "\\2 \\4" GIT_DESCRIBE "${GIT_DESCRIBE}")
 
 # Libraries
 add_subdirectory(libraries)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,12 +168,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 # git describe
 #
-# Grabs the branch we're on, plus a short hash.  We also do a little massaging
-# of the output to make it look better in a version string.
+# Grabs the branch we're on, plus a short hash.
 include(GetGitRevisionDescription)
-git_describe(GIT_DESCRIBE --all --long --abbrev=4)
+git_describe(GIT_DESCRIBE --all --long)
 string(REGEX REPLACE "^(heads\/|tags\/)(.+)(-0-g)([0-9a-f]+)"
-  "\\2 \\4" GIT_DESCRIBE "${GIT_DESCRIBE}")
+  "\\2" GIT_BRANCH "${GIT_DESCRIBE}")
+string(REGEX REPLACE "^(heads\/|tags\/)(.+)(-0-g)([0-9a-f]+)"
+  "\\4" GIT_HASH "${GIT_DESCRIBE}")
 
 # Libraries
 add_subdirectory(libraries)

--- a/README
+++ b/README
@@ -1,11 +1,11 @@
 ===============================================================================
-                              Odamex v0.8.3 README
+                              Odamex v0.9.0 README
                               http://odamex.net/
                                  Authored by:
                             Dean "deathz0r" Joseph
                             Alex "AlexMax" Mayfield
                             Ralph "Ralphis" Vickers
-                        Revision date: May 2, 2020
+                        Revision date: November 8, 2020
 ===============================================================================
 
 Table of contents:

--- a/Xbox/README.Xbox
+++ b/Xbox/README.Xbox
@@ -1,9 +1,9 @@
 ===============================================================================
-                            Odamex v0.8.3 for Xbox
+                            Odamex v0.9.0 for Xbox
                               http://odamex.net/
                                  Authored by:
                             Michael "Hyper_Eye" Wood
-                       Revision date: May 2, 2020
+                       Revision date: November 8, 2020
 ===============================================================================
 
 Table of contents:

--- a/ag-odalaunch/res/Info.plist
+++ b/ag-odalaunch/res/Info.plist
@@ -19,13 +19,13 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.3</string>
+	<string>0.9.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.3</string>
+	<string>0.9.0</string>
 	<key>CFBundleGetInfoString</key>
 	<string>Copyright © 2006-2020 The Odamex Team</string>
 	<key>CFBundleLongVersionString</key>
-	<string>0.8.3</string>
+	<string>0.9.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2006-2020 The Odamex Team</string>
 	<key>LSRequiresCarbon</key>

--- a/client/sdl/client.rc
+++ b/client/sdl/client.rc
@@ -54,8 +54,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,8,3,0
- PRODUCTVERSION 0,8,3,0
+ FILEVERSION 0,9,0,0
+ PRODUCTVERSION 0,9,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -73,14 +73,14 @@ BEGIN
             VALUE "Comments", "Thanks to id Software for Doom, Randy Heit for ZDoom, and Sergey A. Makovkin for csDoom.\0"
             VALUE "CompanyName", " \0"
             VALUE "FileDescription", "Odamex Client\0"
-            VALUE "FileVersion", "0.8.3\0"
+            VALUE "FileVersion", "0.9.0\0"
             VALUE "InternalName", "Odamex Client\0"
             VALUE "LegalCopyright", "Copyright Â© 2006-2020 The Odamex Team\0"
             VALUE "LegalTrademarks", "Doom® is a Registered Trademark of id Software, Inc.\0"
             VALUE "OriginalFilename", "odamex.exe\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "Odamex Client\0"
-            VALUE "ProductVersion", "0.8.3\0"
+            VALUE "ProductVersion", "0.9.0\0"
             VALUE "SpecialBuild", "\0"
         END
     END

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1581,12 +1581,25 @@ void C_DrawConsole()
 
 	if (ConBottom >= 12)
 	{
+		static std::string version;
+		if (version.empty())
+		{
+			if (!strcmp(GitBranch(), "master"))
+			{
+				StrFormat(version, "%s (%s)", DOTVERSIONSTR, GitHash());
+			}
+			else
+			{
+				StrFormat(version, "%s (%s)", GitBranch(), GitHash());
+			}
+		}
+
 		// print the Odamex version in gold in the bottom right corner of console
-		screen->PrintStr(primary_surface_width - 8 - C_StringWidth(GitDescribe()),
-		                 ConBottom - 12, GitDescribe(), CR_ORANGE);
+		screen->PrintStr(primary_surface_width - 8 - C_StringWidth(version.c_str()),
+		                 ConBottom - 12, version.c_str(), CR_ORANGE);
 
 		// Amount of space remaining.
-		int remain = primary_surface_width - 16 - C_StringWidth(GitDescribe());
+		int remain = primary_surface_width - 16 - C_StringWidth(version.c_str());
 
 		if (CL_IsDownloading())
 		{

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1581,25 +1581,14 @@ void C_DrawConsole()
 
 	if (ConBottom >= 12)
 	{
-		static std::string version;
-		if (version.empty())
-		{
-			if (!strcmp(GitBranch(), "master"))
-			{
-				StrFormat(version, "%s (%s)", DOTVERSIONSTR, GitHash());
-			}
-			else
-			{
-				StrFormat(version, "%s (%s)", GitBranch(), GitHash());
-			}
-		}
+		const char* version = GitNiceVersion();
 
 		// print the Odamex version in gold in the bottom right corner of console
-		screen->PrintStr(primary_surface_width - 8 - C_StringWidth(version.c_str()),
-		                 ConBottom - 12, version.c_str(), CR_ORANGE);
+		screen->PrintStr(primary_surface_width - 8 - C_StringWidth(version),
+		                 ConBottom - 12, version, CR_ORANGE);
 
 		// Amount of space remaining.
-		int remain = primary_surface_width - 16 - C_StringWidth(version.c_str());
+		int remain = primary_surface_width - 16 - C_StringWidth(version);
 
 		if (CL_IsDownloading())
 		{

--- a/client/src/m_misc.cpp
+++ b/client/src/m_misc.cpp
@@ -217,7 +217,7 @@ std::string M_ExpandTokens(const std::string &str)
 				buffer << level.mapname;
 				break;
 			case 'r':
-				buffer << "r" << GitDescribe();
+				buffer << "g" << GitShortHash();
 				break;
 			case '%':
 				// Literal percent

--- a/common/git_describe.h.in
+++ b/common/git_describe.h.in
@@ -1,1 +1,3 @@
 #cmakedefine GIT_DESCRIBE "@GIT_DESCRIBE@"
+#cmakedefine GIT_BRANCH "@GIT_BRANCH@"
+#cmakedefine GIT_HASH "@GIT_HASH@"

--- a/common/git_describe.h.in
+++ b/common/git_describe.h.in
@@ -1,3 +1,3 @@
-#cmakedefine GIT_DESCRIBE "@GIT_DESCRIBE@"
-#cmakedefine GIT_BRANCH "@GIT_BRANCH@"
 #cmakedefine GIT_HASH "@GIT_HASH@"
+#cmakedefine GIT_BRANCH "@GIT_BRANCH@"
+#cmakedefine GIT_SHORT_HASH "@GIT_SHORT_HASH@"

--- a/common/version.cpp
+++ b/common/version.cpp
@@ -62,6 +62,24 @@ const char* GitDescribe()
 #endif
 }
 
+const char* GitBranch()
+{
+#ifdef GIT_BRANCH
+	return GIT_BRANCH;
+#else
+	return "unknown";
+#endif
+}
+
+const char* GitHash()
+{
+#ifdef GIT_HASH
+	return GIT_HASH;
+#else
+	return "unknown";
+#endif
+}
+
 BEGIN_COMMAND (version)
 {
 	if (argc == 1)

--- a/common/version.cpp
+++ b/common/version.cpp
@@ -54,24 +54,9 @@ file_version::file_version(const char *uid, const char *id, const char *pp, int 
 	get_source_files()[file] = ss.str();
 }
 
-const char* GitDescribe()
-{
-#ifdef GIT_DESCRIBE
-	return GIT_DESCRIBE;
-#else
-	return "unknown";
-#endif
-}
-
-const char* GitBranch()
-{
-#ifdef GIT_BRANCH
-	return GIT_BRANCH;
-#else
-	return "unknown";
-#endif
-}
-
+/**
+ * @brief Return the current commit hash.
+ */
 const char* GitHash()
 {
 #ifdef GIT_HASH
@@ -82,11 +67,35 @@ const char* GitHash()
 }
 
 /**
+ * @brief Return the current branch name.
+ */
+const char* GitBranch()
+{
+#ifdef GIT_BRANCH
+	return GIT_BRANCH;
+#else
+	return "unknown";
+#endif
+}
+
+/**
+ * @brief Return a truncated unambiguous hash.
+ */
+const char* GitShortHash()
+{
+#ifdef GIT_SHORT_HASH
+	return GIT_SHORT_HASH;
+#else
+	return "unknown";
+#endif
+}
+
+/**
  * @brief Return the Git version in a format that's good-enough to display
  *        in most end-user contexts.
  * 
- * @return A version string in the format of "branch (hash)".  If we are on
- *         master branch, a dotted version number is used instead.
+ * @return A version string in the format of "version (branch, short hash)".
+ *         On master the branch name is omitted.
 */
 const char* GitNiceVersion()
 {
@@ -95,11 +104,11 @@ const char* GitNiceVersion()
 	{
 		if (!strcmp(GitBranch(), "master"))
 		{
-			StrFormat(version, "%s (%s)", DOTVERSIONSTR, GitHash());
+			StrFormat(version, "%s (%s)", DOTVERSIONSTR, GitShortHash());
 		}
 		else
 		{
-			StrFormat(version, "%s (%s)", GitBranch(), GitHash());
+			StrFormat(version, "%s (%s, %s)", DOTVERSIONSTR, GitBranch(), GitShortHash());
 		}
 	}
 	return version.c_str();
@@ -110,7 +119,8 @@ BEGIN_COMMAND (version)
 	if (argc == 1)
 	{
 		// distribution
-		Printf(PRINT_HIGH, "Odamex v%s (%s) - %s\n", DOTVERSIONSTR, GitDescribe(), COPYRIGHTSTR);
+		Printf(PRINT_HIGH, "Odamex v%s - %s\ncommit %s (%s)\n", DOTVERSIONSTR,
+		       COPYRIGHTSTR, GitHash(), GitBranch());
 	}
 	else
 	{

--- a/common/version.cpp
+++ b/common/version.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <memory>
 
+#include "cmdlib.h"
 #include "c_dispatch.h"
 
 typedef std::map<std::string, std::string> source_files_t;
@@ -78,6 +79,30 @@ const char* GitHash()
 #else
 	return "unknown";
 #endif
+}
+
+/**
+ * @brief Return the Git version in a format that's good-enough to display
+ *        in most end-user contexts.
+ * 
+ * @return A version string in the format of "branch (hash)".  If we are on
+ *         master branch, a dotted version number is used instead.
+*/
+const char* GitNiceVersion()
+{
+	static std::string version;
+	if (version.empty())
+	{
+		if (!strcmp(GitBranch(), "master"))
+		{
+			StrFormat(version, "%s (%s)", DOTVERSIONSTR, GitHash());
+		}
+		else
+		{
+			StrFormat(version, "%s (%s)", GitBranch(), GitHash());
+		}
+	}
+	return version.c_str();
 }
 
 BEGIN_COMMAND (version)

--- a/common/version.h
+++ b/common/version.h
@@ -56,5 +56,7 @@ public:
 #define VERSION_CONTROL(uid, id) static file_version file_version_unique_##uid(#uid, id, __FILE__, __LINE__, __TIME__, __DATE__);
 
 const char* GitDescribe();
+const char* GitBranch();
+const char* GitHash();
 
 #endif //__VERSION_H__

--- a/common/version.h
+++ b/common/version.h
@@ -58,5 +58,6 @@ public:
 const char* GitDescribe();
 const char* GitBranch();
 const char* GitHash();
+const char* GitNiceVersion();
 
 #endif //__VERSION_H__

--- a/common/version.h
+++ b/common/version.h
@@ -25,10 +25,10 @@
 #define __VERSION_H__
 
 // Lots of different representations for the version number
-#define CONFIGVERSIONSTR "83"
-#define GAMEVER (0*256+83)
+#define CONFIGVERSIONSTR "90"
+#define GAMEVER (0*256+90)
 
-#define DOTVERSIONSTR "0.8.3"
+#define DOTVERSIONSTR "0.9.0"
 
 #define COPYRIGHTSTR "Copyright (C) 2006-2020 The Odamex Team"
 
@@ -42,7 +42,7 @@
 // SAVESIG is the save game signature. It should be the minimum version
 // whose savegames this version is compatible with, which could be
 // earlier than this version.
-#define SAVESIG "ODAMEXSAVE083   "	// Needs to be exactly 16 chars long
+#define SAVESIG "ODAMEXSAVE090   "	// Needs to be exactly 16 chars long
 
 #define NETDEMOVER 3
 

--- a/common/version.h
+++ b/common/version.h
@@ -55,9 +55,9 @@ public:
 
 #define VERSION_CONTROL(uid, id) static file_version file_version_unique_##uid(#uid, id, __FILE__, __LINE__, __TIME__, __DATE__);
 
-const char* GitDescribe();
-const char* GitBranch();
 const char* GitHash();
+const char* GitBranch();
+const char* GitShortHash();
 const char* GitNiceVersion();
 
 #endif //__VERSION_H__

--- a/installer/windows/odamex.iss
+++ b/installer/windows/odamex.iss
@@ -3,14 +3,14 @@
 
 [Setup]
 AppName=Odamex
-AppVersion=0.8.3
-AppVerName=Odamex 0.8.3
+AppVersion=0.9.0
+AppVerName=Odamex 0.9.0
 AppPublisher=Odamex Development Team
 AppPublisherURL=https://odamex.net
 AppSupportURL=https://odamex.net
 AppUpdatesURL=https://odamex.net
-VersionInfoVersion=0.8.3
-VersionInfoProductVersion=0.8.3
+VersionInfoVersion=0.9.0
+VersionInfoProductVersion=0.9.0
 VersionInfoProductName=Odamex Windows Installer
 DefaultDirName={userpf}\odamex
 DefaultGroupName=Odamex

--- a/odalaunch/res/Info.plist
+++ b/odalaunch/res/Info.plist
@@ -19,13 +19,13 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.3</string>
+	<string>0.9.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.3</string>
+	<string>0.9.0</string>
 	<key>CFBundleGetInfoString</key>
 	<string>Copyright © 2006-2020 The Odamex Team</string>
 	<key>CFBundleLongVersionString</key>
-	<string>0.8.3</string>
+	<string>0.9.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2006-2020 The Odamex Team</string>
 	<key>LSRequiresCarbon</key>

--- a/odalaunch/res/gui_project.fbp
+++ b/odalaunch/res/gui_project.fbp
@@ -10315,7 +10315,7 @@
                                                     <property name="gripper">0</property>
                                                     <property name="hidden">0</property>
                                                     <property name="id">wxID_ANY</property>
-                                                    <property name="label">Copyright (C) 2006-2019 The Odamex Team</property>
+                                                    <property name="label">Copyright (C) 2006-2020 The Odamex Team</property>
                                                     <property name="max_size"></property>
                                                     <property name="maximize_button">0</property>
                                                     <property name="maximum_size"></property>

--- a/odalaunch/res/odalaunch.rc
+++ b/odalaunch/res/odalaunch.rc
@@ -58,8 +58,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,8,3,0
- PRODUCTVERSION 0,8,3,0
+ FILEVERSION 0,9,0,0
+ PRODUCTVERSION 0,9,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -77,14 +77,14 @@ BEGIN
             VALUE "Comments", "\0"
             VALUE "CompanyName", " \0"
             VALUE "FileDescription", "Odamex Launcher\0"
-            VALUE "FileVersion", "0.8.3\0"
+            VALUE "FileVersion", "0.9.0\0"
             VALUE "InternalName", "Odamex Launcher\0"
             VALUE "LegalCopyright", "Copyright © 2006-2020 The Odamex Team\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "odalaunch.exe\0"
             VALUE "PrivateBuild", "$Id$\0"
             VALUE "ProductName", "Odamex Launcher\0"
-            VALUE "ProductVersion", "0.8.3\0"
+            VALUE "ProductVersion", "0.9.0\0"
             VALUE "SpecialBuild", "$Id$\0"
         END
     END

--- a/odalpapi/net_packet.h
+++ b/odalpapi/net_packet.h
@@ -55,7 +55,7 @@
 #define VERSIONMINOR(V) ((V % 256) / 10)
 #define VERSIONPATCH(V) ((V % 256) % 10)
 
-#define VERSION (0*256+83)
+#define VERSION (0*256+90)
 #define PROTOCOL_VERSION 8
 
 #define TAG_ID 0xAD0

--- a/server/src/sv_sqp.cpp
+++ b/server/src/sv_sqp.cpp
@@ -89,7 +89,7 @@ static void IntQryBuildInformation(const DWORD& EqProtocolVersion,
 	// TODO: Remove guard before next release
 	QRYNEWINFO(7)
 	{
-		MSG_WriteString(&ml_message, GitDescribe());
+		MSG_WriteString(&ml_message, GitNiceVersion());
 	}
 	else
 		MSG_WriteLong(&ml_message, -1);

--- a/server/win32/server.rc
+++ b/server/win32/server.rc
@@ -54,8 +54,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,8,3,0
- PRODUCTVERSION 0,8,3,0
+ FILEVERSION 0,9,0,0
+ PRODUCTVERSION 0,9,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -73,14 +73,14 @@ BEGIN
             VALUE "Comments", "Thanks to id Software for Doom, Randy Heit for ZDoom, and Sergey A. Makovkin for csDoom.\0"
             VALUE "CompanyName", " \0"
             VALUE "FileDescription", "Odamex Server\0"
-            VALUE "FileVersion", "0.8.3\0"
+            VALUE "FileVersion", "0.9.0\0"
             VALUE "InternalName", "Odamex Server\0"
             VALUE "LegalCopyright", "Copyright Â© 2006-2020 The Odamex Team\0"
             VALUE "LegalTrademarks", "Doom® is a Registered Trademark of id Software, Inc.\0"
             VALUE "OriginalFilename", "odasrv.exe\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "Odamex Server\0"
-            VALUE "ProductVersion", "0.8.3\0"
+            VALUE "ProductVersion", "0.9.0\0"
             VALUE "SpecialBuild", "\0"
         END
     END


### PR DESCRIPTION
This PR essentially bumps the version to 0.9.0.

I think this should be done to `protobreak` the moment we do a stable release of Odamex, to ensure that standard clients don't attempt to connect to `protobreak` servers we run in the future.

I also worked in a couple of version-related extras, to clean up the look of `version` and the version displayed in the console.