### PR TITLE
Fix mugshot not tracking the attacker online.

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -980,10 +980,12 @@ static void CL_SpawnPlayer(const odaproto::svc::SpawnPlayer* msg)
 static void CL_DamagePlayer(const odaproto::svc::DamagePlayer* msg)
 {
 	uint32_t netid = msg->netid();
+	uint32_t attackerid = msg->inflictorid();
 	int healthDamage = msg->health_damage();
 	int armorDamage = msg->armor_damage();
 
 	AActor* actor = P_FindThingById(netid);
+	AActor* attacker = P_FindThingById(attackerid);
 
 	if (!actor || !actor->player)
 		return;
@@ -992,6 +994,9 @@ static void CL_DamagePlayer(const odaproto::svc::DamagePlayer* msg)
 	p->health -= healthDamage;
 	p->mo->health = p->health;
 	p->armorpoints -= armorDamage;
+
+	if (attacker != NULL)
+		p->attacker = attacker->ptr();
 
 	if (p->health < 0)
 		p->health = 0;

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -68,7 +68,7 @@ void SV_TouchSpecial(AActor *special, player_t *player) {}
 ItemEquipVal SV_FlagTouch (player_t &player, team_t f, bool firstgrab) { return IEV_NotEquipped; }
 void SV_SocketTouch (player_t &player, team_t f) {}
 void SV_SendKillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill) {}
-void SV_SendDamagePlayer(player_t *player, int healthDamage, int armorDamage) {}
+void SV_SendDamagePlayer(player_t *player, AActor* inflictor, int healthDamage, int armorDamage) {}
 void SV_SendDamageMobj(AActor *target, int pain) {}
 void SV_CTFEvent(team_t f, flag_score_t event, player_t &who) {}
 void SV_UpdateFrags(player_t &player) {}

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -76,7 +76,7 @@ void SV_TouchSpecial(AActor *special, player_t *player);
 ItemEquipVal SV_FlagTouch(player_t &player, team_t f, bool firstgrab);
 void SV_SocketTouch(player_t &player, team_t f);
 void SV_SendKillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill);
-void SV_SendDamagePlayer(player_t *player, int healthDamage, int armorDamage);
+void SV_SendDamagePlayer(player_t *player, AActor* inflictor, int healthDamage, int armorDamage);
 void SV_SendDamageMobj(AActor *target, int pain);
 void SV_ActorTarget(AActor *actor);
 void PickupMessage(AActor *toucher, const char *message);
@@ -1467,7 +1467,7 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 		if (tplayer->damagecount > 100)
 			tplayer->damagecount = 100;	// teleport stomp does 10k points...
 
-		SV_SendDamagePlayer(tplayer, damage, armorDamage);
+		SV_SendDamagePlayer(tplayer, inflictor, damage, armorDamage);
 
 		// WDL damage events - they have to be up here to ensure we know how
 		// much armor is subtracted.

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -475,11 +475,12 @@ odaproto::svc::SpawnPlayer SVC_SpawnPlayer(player_t& player)
 	return msg;
 }
 
-odaproto::svc::DamagePlayer SVC_DamagePlayer(player_t& player, int health, int armor)
+odaproto::svc::DamagePlayer SVC_DamagePlayer(player_t& player, AActor* inflictor, int health, int armor)
 {
 	odaproto::svc::DamagePlayer msg;
 
 	msg.set_netid(player.mo->netid);
+	msg.set_inflictorid(inflictor ? inflictor->netid : 0);
 	msg.set_health_damage(health);
 	msg.set_armor_damage(armor);
 

--- a/common/svc_message.h
+++ b/common/svc_message.h
@@ -99,7 +99,7 @@ odaproto::svc::RemoveMobj SVC_RemoveMobj(AActor& mobj);
 odaproto::svc::UserInfo SVC_UserInfo(player_t& player, int64_t time);
 odaproto::svc::UpdateMobj SVC_UpdateMobj(AActor& mobj, uint32_t flags);
 odaproto::svc::SpawnPlayer SVC_SpawnPlayer(player_t& player);
-odaproto::svc::DamagePlayer SVC_DamagePlayer(player_t& player, int health, int armor);
+odaproto::svc::DamagePlayer SVC_DamagePlayer(player_t& player, AActor *inflictor, int health, int armor);
 odaproto::svc::KillMobj SVC_KillMobj(AActor* source, AActor* target, AActor* inflictor,
                                      int mod, bool joinkill);
 odaproto::svc::FireWeapon SVC_FireWeapon(player_t& player);

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -146,9 +146,9 @@ message SpawnPlayer
 message DamagePlayer
 {
 	uint32 netid = 1;
-	int32 inflictorid = 2;
-	int32 health_damage = 3;
-	int32 armor_damage = 4;
+	int32 health_damage = 2;
+	int32 armor_damage = 3;
+	int32 inflictorid = 4;
 }
 
 // svc_killmobj

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -146,8 +146,9 @@ message SpawnPlayer
 message DamagePlayer
 {
 	uint32 netid = 1;
-	int32 health_damage = 2;
-	int32 armor_damage = 3;
+	int32 inflictorid = 2;
+	int32 health_damage = 3;
+	int32 armor_damage = 4;
 }
 
 // svc_killmobj

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4755,14 +4755,14 @@ void ClientObituary(AActor* self, AActor* inflictor, AActor* attacker)
 	SV_BroadcastPrintf(PRINT_OBITUARY, "%s\n", gendermessage);
 }
 
-void SV_SendDamagePlayer(player_t *player, int healthDamage, int armorDamage)
+void SV_SendDamagePlayer(player_t *player, AActor* inflictor, int healthDamage, int armorDamage)
 {
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{
 		client_t *cl = &(it->client);
 
 		MSG_WriteSVC(&cl->reliablebuf,
-		             SVC_DamagePlayer(*player, healthDamage, armorDamage));
+		             SVC_DamagePlayer(*player, inflictor, healthDamage, armorDamage));
 	}
 }
 

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -93,7 +93,7 @@ void MSG_WriteMarker (buf_t *b, svc_t c);
 
 void SV_SendPlayerInfo(player_t& player);
 void SV_SendKillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill);
-void SV_SendDamagePlayer(player_t *player, int healthDamage, int armorDamage);
+void SV_SendDamagePlayer(player_t *player, AActor* inflictor, int healthDamage, int armorDamage);
 void SV_SendDamageMobj(AActor *target, int pain);
 // Tells clients to remove an actor from the world as it doesn't exist anymore
 void SV_SendDestroyActor(AActor *mo);


### PR DESCRIPTION
Send for each damaged player their attacker netID.

When your player is hit, no matter their direction, the mugface is still looking towards us, even if the attack comes from the left and right.
In fact, the server doesn't send out the attacker, and Odamex still believes the attacker is 0 (so a hazard or self-attack).

This is fixed by sending the netid of the attacker (if any) to each damageplayer packet.

Fixes issue #239.