### PR TITLE
More Teams fixes

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -141,6 +141,8 @@ std::set<byte> teleported_players;
 std::map<unsigned short, SectorSnapshotManager> sector_snaps;
 
 EXTERN_CVAR (sv_weaponstay)
+EXTERN_CVAR (sv_teamsinplay)
+
 EXTERN_CVAR (sv_downloadsites)
 EXTERN_CVAR (cl_downloadsites)
 
@@ -1008,7 +1010,7 @@ END_COMMAND (playerteam)
 BEGIN_COMMAND (changeteams)
 {
 	int iTeam = (int)consoleplayer().userinfo.team;
-	iTeam = ++iTeam % NUMTEAMS;
+	iTeam = ++iTeam % sv_teamsinplay.asInt();
 	cl_team.Set(GetTeamInfo((team_t)iTeam)->ColorStringUpper.c_str());
 }
 END_COMMAND (changeteams)

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -918,7 +918,7 @@ bool SV_SetupUserInfo(player_t &player)
 		SV_InvalidateClient(player, "Team preference is invalid");
 		return false;
 	}
-	if (new_team == TEAM_NONE)
+	if (new_team == TEAM_NONE || (new_team == TEAM_GREEN && sv_teamsinplay < NUMTEAMS))
 		new_team = TEAM_BLUE; // Set the default team to the player.
 
 	gender_t gender = static_cast<gender_t>(MSG_ReadLong());
@@ -1083,7 +1083,7 @@ void SV_ForceSetTeam (player_t &who, team_t team)
 //
 void SV_CheckTeam (player_t &player)
 {
-	if (player.userinfo.team < 0 || player.userinfo.team >= sv_teamsinplay)
+	if (!player.spectator && (player.userinfo.team < 0 || player.userinfo.team >= sv_teamsinplay))
 		SV_ForceSetTeam(player, SV_GoodTeam());
 }
 


### PR DESCRIPTION
This PR does the following:
- changeteams' maxvalue is synced with the server
- Disallow serverside green spawning on classic CTF
- The server doesn't forceteam spectators anymore.