### PR TITLE
Remove ts.chaosunleashed.net from download site defaults

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -290,8 +290,8 @@ CVAR_RANGE (sv_teamsinplay, "2", "Teams that are enabled", CVARTYPE_BYTE, CVAR_S
 
 CVAR(cl_downloadsites,
      "https://static.allfearthesentinel.net/wads/ https://doomshack.org/wads/ "
-     "http://grandpachuck.org/files/wads/ http://ts.chaosunleashed.net/ "
-     "https://wads.doomleague.org/ http://files.funcrusher.net/wads/",
+     "http://grandpachuck.org/files/wads/ https://wads.doomleague.org/ "
+     "http://files.funcrusher.net/wads/",
      "A list of websites to download WAD files from.  These websites are used if the "
      "server doesn't provide any websites to download files from, or the file can't be "
      "found on any of their sites.  The list of sites is separated by spaces.  These "

--- a/client/src/m_misc.cpp
+++ b/client/src/m_misc.cpp
@@ -173,7 +173,7 @@ void M_LoadDefaults(void)
 		}
 
 		if (updated)
-			Printf(__FUNCTION__ ": Updating old defaults.");
+			Printf("%s: Updating old defaults.\n", __FUNCTION__);
 	}
 
 	AddCommandString("alias ? help");	

--- a/client/src/m_misc.cpp
+++ b/client/src/m_misc.cpp
@@ -135,6 +135,8 @@ END_COMMAND (savecfg)
 
 extern int cvar_defflags;
 
+EXTERN_CVAR(cl_downloadsites);
+
 /**
  * Load a configuration file from the default configuration file.
  *
@@ -151,6 +153,28 @@ void M_LoadDefaults(void)
 	cvar_defflags = CVAR_ARCHIVE;
 	AddCommandString(cmd);
 	cvar_defflags = 0;
+
+	if (::configver <= 90)
+	{
+		bool updated = false;
+
+		// Convert old default that had ts.chaosunleashed.net.  It's either
+		// dead or so intermittent that it slows down WAD downloading.
+
+		const char* cl_download_old =
+		    "https://static.allfearthesentinel.net/wads/ https://doomshack.org/wads/ "
+		    "http://grandpachuck.org/files/wads/ http://ts.chaosunleashed.net/ "
+		    "https://wads.doomleague.org/ http://files.funcrusher.net/wads/";
+
+		if (!strcmp(::cl_downloadsites.cstring(), cl_download_old))
+		{
+			updated = true;
+			cl_downloadsites.RestoreDefault();
+		}
+
+		if (updated)
+			Printf(__FUNCTION__ ": Updating old defaults.");
+	}
 
 	AddCommandString("alias ? help");	
 


### PR DESCRIPTION
This site is either dead or so intermittent that it slows down the overall download process significantly.