### PR TITLE
Reenable Spying features when out of lives.

### DIFF
--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -39,6 +39,8 @@
 #include "hashtable.h"
 #include "cl_responderkeys.h"
 
+#include "g_gametype.h"
+
 extern NetDemo netdemo;
 
 /* Most of these bindings are equivalent
@@ -289,13 +291,14 @@ bool C_DoNetDemoKey (event_t *ev)
 //
 // C_DoSpectatorKey
 //
-// [SL] 2012-09-14 - Handles the hard-coded key bindings used while spectating
-// or during NetDemo playback.  Returns false if the key pressed is not
-// bound to any spectating command such as spynext.
+// [SL] 2012-09-14 - Handles the hard-coded key bindings used while spectating, 
+// dead-spectating on lives mode or during NetDemo playback.  Returns false if 
+// the key pressed is not bound to any spectating command such as spynext.
 //
 bool C_DoSpectatorKey (event_t *ev)
 {
-	if (!consoleplayer().spectator && !netdemo.isPlaying() && !netdemo.isPaused())
+	if (!consoleplayer().spectator && (G_IsLivesGame() && consoleplayer().lives > 0) 
+		&& !netdemo.isPlaying() && !netdemo.isPaused())
 		return false;
 
 	if (ev->type == ev_keydown && Key_IsSpyPrevKey(ev->data1))

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -788,7 +788,11 @@ bool P_CanSpy(player_t &viewer, player_t &other, bool demo)
 {
 	// Viewers can always spy themselves.
 	if (viewer.id == other.id)
+	{
+		if (G_IsLivesGame() && viewer.lives < 1)
+			return false;
 		return true;
+	}
 
 	// You cannot view those without bodies or spectators.
 	if (!other.mo || other.spectator)


### PR DESCRIPTION
This PR does the following:
- Correct Bug #280 that doesn't give back spectator key features;
- Fixes a bug where spyprev/spynext wouldn't cycle properly for dead players as they would hit themselves.

I haven't tested all possible situations however.