### PR TITLE
Flexibilize video emulation

### DIFF
--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -79,8 +79,7 @@ EXTERN_CVAR(vid_fullscreen)
 EXTERN_CVAR(vid_vsync)
 EXTERN_CVAR(vid_filter)
 EXTERN_CVAR(vid_overscan)
-EXTERN_CVAR(vid_320x200)
-EXTERN_CVAR(vid_640x400)
+EXTERN_CVAR(vid_emulines)
 EXTERN_CVAR(vid_autoadjust)
 EXTERN_CVAR(vid_displayfps)
 EXTERN_CVAR(vid_ticker)
@@ -588,7 +587,6 @@ void I_SetVideoMode(const IVideoMode& requested_mode)
 
 	// [SL] Determine the size of the matted surface.
 	// A matted surface will be used if pillar-boxing or letter-boxing are used, or
-	// if vid_320x200/vid_640x400 are being used in a wide-screen video mode, or
 	// if vid_overscan is used to create a matte around the entire screen.
 	//
 	// Only vid_overscan creates a matted surface if the video mode is 320x200 or 640x400.
@@ -602,9 +600,7 @@ void I_SetVideoMode(const IVideoMode& requested_mode)
 
 	if (!I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight()))
 	{
-		if (vid_320x200 || vid_640x400)
-			surface_width = surface_height * 4 / 3;
-		else if (V_UsePillarBox())
+		if (V_UsePillarBox())
 			surface_width = surface_height * 4 / 3;
 		else if (V_UseLetterBox())
 			surface_height = surface_width * 9 / 16;
@@ -628,14 +624,9 @@ void I_SetVideoMode(const IVideoMode& requested_mode)
 	}
 
 	// Create emulated_surface for emulating low resolution modes.
-	if (vid_320x200)
+	if (vid_emulines >= 200)
 	{
-		emulated_surface = new IWindowSurface(320, 200, primary_surface->getPixelFormat());
-		emulated_surface->clear();
-	}
-	else if (vid_640x400)
-	{
-		emulated_surface = new IWindowSurface(640, 400, primary_surface->getPixelFormat());
+		emulated_surface = new IWindowSurface(clamp<uint16_t>(vid_emulines*surface_width/surface_height, 320, MAXWIDTH), clamp<uint16_t>(vid_emulines, 200, MAXHEIGHT), primary_surface->getPixelFormat());
 		emulated_surface->clear();
 	}
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -661,11 +661,8 @@ CVAR_FUNC_DECL(	vid_fullscreen, "0", "Full screen video mode",
 CVAR_FUNC_DECL(	vid_32bpp, "0", "Enable 32-bit color rendering",
 				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
-CVAR_FUNC_DECL(	vid_320x200, "0", "Enable 320x200 video emulation",
-				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
-
-CVAR_FUNC_DECL(	vid_640x400, "0", "Enable 640x400 video emulation",
-				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+CVAR_FUNC_DECL( vid_emulines, "0", "Enable video emulation, set to 200 for classic doom",
+				CVARTYPE_WORD, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE)
 
 CVAR_FUNC_DECL(	vid_filter, "", "Set render scale quality setting for SDL 2.0, one of \"nearest\",\"linear\",\"best\"",
 				CVARTYPE_STRING, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE)

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -59,8 +59,7 @@ extern bool r_fakingunderwater;
 EXTERN_CVAR (r_flashhom)
 EXTERN_CVAR (r_viewsize)
 EXTERN_CVAR (sv_allowwidescreen)
-EXTERN_CVAR (vid_320x200)
-EXTERN_CVAR (vid_640x400)
+EXTERN_CVAR (vid_emulines)
 
 fixed_t			FocalLengthX;
 fixed_t			FocalLengthY;
@@ -165,7 +164,7 @@ void R_ForceViewWindowResize()
 //
 IWindowSurface* R_GetRenderingSurface()
 {
-	if ((vid_320x200 || vid_640x400) && I_GetEmulatedSurface() != NULL)
+	if ((vid_emulines >= 200) && I_GetEmulatedSurface() != NULL)
 		return I_GetEmulatedSurface();
 	else
 		return I_GetPrimarySurface();
@@ -1154,7 +1153,7 @@ static void R_InitViewWindow()
 	int surface_width = surface->getWidth(), surface_height = surface->getHeight();
 
 	// using a 320x200/640x400 surface or video mode
-	bool protected_res = vid_320x200 || vid_640x400
+	bool protected_res = (vid_emulines >= 200)
 					|| I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight());
 
 	surface->lock();
@@ -1177,10 +1176,7 @@ static void R_InitViewWindow()
 
 	// calculate the vertical stretching factor to emulate 320x200
 	// it's a 5:4 ratio = (320 / 200) / (4 / 3)
-	if (protected_res)
-		yaspectmul = FRACUNIT;
-	else
-		yaspectmul = 320 * 3 * FRACUNIT / (200 * 4);
+	yaspectmul = 320 * 3 * FRACUNIT / (200 * 4);
 
 	// Calculate FieldOfView and CorrectFieldOfView
 	float desired_fov = 90.0f;

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -218,14 +218,7 @@ CVAR_FUNC_IMPL(vid_overscan)
 }
 
 
-CVAR_FUNC_IMPL(vid_320x200)
-{
-	if (gamestate != GS_STARTUP)
-		V_ForceVideoModeAdjustment();
-}
-
-
-CVAR_FUNC_IMPL(vid_640x400)
+CVAR_FUNC_IMPL(vid_emulines)
 {
 	if (gamestate != GS_STARTUP)
 		V_ForceVideoModeAdjustment();
@@ -419,9 +412,6 @@ bool V_UsePillarBox()
 	if (I_IsProtectedResolution(width, height))
 		return false;
 
-	if (vid_320x200 || vid_640x400)
-		return 3 * width > 4 * height;
-
 	return (!vid_widescreen || (!serverside && !sv_allowwidescreen))
 		&& (3 * width > 4 * height);
 }
@@ -443,9 +433,6 @@ bool V_UseLetterBox()
 	if (I_IsProtectedResolution(width, height))
 		return false;
 
-	if (vid_320x200 || vid_640x400)
-		return 3 * width <= 4 * height;
-
 	return (vid_widescreen && (serverside || sv_allowwidescreen))
 		&& (3 * width <= 4 * height);
 }
@@ -463,9 +450,6 @@ bool V_UseWidescreen()
 
 	if (I_IsProtectedResolution(width, height))
 		return false;
-
-	if (vid_320x200 || vid_640x400)
-		return 3 * width > 4 * height;
 
 	return (vid_widescreen && (serverside || sv_allowwidescreen))
 		&& (3 * width > 4 * height);


### PR DESCRIPTION
Currently vid_320x200 and vid_640x400 emulate very specific situation, where
lower resolution emulation is unnecessarily limited and unnecessarily entangled
with nonwidescreen.

This introduces vid_emulines, which only sets the height of the emulated
resolution and the width is automatically derived based on the relevant
aspect ratio, which means it's also disentangled from widescreen.