### PR TITLE
Restore FLY ability to spectators after a game starts.

### DIFF
--- a/client/src/g_game.cpp
+++ b/client/src/g_game.cpp
@@ -1158,7 +1158,9 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 	p.weaponowned[wp_pistol] = true;
 	p.weaponowned[NUMWEAPONS] = true;
 	p.ammo[am_clip] = deh.StartBullets; // [RH] Used to be 50
-	p.cheats = 0;						// Reset cheat flags
+
+	if (!p.spectator)
+		p.cheats = 0; // Reset cheat flags
 
 	p.death_time = 0;
 	p.tic = 0;

--- a/server/src/g_game.cpp
+++ b/server/src/g_game.cpp
@@ -258,7 +258,10 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 	p.weaponowned[wp_pistol] = true;
 	p.weaponowned[NUMWEAPONS] = true;
 	p.ammo[am_clip] = deh.StartBullets; // [RH] Used to be 50
-	p.cheats = 0;						// Reset cheat flags
+
+	if (!p.spectator)
+		p.cheats = 0; // Reset cheat flags
+
 
 	p.death_time = 0;
 	p.tic = 0;


### PR DESCRIPTION
Since G_PlayerReborn is called whenever a game is restarted, all spectators have their CF_FLY flag removed, forcing them to the ground. Of course, this is absolutely an unintended behaviour.

This PR **only** disable cheats for non-spectators.