### PR TITLE
Reset found keys on survival after a game lost.

### DIFF
--- a/server/src/g_level.cpp
+++ b/server/src/g_level.cpp
@@ -532,6 +532,10 @@ void G_DoResetLevel(bool full_reset)
 	// Clear teamgame state.
 	TeamInfo_ResetScores(full_reset);
 
+	// Reset all keys found
+	for (size_t j = 0; j < NUMCARDS; j++)
+		keysfound[j] = false;
+
 	// Clear netids of every non-player actor so we don't spam the
 	// destruction message of actors to clients.
 	AActor* mo;


### PR DESCRIPTION
On coop/survival mode, found keys are added to an array `keysfound`. However, whenever the game must restart on survival (because everyone lost), the array isn't cleared.

As a result, if `sv_sharekeys` is enabled, everyone will get the keys on the newest round, breaking the purpose of the gamemode.

This PR fixes this issue.