### PR TITLE
Don't attempt to load a map without nodes

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -260,7 +260,7 @@ void P_LoadSubsectors(int lump)
 	if (!W_LumpLength(lump))
 	{
 		I_Error(
-		    "P_LoadSegs: SSECTORS lump is empty - levels without nodes are not supported.");
+		    "P_LoadSubsectors: SSECTORS lump is empty - levels without nodes are not supported.");
 	}
 
 	byte *data;
@@ -394,7 +394,7 @@ void P_LoadNodes (int lump)
 	if (!W_LumpLength(lump))
 	{
 		I_Error(
-		    "P_LoadSegs: NODES lump is empty - levels without nodes are not supported.");
+		    "P_LoadNodes: NODES lump is empty - levels without nodes are not supported.");
 	}
 
 	byte*		data;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -169,6 +169,12 @@ void P_LoadVertexes (int lump)
 
 void P_LoadSegs (int lump)
 {
+	if (!W_LumpLength(lump))
+	{
+		I_Error(
+		    "P_LoadSegs: SEGS lump is empty - levels without nodes are not supported.");
+	}
+
 	int  i;
 	byte *data;
 
@@ -249,8 +255,14 @@ void P_LoadSegs (int lump)
 //
 // P_LoadSubsectors
 //
-void P_LoadSubsectors (int lump)
+void P_LoadSubsectors(int lump)
 {
+	if (!W_LumpLength(lump))
+	{
+		I_Error(
+		    "P_LoadSegs: SSECTORS lump is empty - levels without nodes are not supported.");
+	}
+
 	byte *data;
 	int i;
 
@@ -379,6 +391,12 @@ void P_LoadSectors (int lump)
 //
 void P_LoadNodes (int lump)
 {
+	if (!W_LumpLength(lump))
+	{
+		I_Error(
+		    "P_LoadSegs: NODES lump is empty - levels without nodes are not supported.");
+	}
+
 	byte*		data;
 	int 		i;
 	int 		j;


### PR DESCRIPTION
Some ZDoom levels don't have nodes in them.  We don't have an internal nodebuilder, but there was no failsafe that was preventing the level from loading without nodes, resulting in a crash.

This commit rectifies this - if any of the node lumps are zero-length, we bail with an error message.  This [sample map](https://zdoom.org/wiki/PolyObjects) is what I used to test.