### PR TITLE
Clean up packed version macros

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1869,7 +1869,9 @@ bool CL_PrepareConnect(void)
 			gameversiontosend = 40;
 		}
 
-		Printf(PRINT_HIGH, "> Server Version %i.%i.%i\n", gameversion / 256, (gameversion % 256) / 10, (gameversion % 256) % 10);
+		int major, minor, patch;
+		BREAKVER(gameversion, major, minor, patch);
+		Printf(PRINT_HIGH, "> Server Version %i.%i.%i\n", major, minor, patch);
 	}
 
     Printf(PRINT_HIGH, "\n");

--- a/common/version.h
+++ b/common/version.h
@@ -32,20 +32,54 @@
 #error "Odamex is not client or server"
 #endif
 
+/**
+ * @brief Construct a packed integer from major, minor and patch version
+ *        numbers.
+ *
+ * @param major Major version number.
+ * @param minor Minor version number - must be between 0 and 25.
+ * @param patch Patch version number - must be between 0 and 9.
+ */
+#define MAKEVER(major, minor, patch) ((major)*256 + ((minor)*10) + (patch))
+
+/**
+ * @brief Given a packed version integer, return the major version.
+ */
+#define VERMAJ(v) ((v) / 256)
+
+/**
+ * @brief Given a packed version integer, return the minor version.
+ */
+#define VERMIN(v) (((v) % 256) / 10)
+
+/**
+ * @brief Given a packed version integer, return the patch version.
+ */
+#define VERPATCH(v) (((v) % 256) % 10)
+
+/**
+ * @brief Break version into three output variables.
+ */
+#define BREAKVER(v, outmaj, outmin, outpat) \
+	{                                       \
+		outmaj = VERMAJ(v);                 \
+		outmin = VERMIN(v);                 \
+		outpat = VERPATCH(v);               \
+	}
+
 // Lots of different representations for the version number
 #define CONFIGVERSIONSTR "90"
-#define GAMEVER (0*256+90)
-
 #define DOTVERSIONSTR "0.9.0"
+#define GAMEVER (MAKEVER(0, 9, 0))
 
 #define COPYRIGHTSTR "Copyright (C) 2006-2021 The Odamex Team"
 
-#define SERVERMAJ (gameversion / 256)
-#define SERVERMIN ((gameversion % 256) / 10)
-#define SERVERREL ((gameversion % 256) % 10)
-#define CLIENTMAJ (GAMEVER / 256)
-#define CLIENTMIN ((GAMEVER % 256) / 10)
-#define CLIENTREL ((GAMEVER % 256) % 10)
+#define SERVERMAJ (VERMAJ(gameversion))
+#define SERVERMIN (VERMIN(gameversion))
+#define SERVERREL (VERPAT(gameversion))
+#define CLIENTMAJ (VERMAJ(GAMEVER))
+#define CLIENTMIN (VERMIN(GAMEVER))
+#define CLIENTREL (VERPAT(GAMEVER))
 
 // SAVESIG is the save game signature. It should be the minimum version
 // whose savegames this version is compatible with, which could be

--- a/odalpapi/net_packet.h
+++ b/odalpapi/net_packet.h
@@ -43,7 +43,18 @@
 #include "typedefs.h"
 #include "threads/mutex_factory.h"
 
-#define ASSEMBLEVERSION(MAJOR,MINOR,PATCH) ((MAJOR) * 256 + (MINOR)(PATCH))
+/**
+ * @brief Construct a packed integer from major, minor and patch version
+ *        numbers.
+ *
+ * @param major Major version number.
+ * @param minor Minor version number - must be between 0 and 25.
+ * @param patch Patch version number - must be between 0 and 9.
+ */
+#define MAKEVER(major, minor, patch) ((major)*256 + ((minor)*10) + (patch))
+
+// [AM] TODO: Bring over other macros from Odamex proper.
+
 #define DISECTVERSION(V,MAJOR,MINOR,PATCH) \
 { \
     MAJOR = (V / 256); \
@@ -55,7 +66,7 @@
 #define VERSIONMINOR(V) ((V % 256) / 10)
 #define VERSIONPATCH(V) ((V % 256) % 10)
 
-#define VERSION (0*256+90)
+#define VERSION (MAKEVER(0, 9, 0))
 #define PROTOCOL_VERSION 8
 
 #define TAG_ID 0xAD0

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1945,58 +1945,49 @@ void SV_ServerSettingChange (void)
 bool SV_CheckClientVersion(client_t *cl, Players::iterator it)
 {
 	int GameVer = 0;
-	char VersionStr[20];
-	char OurVersionStr[20];
-	memset(VersionStr, 0, sizeof(VersionStr));
-	memset(OurVersionStr, 0, sizeof(VersionStr));
+	std::string VersionStr;
+	std::string OurVersionStr(DOTVERSIONSTR);
 	bool AllowConnect = true;
-	int majorver = 0;
-	int minorver = 0;
-	int releasever = 0;
-	int MAJORVER = GAMEVER / 256;
-	int MINORVER = (GAMEVER % 256) / 10;
-	int RELEASEVER = (GAMEVER % 256) % 10;
-
-	if ((GAMEVER % 256) % 10)
-		sprintf(OurVersionStr, "%i.%i.%i", GAMEVER / 256, (GAMEVER % 256) / 10, (GAMEVER % 256) % 10);
-	else
-		sprintf(OurVersionStr, "%i.%i", GAMEVER / 256, (GAMEVER % 256) / 10);
+	int cl_major = 0;
+	int cl_minor = 0;
+	int cl_patch = 0;
+	int sv_major, sv_minor, sv_patch;
+	BREAKVER(GAMEVER, sv_major, sv_minor, sv_patch);
 
 	switch (cl->version)
 	{
-		case 65:
-			GameVer = MSG_ReadLong();
-			cl->majorversion = GameVer / 256;
-			cl->minorversion = GameVer % 256;
-			if ((GameVer % 256) % 10)
-				sprintf(VersionStr, "%i.%i.%i", cl->majorversion, cl->minorversion / 10, cl->minorversion % 10);
-			else
-				sprintf(VersionStr, "%i.%i", cl->majorversion, cl->minorversion / 10);
+	case 65:
+		GameVer = MSG_ReadLong();
 
-			majorver = GameVer / 256;
-			minorver = (GameVer % 256) / 10;
-			releasever = (GameVer % 256) % 10;
+		cl_major = VERMAJ(GameVer);
+		cl_minor = VERMIN(GameVer);
+		cl_patch = VERPATCH(GameVer);
 
-			if ((majorver == MAJORVER) &&
-				(minorver == MINORVER) &&
-				(releasever >= RELEASEVER))
-				AllowConnect = true;
-			else
-				AllowConnect = false;
-			break;
-		case 64:
-			sprintf(VersionStr, "0.2a or 0.3");
-			break;
-		case 63:
-			sprintf(VersionStr, "Pre-0.2");
-			break;
-		case 62:
-			sprintf(VersionStr, "0.1a");
-			break;
-		default:
-			sprintf(VersionStr, "Unknown");
-			break;
+		StrFormat(VersionStr, "%d.%d.%d", cl_major, cl_minor, cl_patch);
 
+		cl->majorversion = cl_major;
+		cl->minorversion = cl_minor;
+
+		// Major and minor versions must be identical, client is allowed
+		// to have a newer patch.
+		if ((cl_major == sv_major) && (cl_minor == sv_minor) &&
+		    (cl_patch >= sv_patch))
+			AllowConnect = true;
+		else
+			AllowConnect = false;
+		break;
+	case 64:
+		VersionStr = "0.2a or 0.3";
+		break;
+	case 63:
+		VersionStr = "Pre-0.2";
+		break;
+	case 62:
+		VersionStr = "0.1a";
+		break;
+	default:
+		VersionStr = "Unknown";
+		break;
 	}
 
 	// GhostlyDeath -- removes the constant AllowConnects above
@@ -2020,19 +2011,20 @@ bool SV_CheckClientVersion(client_t *cl, Players::iterator it)
             std::endl;
 
 		// GhostlyDeath -- Check to see if it's older or not
-		if (cl->majorversion < (GAMEVER / 256))
+		if (cl->majorversion < sv_major)
+		{
 			older = true;
+		}
+		else if (cl->majorversion > sv_major)
+		{
+			older = false;
+		}
 		else
 		{
-			if (cl->majorversion > (GAMEVER / 256))
+			if (cl->minorversion < sv_minor)
+				older = true;
+			else if (cl->minorversion > sv_minor)
 				older = false;
-			else
-			{
-				if (cl->minorversion < (GAMEVER % 256))
-					older = true;
-				else if (cl->minorversion > (GAMEVER % 256))
-					older = false;
-			}
 		}
 
 		// GhostlyDeath -- Print message depending on older or newer
@@ -2082,8 +2074,8 @@ bool SV_CheckClientVersion(client_t *cl, Players::iterator it)
 		// GhostlyDeath -- And we tell the server
 		Printf("%s -- Version mismatch (%s != %s)\n",
                 NET_AdrToString(net_from),
-                VersionStr,
-                OurVersionStr);
+                VersionStr.c_str(),
+                OurVersionStr.c_str());
 	}
 
 	return AllowConnect;

--- a/server/src/sv_sqp.cpp
+++ b/server/src/sv_sqp.cpp
@@ -350,8 +350,8 @@ static DWORD IntQrySendResponse(const WORD& TagId,
 	}
 
 	// Override other packet types for older enquirer version response
-	if(VERSIONMAJOR(EqVersion) < VERSIONMAJOR(GAMEVER) ||
-	        (VERSIONMAJOR(EqVersion) <= VERSIONMAJOR(GAMEVER) && VERSIONMINOR(EqVersion) < VERSIONMINOR(GAMEVER)))
+	if (VERMAJ(EqVersion) < VERMAJ(GAMEVER) ||
+	    (VERMAJ(EqVersion) <= VERMAJ(GAMEVER) && VERMIN(EqVersion) < VERMIN(GAMEVER)))
 	{
 		RePacketType = 2;
 	}

--- a/server/src/sv_sqp.h
+++ b/server/src/sv_sqp.h
@@ -26,18 +26,6 @@
 #include "version.h"
 #include "doomtype.h"
 
-#define ASSEMBLEVERSION(MAJOR,MINOR,PATCH) ((MAJOR) * 256 + (MINOR)(PATCH))
-#define DISECTVERSION(VERSION,MAJOR,MINOR,PATCH) \
-        { \
-            MAJOR = (VERSION / 256); \
-            MINOR = ((VERSION % 256) / 10); \
-            PATCH = ((VERSION % 256) % 10); \
-        }
-        
-#define VERSIONMAJOR(VERSION) (VERSION / 256)
-#define VERSIONMINOR(VERSION) ((VERSION % 256) / 10)
-#define VERSIONPATCH(VERSION) ((VERSION % 256) % 10)
-
 DWORD SV_QryParseEnquiry(const DWORD &Tag);
 
 #endif // __SV_SQP_H__


### PR DESCRIPTION
While working on a Python version of upversion, I noticed lots of repetition of the same version logic for packed version numbers, so I did a little cleanup to make things easier to replace for 0.9.1.