### PR TITLE
Check for STDISK in an unknown IWAD

### DIFF
--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -197,13 +197,14 @@ public:
 
 		// [SL] not an offical IWAD.
 		// Check for lumps that are required by vanilla Doom.
-		static const int NUM_CHECKLUMPS = 5;
+		static const int NUM_CHECKLUMPS = 6;
 		static const char checklumps[NUM_CHECKLUMPS][8] = {
-			{ 'P','L','A','Y','P','A','L' },		// 0
-			{ 'C','O','L','O','R','M','A','P' },	// 1
-			{ 'F','_','S','T','A','R','T' },		// 2
-			{ 'S','_','S','T','A','R','T' },		// 3
-			{ 'T','E','X','T','U','R','E','1' }		// 4
+		    {'P', 'L', 'A', 'Y', 'P', 'A', 'L'},      // 0
+		    {'C', 'O', 'L', 'O', 'R', 'M', 'A', 'P'}, // 1
+		    {'F', '_', 'S', 'T', 'A', 'R', 'T'},      // 2
+		    {'S', '_', 'S', 'T', 'A', 'R', 'T'},      // 3
+		    {'T', 'E', 'X', 'T', 'U', 'R', 'E', '1'}, // 4
+		    {'S', 'T', 'D', 'I', 'S', 'K'}            // 5
 		};
 
 		WadFileLumpFinder lumps(file.getFullpath());


### PR DESCRIPTION
The current list of lumps had too many false positives and was leading to WADs incorrectly being detected as an IWAD when it wasn't.

STDISK seems to be a lump that is the most common sticky wicket that Odamex complains about missing, so I added that lump to the list of lumps to check for.