### PR TITLE
Fix autostart to be 1.0 for duel games

### DIFF
--- a/common/g_gametypecmd.cpp
+++ b/common/g_gametypecmd.cpp
@@ -295,7 +295,7 @@ BEGIN_COMMAND(game_duel)
 	params.push_back("sv_nomonsters 1");
 	params.push_back("sv_skill 5");
 	params.push_back("sv_warmup 1");
-	params.push_back("sv_warmup_autostart 0");
+	params.push_back("sv_warmup_autostart 1.0");
 
 	std::string config = JoinStrings(params, "; ");
 	Printf("Configuring Duel...\n%s\n", config.c_str());


### PR DESCRIPTION
Previously it was set to 0 by accident because of the misleading name.