### PR TITLE
Created cl_chatsounds CVAR to control chat sounds.

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -212,6 +212,10 @@ CVAR(				cl_connectalert, "1", "Plays a sound when a player joins",
 CVAR(				cl_disconnectalert, "1", "Plays a sound when a player quits",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
+CVAR_RANGE			(cl_chatsounds, "1", "Plays a sound when a chat message appears (0 = never, 1 = always, " \
+					"2 = only teamchat)", 
+					CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
+
 CVAR_RANGE(			cl_switchweapon, "1", "Switch upon weapon pickup (0 = never, 1 = always, " \
 					"2 = use weapon preferences)",
 					CVARTYPE_BYTE, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2099,6 +2099,8 @@ void CL_MidPrint (void)
     C_MidPrint(str,NULL,msgtime);
 }
 
+EXTERN_CVAR(cl_chatsounds)
+
 /**
  * Handle the svc_say server message, which contains a message from another
  * client with a player id attached to it.
@@ -2141,7 +2143,10 @@ void CL_Say()
 			       message);
 
 		if (show_messages && !filtermessage)
+		{	
+			if (cl_chatsounds == 1)
 			S_Sound(CHAN_INTERFACE, gameinfo.chatSound, 1, ATTN_NONE);
+		}
 	}
 	else if (message_visibility == 1)
 	{
@@ -2150,7 +2155,7 @@ void CL_Say()
 		else
 			Printf(PRINT_TEAMCHAT, "%s: %s\n", name, message);
 
-		if (show_messages)
+		if (show_messages && cl_chatsounds)
 			S_Sound(CHAN_INTERFACE, "misc/teamchat", 1, ATTN_NONE);
 	}
 }

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -539,7 +539,15 @@ static value_t VoxType[] = {
 	{ 2.0,			"Possessive" }
 };
 
+static value_t ChatSndType[] = {
+	{ 0.0,			"Disabled" },
+	{ 1.0,			"Enabled" },
+	{ 2.0,			"Teamchat only" }
+};
+
 static float num_mussys = static_cast<float>(ARRAY_LENGTH(MusSys));
+
+EXTERN_CVAR(cl_chatsounds)
 
 static menuitem_t SoundItems[] = {
     { redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
@@ -555,7 +563,9 @@ static menuitem_t SoundItems[] = {
 	{ discrete  ,   "Game SFX"                          , {&snd_gamesfx},		{2.0},			{0.0},		{0.0},		{OnOff} },
 	{ discrete  ,   "Announcer Type"                    , {&snd_voxtype},		{3.0},			{0.0},		{0.0},		{VoxType} },
 	{ discrete  ,   "Player Connect Alert"              , {&cl_connectalert},	{2.0},			{0.0},		{0.0},		{OnOff} },
-	{ discrete  ,   "Player Disconnect Alert"           , {&cl_disconnectalert},{2.0},			{0.0},		{0.0},		{OnOff} }
+	{ discrete  ,   "Player Disconnect Alert"           , {&cl_disconnectalert},{2.0},			{0.0},		{0.0},		{OnOff} },
+    { discrete  ,	"Chat sounds"						, {&cl_chatsounds},		{3.0},			{0.0},		{0.0},		{ChatSndType}},
+
  };
 
 menu_t SoundMenu = {


### PR DESCRIPTION
PR made for Feature #338 .

This PR creates a CVAR (`cl_chatsounds`) that enable/disables/filters chat sounds.

Values:
- 0: No chat sounds 
- 1: All chat sounds
- 2: Teamchat/Private MSGs sounds only.