### PR TITLE
Wad download fallback

### DIFF
--- a/client/src/cl_download.cpp
+++ b/client/src/cl_download.cpp
@@ -407,8 +407,26 @@ static void TickDownload()
 
 	if (!::dlstate.transfer->tick())
 	{
-		// Transfer is done ticking - clean it up.
-		::dlstate.Ready();
+		if (::dlstate.transfer->shouldCheckAgain())
+		{
+			// Check the next site.
+			::dlstate.state = STATE_CHECKING;
+			::dlstate.checkfails = 0;
+			::dlstate.checkurlidx += 1;
+			if (::dlstate.checkurlidx >= ::dlstate.checkurls.size())
+			{
+				// No more base URL's to check - our luck has run out.
+				Printf(PRINT_WARNING, "Download failed, no sites have %s for download.\n",
+				       ::dlstate.checkfilename.c_str());
+				::dlstate.Ready();
+			}
+		}
+		else
+		{
+			// Either we are done or encountered an error that is indicitive
+			// of an issue that we can't hope to recover from.
+			::dlstate.Ready();
+		}
 	}
 }
 

--- a/client/src/otransfer.cpp
+++ b/client/src/otransfer.cpp
@@ -441,6 +441,9 @@ bool OTransfer::tick()
 		ok = rename(m_filePart.c_str(), fallback.c_str());
 		if (ok != 0)
 		{
+			// Something is seriously wrong with our writable directory.
+			m_shouldCheckAgain = false;
+
 			std::string buf;
 			StrFormat(buf, "File %s could not be renamed to %s - %s", m_filePart.c_str(),
 			          m_filename.c_str(), strerror(errno));
@@ -455,8 +458,14 @@ bool OTransfer::tick()
 		Printf("Saved to location \"%s\".\n", m_filename.c_str());
 	}
 
+	m_shouldCheckAgain = false;
 	m_doneProc(info);
 	return false;
+}
+
+bool OTransfer::shouldCheckAgain() const
+{
+	return m_shouldCheckAgain;
 }
 
 std::string OTransfer::getFilename() const

--- a/client/src/otransfer.cpp
+++ b/client/src/otransfer.cpp
@@ -24,6 +24,7 @@
 
 #include "cmdlib.h"
 #include "i_system.h"
+#include "m_fileio.h"
 #include "w_ident.h"
 #include "w_wad.h"
 
@@ -425,11 +426,33 @@ bool OTransfer::tick()
 	int ok = rename(m_filePart.c_str(), m_filename.c_str());
 	if (ok != 0)
 	{
-		std::string buf;
-		StrFormat(buf, "File %s could not be renamed to %s - %s", m_filePart.c_str(),
-		          m_filename.c_str(), strerror(errno));
-		m_errorProc(buf.c_str());
-		return false;
+		// See if we can write a file with a partial hash.
+		std::string path, base, ext, fallback;
+		M_ExtractFilePath(m_filename, path);
+		M_ExtractFileBase(m_filename, base);
+		if (M_ExtractFileExtension(m_filename, ext))
+		{
+			ext = std::string(".") + ext;
+		}
+		StrFormat(fallback, "%s%s%s.%s%s", path.c_str(), PATHSEP, base.c_str(),
+		          actualHash.substr(0, 6).c_str(), ext.c_str());
+
+		// Try one more time.
+		ok = rename(m_filePart.c_str(), fallback.c_str());
+		if (ok != 0)
+		{
+			std::string buf;
+			StrFormat(buf, "File %s could not be renamed to %s - %s", m_filePart.c_str(),
+			          m_filename.c_str(), strerror(errno));
+			m_errorProc(buf.c_str());
+			return false;
+		}
+
+		Printf("Saved to fallback location \"%s\".\n", fallback.c_str());
+	}
+	else
+	{
+		Printf("Saved to location \"%s\".\n", m_filename.c_str());
 	}
 
 	m_doneProc(info);

--- a/client/src/otransfer.h
+++ b/client/src/otransfer.h
@@ -102,6 +102,7 @@ class OTransfer
 	std::string m_filename;
 	std::string m_filePart;
 	std::string m_expectHash;
+	bool m_shouldCheckAgain;
 
 	OTransfer(const OTransfer&);
 	static int curlProgress(void* clientp, double dltotal, double dlnow, double ultotal,
@@ -111,7 +112,7 @@ class OTransfer
 	OTransfer(OTransferDoneProc done, OTransferErrorProc err)
 	    : m_doneProc(done), m_errorProc(err), m_curlm(curl_multi_init()),
 	      m_curl(curl_easy_init()), m_file(NULL), m_progress(OTransferProgress()),
-	      m_filename(""), m_filePart(""), m_expectHash("")
+	      m_filename(""), m_filePart(""), m_expectHash(""), m_shouldCheckAgain(true)
 	{
 	}
 
@@ -134,6 +135,7 @@ class OTransfer
 	bool start();
 	void stop();
 	bool tick();
+	bool shouldCheckAgain() const;
 	std::string getFilename() const;
 	OTransferProgress getProgress() const;
 };

--- a/common/m_fileio_posix.cpp
+++ b/common/m_fileio_posix.cpp
@@ -218,7 +218,7 @@ std::string M_BaseFileSearchDir(std::string dir, const std::string& file,
 		if (!hash.empty())
 		{
 			// Filenames with supplied hashes always match first.
-			cmp_files.push_back(StdStringToUpper(file + *it + "." + hash));
+			cmp_files.push_back(StdStringToUpper(file + "." + hash.substr(0, 6) + *it));
 		}
 		cmp_files.push_back(StdStringToUpper(file + *it));
 	}

--- a/common/m_fileio_win32.cpp
+++ b/common/m_fileio_win32.cpp
@@ -172,7 +172,7 @@ std::string M_BaseFileSearchDir(std::string dir, const std::string& file,
 		if (!hash.empty())
 		{
 			// Filenames with supplied hashes always match first.
-			cmp_files.push_back(StdStringToUpper(file + *it + "." + hash));
+			cmp_files.push_back(StdStringToUpper(file + "." + hash.substr(0, 6) + *it));
 		}
 		cmp_files.push_back(StdStringToUpper(file + *it));
 	}


### PR DESCRIPTION
This is a modification to both the WAD downloader and the existing WAD hash substitution to work in tandem to solve a few problems surrounding downloading ambiguous WAD files that have multiple MD5 hashes floating around.

1. Previously if the WAD downloader downloaded a WAD and it got one with the wrong hash, it gave up.  Now it continues on to the other sites.
2. If the WAD downloader downloaded a WAD file that the client already had, it just errored because of a failed rename.  Now, it renames the file to `MYFILE.a4b2f6.WAD` where `a4b2f6` is a truncated MD5 hash of the file you just downloaded.
3. Odamex has long been able to load WAD files named `MYFILE.WAD.<literally a full MD5 hash>` as a substitute for the original file.  This has been changed to the `MYFILE.a4b2f6.WAD` system above in the interest of brevity and keeping the original file extension.  Exactly six hexdec characters should always mean a truncated MD5 hash and other partial hashes are ignored, so in the future we can add support for other hashes by merely adding characters or possibly adding a non-hexdec character as a prefix.