### PR TITLE
More and more bugfixes, part Deux

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -37,6 +37,7 @@
 #include "m_cheat.h"
 #include "c_dispatch.h"
 #include "cl_demo.h"
+#include "g_gametype.h"
 
 // Needs access to LFB.
 #include "i_video.h"
@@ -1522,8 +1523,8 @@ void AM_drawPlayers(void)
 		mpoint_t pt;
 
 		if (!(it->ingame()) || !p->mo ||
-			(((sv_gametype == GM_DM && p != &conplayer) ||
-			((sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF) && p->userinfo.team != conplayer.userinfo.team))
+			(((G_IsFFAGame() && p != &conplayer) ||
+			(G_IsTeamGame() && p->userinfo.team != conplayer.userinfo.team))
 			&& !(netdemo.isPlaying() || netdemo.isPaused())
 			&& !demoplayback && !(conplayer.spectator)) || p->spectator)
 		{

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -38,6 +38,7 @@
 #include "p_mobj.h"
 #include "g_level.h"
 #include "msg_server.h"
+#include "g_gametype.h"
 
 EXTERN_CVAR(sv_maxclients)
 EXTERN_CVAR(sv_maxplayers)
@@ -1036,7 +1037,7 @@ void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 
 	MSG_WriteString	(netbuffer, "");	// sv_website.cstring()
 
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 	{
 		MSG_WriteLong	(netbuffer, 0);		// sv_scorelimit
 		for (size_t n = 0; n < NUMTEAMS; n++)

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -65,6 +65,8 @@
 #include "p_acs.h"
 #include "i_input.h"
 
+#include "g_gametype.h"
+
 #include <bitset>
 #include <string>
 #include <vector>
@@ -200,11 +202,11 @@ argb_t CL_GetPlayerColor(player_t *player)
 	argb_t shade_color = base_color;
 	
 	bool teammate = false;
-	if (sv_gametype == GM_COOP)
+	if (G_IsCoopGame())
 		teammate = true;
-	if (sv_gametype == GM_DM)
+	if (G_IsFFAGame())
 		teammate = false;
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 	{
 		teammate = P_AreTeammates(consoleplayer(), *player);
 		base_color = GetTeamInfo(player->userinfo.team)->Color;
@@ -1002,7 +1004,7 @@ END_COMMAND (rcon_logout)
 
 BEGIN_COMMAND (playerteam)
 {
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 		Printf("Your are in the %s team.\n", V_GetTeamColor(consoleplayer().userinfo.team).c_str());
 	else
 		Printf("You need to play a team-based gamemode in order to use this command.\n");
@@ -2081,8 +2083,8 @@ void CL_Say()
 			filtermessage = true;
 
 		if (mute_enemies && !spectator &&
-		    (sv_gametype == GM_DM ||
-		    ((sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF) &&
+		    (G_IsFFAGame() ||
+		    (G_IsTeamGame() &&
 		     player.userinfo.team != consoleplayer().userinfo.team)))
 			filtermessage = true;
 	}

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -260,6 +260,9 @@ CVAR_FUNC_IMPL (r_forceteamcolor)
 
 CVAR_FUNC_IMPL (cl_team)
 {
+	if (var.asInt() >= sv_teamsinplay)
+		var.Set(sv_teamsinplay.asInt() - 1);
+	
 	CL_RebuildAllPlayerTranslations();
 }
 

--- a/client/src/cl_mobj.cpp
+++ b/client/src/cl_mobj.cpp
@@ -35,6 +35,7 @@
 #include "st_stuff.h"
 #include "p_acs.h"
 #include "p_ctf.h"
+#include "g_gametype.h"
 
 EXTERN_CVAR(sv_nomonsters)
 EXTERN_CVAR(cl_showspawns)
@@ -181,7 +182,7 @@ void P_ShowSpawns(mapthing2_t* mthing)
 			spawn->args[0] = 7; // White
 		}
 
-		if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+		if (G_IsTeamGame())
 		{
 			for (int iTeam = 0; iTeam < NUMTEAMS; iTeam++)
 			{

--- a/client/src/hu_elements.cpp
+++ b/client/src/hu_elements.cpp
@@ -932,7 +932,7 @@ void EATeamPlayerNames(int x, int y, const float scale,
 		player_t* player = sortedPlayers()[i];
 		if (inTeamPlayer(player, team)) {
 			int color = CR_GREY;
-			if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+			if (G_IsTeamGame())
 			{
 				color = GetTeamPlayerColor(player);
 			}
@@ -966,7 +966,7 @@ void EASpectatorNames(int x, int y, const float scale,
 		if (spectatingPlayer(player)) {
 			if (skip <= 0) {
 				int color = CR_GREY;
-				if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF) {
+				if (G_IsTeamGame()) {
 					if (player->ready) {
 						color = CR_GREEN;
 					} else if (player->id == displayplayer().id) {
@@ -1479,7 +1479,7 @@ void EATargets(int x, int y, const float scale,
 
 		// Pick a decent color for the player name.
 		int color;
-		if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF) {
+		if (G_IsTeamGame()) {
 			// In teamgames, we want to use team colors for targets.
 			color = V_GetTextColor(GetTeamInfo(it->userinfo.team)->TextColor.c_str());
 		} else {

--- a/client/src/hu_elements.cpp
+++ b/client/src/hu_elements.cpp
@@ -298,24 +298,35 @@ std::string Timer()
 		return "";
 	}
 
+
 	OTimespan tspan;
-	if (hud_timer == 2)
+	if (::levelstate.getState() == LevelState::WARMUP || 
+		::levelstate.getState() == LevelState::WARMUP_COUNTDOWN ||
+		::levelstate.getState() == LevelState::WARMUP_FORCED_COUNTDOWN )
 	{
-		// Timer counts up.
-		TicsToTime(tspan, level.time);
-	}
-	else if (hud_timer == 1)
-	{
-		// Timer counts down.
-		int timeleft = G_EndingTic() - level.time;
+		int timeleft = G_EndingTic()-1;
 		TicsToTime(tspan, timeleft, true);
 	}
-
-	// If we're in the danger zone flip the color.
-	int warning = G_EndingTic() - (60 * TICRATE);
-	if (level.time > warning)
+	else
 	{
-		color = TEXTCOLOR_BRICK;
+		if (hud_timer == 2)
+		{
+			// Timer counts up.
+			TicsToTime(tspan, level.time);
+		}
+		else if (hud_timer == 1)
+		{
+			// Timer counts down.
+			int timeleft = G_EndingTic() - level.time;
+			TicsToTime(tspan, timeleft, true);
+		}
+
+		// If we're in the danger zone flip the color.
+		int warning = G_EndingTic() - (60 * TICRATE);
+		if (level.time > warning)
+		{
+			color = TEXTCOLOR_BRICK;
+		}
 	}
 
 	std::string str;

--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -720,7 +720,7 @@ void drawHeader(player_t *player, int y)
 	              hud::ClientsSplit().c_str(), CR_GREEN, true);
 
 	int yOffset = 0;
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF) 
+	if (G_IsTeamGame()) 
 	{
 		int xOffset = GetLongestTeamWidth();
 		
@@ -1291,7 +1291,7 @@ void Scoreboard(player_t *player)
 
 	int extraQuadRows = 0;
 
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 	{
 		height = 100;
 
@@ -1340,7 +1340,7 @@ void Scoreboard(player_t *player)
 	hud::Dim(0, y, HiResolutionWidth, height, hud_scalescoreboard, hud::X_CENTER, hud::Y_MIDDLE, hud::X_CENTER, hud::Y_TOP);
 
 	hud::drawHeader(player, y + 4);
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 	{
 		// Teams after 2 require extra player count in header
 		int teams = sv_teamsinplay - 2;
@@ -1759,7 +1759,7 @@ void LowScoreboard(player_t *player)
 	byte extra_spec_rows = 0;
 	byte extra_player_rows = 0;
 
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 	{
 		height = 129;
 		// Team scoreboard was designed for 4 players on a team.  If
@@ -1799,14 +1799,11 @@ void LowScoreboard(player_t *player)
 	hud::Dim(0, y, 300, height, hud_scalescoreboard, hud::X_CENTER, hud::Y_MIDDLE, hud::X_CENTER, hud::Y_TOP);
 
 	hud::drawLowHeader(player, y + 4);
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
-	{
+
+	if (G_IsTeamGame())
 		hud::drawLowTeamScores(player, y + 15, extra_player_rows);
-	}
 	else
-	{
 		hud::drawLowScores(player, y + 15, extra_player_rows);
-	}
 
 	hud::drawLowSpectators(player, y + (height - 14 - (extra_spec_rows * 8)),
 	                       extra_spec_rows);

--- a/client/src/r_interp.cpp
+++ b/client/src/r_interp.cpp
@@ -26,6 +26,7 @@
 #include "m_fixed.h"
 #include "r_state.h"
 #include "p_local.h"
+#include "cl_demo.h"
 
 #include <vector>
 
@@ -35,6 +36,8 @@ static std::vector<fixed_uint_pair> prev_ceilingheight;
 static std::vector<fixed_uint_pair> saved_ceilingheight;
 static std::vector<fixed_uint_pair> prev_floorheight;
 static std::vector<fixed_uint_pair> saved_floorheight;
+
+extern NetDemo netdemo;
 
 //
 // R_InterpolationTicker
@@ -170,7 +173,8 @@ void R_InterpolateCamera(fixed_t amount)
 		player_t& consolePlayer = consoleplayer();
 
 		if (!::localview.skipangle && consolePlayer.id == displayplayer().id &&
-		    consolePlayer.health > 0 && !consolePlayer.mo->reactiontime)
+		    consolePlayer.health > 0 && !consolePlayer.mo->reactiontime && 
+			(!netdemo.isPlaying() && !demoplayback && !demorecording))
 		{
 			viewangle = camera->angle + ::localview.angle;
 		}

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -416,6 +416,9 @@ void G_AssertValidPlayerCount()
 		valid = false;
 	}
 
+	// Check if we have still players alive
+	G_LivesCheckEndGame();
+
 	// If we haven't signaled an invalid state by now, we're cool.
 	if (valid == true)
 		return;

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -516,6 +516,7 @@ void G_TimeCheckEndGame()
 		{
 			// Defense always wins in the event of a timeout.
 			TeamInfo& ti = *GetTeamInfo(::levelstate.getDefendingTeam());
+			GiveTeamWins(ti.Team, 1);
 			SV_BroadcastPrintf("Time limit hit. %s team wins!\n",
 			                   ti.ColorizedTeamName().c_str());
 			::levelstate.setWinner(WinInfo::WIN_TEAM, ti.Team);

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -402,9 +402,12 @@ void G_AssertValidPlayerCount()
 		{
 			if (pr.teamTotal[i] > 0)
 			{
-				// Does more than one team has players?  If so, the game continues.
+				// Does the team has more than one players?  If so, the game continues.
 				if (hasplayers != TEAM_NONE)
+				{
+					G_LivesCheckEndGame();	// Check if Whole team is alive
 					return;
+				}
 				hasplayers = i;
 			}
 		}

--- a/common/g_levelstate.cpp
+++ b/common/g_levelstate.cpp
@@ -390,7 +390,7 @@ void LevelState::tic()
 				setState(LevelState::WARMUP_FORCED_COUNTDOWN);
 				return;
 			}
-			else if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+			else if (G_IsTeamGame())
 			{
 				// We need at least one person on at least two different teams.
 				int ready = 0;

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -1063,7 +1063,7 @@ void P_KillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill
 					}
 				}
 				// [Toke] Minus a team frag for killing teammate
-				else if ((sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF) &&
+				else if (G_IsTeamGame() &&
 				         (splayer->userinfo.team == tplayer->userinfo.team))
 				{
 					// [Toke - Teamplay || deathz0r - updated]
@@ -1378,8 +1378,8 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 		if (!sv_friendlyfire && source && splayer && target != source &&
 			mod != MOD_TELEFRAG)
 		{
-			if (sv_gametype == GM_COOP ||
-				((sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF) &&
+			if (G_IsCoopGame() ||
+				(G_IsTeamGame() &&
 					tplayer->userinfo.team == splayer->userinfo.team))
 			{
 				damage = 0;

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -36,6 +36,7 @@
 #include "gi.h"
 
 #include "p_snapshot.h"
+#include "g_gametype.h"
 
 // Index of the special effects (INVUL inverse) map.
 #define INVERSECOLORMAP 		32
@@ -742,9 +743,9 @@ bool P_AreTeammates(player_t &a, player_t &b)
 	if (a.id == b.id)
 		return false;
 
-	return (sv_gametype == GM_COOP) ||
+	return G_IsCoopGame() ||
 		  ((a.userinfo.team == b.userinfo.team) &&
-		   (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF));
+		   G_IsTeamGame());
 }
 
 bool P_CanSpy(player_t &viewer, player_t &other, bool demo)

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -763,11 +763,19 @@ bool P_CanSpy(player_t &viewer, player_t &other, bool demo)
 
 	// A teammate can see their other teammates
 	if (P_AreTeammates(viewer, other))
+	{
+		// If a player has no more lives, don't show him.
+		if (::g_lives && other.lives < 1)
+			return false;
+
 		return true;
+	}
 
 	// A player who is out of lives in LMS can see everyone else
 	if (::sv_gametype == GM_DM && ::g_lives && viewer.lives < 1)
 		return true;
+
+
 
 	return false;
 }

--- a/server/src/g_game.cpp
+++ b/server/src/g_game.cpp
@@ -526,7 +526,7 @@ void G_DeathMatchSpawnPlayer (player_t &player)
 	if(sv_gametype == GM_COOP)
 		return;
 
-	if(sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if(G_IsTeamGame())
 	{
 		G_TeamSpawnPlayer (player);
 		return;
@@ -575,7 +575,7 @@ void G_DoReborn (player_t &player)
 		player.mo->player = NULL;
 
 	// spawn at random team spot if in team game
-	if(sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if(G_IsTeamGame())
 	{
 		G_TeamSpawnPlayer (player);
 		return;

--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -312,7 +312,7 @@ void G_DoNewGame (void)
 		if (!(it->ingame()))
 			continue;
 
-		if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+		if (G_IsTeamGame())
 			SV_CheckTeam(*it);
 		else
 			memcpy(it->userinfo.color, it->prefcolor, 4);
@@ -742,7 +742,7 @@ void G_DoLoadLevel (int position)
 	}
 
 	// [deathz0r] It's a smart idea to reset the team points
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 	{
 		for (size_t i = 0; i < NUMTEAMS; i++)
 			GetTeamInfo((team_t)i)->Points = 0;

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1340,7 +1340,7 @@ void SV_UpdateSector(client_t* cl, int sectornum)
 	sector_t* sector = &sectors[sectornum];
 
 	// Only update moveable sectors to clients, OR secret sectors that've been discovered.
-	if (sector != NULL && sector->moveable || (sector->special & SECRET_MASK) == 0 && sector->secretsector)
+	if (sector != NULL && sector->moveable || (sector->special & SECRET_MASK == 0 && sector->secretsector))
 	{
 		MSG_WriteMarker(&cl->reliablebuf, svc_sector);
 		MSG_WriteShort(&cl->reliablebuf, sectornum);

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1185,7 +1185,7 @@ bool SV_IsTeammate(player_t &a, player_t &b)
 	if(&a == &b)
 		return false;
 
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 	{
 		if (a.userinfo.team == b.userinfo.team)
 			return true;
@@ -2307,7 +2307,7 @@ void SV_DisconnectClient(player_t &who)
 			status = "SPECTATOR";
 		else
 		{
-			if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+			if (G_IsTeamGame())
 			{
 				sprintf(str, "%s TEAM, ", GetTeamInfo(who.userinfo.team)->ColorStringUpper.c_str());
 				status += str;
@@ -2989,7 +2989,7 @@ bool SV_Say(player_t &player)
 	{
 		if (spectator)
 			SVC_SpecSay(player, message.c_str());
-		else if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+		else if (G_IsTeamGame())
 			SVC_TeamSay(player, message.c_str());
 		else
 			SVC_Say(player, message.c_str());
@@ -5000,10 +5000,10 @@ void ClientObituary(AActor* self, AActor* inflictor, AActor* attacker)
 	if (inflictor && inflictor->player == self->player)
 		MeansOfDeath = MOD_UNKNOWN;
 
-	if (sv_gametype == GM_COOP)
+	if (G_IsCoopGame())
 		MeansOfDeath |= MOD_FRIENDLY_FIRE;
 
-	if ((sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF) &&
+	if (G_IsTeamGame() &&
 		attacker && attacker->player &&
 		self->player->userinfo.team == attacker->player->userinfo.team)
 		MeansOfDeath |= MOD_FRIENDLY_FIRE;

--- a/server/src/sv_pickup.cpp
+++ b/server/src/sv_pickup.cpp
@@ -42,7 +42,7 @@ EXTERN_CVAR(sv_teamsinplay)
 // Distribute X number of players between teams.
 bool Pickup_DistributePlayers(size_t num_players, std::string &error) {
 	// This function shouldn't do anything unless you're in a teamgame.
-	if (!(sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)) {
+	if (!G_IsTeamGame()) {
 		error = "Server is not in a team game.";
 		return false;
 	}

--- a/server/src/sv_sqp.cpp
+++ b/server/src/sv_sqp.cpp
@@ -32,6 +32,7 @@
 #include "md5.h"
 #include "p_ctf.h"
 #include "version.h"
+#include "g_gametype.h"
 
 static buf_t ml_message(MAX_UDP_PACKET);
 
@@ -187,7 +188,7 @@ next:
 		MSG_WriteShort(&ml_message, timeleft);
 	
 	// Teams
-	if(sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if(G_IsTeamGame())
 	{
 		// Team data
 		int teams = sv_teamsinplay.asInt();
@@ -229,7 +230,7 @@ next:
 		for (int i = 3; i >= 0; i--)
 			MSG_WriteByte(&ml_message, it->userinfo.color[i]);
 
-		if(sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+		if(G_IsTeamGame())
 			MSG_WriteByte(&ml_message, it->userinfo.team);
 
 		MSG_WriteShort(&ml_message, it->ping);

--- a/server/src/sv_sqpold.cpp
+++ b/server/src/sv_sqpold.cpp
@@ -31,6 +31,7 @@
 #include "d_player.h"
 #include "i_system.h"
 #include "p_ctf.h"
+#include "g_gametype.h"
 
 static buf_t ml_message(MAX_UDP_PACKET);
 
@@ -186,7 +187,7 @@ void SV_SendServerInfo()
 			MSG_WriteShort(&ml_message, it->fragcount);
 			MSG_WriteLong(&ml_message, it->ping);
 
-			if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+			if (G_IsTeamGame())
 				MSG_WriteByte(&ml_message, it->userinfo.team);
 			else
 				MSG_WriteByte(&ml_message, TEAM_NONE);
@@ -199,7 +200,7 @@ void SV_SendServerInfo()
 	// [AM] Used to be sv_website - sv_downloadsites can have multiple sites.
 	MSG_WriteString(&ml_message, sv_downloadsites.cstring());
 
-	if (sv_gametype == GM_TEAMDM || sv_gametype == GM_CTF)
+	if (G_IsTeamGame())
 	{
 		MSG_WriteLong(&ml_message, sv_scorelimit.asInt());
 		


### PR DESCRIPTION
This PR does the following:
- Freeze the timer during a warmup, if sv_timelimit is set.
- Give 1 round point for the defending team if `g_sides` is enabled and the timelimit is hit.
- Fixes the new cameraangle interpolation in case of demoplayback.
- Fix softlocks when 1 player on a team has no more lives, and another from the same team leaves/is kicked/spectates.
- Clamp `cl_team` CVAR if the value is higher than sv_teamsinplay.
- Fix alive players to be able to spectate players who don't have lives anymore.