### PR TITLE
Fix some instances of using Z_ChangeTag on a NULL pointer

### DIFF
--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -214,8 +214,7 @@ void HU_Init()
 //
 void STACK_ARGS HU_Shutdown()
 {
-	Z_ChangeTag(sbline, PU_CACHE);
-	sbline = NULL;
+	Z_Discard(&::sbline);
 
 	V_TextShutdown();
 }

--- a/client/src/v_text.cpp
+++ b/client/src/v_text.cpp
@@ -100,10 +100,8 @@ void V_TextShutdown()
 	{
 		::hu_font[i] = NULL;
 
-		Z_ChangeTag(::hu_bigfont[i], PU_CACHE);
-		::hu_bigfont[i] = NULL;
-		Z_ChangeTag(::hu_smallfont[i], PU_CACHE);
-		::hu_smallfont[i] = NULL;
+		Z_Discard(&::hu_bigfont[i]);
+		Z_Discard(&::hu_smallfont[i]);
 	}
 }
 


### PR DESCRIPTION
Encountered these during a failed WAD load that tried to revert before the HUD had been allocated, causing Z_ChangeTag on a null pointer and then a crash.