### PR TITLE
Add a Serverside CVAR to disable MP-things on Coop.

### DIFF
--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -227,6 +227,9 @@ CVAR(g_preroundtime, "5", "Amount of time before a round where you can't shoot",
 CVAR(g_postroundtime, "3", "Amount of time after a round before the next round/endgame",
      CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE)
 
+CVAR_RANGE(g_coopthingfilter, "0.0",
+     "Removes cooperative things of the map.\nValues: 1 - Only Coop weapons.\n 2 - All Coop things.",
+      CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
 
 // Game mode options commonized from the server
 //     At some point, replace "sv_" with "g_"

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -45,6 +45,7 @@
 #include "p_lnspec.h"
 #include "v_palette.h"
 #include "c_console.h"
+#include "g_gametype.h"
 
 #include "p_setup.h"
 
@@ -63,6 +64,8 @@ void P_InvertPlane(plane_t *plane);
 
 extern dyncolormap_t NormalLight;
 extern AActor* shootthing;
+
+EXTERN_CVAR(g_coopthingfilter)
 
 //
 // MAP related Lookup tables.
@@ -589,7 +592,17 @@ void P_LoadThings (int lump)
 		// [RH] Need to translate the spawn flags to Hexen format.
 		short flags = LESHORT(mt->options);
 		mt2.flags = (short)((flags & 0xf) | 0x7e0);
-		if (flags & BTF_NOTSINGLE)			mt2.flags &= ~MTF_SINGLE;
+		if (flags & BTF_NOTSINGLE)
+		{
+			if (G_IsCoopGame())
+			{ 
+				if ((g_coopthingfilter.asInt() == 1 && mt2.flags & IT_WEAPON) ||
+				    (g_coopthingfilter.asInt() == 2))
+					mt2.flags &= ~MTF_COOPERATIVE;
+			}
+			else
+				mt2.flags &= ~MTF_SINGLE;
+		}
 		if (flags & BTF_NOTDEATHMATCH)		mt2.flags &= ~MTF_DEATHMATCH;
 		if (flags & BTF_NOTCOOPERATIVE)		mt2.flags &= ~MTF_COOPERATIVE;
 


### PR DESCRIPTION
This PR adds a CVAR (`g_coopthingfilter`) that removes MP-only things on Cooperative gamemode.
Values: 
- 0: Spawns all MP things normally.
- 1: Removes only Coop Weapon things, leaving only Exclusive ammo & monsters.
- 2: Removes all MP-Exclusive things no matter the type.