### PR TITLE
Add static ArrayInit and ArrayCopy functions

### DIFF
--- a/common/cmdlib.h
+++ b/common/cmdlib.h
@@ -117,4 +117,37 @@ void StripColorCodes(std::string& str);
 uint32_t CRC32(const uint8_t* buf, uint32_t len);
 uint32_t Log2(uint32_t n);
 
+/**
+ * @brief Initialize an array with a specific value.
+ * 
+ * @tparam A Array type to initialize.
+ * @tparam T Value type to initialize with.
+ * @param dst Array to initialize.
+ * @param val Value to initialize with.
+ */
+template <typename A, typename T>
+static void ArrayInit(A& dst, const T& val)
+{
+	for (size_t i = 0; i < ARRAY_LENGTH(dst); i++)
+		dst[i] = val;
+}
+
+/**
+ * @brief Copy the complete contents of an array from one to the other.
+ * 
+ * @detail Both params are templated in case the destination's type doesn't
+ *         line up 100% with the source.
+ * 
+ * @tparam A1 Destination array type.
+ * @tparam A2 Source array type.
+ * @param dst Destination array to write to.
+ * @param src Source array to write from.
+ */
+template <typename A1, typename A2>
+static void ArrayCopy(A1& dst, const A2& src)
+{
+	for (size_t i = 0; i < ARRAY_LENGTH(src); i++)
+		dst[i] = src[i];
+}
+
 #endif

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -1253,37 +1253,25 @@ player_s::player_s() :
 	client(player_s::client_t())
 {
 	cmd.clear();
-	for (size_t i = 0; i < ARRAY_LENGTH(powers); i++)
-		powers[i] = 0;
-	for (size_t i = 0; i < ARRAY_LENGTH(cards); i++)
-		cards[i] = false;
-	for (size_t i = 0; i < ARRAY_LENGTH(flags); i++)
-		flags[i] = false;
-	for (size_t i = 0; i < ARRAY_LENGTH(weaponowned); i++)
-		weaponowned[i] = false;
-	for (size_t i = 0; i < ARRAY_LENGTH(ammo); i++)
-		ammo[i] = false;
-	for (size_t i = 0; i < ARRAY_LENGTH(maxammo); i++)
-		maxammo[i] = false;
+	ArrayInit(powers, 0);
+	ArrayInit(cards, false);
+	ArrayInit(flags, false);
+	ArrayInit(weaponowned, false);
+	ArrayInit(ammo, false);
+	ArrayInit(maxammo, false);
 
 	// Can't put this in initializer list?
 	attacker = AActor::AActorPtr();
 
 	pspdef_t zeropsp = { NULL, 0, 0, 0 };
-	for (size_t i = 0; i < ARRAY_LENGTH(psprites); i++)
-		psprites[i] = zeropsp;
-	for (size_t i = 0; i < ARRAY_LENGTH(oldvelocity); i++)
-		oldvelocity[i] = 0;
-	for (size_t i = 0; i < ARRAY_LENGTH(prefcolor); i++)
-		prefcolor[i] = 0;
+	ArrayInit(psprites, zeropsp);
+	ArrayInit(oldvelocity, 0);
+	ArrayInit(prefcolor, 0);
 
 	LastMessage.Time = 0;
 	LastMessage.Message = "";
 
-	for (size_t i = 0; i < ARRAY_LENGTH(netcmds); i++)
-	{
-		netcmds[i] = ticcmd_t();
-	}
+	ArrayInit(netcmds, ticcmd_t());
 }
 
 player_s &player_s::operator =(const player_s &other)
@@ -1306,17 +1294,13 @@ player_s &player_s::operator =(const player_s &other)
 	armorpoints = other.armorpoints;
 	armortype = other.armortype;
 
-	for(i = 0; i < NUMPOWERS; i++)
-		powers[i] = other.powers[i];
-
-	for(i = 0; i < NUMCARDS; i++)
-		cards[i] = other.cards[i];
+	ArrayCopy(powers, other.powers);
+	ArrayCopy(cards, other.cards);
 
 	lives = other.lives;
 	roundwins = other.roundwins;
 
-	for(i = 0; i < NUMTEAMS; i++)
-		flags[i] = other.flags[i];
+	ArrayCopy(flags, other.flags);
 
 	points = other.points;
 	backpack = other.backpack;
@@ -1330,12 +1314,9 @@ player_s &player_s::operator =(const player_s &other)
 	pendingweapon = other.pendingweapon;
 	readyweapon = other.readyweapon;
 
-	for(i = 0; i < NUMWEAPONS; i++)
-		weaponowned[i] = other.weaponowned[i];
-	for(i = 0; i < NUMAMMO; i++)
-		ammo[i] = other.ammo[i];
-	for(i = 0; i < NUMAMMO; i++)
-		maxammo[i] = other.maxammo[i];
+	ArrayCopy(weaponowned, other.weaponowned);
+	ArrayCopy(ammo, other.ammo);
+	ArrayCopy(maxammo, other.maxammo);
 
 	attackdown = other.attackdown;
 	usedown = other.usedown;
@@ -1354,14 +1335,13 @@ player_s &player_s::operator =(const player_s &other)
 
 	xviewshift = other.xviewshift;
 
-	for(i = 0; i < NUMPSPRITES; i++)
-		psprites[i] = other.psprites[i];
+	ArrayCopy(psprites, other.psprites);
 
     jumpTics = other.jumpTics;
 
 	death_time = other.death_time;
 
-	memcpy(oldvelocity, other.oldvelocity, sizeof(oldvelocity));
+	ArrayCopy(oldvelocity, other.oldvelocity);
 
 	camera = other.camera;
 	air_finished = other.air_finished;
@@ -1383,10 +1363,8 @@ player_s &player_s::operator =(const player_s &other)
 	ready = other.ready;
 	timeout_ready = other.timeout_ready;
 
-	memcpy(prefcolor, other.prefcolor, 4);
-
-	for(i = 0; i < BACKUPTICS; i++)
-		netcmds[i] = other.netcmds[i];
+	ArrayCopy(prefcolor, other.prefcolor);
+	ArrayCopy(netcmds, other.netcmds);
 
     LastMessage.Time = other.LastMessage.Time;
 	LastMessage.Message = other.LastMessage.Message;


### PR DESCRIPTION
Just what they say on the tin.  We do a lot of initialization and copying of C arrays in-tree, and I hope these functions can ease the burden of having to write for loops, the verbosity and repetitiveness of using `std::copy/begin/end` or chancing memcpy.