### PR TITLE
HUD Bigfont toggle

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -440,6 +440,10 @@ CVAR(			idmypos, "0", "Shows current player position on map",
 
 // Heads up display
 // ----------------
+CVAR(hud_bigfont, "0",
+     "Use BIGFONT for certain HUD items - intended as a stopgap feature for streamers",
+     CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 CVAR(			hud_crosshairdim, "0", "Crosshair transparency",
 				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 

--- a/client/src/hu_drawers.cpp
+++ b/client/src/hu_drawers.cpp
@@ -183,7 +183,7 @@ void DrawText(int x, int y, const float scale,
 
 	// Calculate width and height of string
 	unsigned short w = V_StringWidth(str);
-	unsigned short h = 7;
+	unsigned short h = V_LineHeight();
 
 	// Turn our scaled coordinates into real coordinates.
 	int x_scale, y_scale;

--- a/client/src/hu_elements.cpp
+++ b/client/src/hu_elements.cpp
@@ -393,13 +393,13 @@ std::string PersonalSpread()
 		if (max_players.total <= 1)
 		{
 			// With only one player, this is the only reasonable thing to show.
-			return TEXTCOLOR_GREY "=0";
+			return TEXTCOLOR_GREY "+0";
 		}
 
 		if (max_players.count < 1)
 		{
 			// How did we get here?
-			return TEXTCOLOR_GREY "=0";
+			return TEXTCOLOR_GREY "+0";
 		}
 
 		// The interesting thing changes based on rounds.
@@ -410,7 +410,7 @@ std::string PersonalSpread()
 		if (max_players.players.size() > 1 && top_number == plyr_number)
 		{
 			// Share the throne with someone else.
-			return TEXTCOLOR_GREY "=0";
+			return TEXTCOLOR_GREY "+0";
 		}
 
 		if (max_players.players.at(0)->id == plyr.id)
@@ -458,7 +458,7 @@ std::string PersonalSpread()
 		if (max_teams.size() < 1)
 		{
 			// How did we get here?
-			return TEXTCOLOR_GREY "=0";
+			return TEXTCOLOR_GREY "+0";
 		}
 
 		// The interesting thing changes based on rounds.
@@ -468,7 +468,7 @@ std::string PersonalSpread()
 		if (max_teams.size() > 1 && top_number == plyr_number)
 		{
 			// Share the throne with someone else.
-			return TEXTCOLOR_GREY "=0";
+			return TEXTCOLOR_GREY "+0";
 		}
 
 		if (max_teams.at(0)->Team == plyr_team.Team)

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -105,6 +105,7 @@ EXTERN_CVAR (hud_gamemsgtype)
 EXTERN_CVAR (hud_scale)
 EXTERN_CVAR (hud_scalescoreboard)
 EXTERN_CVAR (hud_timer)
+EXTERN_CVAR (hud_bigfont)
 EXTERN_CVAR (hud_heldflag)
 EXTERN_CVAR (hud_heldflag_flash)
 EXTERN_CVAR (hud_transparency)
@@ -801,6 +802,7 @@ static menuitem_t VideoItems[] = {
 	{ redtext,	" ",					    {NULL},					{0.0}, {0.0},	{0.0},  {NULL} },
 	{ discrete, "Scale status bar",	        {&st_scale},			{2.0}, {0.0},	{0.0},  {OnOff} },
 	{ discrete, "Scale HUD",	            {&hud_scale},			{2.0}, {0.0},	{0.0},  {OnOff} },
+    { discrete, "Bigger font in HUD",       {&hud_bigfont},			{2.0}, {0.0},	{0.0},  {OnOff} },
 	{ discrete, "New HUD Style",	        {&hud_fullhudtype},		{2.0}, {0.0},	{0.0},  {HUDStyles} },
 	{ slider,   "HUD Visibility",           {&hud_transparency},    {0.0}, {1.0},   {0.1},  {NULL} },
 	{ discrete, "Display Timer",			{&hud_timer},           {3.0}, {0.0},   {0.0},  {TimerStyles} },

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -105,6 +105,7 @@ int V_TextScaleXAmount();
 int V_TextScaleYAmount();
 
 EXTERN_CVAR(hud_scale)
+EXTERN_CVAR(hud_bigfont)
 EXTERN_CVAR(hud_timer)
 EXTERN_CVAR(hud_targetcount)
 EXTERN_CVAR(hud_transparency)
@@ -502,7 +503,7 @@ static void drawGametype()
 	int xscale = hud_scale ? CleanXfac : 1;
 	int yscale = hud_scale ? CleanYfac : 1;
 
-	int patchPosY = 43;
+	int patchPosY = ::hud_bigfont ? 53 : 43;
 
 	bool shouldShowScores = G_IsTeamGame();
 	bool shouldShowLives = G_IsLivesGame();
@@ -713,29 +714,44 @@ void OdamexHUD() {
 
 	int color;
 	std::string str;
+	int iy = 4;
 
-	if (hud_timer)
+	if (::hud_timer)
 	{
+		if (::hud_bigfont)
+			V_SetFont("BIGFONT");
+
 		hud::DrawText(0, 4, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
 		              hud::Y_BOTTOM, hud::Timer().c_str(), CR_GREY);
+		iy += V_LineHeight() + 1;
+
+		if (::hud_bigfont)
+			V_SetFont("SMALLFONT");
 	}
 
 	// Draw other player name, if spying
-	hud::DrawText(0, 12, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
+	hud::DrawText(0, iy, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
 	              hud::Y_BOTTOM, hud::SpyPlayerName().c_str(), CR_GREY);
+	iy += V_LineHeight() + 1;
 
 	// Draw targeted player names.
-	hud::EATargets(0, 20, hud_scale,
-	               hud::X_CENTER, hud::Y_BOTTOM,
-	               hud::X_CENTER, hud::Y_BOTTOM,
-	               1, hud_targetcount);
+	hud::EATargets(0, iy, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
+	               hud::Y_BOTTOM, 1, hud_targetcount);
+	iy += V_LineHeight() + 1;
 
 	// Draw stat lines.  Vertically aligned with the bottom of the armor
 	// number on the other side of the screen.
-	hud::DrawText(4, 32, hud_scale, hud::X_RIGHT, hud::Y_BOTTOM, hud::X_RIGHT,
-	              hud::Y_BOTTOM, hud::PersonalSpread().c_str(), CR_UNTRANSLATED);
+	if (::hud_bigfont)
+		V_SetFont("BIGFONT");
+
+	hud::DrawText(4, 24 + V_LineHeight() + 1, hud_scale, hud::X_RIGHT, hud::Y_BOTTOM,
+	              hud::X_RIGHT, hud::Y_BOTTOM, hud::PersonalSpread().c_str(),
+	              CR_UNTRANSLATED);
 	hud::DrawText(4, 24, hud_scale, hud::X_RIGHT, hud::Y_BOTTOM, hud::X_RIGHT,
 	              hud::Y_BOTTOM, hud::PersonalScore().c_str(), CR_UNTRANSLATED);
+
+	if (::hud_bigfont)
+		V_SetFont("SMALLFONT");
 
 	// Draw keys in coop
 	if (sv_gametype == GM_COOP) {
@@ -989,33 +1005,35 @@ void LevelStateHUD()
 }
 
 // [AM] Spectator HUD.
-void SpectatorHUD() {
+void SpectatorHUD()
+{
 	int color;
-	std::string str;
+	int iy = 4;
 
 	// Draw warmup state or timer
-	if (hud_timer) {
-		hud::DrawText(0, 4, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
+	if (::hud_timer)
+	{
+		if (::hud_bigfont)
+		{
+			V_SetFont("BIGFONT");
+		}
+
+		hud::DrawText(0, iy, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
 		              hud::Y_BOTTOM, hud::Timer().c_str(), CR_GREY);
+		iy += V_LineHeight() + 1;
+
+		if (::hud_bigfont)
+			V_SetFont("SMALLFONT");
 	}
 
-	// Draw other player name, if spying
-	hud::DrawText(0, 12, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
-	              hud::Y_BOTTOM, hud::SpyPlayerName().c_str(), CR_GREY);
-
-	// Draw help text if there's no other player name
-	if (str.empty()) {
-		hud::DrawText(0, 12, hud_scale,
-		              hud::X_CENTER, hud::Y_BOTTOM,
-		              hud::X_CENTER, hud::Y_BOTTOM,
-		              hud::HelpText().c_str(), CR_GREY);
-	}
+	// Draw help text - spy player name is handled elsewhere.
+	hud::DrawText(0, iy, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
+	              hud::Y_BOTTOM, hud::HelpText().c_str(), CR_GREY);
+	iy += V_LineHeight() + 1;
 
 	// Draw targeted player names.
-	hud::EATargets(0, 20, hud_scale,
-	               hud::X_CENTER, hud::Y_BOTTOM,
-	               hud::X_CENTER, hud::Y_BOTTOM,
-	               1, 0);
+	hud::EATargets(0, iy, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
+	               hud::Y_BOTTOM, 1, 0);
 
 	// Draw gametype scoreboard
 	hud::drawGametype();

--- a/client/src/v_text.cpp
+++ b/client/src/v_text.cpp
@@ -414,6 +414,13 @@ static void breakit(brokenlines_t* line, const byte* start, const byte* string, 
 	line->width = V_StringWidth(line->string);
 }
 
+int V_LineHeight()
+{
+	if (::hu_font[0] == ::hu_bigfont[0])
+		return 12;
+	return 7;
+}
+
 brokenlines_t* V_BreakLines(int maxwidth, const byte* str)
 {
 	if (::hu_font[0] == NULL)

--- a/client/src/v_text.h
+++ b/client/src/v_text.h
@@ -46,6 +46,7 @@ typedef struct brokenlines_s brokenlines_t;
 
 int V_StringWidth(const byte* str);
 inline int V_StringWidth(const char* str) { return V_StringWidth((const byte*)str); }
+int V_LineHeight();
 
 brokenlines_t *V_BreakLines (int maxwidth, const byte *str);
 void V_FreeBrokenLines (brokenlines_t *lines);


### PR DESCRIPTION
This is a quick and dirty addition to the HUD that was done to address at least part of #260 - arguably the most important.

This commit adds a new cvar `hud_bigfont` that replaces some of the most important HUD items with their BIGFONT equivalents.  These fonts are not translated because we still only shift the red range, but it was something that was easy to get out the door in time for 0.9.1 so I took the opportunity.

Here's a picture of what is replaced - it's really just the spread and timer.

![odamex_ckMrp9ofnT](https://user-images.githubusercontent.com/23563/116635034-c04ea700-a92b-11eb-85e2-b7605a0c8df3.png)