### PR TITLE
Reenable Spying features when out of lives. [Re-PR]

### DIFF
--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -297,9 +297,17 @@ bool C_DoNetDemoKey (event_t *ev)
 //
 bool C_DoSpectatorKey (event_t *ev)
 {
-	if (!consoleplayer().spectator && (G_IsLivesGame() && consoleplayer().lives > 0) 
-		&& !netdemo.isPlaying() && !netdemo.isPaused())
+	if (G_IsLivesGame())
+	{
+		if (!consoleplayer().spectator && consoleplayer().lives > 0 &&
+		    !netdemo.isPlaying() && !netdemo.isPaused())
 		return false;
+	}
+	else
+	{
+		if (!consoleplayer().spectator && !netdemo.isPlaying() && !netdemo.isPaused())
+		return false;
+	}
 
 	if (ev->type == ev_keydown && Key_IsSpyPrevKey(ev->data1))
 	{

--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -37,6 +37,7 @@
 #include "d_player.h"
 #include "i_input.h"
 #include "hashtable.h"
+#include "g_gametype.h"
 #include "cl_responderkeys.h"
 
 extern NetDemo netdemo;


### PR DESCRIPTION
Previous PR was merged without further testing and got reverted as a result. This PR thus does the following:

• Correct Bug #280 that doesn't give back spectator key features;
• Fixes a bug where spyprev/spynext wouldn't cycle properly for dead players as they would hit themselves.
• Make sure that bound keys aren't overwritten on specific cases (Thanks Ralphis for spotting this out!)

I haven't tested all possible situations however, but from my testings, it should be good.