### PR TITLE
Allow multiple DeHackEd patches, fix language strings

### DIFF
--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -615,9 +615,6 @@ void D_Init()
 //		Printf(PRINT_HIGH, "Res_InitTextureManager: Init image resource management.\n");
 //	Res_InitTextureManager();
 
-	// [RH] Initialize localizable strings.
-	GStrings.loadStrings();
-
 	// init the renderer
 	if (first_time)
 		Printf(PRINT_HIGH, "R_Init: Init DOOM refresh daemon.\n");

--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -92,6 +92,9 @@ static char *Line1, *Line2;
 static int	 dversion, pversion;
 static BOOL  including, includenotext;
 
+// English strings for DeHackEd replacement.
+static StringTable ENGStrings;
+
 // This is an offset to be used for computing the text stuff.
 // Straight from the DeHackEd source which was
 // Written by Greg Lewis, gregl@umich.edu.
@@ -1613,7 +1616,7 @@ static int PatchText (int oldSize)
 		goto donewithtext;
 	
 	// Search through most other texts
-	name = &GStrings.matchString(oldStr);
+	name = &ENGStrings.matchString(oldStr);
 	if (name != NULL && !name->empty())
 	{
 		GStrings.setString(*name, newStr);
@@ -1759,7 +1762,7 @@ static int DoInclude(int dummy)
 		goto endinclude;
 	}
 
-	D_DoDehPatch(&res, false);
+	D_DoDehPatch(&res, -1);
 
 	DPrintf("Done with include\n");
 	PatchFile = savepatchfile;
@@ -1776,18 +1779,15 @@ endinclude:
 /**
  * @brief Attempt to load a DeHackEd file.
  * 
- * @param patchfile File to attempt to load.
- * @param autoloading 
- * @return 
-*/
-bool D_DoDehPatch(const OResFile* patchfile, bool autoloading)
+ * @param patchfile File to attempt to load, NULL if not a file.
+ * @param lump Lump index to load, -1 if not a lump.
+ */
+bool D_DoDehPatch(const OResFile* patchfile, const int lump)
 {
 	BackupData();
 	::PatchFile = NULL;
 
-	int lump = W_CheckNumForName("DEHACKED");
-
-	if (lump >= 0 && autoloading)
+	if (lump >= 0)
 	{
 		// Execute the DEHACKED lump as a patch.
 		::filelen = W_LumpLength(lump);
@@ -1820,6 +1820,9 @@ bool D_DoDehPatch(const OResFile* patchfile, bool autoloading)
 		// Nothing to do.
 		return false;
 	}
+
+	// Load english strings to match against.
+	::ENGStrings.loadStrings(true);
 
 	// End file with a NULL for our parser
 	::PatchFile[::filelen] = 0;

--- a/common/d_dehacked.h
+++ b/common/d_dehacked.h
@@ -28,7 +28,6 @@
 #include "m_resfile.h"
 
 void D_UndoDehPatch();
-bool D_DoDehPatch(const OResFile* patchfile, bool autoloading);
+bool D_DoDehPatch(const OResFile* patchfile, const int lump);
 
 #endif //__D_DEHACK_H__
-

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -409,43 +409,28 @@ static void D_PrintIWADIdentity()
 }
 
 
-//
-// D_DoDefDehackedPatch
-//
-// [Russell] - Change the meaning, this will load multiple patch files if
-//             specified
-static void DoDefDehackedPatches(const OResFiles& newpatchfiles)
+/**
+ * @brief Load all found DEH patches, as well as all found DEHACKED lumps.
+ */
+void D_LoadResolvedPatches()
 {
-	bool use_default = true;
-	if (!newpatchfiles.empty())
-	{
-		for (OResFiles::const_iterator it = newpatchfiles.begin();
-		     it != newpatchfiles.end(); ++it)
-		{
-			if (D_DoDehPatch(&*it, false))
-			{
-				use_default = false;
-			}
-		}
-	}
-
-	// try default patches
-	if (use_default)
-	{
-		// See if there's a patch in a PWAD
-		D_DoDehPatch(NULL, true);
-	}
-
-	// check for ChexQuest
+	// Load external patch files first.
 	bool chexLoaded = false;
-	for (OResFiles::const_iterator it = newpatchfiles.begin(); it != newpatchfiles.end();
+	for (OResFiles::const_iterator it = ::patchfiles.begin(); it != ::patchfiles.end();
 	     ++it)
 	{
 		if (it->getBasename() == "CHEX.DEH")
 		{
 			chexLoaded = true;
-			break;
 		}
+		D_DoDehPatch(&*it, -1);
+	}
+
+	// Check WAD files for lumps.
+	int lump = -1;
+	while ((lump = W_FindLump("DEHACKED", lump)) != -1)
+	{
+		D_DoDehPatch(NULL, lump);
 	}
 
 	if (::gamemode == retail_chex && !::multiplayer && !chexLoaded)
@@ -554,9 +539,10 @@ static void LoadResolvedFiles(const OResFiles& newwadfiles,
 	// [RH] Initialize localizable strings.
 	// [SL] It is necessary to load the strings here since a dehacked patch
 	// might change the strings
-	::GStrings.loadStrings();
+	::GStrings.loadStrings(false);
 
-	DoDefDehackedPatches(::patchfiles);
+	// Apply DEH patches.
+	D_LoadResolvedPatches();
 }
 
 //

--- a/common/d_main.h
+++ b/common/d_main.h
@@ -60,6 +60,7 @@ extern const char *D_DrawIcon;
 
 void D_AddSearchDir(std::vector<std::string> &dirs, const char *dir, const char separator);
 void D_AddPlatformSearchDirs(std::vector<std::string>& dirs);
+void D_LoadResolvedPatches();
 std::string D_CleanseFileName(const std::string &filename, const std::string &ext = "");
 
 extern OResFiles wadfiles;

--- a/common/doomstat.cpp
+++ b/common/doomstat.cpp
@@ -27,7 +27,7 @@
 #include "c_cvars.h"
 #include "i_system.h"
 #include "p_acs.h"
-#include "d_dehacked.h"
+#include "d_main.h"
 
 // Game Mode - identify IWAD as shareware, retail etc.
 GameMode_t		gamemode = undetermined;
@@ -44,11 +44,10 @@ CVAR_FUNC_IMPL (language)
 	}
 
 	// Reload LANGUAGE strings.
-	GStrings.loadStrings();
+	::GStrings.loadStrings(false);
 
 	// Reapply DeHackEd patches on top of these strings.
-	// FIXME: This only handles PWAD patches for now.
-	D_DoDehPatch(NULL, true);
+	D_LoadResolvedPatches();
 
 	// Set default level strings based on those DeHackEd patches.
 	G_SetLevelStrings();

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -1994,14 +1994,24 @@ void G_InitLevelLocals()
 			else
 				begin = info.level_name;
 		}
-		strncpy(::level.level_name, begin, ARRAY_LENGTH(::level.level_name) - 1);
+
+		if (begin != NULL)
+		{
+			std::string level_name(begin);
+			TrimString(level_name);
+			strncpy(::level.level_name, level_name.c_str(),
+			        ARRAY_LENGTH(::level.level_name) - 1);
+		}
+		else
+		{
+			strncpy(::level.level_name, "Untitled Level",
+			        ARRAY_LENGTH(::level.level_name) - 1);
+		}
 	}
 	else
 	{
-		strncpy(
-			::level.level_name, "Untitled Level",
-			ARRAY_LENGTH(::level.level_name) - 1
-		);
+		strncpy(::level.level_name, "Untitled Level",
+		        ARRAY_LENGTH(::level.level_name) - 1);
 	}
 
 	strncpy(::level.nextmap, info.nextmap, 8);

--- a/common/stringtable.cpp
+++ b/common/stringtable.cpp
@@ -225,7 +225,7 @@ void StringTable::loadLanguage(const char* code, bool exactMatch, int pass, char
 	}
 }
 
-void StringTable::loadStringsLump(int lump, const char* lumpname)
+void StringTable::loadStringsLump(const int lump, const char* lumpname, const bool engOnly)
 {
 	// Can't use Z_Malloc this early, so we use raw new/delete.
 	size_t len = W_LumpLength(lump);
@@ -237,25 +237,28 @@ void StringTable::loadStringsLump(int lump, const char* lumpname)
 	// by a string in an earlier pass from another lump.
 	int pass = 1;
 
-	// Load language-specific strings.
-	for (size_t i = 0; i < ARRAY_LENGTH(LanguageIDs); i++)
+	if (!engOnly)
 	{
-		// Deconstruct code into something less confusing.
-		char code[4];
-		UNMAKE_ID(code, LanguageIDs[i]);
+		// Load language-specific strings.
+		for (size_t i = 0; i < ARRAY_LENGTH(::LanguageIDs); i++)
+		{
+			// Deconstruct code into something less confusing.
+			char code[4];
+			UNMAKE_ID(code, ::LanguageIDs[i]);
 
-		// Language codes are up to three letters long.
-		code[3] = '\0';
+			// Language codes are up to three letters long.
+			code[3] = '\0';
 
-		// Try the full language code (enu).
-		loadLanguage(code, true, pass++, languageLump, len);
+			// Try the full language code (enu).
+			loadLanguage(code, true, pass++, languageLump, len);
 
-		// Try the partial language code (en).
-		code[2] = '\0';
-		loadLanguage(code, true, pass++, languageLump, len);
+			// Try the partial language code (en).
+			code[2] = '\0';
+			loadLanguage(code, true, pass++, languageLump, len);
 
-		// Try an inexact match for all languages in the same family (en_).
-		loadLanguage(code, false, pass++, languageLump, len);
+			// Try an inexact match for all languages in the same family (en_).
+			loadLanguage(code, false, pass++, languageLump, len);
+		}
 	}
 
 	// Load string defaults.
@@ -338,7 +341,7 @@ bool StringTable::hasString(const OString& name) const
 //
 // Load strings from all LANGUAGE lumps in all loaded WAD files.
 //
-void StringTable::loadStrings()
+void StringTable::loadStrings(const bool engOnly)
 {
 	clearStrings();
 	prepareIndexes();
@@ -348,7 +351,7 @@ void StringTable::loadStrings()
 	lump = -1;
 	while ((lump = W_FindLump("LANGUAGE", lump)) != -1)
 	{
-		loadStringsLump(lump, "LANGUAGE");
+		loadStringsLump(lump, "LANGUAGE", engOnly);
 	}
 }
 

--- a/common/stringtable.h
+++ b/common/stringtable.h
@@ -68,7 +68,7 @@ class StringTable
 	void clearStrings();
 	void loadLanguage(const char* code, bool exactMatch, int pass, char* lump,
 	                  size_t lumpLen);
-	void loadStringsLump(int lump, const char* lumpname);
+	void loadStringsLump(const int lump, const char* lumpname, const bool engOnly);
 	void prepareIndexes();
 	void replaceEscapes(std::string& str);
 
@@ -133,7 +133,7 @@ class StringTable
 
 	void dumpStrings();
 	bool hasString(const OString& name) const;
-	void loadStrings();
+	void loadStrings(const bool engOnly);
 	const OString& matchString(const OString& string) const;
 	void setString(const OString& name, const OString& string);
 	void setPassString(int pass, const OString& name, const OString& string);

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -164,7 +164,7 @@ void D_Init()
 	R_InitColormaps();
 
 	// [RH] Initialize localizable strings.
-	GStrings.loadStrings();
+	::GStrings.loadStrings(false);
 
 	// init the renderer
 	if (first_time)


### PR DESCRIPTION
This patch largely aims to solve problems encountered when trying to layer multiple DEH patches at once.

1. In some instances, only one DeHackEd patch was recognized.  Now, multiples of normal patches, WAD patches, or both are applied.
1. String replacement was inconsistent due to previously only being applied from WAD files when the `language` cvar was changed, as well as only being applied properly when english strings were in use (DEH strings are supposed to override all language-specific strings).