### PR TITLE
Client-only and Server-only defines

### DIFF
--- a/common/doomdef.h
+++ b/common/doomdef.h
@@ -69,6 +69,33 @@ enum baseapp_t
 
 extern baseapp_t baseapp;
 
+// [AM] These macros exist so function calls to CL/SV functions can exist
+//      without having to create a stub for them.
+
+#if defined(CLIENT_APP)
+/**
+ * @brief The passed expression only appears on the client.
+ */
+#define CLIENT_ONLY(expr) expr
+#else
+/**
+ * @brief The passed expression only appears on the client.
+ */
+#define CLIENT_ONLY(expr)
+#endif
+
+#if defined(SERVER_APP)
+/**
+ * @brief The passed expression only appears on the server.
+ */
+#define SERVER_ONLY(expr) expr
+#else
+/**
+ * @brief The passed expression only appears on the server.
+ */
+#define SERVER_ONLY(expr)
+#endif
+
 // 
 // Environment Platform
 // 


### PR DESCRIPTION
These two defines came from my work on `protobuf`.

These defines show or hide expressions from the compiler depending on if we're compiling the server or client.  In my opinion, this is a much better (and less messy) idea than any sort of runtime checks, because in current code any client or server functions you call have to be stubbed on the opposite side.

You just use it like:

```c++
CLIENT_ONLY(CL_MyClientFunction());
SERVER_ONLY(SV_MyServerFunction());
```

For extended blocks, you can either put multiple expressions in a `{` `}` brace pair, or you can just use a normal `CLIENT_APP` or `SERVER_APP` define.