### PR TITLE
Improve state cycle detector

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -973,7 +973,8 @@ bool P_SetMobjState(AActor *mobj, statenum_t state, bool cl_update)
 		// [AM] A slightly different heruistic that doesn't involve global state.
 		if (cycle_counter++ > MOBJ_CYCLE_LIMIT)
 		{
-			I_Error("P_SetMobjState: Infinite state cycle detected!");
+			I_Error("P_SetMobjState: Infinite state cycle detected for %s at state %d.",
+			        mobj->info->name, state);
 		}
 	} while (!mobj->tics);
 

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -920,20 +920,22 @@ int P_ThingInfoHeight(mobjinfo_t *mi)
 
 extern void SV_UpdateMobjState(AActor *mo);
 
+// Use a heuristic approach to detect infinite state cycles: Count the number
+// of times the loop in P_SetMobjState() executes and exit with an error once
+// an arbitrary very large limit is reached.
+//
+// [AM] Taken from Crispy Doom, with a smaller limit - 10,000 iterations
+//      still seems like a lot to me.
+
+#define MOBJ_CYCLE_LIMIT 10000
+
 // P_SetMobjState
 //
 // Returns true if the mobj is still present.
 bool P_SetMobjState(AActor *mobj, statenum_t state, bool cl_update)
 {
 	state_t* st;
-
-	// denis - prevent harmful state cycles
-	static unsigned int callstack;
-	if(callstack++ > 16)
-	{
-		callstack = 0;
-		I_Error("P_SetMobjState: callstack depth exceeded bounds");
-	}
+	int cycle_counter = 0;
 
 	do
 	{
@@ -946,8 +948,6 @@ bool P_SetMobjState(AActor *mobj, statenum_t state, bool cl_update)
 		{
 			mobj->state = (state_t *) S_NULL;
 			mobj->Destroy();
-
-			callstack--;
 			return false;
 		}
 
@@ -968,9 +968,15 @@ bool P_SetMobjState(AActor *mobj, statenum_t state, bool cl_update)
 			st->action(mobj);
 
 		state = st->nextstate;
+
+		// denis - prevent harmful state cycle
+		// [AM] A slightly different heruistic that doesn't involve global state.
+		if (cycle_counter++ > MOBJ_CYCLE_LIMIT)
+		{
+			I_Error("P_SetMobjState: Infinite state cycle detected!");
+		}
 	} while (!mobj->tics);
 
-	callstack--;
 	return true;
 }
 


### PR DESCRIPTION
Our previous state cycle detector relied on global state, so I swapped it with Crispy Doom's.  I also adjusted the error message so it's better at what is causing the cycle.