### PR TITLE
Miscellanous fixes

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -2220,7 +2220,9 @@ void C_RevealSecret()
 		return;                      // NES - Also check for deathmatch
 
 	C_MidPrint("A secret is revealed!");
-	S_Sound(CHAN_INTERFACE, "misc/secret", 1, ATTN_NONE);
+
+	if (hud_revealsecrets == 1 || hud_revealsecrets == 3)
+		S_Sound(CHAN_INTERFACE, "misc/secret", 1, ATTN_NONE);
 }
 
 VERSION_CONTROL (c_console_cpp, "$Id$")

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -455,8 +455,8 @@ CVAR_RANGE(		hud_fullhudtype, "1","Fullscreen HUD to display:\n// 0: ZDoom HUD\n
 CVAR_RANGE(		hud_gamemsgtype, "2", "Game message type",
 				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 1.0f, 2.0f)
 
-CVAR(			hud_revealsecrets, "1", "Print HUD message when secrets are discovered",
-				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+CVAR(			hud_revealsecrets, "1", "Print a HUD message and|or play a sound when a secret is discovered.",
+				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 3.0f)
 
 CVAR(			hud_scale, "1", "HUD scaling",
 				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -455,7 +455,7 @@ CVAR_RANGE(		hud_fullhudtype, "1","Fullscreen HUD to display:\n// 0: ZDoom HUD\n
 CVAR_RANGE(		hud_gamemsgtype, "2", "Game message type",
 				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 1.0f, 2.0f)
 
-CVAR(			hud_revealsecrets, "1", "Print a HUD message and|or play a sound when a secret is discovered.",
+CVAR_RANGE(		hud_revealsecrets, "1", "Get a notification if you or another player finds a secret.",
 				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 3.0f)
 
 CVAR(			hud_scale, "1", "HUD scaling",

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -158,6 +158,9 @@ EXTERN_CVAR (cl_forcedownload)
 // [SL] Force enemies to have the specified color
 EXTERN_CVAR (r_forceenemycolor)
 EXTERN_CVAR (r_forceteamcolor)
+
+EXTERN_CVAR (hud_revealsecrets)
+
 static argb_t enemycolor, teamcolor;
 
 void P_PlayerLeavesGame(player_s* player);
@@ -2960,6 +2963,26 @@ void CL_ClearSectorSnapshots()
 }
 
 //
+// CL_SecretEvent
+// Client interpretation of a secret found by another player
+//
+void CL_SecretEvent()
+{
+	player_t& player = idplayer(MSG_ReadByte());
+
+	// Don't show other secrets if requested
+	if (!hud_revealsecrets || hud_revealsecrets > 2)
+		return;
+
+	std::string buf;
+	StrFormat(buf, "%s%s %sfound a secret!\n", TEXTCOLOR_YELLOW, player.userinfo.netname, TEXTCOLOR_NORMAL);
+	Printf(buf.c_str());
+
+	if (hud_revealsecrets == 1)
+		S_Sound(CHAN_INTERFACE, "misc/secret", 1, ATTN_NONE);
+}
+
+//
 // CL_UpdateSector
 // Updates floorheight and ceilingheight of a sector.
 //
@@ -3762,6 +3785,7 @@ void CL_InitCommands(void)
 	cmds[svc_forceteam]			= &CL_ForceSetTeam;
 
 	cmds[svc_ctfevent]			= &CL_CTFEvent;
+	cmds[svc_secretevent]		= &CL_SecretEvent;
 	cmds[svc_serversettings]	= &CL_GetServerSettings;
 	cmds[svc_disconnect]		= &CL_EndGame;
 	cmds[svc_full]				= &CL_FullGame;

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2975,7 +2975,7 @@ void CL_SecretEvent()
 		return;
 
 	std::string buf;
-	StrFormat(buf, "%s%s %sfound a secret!\n", TEXTCOLOR_YELLOW, player.userinfo.netname, TEXTCOLOR_NORMAL);
+	StrFormat(buf, "%s%s %sfound a secret!\n", TEXTCOLOR_YELLOW, player.userinfo.netname.c_str(), TEXTCOLOR_NORMAL);
 	Printf(buf.c_str());
 
 	if (hud_revealsecrets == 1)

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -50,6 +50,12 @@ void STACK_ARGS SV_BroadcastPrintf(int printlevel, const char* format, ...)
 	Printf(printlevel, "%s", str.c_str());
 }
 
+FORMAT_PRINTF(1, 2)
+void STACK_ARGS SV_BroadcastPrintf(const char* format, ...)
+{
+	SV_BroadcastPrintf(PRINT_HIGH, format);
+}
+
 void D_SendServerInfoChange(const cvar_t *cvar, const char *value) {}
 void D_DoServerInfoChange(byte **stream) {}
 void D_WriteUserInfoStrings(int i, byte **stream, bool compact) {}

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -110,11 +110,11 @@ team_t D_TeamByName (const char *team)
 			return (team_t)i;
 	}
 
-	if (stricmp(team, "0") == 0)
+	if (strcmp(team, "0") == 0)
 		return TEAM_BLUE;
-	else if (stricmp(team, "1") == 0)
+	else if (strcmp(team, "1") == 0)
 		return TEAM_RED;
-	else if (stricmp(team, "2") == 0)
+	else if (strcmp(team, "2") == 0)
 		return TEAM_GREEN;
 
 	return TEAM_NONE;

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -110,6 +110,13 @@ team_t D_TeamByName (const char *team)
 			return (team_t)i;
 	}
 
+	if (stricmp(team, "0") == 0)
+		return TEAM_BLUE;
+	else if (stricmp(team, "1") == 0)
+		return TEAM_RED;
+	else if (stricmp(team, "2") == 0)
+		return TEAM_GREEN;
+
 	return TEAM_NONE;
 }
 
@@ -151,8 +158,15 @@ void D_SetupUserInfo(void)
 	if (netname.length() > MAXPLAYERNAME)
 		netname.erase(MAXPLAYERNAME);
 
+	team_t newteam = D_TeamByName(cl_team.cstring());
+	if (newteam == TEAM_NONE){
+		cl_team.RestoreDefault();
+		newteam = TEAM_BLUE;
+	}
+
+
 	coninfo->netname			= netname;
-	coninfo->team				= D_TeamByName (cl_team.cstring()); // [Toke - Teams]
+	coninfo->team				= newteam; // [Toke - Teams]
 	coninfo->gender				= D_GenderByName (cl_gender.cstring());
 	coninfo->aimdist			= (fixed_t)(cl_autoaim * 16384.0);
 	coninfo->predict_weapons	= (cl_predictweapons != 0);

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -892,6 +892,13 @@ static value_t Languages[] = {
 	{ 3.0, "Italian" }
 };
 
+static value_t SecretOptions[] = {
+    {0.0, "Off"}, 
+	{1.0, "On (with sounds)"}, 
+	{2.0, "On (w/o sounds)"}, 
+	{3.0, "Own only"}, 
+};
+
 static menuitem_t MessagesItems[] = {
 	{ discrete, "Language", 			 {&language},		   	{4.0}, {0.0},   {0.0}, {Languages} },
 	{ slider,	"Scale message text",    {&hud_scaletext},		{1.0}, {4.0}, 	{1.0}, {NULL} },
@@ -905,7 +912,7 @@ static menuitem_t MessagesItems[] = {
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
     { discrete,	"Player target names",	{&hud_targetnames},		{2.0}, {0.0},   {0.0}, {HideShow} },
 	{ discrete ,"CTF Alerts Type",		{&hud_gamemsgtype},		{3.0}, {0.0},   {0.0}, {VoxType} },
-	{ discrete, "Reveal Secrets",       {&hud_revealsecrets},	{2.0}, {0.0},   {0.0}, {OnOff} },
+	{ discrete, "Reveal Secrets",       {&hud_revealsecrets},	{4.0}, {0.0},   {0.0}, {SecretOptions} },
 
 
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -2285,7 +2285,7 @@ static void UpdateStuff (void)
 void Reset2Defaults (void)
 {
 	AddCommandString ("unbindall; binddefaults");
-	cvar_t::C_SetCVarsToDefaults(CVAR_ARCHIVE | CVAR_CLIENTARCHIVE);
+	cvar_t::C_SetCVarsToDefaults(CVAR_CLIENTARCHIVE);
 	UpdateStuff();
 }
 

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1215,7 +1215,7 @@ void ST_drawWidgets(bool force_refresh)
 
 	STlib_updateNum(&w_frags, force_refresh);
 
-	STlib_updateNum(&w_lives, force_refresh);
+	STlib_updateNum(&w_lives, true);	// Force refreshing to avoid tens to be hidden by Doomguy's face
 }
 
 

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -462,13 +462,12 @@ void G_TimeCheckEndGame()
 		}
 		else if (pr.count >= 2)
 		{
-			SV_BroadcastPrintf(PRINT_HIGH, "Time limit hit. Game is a draw!\n");
+			SV_BroadcastPrintf("Time limit hit. Game is a draw!\n");
 			::levelstate.setWinner(WinInfo::WIN_DRAW, 0);
 		}
 		else
 		{
-			SV_BroadcastPrintf(PRINT_HIGH, "Time limit hit. Game won by %s!\n",
-			                   pr.players.front()->userinfo.netname.c_str());
+			SV_BroadcastPrintf("Time limit hit. Game won by %s!\n", pr.players.front()->userinfo.netname.c_str());
 			::levelstate.setWinner(WinInfo::WIN_PLAYER, pr.players.front()->id);
 		}
 	}
@@ -478,8 +477,7 @@ void G_TimeCheckEndGame()
 		{
 			// Defense always wins in the event of a timeout.
 			const TeamInfo& ti = *GetTeamInfo(::levelstate.getDefendingTeam());
-			SV_BroadcastPrintf(PRINT_HIGH, "Time limit hit. %s team wins!\n",
-			                   ti.ColorStringUpper.c_str());
+			SV_BroadcastPrintf("Time limit hit. %s team wins!\n", ti.ColorStringUpper.c_str());
 			::levelstate.setWinner(WinInfo::WIN_TEAM, ti.Team);
 		}
 		else
@@ -488,13 +486,12 @@ void G_TimeCheckEndGame()
 
 			if (tv.size() != 1)
 			{
-				SV_BroadcastPrintf(PRINT_HIGH, "Time limit hit. Game is a draw!\n");
+				SV_BroadcastPrintf("Time limit hit. Game is a draw!\n");
 				::levelstate.setWinner(WinInfo::WIN_DRAW, 0);
 			}
 			else
 			{
-				SV_BroadcastPrintf(PRINT_HIGH, "Time limit hit. %s team wins!\n",
-				                   tv.front()->ColorStringUpper.c_str());
+				SV_BroadcastPrintf("Time limit hit. %s team wins!\n", tv.front()->ColorStringUpper.c_str());
 				::levelstate.setWinner(WinInfo::WIN_TEAM, tv.front()->Team);
 			}
 		}
@@ -524,8 +521,7 @@ void G_FragsCheckEndGame()
 			GiveWins(*top, 1);
 
 			// [ML] 04/4/06: Added !sv_fragexitswitch
-			SV_BroadcastPrintf(PRINT_HIGH, "Frag limit hit. Game won by %s!\n",
-			                   top->userinfo.netname.c_str());
+			SV_BroadcastPrintf("Frag limit hit. Game won by %s!\n", top->userinfo.netname.c_str());
 			::levelstate.setWinner(WinInfo::WIN_PLAYER, top->id);
 			::levelstate.endRound();
 		}
@@ -550,8 +546,7 @@ void G_TeamFragsCheckEndGame()
 		if (team->Points >= sv_fraglimit)
 		{
 			GiveTeamWins(team->Team, 1);
-			SV_BroadcastPrintf(PRINT_HIGH, "Frag limit hit. %s team wins!\n",
-			                   team->ColorString.c_str());
+			SV_BroadcastPrintf("Frag limit hit. %s team wins!\n", team->ColorString.c_str());
 			::levelstate.setWinner(WinInfo::WIN_TEAM, team->Team);
 			::levelstate.endRound();
 			return;
@@ -577,8 +572,7 @@ void G_TeamScoreCheckEndGame()
 		if (team->Points >= sv_scorelimit)
 		{
 			GiveTeamWins(team->Team, 1);
-			SV_BroadcastPrintf(PRINT_HIGH, "Score limit hit. %s team wins!\n",
-			                   team->ColorString.c_str());
+			SV_BroadcastPrintf("Score limit hit. %s team wins!\n", team->ColorString.c_str());
 			::levelstate.setWinner(WinInfo::WIN_TEAM, team->Team);
 			::levelstate.endRound();
 			M_CommitWDLLog();
@@ -659,10 +653,7 @@ void G_LivesCheckEndGame()
 			if (tv.size() == 1)
 			{
 				GiveTeamWins(tv.front()->Team, 1);
-				SV_BroadcastPrintf(
-				    PRINT_HIGH,
-				    "%s team wins for having the highest score with %s left!\n",
-				    tv.front()->ColorString.c_str(), teams);
+				SV_BroadcastPrintf("%s team wins for having the highest score with %s left!\n", tv.front()->ColorString.c_str(), teams);
 				::levelstate.setWinner(WinInfo::WIN_TEAM, tv.front()->Team);
 				::levelstate.endRound();
 			}
@@ -686,7 +677,7 @@ void G_LivesCheckEndGame()
 		{
 			team_t team = pr.players.front()->userinfo.team;
 			GiveTeamWins(team, 1);
-			SV_BroadcastPrintf(PRINT_HIGH, "%s team wins as the last team standing!\n",
+			SV_BroadcastPrintf("%s team wins as the last team standing!\n",
 			                   GetTeamInfo(team)->ColorString.c_str());
 			::levelstate.setWinner(WinInfo::WIN_TEAM, team);
 			::levelstate.endRound();
@@ -745,8 +736,7 @@ bool G_RoundsShouldEndGame()
 			TeamInfo* team = GetTeamInfo((team_t)i);
 			if (team->RoundWins >= g_winlimit)
 			{
-				SV_BroadcastPrintf(PRINT_HIGH, "Win limit hit. %s team wins!\n",
-				                   team->ColorString.c_str());
+				SV_BroadcastPrintf("Win limit hit. %s team wins!\n", team->ColorString.c_str());
 				::levelstate.setWinner(WinInfo::WIN_TEAM, team->Team);
 				return true;
 			}

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -76,7 +76,7 @@ const std::string& G_GametypeName()
 
 /**
  * @brief Check if the round should be allowed to end.
- * 
+ *
  * @detail This is not an appropriate function to call on level exit.
  */
 bool G_CanEndGame()
@@ -215,7 +215,7 @@ bool G_CanTickGameplay()
 
 /**
  * @brief Check if the passed team is on defense.
- * 
+ *
  * @param team Team to check.
  * @return True if the team is on defense, or if sides aren't enabled.
  */
@@ -259,7 +259,7 @@ bool G_IsRoundsGame()
 
 /**
  * @brief Check if the game uses lives.
-*/
+ */
 bool G_IsLivesGame()
 {
 	return g_lives > 0;
@@ -467,7 +467,8 @@ void G_TimeCheckEndGame()
 		}
 		else
 		{
-			SV_BroadcastPrintf("Time limit hit. Game won by %s!\n", pr.players.front()->userinfo.netname.c_str());
+			SV_BroadcastPrintf("Time limit hit. Game won by %s!\n",
+			                   pr.players.front()->userinfo.netname.c_str());
 			::levelstate.setWinner(WinInfo::WIN_PLAYER, pr.players.front()->id);
 		}
 	}
@@ -477,7 +478,8 @@ void G_TimeCheckEndGame()
 		{
 			// Defense always wins in the event of a timeout.
 			const TeamInfo& ti = *GetTeamInfo(::levelstate.getDefendingTeam());
-			SV_BroadcastPrintf("Time limit hit. %s team wins!\n", ti.ColorStringUpper.c_str());
+			SV_BroadcastPrintf("Time limit hit. %s team wins!\n",
+			                   ti.ColorStringUpper.c_str());
 			::levelstate.setWinner(WinInfo::WIN_TEAM, ti.Team);
 		}
 		else
@@ -491,7 +493,8 @@ void G_TimeCheckEndGame()
 			}
 			else
 			{
-				SV_BroadcastPrintf("Time limit hit. %s team wins!\n", tv.front()->ColorStringUpper.c_str());
+				SV_BroadcastPrintf("Time limit hit. %s team wins!\n",
+				                   tv.front()->ColorStringUpper.c_str());
 				::levelstate.setWinner(WinInfo::WIN_TEAM, tv.front()->Team);
 			}
 		}
@@ -521,7 +524,8 @@ void G_FragsCheckEndGame()
 			GiveWins(*top, 1);
 
 			// [ML] 04/4/06: Added !sv_fragexitswitch
-			SV_BroadcastPrintf("Frag limit hit. Game won by %s!\n", top->userinfo.netname.c_str());
+			SV_BroadcastPrintf("Frag limit hit. Game won by %s!\n",
+			                   top->userinfo.netname.c_str());
 			::levelstate.setWinner(WinInfo::WIN_PLAYER, top->id);
 			::levelstate.endRound();
 		}
@@ -546,7 +550,8 @@ void G_TeamFragsCheckEndGame()
 		if (team->Points >= sv_fraglimit)
 		{
 			GiveTeamWins(team->Team, 1);
-			SV_BroadcastPrintf("Frag limit hit. %s team wins!\n", team->ColorString.c_str());
+			SV_BroadcastPrintf("Frag limit hit. %s team wins!\n",
+			                   team->ColorString.c_str());
 			::levelstate.setWinner(WinInfo::WIN_TEAM, team->Team);
 			::levelstate.endRound();
 			return;
@@ -572,7 +577,8 @@ void G_TeamScoreCheckEndGame()
 		if (team->Points >= sv_scorelimit)
 		{
 			GiveTeamWins(team->Team, 1);
-			SV_BroadcastPrintf("Score limit hit. %s team wins!\n", team->ColorString.c_str());
+			SV_BroadcastPrintf("Score limit hit. %s team wins!\n",
+			                   team->ColorString.c_str());
 			::levelstate.setWinner(WinInfo::WIN_TEAM, team->Team);
 			::levelstate.endRound();
 			M_CommitWDLLog();
@@ -598,7 +604,7 @@ void G_LivesCheckEndGame()
 		PlayerResults pr = PlayerQuery().hasLives().execute();
 		if (pr.count == 0)
 		{
-			SV_BroadcastPrintf(PRINT_HIGH, "All players have run out of lives.\n");
+			SV_BroadcastPrintf("All players have run out of lives.\n");
 			::levelstate.setWinner(WinInfo::WIN_NOBODY, 0);
 			::levelstate.endRound();
 		}
@@ -609,14 +615,14 @@ void G_LivesCheckEndGame()
 		PlayerResults pr = PlayerQuery().hasLives().execute();
 		if (pr.count == 0)
 		{
-			SV_BroadcastPrintf(PRINT_HIGH, "All players have run out of lives.\n");
+			SV_BroadcastPrintf("All players have run out of lives.\n");
 			::levelstate.setWinner(WinInfo::WIN_DRAW, 0);
 			::levelstate.endRound();
 		}
 		else if (pr.count == 1)
 		{
 			GiveWins(*pr.players.front(), 1);
-			SV_BroadcastPrintf(PRINT_HIGH, "%s wins as the last player standing!\n",
+			SV_BroadcastPrintf("%s wins as the last player standing!\n",
 			                   pr.players.front()->userinfo.netname.c_str());
 			::levelstate.setWinner(WinInfo::WIN_PLAYER, pr.players.front()->id);
 			::levelstate.endRound();
@@ -653,14 +659,15 @@ void G_LivesCheckEndGame()
 			if (tv.size() == 1)
 			{
 				GiveTeamWins(tv.front()->Team, 1);
-				SV_BroadcastPrintf("%s team wins for having the highest score with %s left!\n", tv.front()->ColorString.c_str(), teams);
+				SV_BroadcastPrintf(
+				    "%s team wins for having the highest score with %s left!\n",
+				    tv.front()->ColorString.c_str(), teams);
 				::levelstate.setWinner(WinInfo::WIN_TEAM, tv.front()->Team);
 				::levelstate.endRound();
 			}
 			else
 			{
-				SV_BroadcastPrintf(PRINT_HIGH,
-				                   "Score is tied with with %s left. Game is a draw!\n",
+				SV_BroadcastPrintf("Score is tied with with %s left. Game is a draw!\n",
 				                   teams);
 				::levelstate.setWinner(WinInfo::WIN_DRAW, 0);
 				::levelstate.endRound();
@@ -669,7 +676,7 @@ void G_LivesCheckEndGame()
 
 		if (aliveteams == 0 || pr.count == 0)
 		{
-			SV_BroadcastPrintf(PRINT_HIGH, "All teams have run out of lives.\n");
+			SV_BroadcastPrintf("All teams have run out of lives.\n");
 			::levelstate.setWinner(WinInfo::WIN_DRAW, 0);
 			::levelstate.endRound();
 		}
@@ -736,7 +743,8 @@ bool G_RoundsShouldEndGame()
 			TeamInfo* team = GetTeamInfo((team_t)i);
 			if (team->RoundWins >= g_winlimit)
 			{
-				SV_BroadcastPrintf("Win limit hit. %s team wins!\n", team->ColorString.c_str());
+				SV_BroadcastPrintf("Win limit hit. %s team wins!\n",
+				                   team->ColorString.c_str());
 				::levelstate.setWinner(WinInfo::WIN_TEAM, team->Team);
 				return true;
 			}

--- a/common/g_gametypecmd.cpp
+++ b/common/g_gametypecmd.cpp
@@ -140,7 +140,7 @@ static StringList GametypeArgs(const GametypeParam (&params)[SIZE], size_t argc,
  */
 
 static GametypeParam coopParams[] = {
-    {"g_skill", 4, "skill", "SKILL",
+    {"sv_skill", 4, "skill", "SKILL",
      "Set the skill of the game to SKILL.  Defaults to 4."}};
 
 static void CoopHelp()
@@ -181,7 +181,7 @@ END_COMMAND(coop)
 static GametypeParam survivalParams[] = {
     {"g_lives", 3, "lives", "LIVES",
      "Set number of player lives to LIVES.  Defaults to 3."},
-    {"g_skill", 4, "skill", "SKILL",
+    {"sv_skill", 4, "skill", "SKILL",
      "Set the skill of the game to SKILL.  Defaults to 4."}};
 
 static void SurvivalHelp()

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -162,6 +162,7 @@ enum svc_t
 	svc_spawnhiddenplayer,	// [denis] when client can't see player
 	svc_updatedeaths,		// [byte] [short]
 	svc_ctfevent,			// [Toke - CTF] - [int]
+	svc_secretevent,		// [Ch0wW] informs clients of a secret discovered
 	svc_serversettings,		// 55 [Toke] - informs clients of server settings
 	svc_connectclient,
     svc_midprint,

--- a/common/msg_server.cpp
+++ b/common/msg_server.cpp
@@ -270,7 +270,7 @@ void SVC_LevelState(buf_t& b, const SerializedLevelState& sls)
 /**
  * @brief Send information about a player who discovered a secret.
  */
-void SVC_BroadcastSecretFound(buf_t& b, int playerid)
+void SVC_SecretFound(buf_t& b, int playerid)
 {
 	MSG_WriteMarker(&b, svc_secretevent);
 	MSG_WriteByte(&b, playerid);			// ID of player who discovered it

--- a/common/msg_server.cpp
+++ b/common/msg_server.cpp
@@ -267,4 +267,13 @@ void SVC_LevelState(buf_t& b, const SerializedLevelState& sls)
 	MSG_WriteVarint(&b, sls.last_wininfo_id);
 }
 
+/**
+ * @brief Send information about a player who discovered a secret.
+ */
+void SVC_BroadcastSecretFound(buf_t& b, int playerid)
+{
+	MSG_WriteMarker(&b, svc_secretevent);
+	MSG_WriteByte(&b, playerid);			// ID of player who discovered it
+}
+
 VERSION_CONTROL(msg_server, "$Id$")

--- a/common/msg_server.h
+++ b/common/msg_server.h
@@ -49,6 +49,6 @@ void SVC_PlayerMembers(buf_t& b, player_t& player, byte flags);
 void SVC_TeamMembers(buf_t& b, team_t team);
 void SVC_PlayerState(buf_t& b, player_t& player);
 void SVC_LevelState(buf_t& b, const SerializedLevelState& sls);
-void SVC_BroadcastSecretFound(buf_t& b, int playerid);
+void SVC_SecretFound(buf_t& b, int playerid);
 
 #endif

--- a/common/msg_server.h
+++ b/common/msg_server.h
@@ -49,5 +49,6 @@ void SVC_PlayerMembers(buf_t& b, player_t& player, byte flags);
 void SVC_TeamMembers(buf_t& b, team_t team);
 void SVC_PlayerState(buf_t& b, player_t& player);
 void SVC_LevelState(buf_t& b, const SerializedLevelState& sls);
+void SVC_BroadcastSecretFound(buf_t& b, int playerid);
 
 #endif

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -406,6 +406,9 @@ void SV_InvalidateClient(player_t &player, const std::string& reason)
 	}
 
 	Printf("%s fails security check (%s), dropping client.\n", NET_AdrToString(player.client.address), reason.c_str());
+	SV_PlayerPrintf(PRINT_ERROR, player.id,
+	                "The server closed your connection for the following reason: %s.\n",
+	                reason.c_str());
 	SV_DropClient(player);
 }
 

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -910,11 +910,13 @@ bool SV_SetupUserInfo(player_t &player)
 	team_t old_team = static_cast<team_t>(player.userinfo.team);
 	team_t new_team = static_cast<team_t>(MSG_ReadByte());
 
-	if ((new_team >= NUMTEAMS && new_team != TEAM_NONE) || new_team < 0)
+	if (new_team >= NUMTEAMS || new_team < 0)
 	{
 		SV_InvalidateClient(player, "Team preference is invalid");
 		return false;
 	}
+	if (new_team == TEAM_NONE)
+		new_team = TEAM_BLUE; // Set the default team to the player.
 
 	gender_t gender = static_cast<gender_t>(MSG_ReadLong());
 
@@ -3737,7 +3739,7 @@ void SV_ChangeTeam (player_t &player)  // [Toke - Teams]
 {
 	team_t team = (team_t)MSG_ReadByte();
 
-	if ((team >= NUMTEAMS && team != TEAM_NONE) || team < 0)
+	if (team >= TEAM_NONE || team < 0)
 		return;
 
 	if (team >= sv_teamsinplay)

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -5157,6 +5157,7 @@ void ClientObituary(AActor* self, AActor* inflictor, AActor* attacker)
 		{
 			gender = attacker->player->userinfo.gender;
 			messagename = GStrings.getIndex(GStrings.toIndex(OB_FRIENDLY1) + (P_Random() & 3));
+			message = messagename.c_str();
 		}
 		else
 		{
@@ -5202,9 +5203,12 @@ void ClientObituary(AActor* self, AActor* inflictor, AActor* attacker)
 				messagename = OB_RAILGUN;
 				break;
 			}
+
+			if (!messagename.empty())
+				message = GStrings(messagename);
 		}
-		if (!messagename.empty())
-			message = GStrings(messagename);
+
+
 	}
 
 	if (message && attacker && attacker->player)

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3294,8 +3294,7 @@ void SV_UpdateSecretCount(player_t& player)
 
 		client_t* cl = &(it->client);
 
-		MSG_WriteMarker(&cl->reliablebuf, svc_secretevent);
-		MSG_WriteByte(&cl->reliablebuf, it->id);
+		SVC_BroadcastSecretFound(cl->reliablebuf, it->id);
 	}
 }
 

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3287,10 +3287,10 @@ void SV_UpdateSecretCount(player_t& player)
 	    if (&*it == &player)
 	        continue;
 
-	    std::ostringstream buf;
-		
-	    buf << player.userinfo.netname << " found a secret!";
-	    SV_MidPrint(buf.str().c_str(), &(*it), 0);
+		client_t* cl = &(it->client);
+
+		MSG_WriteMarker(&cl->reliablebuf, svc_secretevent);
+		MSG_WriteByte(&cl->reliablebuf, it->id);
 	}
 }
 

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3294,7 +3294,7 @@ void SV_UpdateSecretCount(player_t& player)
 
 		client_t* cl = &(it->client);
 
-		SVC_BroadcastSecretFound(cl->reliablebuf, it->id);
+		SVC_SecretFound(cl->reliablebuf, it->id);
 	}
 }
 


### PR DESCRIPTION
The following PR fixes a few bugs discovered: 

- Fix the statbar to not render tens of lives
- Improved the hud_revealsecrets behaviour online
- Fix Teamkill messages not being displayed
- Display a message in case of an invalid client
- Fix attempt to crash when a player tries to join an unknown team
- Fix serverside CVARs being forced-reset by the client when resetting to default