### PR TITLE
Fix looking around with keyboard/joystick

### DIFF
--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -552,10 +552,16 @@ void G_BuildTiccmd(ticcmd_t *cmd)
 	}
 	else
 	{
+		// [AM] LocalViewPitch is an offset on look.
 		cmd->pitch = look + (LocalViewPitch >> 16);
 	}
 	
-	cmd->yaw = LocalViewAngle >> 16;
+	if (LocalViewAngle)
+	{
+		// [AM] LocalViewAngle is a global angle, only pave over the existing
+		//      yaw if we have local yaw.
+		cmd->yaw = LocalViewAngle >> 16;
+	}
 
 	if (!longtics)
 		cmd->yaw = (cmd->yaw + 128) & 0xFF00;

--- a/client/src/r_interp.cpp
+++ b/client/src/r_interp.cpp
@@ -168,7 +168,7 @@ void R_InterpolateCamera(fixed_t amount)
 	{
 		player_t& consolePlayer = consoleplayer();
 
-		if (consolePlayer.id == displayplayer().id && consolePlayer.health > 0)
+		if (LocalViewAngle && consolePlayer.id == displayplayer().id && consolePlayer.health > 0)
 		{
 			viewangle = camera->angle + LocalViewAngle;
 		}

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -865,7 +865,7 @@ void R_SetupFrame (player_t *player)
 
 	player_t& consolePlayer = consoleplayer();
 
-	if (consolePlayer.id == displayplayer().id && consolePlayer.health > 0)
+	if (LocalViewPitch && consolePlayer.id == displayplayer().id && consolePlayer.health > 0)
 	{
 		R_ViewShear(clamp(camera->pitch - LocalViewPitch, -ANG(32), ANG(56)));
 	}


### PR DESCRIPTION
The improved mouse code I believe exposed an issue where turning with the keyboard and joystick stopped working, and looking up and down was incredibly jittery.

I believe this PR fixes both issues.  Now, we interpolate if there is no accumulated yaw or pitch values, and we also fix a bug where accumulated yaw was blasting away any other types of yaw.