### PR TITLE
Fix a few bugs causing HOM on netplay

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -707,6 +707,7 @@ void NetDemo::writeLocalCmd(buf_t *netbuffer) const
 	MSG_WriteLong(netbuffer, mo->momz);
 	MSG_WriteLong(netbuffer, mo->angle);
 	MSG_WriteLong(netbuffer, mo->pitch);
+	MSG_WriteLong(netbuffer, player->viewz);
 	MSG_WriteLong(netbuffer, player->viewheight);
 	MSG_WriteLong(netbuffer, player->deltaviewheight);
 	MSG_WriteLong(netbuffer, player->jumpTics);

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -3923,7 +3923,7 @@ void CL_LocalDemoTic()
 	player_t* clientPlayer = &consoleplayer();
 	fixed_t x, y, z;
 	fixed_t momx, momy, momz;
-	fixed_t pitch, viewheight, deltaviewheight;
+	fixed_t pitch, viewz, viewheight, deltaviewheight;
 	angle_t angle;
 	int jumpTics, reactiontime;
 	byte waterlevel;
@@ -3946,6 +3946,7 @@ void CL_LocalDemoTic()
 	momz = MSG_ReadLong();
 	angle = MSG_ReadLong();
 	pitch = MSG_ReadLong();
+	viewz = MSG_ReadLong();
 	viewheight = MSG_ReadLong();
 	deltaviewheight = MSG_ReadLong();
 	jumpTics = MSG_ReadLong();
@@ -3963,6 +3964,7 @@ void CL_LocalDemoTic()
 		clientPlayer->mo->momz = momz;
 		clientPlayer->mo->angle = angle;
 		clientPlayer->mo->pitch = pitch;
+		clientPlayer->viewz = viewz;
 		clientPlayer->viewheight = viewheight;
 		clientPlayer->deltaviewheight = deltaviewheight;
 		clientPlayer->jumpTics = jumpTics;

--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -976,7 +976,7 @@ void G_Ticker (void)
 				AActor *mobj = new AActor (0, 0, 0, MT_PLAYER);
 				mobj->flags &= ~MF_SOLID;
 				mobj->flags2 |= MF2_DONTDRAW;
-				consoleplayer().mo = mobj->ptr();
+				consoleplayer().mo = consoleplayer().camera = mobj->ptr();
 				consoleplayer().mo->player = &consoleplayer();
 				G_PlayerReborn(consoleplayer());
 				DPrintf("Did not receive spawn for consoleplayer.\n");


### PR DESCRIPTION
I think I figured out what was causing HOM when playing a netdemo.

First off, the newly-spawned player did not have a camera, so their head was somewhere in the void, or if you were terribly unlucky, the position where the player on the map before netplay began.

Next, `viewz` was not being recorded in the demo.  Normally, this would not be a problem, since it gets initialized upon player spawn, but the demo machinery reloads the map when first starting and `viewz` is reset to 1 without being reset by another player spawn.  There's probably a more elegant way to fix this, but writing `viewz` works well enough for now.