### PR TITLE
More... More Fixes for Misc-Fixes

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -1693,7 +1693,7 @@ void AM_Drawer()
 			{
 				sprintf(line, TEXTCOLOR_RED "MONSTERS:"
 								TEXTCOLOR_NORMAL " %d / %d",
-								level.killed_monsters, level.total_monsters);
+								level.killed_monsters, (level.total_monsters+level.respawned_monsters));
 
 				int x, y;
 				int text_width = V_StringWidth(line) * CleanXfac;

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -796,7 +796,7 @@ CVAR_FUNC_IMPL(msg4color)
 
 CVAR_FUNC_IMPL(msgmidcolor)
 {
-	setmsgcolor(PRINTLEVELS, var.cstring());
+	setmsgcolor(PRINTLEVELS-1, var.cstring());
 }
 
 // NES - Activating this locks the scroll position in place when
@@ -2160,7 +2160,7 @@ void C_DrawMid()
 
 		for (int i = 0; i < MidLines; i++, y += line_height)
 		{
-			screen->DrawTextStretched(PrintColors[PRINTLEVELS],
+			screen->DrawTextStretched(PrintColors[PRINTLEVELS-1],
 					x - xscale * (MidMsg[i].width / 2),
 					y, (byte *)MidMsg[i].string, xscale, yscale);
 		}

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2417,7 +2417,7 @@ void CL_SpawnMobj()
 		CL_SetMobjSpeedAndAngle();
 	}
 
-    if (mo->flags & MF_COUNTKILL)
+    if (serverside && mo->flags & MF_COUNTKILL)
 		level.total_monsters++;
 
 	if (connected && (mo->flags & MF_MISSILE ) && mo->info->seesound)
@@ -3731,6 +3731,9 @@ void CL_LevelLocals()
 
 	if (flags & SVC_LL_MONSTERS)
 		::level.killed_monsters = MSG_ReadVarint();
+
+	if (flags & SVC_LL_MONSTER_RESPAWNS)
+		::level.respawned_monsters = MSG_ReadVarint();
 }
 
 // client source (once)

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -88,6 +88,10 @@ void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, bo
 	int arg4 = -1, int arg5 = -1, int arg6 = -1, int arg7 = -1, int arg8 = -1) {}
 void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg0, byte arg1, byte arg2, byte arg3, byte arg4) {}
 
+void SV_UpdateMonsterRespawnCount() {}
+void SV_Sound(AActor* mo, byte channel, const char* name, byte attenuation) {}
+
+
 CVAR_FUNC_IMPL(sv_sharekeys) {}
 
 VERSION_CONTROL (cl_stubs_cpp, "$Id$")

--- a/client/src/g_level.cpp
+++ b/client/src/g_level.cpp
@@ -389,7 +389,7 @@ void G_DoCompleted (void)
 		}
 	}
 
-	wminfo.maxkills = level.total_monsters;
+	wminfo.maxkills = (level.total_monsters+level.respawned_monsters);
 	wminfo.maxitems = level.total_items;
 	wminfo.maxsecret = level.total_secrets;
 	wminfo.maxfrags = 0;

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -1041,6 +1041,19 @@ void ZDoomHUD() {
 		              hud::Y_BOTTOM, hud::Timer().c_str(), CR_GREY);
 	}
 
+	if (g_lives)
+	{
+		// Lives are next to doomguy.  Supposed to be vertically-centered with his head.
+		int lives_color = CR_GREY;
+		if (plyr->lives <= 0)
+			lives_color = CR_DARKGREY;
+		
+		std::string buf;
+		StrFormat(buf, "x%d", plyr->lives);
+		hud::DrawText(60 + 2 + 20 + 2, 10 + 2, hud_scale, hud::X_LEFT, hud::Y_BOTTOM,
+		              hud::X_LEFT, hud::Y_MIDDLE, buf.c_str(), lives_color, false);
+	}
+
 	// Draw other player name, if spying
 	hud::DrawText(0, 12, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
 	              hud::Y_BOTTOM, hud::SpyPlayerName().c_str(), CR_GREY);

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -167,6 +167,7 @@ struct level_locals_t {
 
 	int				total_monsters;
 	int				killed_monsters;
+	int				respawned_monsters;	// Ch0wW - Keep track of respawned monsters
 
 	float			gravity;
 	fixed_t			aircontrol;

--- a/common/g_levelstate.cpp
+++ b/common/g_levelstate.cpp
@@ -430,8 +430,11 @@ void LevelState::tic()
 			if (g_rounds)
 				printRoundStart();
 			else
-				SV_BroadcastPrintf("The match has started.\n");
+			{
+				SV_BroadcastPrintf ("The %s has started.\n",
+				                   (sv_gametype == GM_COOP) ? "game" : "match");
 
+			}
 			return;
 		}
 		break;

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -74,6 +74,11 @@
 #define SVC_LL_MONSTERS (1 << 4)
 
 /**
+ * @brief svc_levellocals: Respawned monsters.
+ */
+#define SVC_LL_MONSTER_RESPAWNS (1 << 5)
+
+/**
  * @brief svc_playermembers: Spectator status.
  */
 #define SVC_PM_SPECTATOR (1 << 0)

--- a/common/msg_server.cpp
+++ b/common/msg_server.cpp
@@ -106,6 +106,9 @@ void SVC_LevelLocals(buf_t& b, const level_locals_t& locals, byte flags)
 
 	if (flags & SVC_LL_MONSTERS)
 		MSG_WriteVarint(&b, locals.killed_monsters);
+
+	if (flags & SVC_LL_MONSTER_RESPAWNS)
+		MSG_WriteVarint(&b, locals.respawned_monsters);
 }
 
 /**

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -39,6 +39,7 @@
 
 #include "d_player.h"
 
+
 extern bool HasBehavior;
 
 EXTERN_CVAR (sv_allowexit)
@@ -85,6 +86,9 @@ void A_Explode (AActor *thing);
 void A_Mushroom (AActor *actor);
 void A_Fall (AActor *actor);
 
+
+void SV_UpdateMonsterRespawnCount();
+void SV_Sound(AActor* mo, byte channel, const char* name, byte attenuation);
 
 //
 // ENEMY THINKING
@@ -1400,11 +1404,19 @@ void A_VileChase (AActor *actor)
 					actor->target = temp;
 
 					P_SetMobjState (actor, S_VILE_HEAL1, true);
-					S_Sound (corpsehit, CHAN_BODY, "vile/raise", 1, ATTN_IDLE);
+
+					if (!clientside)
+						SV_Sound(corpsehit, CHAN_BODY, "vile/raise", ATTN_IDLE);
+					else
+						S_Sound(corpsehit, CHAN_BODY, "vile/raise", 1, ATTN_IDLE);
+
 					info = corpsehit->info;
 
 					if (serverside)
-						level.total_monsters++;
+					{
+						level.respawned_monsters++;
+						SV_UpdateMonsterRespawnCount();
+					}
 
 					P_SetMobjState (corpsehit,info->raisestate, true);
 

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -55,6 +55,7 @@ void P_ExplodeMissile(AActor* mo);
 void SV_SpawnMobj(AActor *mobj);
 void SV_SendDestroyActor(AActor *);
 void SV_ExplodeMissile(AActor *);
+void SV_UpdateMonsterRespawnCount();
 
 EXTERN_CVAR(sv_freelook)
 EXTERN_CVAR(sv_itemsrespawn) 
@@ -1704,9 +1705,6 @@ void P_NightmareRespawn (AActor *mobj)
     else
 		z = ONFLOORZ;
 
-	if (serverside)
-		level.total_monsters++;
-
 	// spawn it
 	// inherit attributes from deceased one
 	if(serverside)
@@ -1718,8 +1716,11 @@ void P_NightmareRespawn (AActor *mobj)
 		if (mthing->flags & MTF_AMBUSH)
 			mo->flags |= MF_AMBUSH;
 
-        if (serverside)
-            SV_SpawnMobj(mo);
+		SV_SpawnMobj(mo);
+
+		// Count the respawned_monsters up.
+		level.respawned_monsters++;
+		SV_UpdateMonsterRespawnCount();
 
 		mo->reactiontime = 18;
 	}

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1651,7 +1651,7 @@ void P_SetupLevel (char *lumpname, int position)
 {
 	size_t lumpnum;
 
-	level.total_monsters = level.total_items = level.total_secrets =
+	level.total_monsters = level.respawned_monsters = level.total_items = level.total_secrets =
 		level.killed_monsters = level.found_items = level.found_secrets =
 		wminfo.maxfrags = 0;
 	wminfo.partime = 180;

--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -573,9 +573,6 @@ void G_DoResetLevel(bool full_reset)
 	G_SerializeLevel(arc, false, true);
 	reset_snapshot->Seek(0, FFile::ESeekSet);
 
-	// Set time to the initial tic.
-	level.time = 0;
-
 	{
 		AActor* mo;
 		TThinkerIterator<AActor> iterator;
@@ -631,6 +628,9 @@ void G_DoResetLevel(bool full_reset)
 	// [SL] always reset the time (for now at least)
 	level.time = 0;
 	level.inttimeleft = mapchange / TICRATE;
+
+	// Reset the respawned monster count
+	level.respawned_monsters = 0;	
 
 	// Send information about the newly reset map.
 	for (it = players.begin(); it != players.end(); ++it)

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3272,7 +3272,6 @@ void SV_SendPingRequest(client_t* cl)
 
 void SV_UpdateSecretCount(player_t& player)
 {
-
 	// Don't announce secrets on PvP gamemodes
 	if (sv_gametype != GM_COOP)
 		return;
@@ -3291,6 +3290,18 @@ void SV_UpdateSecretCount(player_t& player)
 		client_t* cl = &(it->client);
 
 		SVC_SecretFound(cl->reliablebuf, player.id);
+	}
+}
+
+void SV_UpdateMonsterRespawnCount()
+{
+	if (sv_gametype != GM_COOP)
+		return;
+
+	for (Players::iterator it = players.begin(); it != players.end(); ++it)
+	{
+		client_t* cl = &(it->client);
+		SVC_LevelLocals(cl->reliablebuf, ::level, SVC_LL_MONSTER_RESPAWNS);
 	}
 }
 

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -122,6 +122,7 @@ void SV_SendPlayerQueuePosition(player_t* source, player_t* dest);
 void SV_ClearPlayerQueue();
 
 void SV_UpdateSecretCount(player_t & player);
+void SV_UpdateMonsterRespawnCount();
 void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, byte arg0, byte arg1, byte arg2, byte arg3, byte arg4);
 void SV_ACSExecuteSpecial(byte special, AActor* activator, const char* print, bool playerOnly, int arg0 = -1, int arg1 = -1, int arg2 = -1, int arg3 = -1,
 	int arg4 = -1, int arg5 = -1, int arg6 = -1, int arg7 = -1, int arg8 = -1);


### PR DESCRIPTION
This PR does the following:
- Fix an OoB found with ASAN and msgmid.
- Properly synchronize total monsters online and respawned monsters.
- Fix the Archvile resurrecting sound for clients. (it isn't played at all)
- Add Lives counter to ZDoom HUD.
- Changed slightly the Match-Broadcasted message in case of a Coop game.

(it's the last one, I swear! 👀)