### PR TITLE
Add support 16 rotational frame sprites

### DIFF
--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -101,7 +101,7 @@ void R_CacheSprite (spritedef_t *sprite)
 		sprite - sprites < NUMSPRITES ? sprnames[sprite - sprites] : "");
 	for (int i = 0; i < sprite->numframes; i++)
 	{
-		for (int r = 0; r < 8; r++)
+		for (int r = 0; r < 16; r++)
 		{
 			if (sprite->spriteframes[i].width[r] == SPRITE_NEEDS_INFO)
 			{
@@ -127,7 +127,8 @@ void R_CacheSprite (spritedef_t *sprite)
 //
 static void R_InstallSpriteLump (int lump, unsigned frame, unsigned rot, BOOL flipped)
 {
-	unsigned rotation = rot;// (rot >= 0 && rot <= 9 ? rot : (rot >= 17 ? rot - 7 : 17));
+	rot += '0';
+	unsigned rotation = (rot >= '0' && rot <= '9' ? rot - '0' : (rot >= 'A' ? rot - 'A' + 10 : 17)); //rot;// (rot >= 0 && rot <= 9 ? rot : (rot >= 17 ? rot - 7 : 17));
 	
 	if (frame >= MAX_SPRITE_FRAMES || rotation > 16)
 	{
@@ -727,7 +728,7 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 	}
 
 #ifdef RANGECHECK
-	if ((unsigned)thing->sprite >= (unsigned)numsprites)
+	if (static_cast<unsigned>(thing->sprite) >= static_cast<unsigned>(numsprites))
 	{
 		DPrintf ("R_ProjectSprite: invalid sprite number %i\n", thing->sprite);
 		return;
@@ -754,7 +755,7 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 		// choose a different rotation based on player view
 		if (sprframe->lump[0] == sprframe->lump[1])
 		{
-			rot = (ang - thing->angle + (angle_t)(ANG45 / 2) * 9) >> 29;
+			rot = (ang - thing->angle + (angle_t)(ANG45 / 2) * 9) >> 28;
 		}
 		else
 		{
@@ -762,7 +763,7 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 		}
 		
 		lump = sprframe->lump[rot];
-		flip = static_cast<BOOL>(sprframe->flip[rot]);
+		flip = static_cast<BOOL>(sprframe->flip[rot] & (1 << rot));
 	}
 	else
 	{

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -208,13 +208,15 @@ static void R_InstallSprite (const char *name, int num)
 				if (sprtemp[frame].lump[rotation + 1] == -1)
 				{
 					sprtemp[frame].lump[rotation + 1] = sprtemp[frame].lump[rotation];
+					sprtemp[frame].flip[rotation + 1] = sprtemp[frame].flip[rotation];
 					sprtemp[frame].width[rotation + 1] = SPRITE_NEEDS_INFO;
 				}
 				
 				if (sprtemp[frame].lump[rotation] == -1)
 				{
 					sprtemp[frame].lump[rotation] = sprtemp[frame].lump[rotation + 1];
-					sprtemp[frame].width[rotation + 1] = SPRITE_NEEDS_INFO;
+					sprtemp[frame].flip[rotation] = sprtemp[frame].flip[rotation + 1];
+					sprtemp[frame].width[rotation] = SPRITE_NEEDS_INFO;
 				}
 			}
 
@@ -763,13 +765,13 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 		}
 		
 		lump = sprframe->lump[rot];
-		flip = static_cast<BOOL>(sprframe->flip[rot] & (1 << rot));
+		flip = static_cast<bool>(sprframe->flip[rot] & (1 << rot));
 	}
 	else
 	{
 		// use single rotation for all views
 		lump = sprframe->lump[rot = 0];
-		flip = static_cast<BOOL>(sprframe->flip[0]);
+		flip = static_cast<bool>(sprframe->flip[0]);
 	}
 
 	if (sprframe->width[rot] == SPRITE_NEEDS_INFO)

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -127,8 +127,16 @@ void R_CacheSprite (spritedef_t *sprite)
 //
 static void R_InstallSpriteLump (int lump, unsigned frame, unsigned rot, BOOL flipped)
 {
-	rot += '0';
-	unsigned rotation = (rot >= '0' && rot <= '9' ? rot - '0' : (rot >= 'A' ? rot - 'A' + 10 : 17)); //rot;// (rot >= 0 && rot <= 9 ? rot : (rot >= 17 ? rot - 7 : 17));
+	unsigned rotation;
+
+	if (rot >= 0 && rot <= 9)
+	{
+		rotation = rot;
+	}
+	else
+	{
+		rotation = (rot >= 17) ? rot - 7 : 17;
+	}
 	
 	if (frame >= MAX_SPRITE_FRAMES || rotation > 16)
 	{
@@ -765,7 +773,7 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 		}
 		
 		lump = sprframe->lump[rot];
-		flip = static_cast<bool>(sprframe->flip[rot] & (1 << rot));
+		flip = static_cast<bool>(sprframe->flip[rot]);
 	}
 	else
 	{

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -610,10 +610,10 @@ struct spriteframe_s
     //  we might as well insert the same name eight times.
 	bool	rotate;
 
-    // Lump to use for view angles 0-7.
+    // Lump to use for view angles 0-15.
     short	lump[16];
 
-    // Flip bit (1 = flip) to use for view angles 0-7.
+    // Flip bit (1 = flip) to use for view angles 0-15.
     byte	flip[16];
 
 	// [RH] Move some data out of spritewidth, spriteoffset,

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -611,16 +611,16 @@ struct spriteframe_s
 	bool	rotate;
 
     // Lump to use for view angles 0-7.
-    short	lump[8];
+    short	lump[16];
 
     // Flip bit (1 = flip) to use for view angles 0-7.
-    byte	flip[8];
+    byte	flip[16];
 
 	// [RH] Move some data out of spritewidth, spriteoffset,
 	//		and spritetopoffset arrays.
-	fixed_t		width[8];
-	fixed_t		topoffset[8];
-	fixed_t		offset[8];
+	fixed_t		width[16];
+	fixed_t		topoffset[16];
+	fixed_t		offset[16];
 };
 typedef struct spriteframe_s spriteframe_t;
 


### PR DESCRIPTION
Support for an extra 8 frames to look at an object from in between the existing frames. Tested with teapot16.wad, code reworked using Doom Retro as a guide.