### PR TITLE
Correct spectators being able to spy 0-lives players.

### DIFF
--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -794,12 +794,13 @@ bool P_CanSpy(player_t &viewer, player_t &other, bool demo)
 	if (!other.mo || other.spectator)
 		return false;
 
-	// Demo-watchers and spectators can view anybody.
-	if (demo || viewer.spectator)
+	// Demo-watchers can view anybody.
+	if (demo)
 		return true;
 
-	// A teammate can see their other teammates
-	if (P_AreTeammates(viewer, other))
+	// A teammate can see their other teammates.
+	// Spectators see anyone with one slight restriction.
+	if (P_AreTeammates(viewer, other) || viewer.spectator)
 	{
 		// If a player has no more lives, don't show him.
 		if (::g_lives && other.lives < 1)


### PR DESCRIPTION
When in a game with lives, spectators can spy players with 0 lives.

Players cannot, but spectators were still able to do that. This PR corrects it by applying the same lives restrictions that players have.