### PR TITLE
Fix Ancient Aliens teleport

### DIFF
--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -829,10 +829,12 @@ FUNC(LS_Teleport_NoStop)
 }
 
 FUNC(LS_Teleport_NoFog)
-// Teleport_NoFog (tid)
+// Teleport_NoFog (tid, useangle, tag, keepheight)
 {
-	if(!it) return false;
-	return EV_SilentTeleport (arg0, ln, TeleportSide, it);
+	if(!it)
+		return false;
+
+	return EV_SilentTeleport(arg0, arg1, arg2, arg3, ln, TeleportSide, it);
 }
 
 FUNC(LS_Teleport_EndGame)

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -1019,7 +1019,8 @@ BOOL EV_DoChange (line_t *line, EChange changetype, int tag);
 //
 BOOL EV_Teleport (int tid, int tag, int arg0, int side, AActor *thing, int nostop);
 BOOL EV_LineTeleport (line_t *line, int side, AActor *thing);
-BOOL EV_SilentTeleport (int tid, line_t *line, int side, AActor *thing);
+BOOL EV_SilentTeleport(int tid, int useangle, int tag, int keepheight, line_t* line,
+                       int side, AActor* thing);
 BOOL EV_SilentLineTeleport (line_t *line, int side, AActor *thing, int id,
 							BOOL reverse);
 

--- a/common/p_teleport.cpp
+++ b/common/p_teleport.cpp
@@ -327,7 +327,8 @@ BOOL EV_LineTeleport (line_t *line, int side, AActor *thing)
 // [RH] Changed to find destination by tid rather than sector
 //
 
-BOOL EV_SilentTeleport (int tid, line_t *line, int side, AActor *thing)
+BOOL EV_SilentTeleport(int tid, int useangle, int tag, int keepheight, line_t* line,
+                       int side, AActor* thing)
 {
 	AActor    *m;
 
@@ -339,10 +340,10 @@ BOOL EV_SilentTeleport (int tid, line_t *line, int side, AActor *thing)
 	if (thing->flags & MF_MISSILE || !line)
 		return false;
 
-	// [AM] TODO: Change this to use SelectTeleDest.
-	if (NULL == (m = AActor::FindGoal (NULL, tid, MT_TELEPORTMAN)))
-		if (NULL == (m = AActor::FindGoal (NULL, tid, MT_TELEPORTMAN2)))
-			return false;
+	// [AM] Use modern ZDoom teleport destination selection.
+	m = SelectTeleDest(tid, tag);
+	if (m == NULL)
+		return false;
 
 	// Height of thing above ground, in case of mid-air teleports:
 	fixed_t z = thing->z - thing->floorz;

--- a/common/p_xlat.cpp
+++ b/common/p_xlat.cpp
@@ -716,15 +716,21 @@ void P_TranslateTeleportThings()
 	{
 		for (int i = 0; i < ::numlines; i++)
 		{
+			// Transfer the tag to the proper argument slot.
 			if (::lines[i].special == Teleport)
 			{
-				if (::lines[i].args[1] == 0)
-					::lines[i].args[0] = 1;
+				::lines[i].args[1] = ::lines[i].args[0];
+				::lines[i].args[0] = 0;
 			}
 			else if (::lines[i].special == Teleport_NoFog)
 			{
-				if (::lines[i].args[2] == 0)
-					::lines[i].args[0] = 1;
+				::lines[i].args[2] = ::lines[i].args[0];
+				::lines[i].args[0] = 0;
+			}
+			else if (::lines[i].special == Teleport_NoStop)
+			{
+				::lines[i].args[1] = ::lines[i].args[0];
+				::lines[i].args[0] = 0;
 			}
 		}
 	}


### PR DESCRIPTION
This is a fix for a bug introduced in #320 that was discovered after further testing.  You can't even start MAP01 of AA because the first teleport doesn't work right.

I think the version of ZDoom had a slightly different set of xlat assumptions than whatever Odamex's xlat was sourced from.  I went through and traced from map load to `P_TranslateTeleportThings` itself to the actual line activation and found arguments in positions that weren't correct for the transplanted code, and found a lack of proper teleport destination selection on the other end.

Fixed both, ran the new commit through a ZDoom teleport test map since I swapped out one of its functions, played through some Ancient Aliens to make sure there wasn't another snare trap waiting.