### PR TITLE
Replace Zone Heap with OZone

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -606,7 +606,6 @@ void G_DoLoadLevel (int position)
 	displayplayer_id = consoleplayer_id;				// view the guy you are playing
 	ST_Start();		// [RH] Make sure status bar knows who we are
 	gameaction = ga_nothing;
-	Z_CheckHeap ();
 
 	// clear cmd building stuff // denis - todo - could we get rid of this?
 	Impulse = 0;

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -603,10 +603,9 @@ void D_Init()
 	M_ClearRandom();
 
 	// start the Zone memory manager
-	bool use_zone = !Args.CheckParm("-nozone");
-	Z_Init(false);
+	Z_Init();
 	if (first_time)
-		Printf(PRINT_HIGH, "Z_Init: Heapsize: %" PRIuSIZE " megabytes\n", got_heapsize);
+		Printf("Z_Init: Using native allocator with OZone bookkeeping.\n");
 
 	// Load palette and set up colormaps
 	V_Init();

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -604,7 +604,7 @@ void D_Init()
 
 	// start the Zone memory manager
 	bool use_zone = !Args.CheckParm("-nozone");
-	Z_Init(use_zone);
+	Z_Init(false);
 	if (first_time)
 		Printf(PRINT_HIGH, "Z_Init: Heapsize: %" PRIuSIZE " megabytes\n", got_heapsize);
 

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -130,6 +130,9 @@
 #ifndef MAXINT
 	#define MAXINT			(0x7fffffff)
 #endif
+#ifndef MAXUINT
+	#define MAXUINT			(0xffffffff)
+#endif
 
 #ifndef MAXLONG
 	#ifndef ALPHA

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1704,7 +1704,7 @@ void P_SetupLevel (char *lumpname, int position)
 	shootthing = NULL;
 
 	DThinker::DestroyAllThinkers ();
-	Z_FreeTags (PU_LEVEL, PU_PURGELEVEL-1);
+	Z_FreeTags (PU_LEVEL, PU_LEVELMAX);
 	NormalLight.next = NULL;	// [RH] Z_FreeTags frees all the custom colormaps
 
 	// [AM] Every new level starts with fresh netids.

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -662,7 +662,7 @@ void W_GetLumpName (char *to, unsigned  lump)
 //
 // W_CacheLumpNum
 //
-void* W_CacheLumpNum(unsigned int lump, int tag)
+void* W_CacheLumpNum(unsigned int lump, const zoneTag_e tag)
 {
 	if ((unsigned)lump >= numlumps)
 		I_Error ("W_CacheLumpNum: %i >= numlumps",lump);
@@ -693,7 +693,7 @@ void* W_CacheLumpNum(unsigned int lump, int tag)
 //
 // W_CacheLumpName
 //
-void* W_CacheLumpName(const char* name, int tag)
+void* W_CacheLumpName(const char* name, const zoneTag_e tag)
 {
 	return W_CacheLumpNum (W_GetNumForName(name), tag);
 }
@@ -708,7 +708,7 @@ void R_ConvertPatch(patch_t *rawpatch, patch_t *newpatch);
 // patch from the standard Doom format of posts with 1-byte lengths and offsets
 // to a new format for posts that uses 2-byte lengths and offsets.
 //
-patch_t* W_CachePatch(unsigned lumpnum, int tag)
+patch_t* W_CachePatch(unsigned lumpnum, const zoneTag_e tag)
 {
 	if (lumpnum >= numlumps)
 		I_Error ("W_CachePatch: %u >= numlumps", lumpnum);
@@ -752,7 +752,7 @@ patch_t* W_CachePatch(unsigned lumpnum, int tag)
 	return (patch_t*)lumpcache[lumpnum];
 }
 
-patch_t* W_CachePatch(const char* name, int tag)
+patch_t* W_CachePatch(const char* name, const zoneTag_e tag)
 {
 	return W_CachePatch(W_GetNumForName(name), tag);
 	// denis - todo - would be good to replace non-existant patches with a default '404' patch

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -102,10 +102,10 @@ unsigned	W_LumpLength (unsigned lump);
 void		W_ReadLump (unsigned lump, void *dest);
 unsigned	W_ReadChunk (const char *file, unsigned offs, unsigned len, void *dest, unsigned &filelen);
 
-void *W_CacheLumpNum (unsigned lump, int tag);
-void *W_CacheLumpName (const char *name, int tag);
-patch_t* W_CachePatch (unsigned lump, int tag = PU_CACHE);
-patch_t* W_CachePatch (const char *name, int tag = PU_CACHE);
+void* W_CacheLumpNum(unsigned lump, const zoneTag_e tag);
+void* W_CacheLumpName(const char* name, const zoneTag_e tag);
+patch_t* W_CachePatch(unsigned lump, const zoneTag_e tag = PU_CACHE);
+patch_t* W_CachePatch(const char* name, const zoneTag_e tag = PU_CACHE);
 
 void	W_Profile (const char *fname);
 

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -31,8 +31,6 @@
 #include "hashtable.h"
 #include "cmdlib.h"
 
-static bool use_zone = true;
-
 struct OFileLine
 {
 	const char* file;
@@ -146,8 +144,8 @@ class OZone
 
 	void* alloc(size_t size, zoneTag_e tag, void* user, const OFileLine& info)
 	{
-		// This is implementation-defined behavior with malloc, so passing
-		// back NULL is the behavior we choose.
+		// This is implementation-defined behavior with malloc.  Since we
+		// are the implementation, we get to choose the behavior.  Neat.
 		if (size == 0)
 		{
 			return NULL;
@@ -270,73 +268,19 @@ class OZone
 
 
 //
-// ZONE MEMORY ALLOCATION
-//
-// There is never any space between memblocks,
-//  and there will never be two contiguous free memblocks.
-// The rover can be left pointing at a non-empty block.
-//
-// It is of no value to free a cachable block,
-//  because it will get overwritten automatically if needed.
-// 
-
-#define ZONEID	0x1d4a11
-
-typedef struct
-{
-	// total bytes malloced, including header
-	size_t		size;
-	
-	// start / end cap for linked list
-	memblock_t	blocklist;
-	
-	memblock_t	*rover;
-	
-} memzone_t;
-
-static memzone_t* mainzone;
-static size_t zonesize;
-
-//
 // Z_Close
 //
 void STACK_ARGS Z_Close()
 {
-	M_Free(mainzone);
 	g_zone.clear();
 }
 
 //
 // Z_Init
 //
-void Z_Init(bool _use_zone)
+void Z_Init()
 {
-	use_zone = _use_zone;
-	if (!use_zone)
-	{
-		Z_Close();
-		return;
-	}
-
-	// denis - allow reinitiation of entire memory system
-	if (!mainzone)
-		mainzone = (memzone_t*)I_ZoneBase(&zonesize);
-
-	// set the entire zone to one free block
-	memblock_t* block = (memblock_t*)((byte*)mainzone + sizeof(memzone_t));
-	mainzone->size = zonesize;
-	mainzone->blocklist.next = mainzone->blocklist.prev = block;
-	
-	mainzone->blocklist.user = (void**)mainzone;
-	mainzone->blocklist.tag = PU_STATIC;
-	mainzone->rover = block;
-		
-	block->prev = block->next = &mainzone->blocklist;
-	
-	block->tag = PU_FREE;
-	block->user = NULL;
-	
-	block->size = mainzone->size - sizeof(memzone_t);
+	g_zone.clear();
 }
 
 
@@ -345,61 +289,7 @@ void Z_Init(bool _use_zone)
 //
 void Z_Free2(void* ptr, const char* file, int line)
 {
-	if (!use_zone)
-	{
-		g_zone.deallocPtr(ptr, OFileLine::create(file, line));
-		return;
-	}
-
-	if (ptr == NULL)
-		return;
-
-	#ifdef ODAMEX_DEBUG
-	Z_CheckHeap();
-	#endif
-
-	memblock_t* block = (memblock_t*)((byte*)ptr - sizeof(memblock_t));
-
-	if (block->id != ZONEID)
-		I_FatalError("Z_Free: freed a pointer without ZONEID at %s:%i", file, line);
-
-	if (block->user != NULL)
-		*block->user = NULL;	// clear the user's mark
-
-	// mark as free
-	block->tag = PU_FREE;
-	block->user = NULL; 
-	block->id = 0;
-		
-	memblock_t* other = block->prev;
-	if (other->tag == PU_FREE)
-	{
-		// merge with previous free block
-		other->size += block->size;
-		other->next = block->next;
-		other->next->prev = other;
-
-		if (block == mainzone->rover)
-			mainzone->rover = other;
-
-		block = other;
-	}
-
-	other = block->next;
-	if (other->tag == PU_FREE)
-	{
-		// merge the next free block onto the end
-		block->size += other->size;
-		block->next = other->next;
-		block->next->prev = block;
-
-		if (other == mainzone->rover)
-			mainzone->rover = block;
-	}
-
-	#ifdef ODAMEX_DEBUG
-	Z_CheckHeap();
-	#endif
+	g_zone.deallocPtr(ptr, OFileLine::create(file, line));
 }
 
 
@@ -413,108 +303,8 @@ void Z_Free2(void* ptr, const char* file, int line)
 void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,
                 const int line)
 {
-	if (!use_zone)
-	{
-		return g_zone.alloc(size, tag, user, OFileLine::create(file, line));
-	}
-
-	#ifdef ODAMEX_DEBUG
-	Z_CheckHeap();
-	#endif
-
-	if (tag == PU_FREE)
-		I_FatalError("Z_Malloc: cannot allocate a block with tag PU_FREE at %s:%i", file, line);
-
-	size = (size + ALIGN - 1) & ~(ALIGN - 1);
-
-    // scan through the block list,
-    // looking for the first free block
-    // of sufficient size,
-    // throwing out any purgable blocks along the way.
-	
-	// account for size of block header
-	size += sizeof(memblock_t);
-
-    // if there is a free block behind the rover,
-    //  back up over them
-	memblock_t* base = mainzone->rover;
-	if (base->prev->tag == PU_FREE)
-		base = base->prev;
-
-	memblock_t* rover = base;
-	memblock_t* start = base->prev;
-
-	do
-	{
-		if (rover == start)
-		{
-			// scanned all the way around the list
-			I_FatalError("Z_Malloc: failed on allocation of %i bytes at %s:%i", size, file, line);
-		}
-		
-		if (rover->tag != PU_FREE)
-		{
-			if (rover->tag < PU_PURGELEVEL)
-			{
-				// hit a block that can't be purged,
-				//  so move past it
-				base = rover = rover->next;
-			}
-			else
-			{
-				// free the rover block (adding the size to base)
-				
-				// the rover can be the base block
-				base = base->prev;
-				Z_Free((byte*)rover+sizeof(memblock_t));
-				base = base->next;
-				rover = base->next;
-			}
-		}
-		else
-			rover = rover->next;
-	} while (base->tag != PU_FREE || base->size < size);
-
-	// found a block big enough
-	int extra = base->size - size;
-	
-	if (extra > MINFRAGMENT)
-	{
-		// there will be a free fragment after the allocated block
-		memblock_t* newblock = (memblock_t*)((byte*)base + size );
-		newblock->size = extra;
-		
-		newblock->tag = PU_FREE;
-		newblock->user = NULL;	
-		newblock->prev = base;
-		newblock->next = base->next;
-		newblock->next->prev = newblock;
-
-		base->next = newblock;
-		base->size = size;
-	}
-		
-	base->tag = tag;
-	base->user = (void**)user;
-	base->id = ZONEID;
-
-	if (user)
-		*(void**)user = (void*)((byte*)base + sizeof(memblock_t));
-	else
-		if (tag >= PU_PURGELEVEL)
-			I_FatalError("Z_Malloc: an owner is required for purgable blocks at %s:%i", file, line);
-
-	// next allocation will start looking here
-	mainzone->rover = base->next;
-
-
-	#ifdef ODAMEX_DEBUG
-	Z_CheckHeap();
-	#endif
-
-	return (void*)((byte*)base + sizeof(memblock_t));
+	return g_zone.alloc(size, tag, user, OFileLine::create(file, line));
 }
-
 
 
 //
@@ -522,60 +312,7 @@ void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,
 //
 void Z_FreeTags(const zoneTag_e lowtag, const zoneTag_e hightag)
 {
-	if (!use_zone)
-	{
-		return ::g_zone.deallocTags(lowtag, hightag);
-	}
-
-	#ifdef ODAMEX_DEBUG
-	Z_CheckHeap();
-	#endif
-
-	memblock_t* block;
-	memblock_t* next;
-
-	for (block = mainzone->blocklist.next; block != &mainzone->blocklist; block = next)
-	{
-		// get link before freeing
-		next = block->next;
-
-		// free block?
-		if (block->tag == PU_FREE)
-			continue;
-	    
-		if (block->tag >= lowtag && block->tag <= hightag)
-			Z_Free((byte*)block+sizeof(memblock_t));
-	}
-
-	#ifdef ODAMEX_DEBUG
-	Z_CheckHeap();
-	#endif
-}
-
-//
-// Z_CheckHeap
-//
-void Z_CheckHeap()
-{
-	if (!use_zone)
-		return;
-
-    memblock_t*	block;
-	
-    for (block = mainzone->blocklist.next ; ; block = block->next)
-    {
-		if (block->next == &mainzone->blocklist)
-			break;		// all blocks have been hit
-		
-		if ((byte*)block + block->size != (byte*)block->next)
-			I_Error("Z_CheckHeap: block size does not touch the next block\n");
-
-		if ( block->next->prev != block)
-			I_Error("Z_CheckHeap: next block doesn't have proper back link\n");
-
-		if (block->tag == PU_FREE && block->next->tag == PU_FREE)
-			I_Error("Z_CheckHeap: two consecutive free blocks\n");
-    }
+	return ::g_zone.deallocTags(lowtag, hightag);
 }
 
 //
@@ -583,108 +320,13 @@ void Z_CheckHeap()
 //
 void Z_ChangeTag2(void* ptr, const zoneTag_e tag, const char* file, int line)
 {
-	if (!use_zone)
-	{
-		return ::g_zone.changeTag(ptr, tag, OFileLine::create(file, line));
-	}
-
-	memblock_t*	block = (memblock_t*)((byte*)ptr - sizeof(memblock_t));
-	if (block->id != ZONEID)
-		I_Error("Z_ChangeTag: block does not have a proper ID at %s:%i", file, line);
-
-	if (tag == PU_FREE)
-		I_Error("Z_ChangeTag: cannot change a tag to PU_FREE");
-
-    if (tag >= PU_PURGELEVEL && block->user == NULL)
-        I_Error("Z_ChangeTag: an owner is required for purgable blocks");
-
-    block->tag = tag;
+	return ::g_zone.changeTag(ptr, tag, OFileLine::create(file, line));
 }
 
 
 void Z_ChangeOwner2(void* ptr, void* user, const char* file, int line)
 {
-	if (!use_zone)
-	{
-		return ::g_zone.changeOwner(ptr, user, OFileLine::create(file, line));
-	}
-
-	memblock_t*	block = (memblock_t*)((byte*)ptr - sizeof(memblock_t));
-	if (block->id != ZONEID)
-		I_Error("Z_ChangeOwner: block does not have a proper ID at %s:%i", file, line);
-
-	if (block->tag >= PU_PURGELEVEL && user == NULL)
-        I_Error("Z_ChangeOwner: an owner is required for purgable blocks at %s:%i", file, line);
-
-	if (block->user)
-		*block->user = NULL;
-	
-	block->user = (void**)user;
-
-	if (block->user)
-		*block->user = (void*)((byte*)block + sizeof(memblock_t));
-}
-
-//
-// Z_FreeMemory
-//
-static size_t numblocks;
-static size_t largestpfree, pfree, usedpblocks;	// Purgable blocks
-static size_t largestefree, efree, usedeblocks; // Empty (Unused) blocks
-static size_t largestlsize, lsize, usedlblocks;	// Locked blocks
-
-size_t Z_FreeMemory()
-{
-	if (!use_zone)
-		return 0;
-
-	#ifdef ODAMEX_DEBUG
-	Z_CheckHeap();
-	#endif
-
-	bool lastpurgable = false;
-		
-	numblocks =
-		largestpfree = pfree = usedpblocks =
-		largestefree = efree = usedeblocks =
-		largestlsize = lsize = usedlblocks = 0;
-	
-	for (memblock_t* block = mainzone->blocklist.next; block != &mainzone->blocklist; block = block->next)
-	{
-		numblocks++;
-
-		if (block->tag >= PU_PURGELEVEL)
-		{
-			usedpblocks++;
-			pfree += block->size;
-			if (lastpurgable)
-			{
-				largestpfree += block->size;
-			}
-			else if (block->size > largestpfree)
-			{
-				largestpfree = block->size;
-				lastpurgable = true;
-			}
-		}
-		else if (block->tag == PU_FREE)
-		{
-			usedeblocks++;
-			efree += block->size;
-			if (block->size > largestefree)
-				largestefree = block->size;
-			lastpurgable = false;
-		}
-		else
-		{
-			usedlblocks++;
-			lsize += block->size;
-			if (block->size > largestlsize)
-				largestlsize = block->size;
-			lastpurgable = false;
-		}
-	}
-	return pfree + efree;
+	return ::g_zone.changeOwner(ptr, user, OFileLine::create(file, line));
 }
 
 //
@@ -693,70 +335,10 @@ size_t Z_FreeMemory()
 //
 void Z_DumpHeap(const zoneTag_e lowtag, const zoneTag_e hightag)
 {
-	if (!use_zone)
-	{
-		::g_zone.dump();
-		return;
-	}
-
-	Z_FreeMemory();
-    memblock_t*	block;
-
-	Printf(PRINT_HIGH, "zone size: %" PRIuSIZE "  location: %p\n", mainzone->size,
-	       mainzone);
-	Printf(PRINT_HIGH, "used: %" PRIuSIZE "  free: %" PRIuSIZE "\n", pfree + lsize,
-	       efree);
-	Printf(PRINT_HIGH, "tag range: %i to %i\n", lowtag, hightag);
-
-	for (block = mainzone->blocklist.next;; block = block->next)
-	{
-		char user[30];
-		if (block->user == NULL || block->tag == PU_FREE)
-			sprintf(user, "---");
-		else
-			sprintf(user, "%p", block->user);
-
-		char tag[30];
-		if (block->tag == PU_FREE)
-			sprintf(tag, "FREE");
-		else if (block->tag == PU_STATIC)
-			sprintf(tag, "STATIC");
-		else if (block->tag == PU_SOUND)
-			sprintf(tag, "SOUND");
-		else if (block->tag == PU_MUSIC)
-			sprintf(tag, "MUSIC");
-		else if (block->tag == PU_LEVEL)
-			sprintf(tag, "LEVEL");
-		else if (block->tag == PU_LEVSPEC)
-			sprintf(tag, "LEVSPEC");
-		else if (block->tag == PU_LEVACS)
-			sprintf(tag, "LEVACS");
-		else if (block->tag == PU_CACHE)
-			sprintf(tag, "CACHE");
-		else
-			sprintf(tag, "UNKNOWN");
-
-		if (block->tag >= lowtag && block->tag <= hightag)
-			Printf(PRINT_HIGH,
-			       "block:%p    size:%9" PRIuSIZE "    user:%-9s    tag:%-s\n", block,
-			       block->size, user, tag);
-
-		if (block->next == &mainzone->blocklist)
-			break;		// all blocks have been hit
-	
-		if ((byte*)block + block->size != (byte*)block->next)
-			Printf(PRINT_WARNING, "ERROR: block size does not touch the next block\n");
-
-		if (block->next->prev != block)
-			Printf(PRINT_WARNING, "ERROR: next block doesn't have proper back link\n");
-
-		if (block->tag == PU_FREE && block->next->tag == PU_FREE)
-			Printf(PRINT_WARNING, "ERROR: two consecutive free blocks\n");
-    }
+	::g_zone.dump();
 }
 
-
-BEGIN_COMMAND (dumpheap)
+BEGIN_COMMAND(dumpheap)
 {
 	int lo = MININT, hi = MAXINT;
 
@@ -769,25 +351,6 @@ BEGIN_COMMAND (dumpheap)
 
 	Z_DumpHeap(static_cast<zoneTag_e>(lo), static_cast<zoneTag_e>(hi));
 }
-END_COMMAND (dumpheap)
-
-BEGIN_COMMAND (mem)
-{
-	Z_FreeMemory();
-
-	Printf(PRINT_HIGH,
-	       "%" PRIuSIZE " blocks:\n"
-	       "%5" PRIuSIZE " used      (%" PRIuSIZE ", %" PRIuSIZE ")\n"
-	       " %5" PRIuSIZE " purgable (%" PRIuSIZE ", %" PRIuSIZE ")\n"
-	       " %5" PRIuSIZE " locked   (%" PRIuSIZE ", %" PRIuSIZE ")\n"
-	       "%5" PRIuSIZE " unused    (%" PRIuSIZE ", %" PRIuSIZE ")\n"
-	       "%5" PRIuSIZE " p-free    (%" PRIuSIZE ", %" PRIuSIZE ")\n",
-	       numblocks, usedpblocks + usedlblocks, pfree + lsize,
-	       largestpfree > largestlsize ? largestpfree : largestlsize, usedpblocks, pfree,
-	       largestpfree, usedlblocks, lsize, largestlsize, usedeblocks, efree,
-	       largestefree, usedpblocks + usedeblocks, pfree + efree,
-	       largestpfree > largestefree ? largestpfree : largestefree);
-}
-END_COMMAND (mem)
+END_COMMAND(dumpheap)
 
 VERSION_CONTROL (z_zone_cpp, "$Id$")

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -43,7 +43,7 @@ struct OFileLine
 		return rvo;
 	}
 
-	const char* shortFile()
+	const char* shortFile() const
 	{
 		const char* ret = file;
 		for (size_t i = 0; file[i] != '\0'; i++)
@@ -135,8 +135,9 @@ class OZone
 		if (ptr == NULL)
 		{
 			// Don't format these bytes, the byte formatter allocates.
-			I_Error(__FUNCTION__ ": Could not allocate %" PRI_SIZE_PREFIX "u bytes.\n",
-			        size);
+			I_Error(__FUNCTION__ ": Could not allocate %" PRI_SIZE_PREFIX
+			                     "u bytes at %s:%i.\n",
+			        size, info.shortFile(), info.line);
 		}
 
 		// Construct the memory block.
@@ -163,18 +164,23 @@ class OZone
 	{
 		if (tag == PU_FREE)
 		{
-			I_Error(__FUNCTION__ ": cannot change a tag to PU_FREE");
+			I_Error(__FUNCTION__ ": Tried to change a tag to PU_FREE at %s:%i.",
+			        info.shortFile(), info.line);
 		}
 
 		MemoryBlockTable::iterator it = m_heap.find(ptr);
 		if (it == m_heap.end())
 		{
-			I_Error(__FUNCTION__ ": pointer does not exist in the heap");
+			I_Error(__FUNCTION__ ": Address 0x%p is not tracked by zone at %s:%i.",
+			        it->first, info.shortFile(), info.line);
 		}
 
 		if (tag >= PU_PURGELEVEL && it->second.user == NULL)
 		{
-			I_Error(__FUNCTION__ ": an owner is required for purgable blocks");
+			I_Error(__FUNCTION__ ": Found purgable block without an owner at %s:%i, "
+			                     "allocated at %s:%i.",
+			        info.shortFile(), info.line, it->second.fileLine.shortFile(),
+			        it->second.fileLine.line);
 		}
 
 		it->second.tag = tag;
@@ -193,7 +199,8 @@ class OZone
 		MemoryBlockTable::iterator it = m_heap.find(ptr);
 		if (it == m_heap.end())
 		{
-			I_Error(__FUNCTION__ ": pointer does not exist in the heap");
+			I_Error(__FUNCTION__ ": Address 0x%p is not tracked by zone at %s:%i.",
+			        it->first, info.shortFile(), info.line);
 		}
 
 		dealloc(it);

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -529,7 +529,7 @@ void Z_CheckHeap()
 //
 // Z_ChangeTag
 //
-void Z_ChangeTag2(void* ptr, zoneTag_e tag, const char* file, int line)
+void Z_ChangeTag2(void* ptr, const zoneTag_e tag, const char* file, int line)
 {
 	if (!use_zone)
 	{

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -135,9 +135,8 @@ class OZone
 		if (ptr == NULL)
 		{
 			// Don't format these bytes, the byte formatter allocates.
-			I_Error(__FUNCTION__ ": Could not allocate %" PRI_SIZE_PREFIX
-			                     "u bytes at %s:%i.\n",
-			        size, info.shortFile(), info.line);
+			I_Error("%s: Could not allocate %" PRI_SIZE_PREFIX "u bytes at %s:%i.",
+			        __FUNCTION__, size, info.shortFile(), info.line);
 		}
 
 		// Construct the memory block.
@@ -164,23 +163,23 @@ class OZone
 	{
 		if (tag == PU_FREE)
 		{
-			I_Error(__FUNCTION__ ": Tried to change a tag to PU_FREE at %s:%i.",
+			I_Error("%s: Tried to change a tag to PU_FREE at %s:%i.", __FUNCTION__,
 			        info.shortFile(), info.line);
 		}
 
 		MemoryBlockTable::iterator it = m_heap.find(ptr);
 		if (it == m_heap.end())
 		{
-			I_Error(__FUNCTION__ ": Address 0x%p is not tracked by zone at %s:%i.",
+			I_Error("%s: Address 0x%p is not tracked by zone at %s:%i.", __FUNCTION__,
 			        it->first, info.shortFile(), info.line);
 		}
 
 		if (tag >= PU_PURGELEVEL && it->second.user == NULL)
 		{
-			I_Error(__FUNCTION__ ": Found purgable block without an owner at %s:%i, "
-			                     "allocated at %s:%i.",
-			        info.shortFile(), info.line, it->second.fileLine.shortFile(),
-			        it->second.fileLine.line);
+			I_Error("%s: Found purgable block without an owner at %s:%i, "
+			        "allocated at %s:%i.",
+			        __FUNCTION__, info.shortFile(), info.line,
+			        it->second.fileLine.shortFile(), it->second.fileLine.line);
 		}
 
 		it->second.tag = tag;
@@ -188,7 +187,8 @@ class OZone
 
 	void changeOwner(void* ptr, void* user, const OFileLine& info)
 	{
-		I_Error(__FUNCTION__ ": not implemented");
+		// [AM] Nothing calls this as far as I know.
+		I_Error("%s: not implemented", __FUNCTION__);
 	}
 
 	void deallocPtr(void* ptr, const OFileLine& info)
@@ -199,7 +199,7 @@ class OZone
 		MemoryBlockTable::iterator it = m_heap.find(ptr);
 		if (it == m_heap.end())
 		{
-			I_Error(__FUNCTION__ ": Address 0x%p is not tracked by zone at %s:%i.",
+			I_Error("%s: Address 0x%p is not tracked by zone at %s:%i.", __FUNCTION__,
 			        it->first, info.shortFile(), info.line);
 		}
 

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -166,7 +166,7 @@ class OZone
 		MemoryBlockInfo block;
 		block.tag = tag;
 		block.user = static_cast<void**>(user);
-		block.size = size > UINT_MAX ? UINT_MAX : static_cast<uint32_t>(size);
+		block.size = size > MAXUINT ? MAXUINT : static_cast<uint32_t>(size);
 
 		// Store the allocating function.  12 byte overhead per allocation,
 		// but the information we get while debugging is priceless.

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -78,7 +78,7 @@ class OZone
 {
 	struct MemoryBlockInfo
 	{
-		int tag;            // PU_* tag
+		zoneTag_e tag;      // PU_* tag
 		void** user;        // Pointer owner
 		OFileLine fileLine; // __FILE__, __LINE__
 	};
@@ -121,7 +121,7 @@ class OZone
 		m_heap.clear();
 	}
 
-	void* alloc(size_t size, int tag, void* user, const OFileLine& info)
+	void* alloc(size_t size, zoneTag_e tag, void* user, const OFileLine& info)
 	{
 		// This is implementation-defined behavior with malloc, so passing
 		// back NULL is the behavior we choose.
@@ -159,7 +159,7 @@ class OZone
 		return ptr;
 	}
 
-	void changeTag(void* ptr, int tag, const OFileLine& info)
+	void changeTag(void* ptr, zoneTag_e tag, const OFileLine& info)
 	{
 		if (tag == PU_FREE)
 		{
@@ -358,7 +358,8 @@ void Z_Free2(void* ptr, const char* file, int line)
 #define MINFRAGMENT	64
 #define ALIGN		8
 
-void* Z_Malloc2(size_t size, int tag, void* user, const char* file, int line)
+void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,
+                const int line)
 {
 	if (!use_zone)
 	{
@@ -467,7 +468,7 @@ void* Z_Malloc2(size_t size, int tag, void* user, const char* file, int line)
 //
 // Z_FreeTags
 //
-void Z_FreeTags(int lowtag, int hightag)
+void Z_FreeTags(const zoneTag_e lowtag, const zoneTag_e hightag)
 {
 	if (!use_zone)
 	{
@@ -528,7 +529,7 @@ void Z_CheckHeap()
 //
 // Z_ChangeTag
 //
-void Z_ChangeTag2(void* ptr, int tag, const char* file, int line)
+void Z_ChangeTag2(void* ptr, zoneTag_e tag, const char* file, int line)
 {
 	if (!use_zone)
 	{
@@ -638,7 +639,7 @@ size_t Z_FreeMemory()
 // Z_DumpHeap
 // Note: TFileDumpHeap( stdout ) ?
 //
-void Z_DumpHeap(int lowtag, int hightag)
+void Z_DumpHeap(const zoneTag_e lowtag, const zoneTag_e hightag)
 {
 	if (!use_zone)
 		return;
@@ -711,7 +712,7 @@ BEGIN_COMMAND (dumpheap)
 			hi = atoi(argv[2]);
 	}
 
-	Z_DumpHeap(lo, hi);
+	Z_DumpHeap(static_cast<zoneTag_e>(lo), static_cast<zoneTag_e>(hi));
 }
 END_COMMAND (dumpheap)
 

--- a/common/z_zone.h
+++ b/common/z_zone.h
@@ -33,31 +33,34 @@
 // ZONE MEMORY
 // PU - purge tags.
 // Tags < 100 are not overwritten until freed.
-#define PU_FREE                 0       // a free block [ML] 12/4/06: Readded from Chocodoom
-#define PU_STATIC				1		// static entire execution time
-#define PU_SOUND				2		// static while playing
-#define PU_MUSIC				3		// static while playing
-#define PU_LEVEL				50		// static until level exited
-#define PU_LEVSPEC				51		// a special thinker in a level
-#define PU_LEVACS				52		// [RH] An ACS script in a level
-// Tags >= 100 are purgable whenever needed.
-#define PU_PURGELEVEL			100
-#define PU_CACHE				101
+enum zoneTag_e
+{
+	PU_FREE = 0,             // a free block [ML] 12/4/06: Readded from Chocodoom
+	PU_STATIC = 1,           // static entire execution time
+	PU_SOUND = 2,            // static while playing
+	PU_MUSIC = 3,            // static while playing
+	PU_LEVEL = 50,           // static until level exited
+	PU_LEVSPEC = 51,         // a special thinker in a level
+	PU_LEVACS = 52,          // [RH] An ACS script in a level
+	PU_LEVELMAX = PU_LEVACS, // Maximum level-specific tag
+	PU_PURGELEVEL = 100,     // Level-based tag that can be purged anytime.
+	PU_CACHE = 101,          // Generic purge-anytime tag.
+};
 
-
-void	Z_Init(bool use_zone = true);
-void	Z_Close (void);
-void	Z_FreeTags (int lowtag, int hightag);
-void	Z_DumpHeap (int lowtag, int hightag);
-void	Z_CheckHeap (void);
-size_t 	Z_FreeMemory (void);
+void Z_Init(bool use_zone = true);
+void Z_Close();
+void Z_FreeTags(const zoneTag_e lowtag, const zoneTag_e hightag);
+void Z_DumpHeap(const zoneTag_e lowtag, const zoneTag_e hightag);
+void Z_CheckHeap();
+size_t Z_FreeMemory();
 
 // Don't use these, use the macros instead!
-void*   Z_Malloc2 (size_t size, int tag, void *user, const char *file, int line);
-void    Z_Free2 (void *ptr, const char *file, int line);
-void    Z_Discard2 (void** ptr, const char* file, int line);
-void	Z_ChangeTag2 (void *ptr, int tag, const char* file, int line);
-void	Z_ChangeOwner2 (void *ptr, void* user, const char* file, int line);
+void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,
+                const int line);
+void Z_Free2(void* ptr, const char* file, int line);
+void Z_Discard2(void** ptr, const char* file, int line);
+void Z_ChangeTag2(void* ptr, const zoneTag_e tag, const char* file, int line);
+void Z_ChangeOwner2(void* ptr, void* user, const char* file, int line);
 
 typedef struct memblock_s
 {
@@ -69,7 +72,7 @@ typedef struct memblock_s
 	struct memblock_s*	prev;
 } memblock_t;
 
-inline void Z_ChangeTag2(const void *ptr, int tag, const char* file, int line)
+inline void Z_ChangeTag2(const void* ptr, const zoneTag_e tag, const char* file, int line)
 {
 	Z_ChangeTag2(const_cast<void *>(ptr), tag, file, line);
 }

--- a/common/z_zone.h
+++ b/common/z_zone.h
@@ -47,12 +47,10 @@ enum zoneTag_e
 	PU_CACHE = 101,          // Generic purge-anytime tag.
 };
 
-void Z_Init(bool use_zone = true);
+void Z_Init();
 void Z_Close();
 void Z_FreeTags(const zoneTag_e lowtag, const zoneTag_e hightag);
 void Z_DumpHeap(const zoneTag_e lowtag, const zoneTag_e hightag);
-void Z_CheckHeap();
-size_t Z_FreeMemory();
 
 // Don't use these, use the macros instead!
 void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -154,10 +154,9 @@ void D_Init()
 	srand(time(NULL));
 
 	// start the Zone memory manager
-	bool use_zone = !Args.CheckParm("-nozone");
-	Z_Init(false);
+	Z_Init();
 	if (first_time)
-		Printf(PRINT_HIGH, "Z_Init: Heapsize: %" PRIuSIZE " megabytes\n", got_heapsize);
+		Printf("Z_Init: Using native allocator with OZone bookkeeping.\n");
 
 	// Load palette and set up colormaps
 	V_InitPalette("PLAYPAL");

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -155,7 +155,7 @@ void D_Init()
 
 	// start the Zone memory manager
 	bool use_zone = !Args.CheckParm("-nozone");
-	Z_Init(use_zone);
+	Z_Init(false);
 	if (first_time)
 		Printf(PRINT_HIGH, "Z_Init: Heapsize: %" PRIuSIZE " megabytes\n", got_heapsize);
 

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -156,7 +156,7 @@ int __cdecl main(int argc, char *argv[])
         // Don't call this on windows!
 		//atexit (call_terms);
 
-		Z_Init(false);
+		Z_Init();
 
 		atterm (I_Quit);
 		atterm (DObject::StaticShutdown);

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -156,7 +156,7 @@ int __cdecl main(int argc, char *argv[])
         // Don't call this on windows!
 		//atexit (call_terms);
 
-		Z_Init();
+		Z_Init(false);
 
 		atterm (I_Quit);
 		atterm (DObject::StaticShutdown);
@@ -268,7 +268,7 @@ int main (int argc, char **argv)
 
         // Don't use this on other platforms either
 		//atexit (call_terms);
-		Z_Init();					// 1/18/98 killough: start up memory stuff first
+		Z_Init(false);					// 1/18/98 killough: start up memory stuff first
 
 		atterm (I_Quit);
 		atterm (DObject::StaticShutdown);

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -268,7 +268,7 @@ int main (int argc, char **argv)
 
         // Don't use this on other platforms either
 		//atexit (call_terms);
-		Z_Init(false);					// 1/18/98 killough: start up memory stuff first
+		Z_Init();					// 1/18/98 killough: start up memory stuff first
 
 		atterm (I_Quit);
 		atterm (DObject::StaticShutdown);

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -786,7 +786,6 @@ void G_DoLoadLevel (int position)
 	displayplayer_id = consoleplayer_id;				// view the guy you are playing
 
 	gameaction = ga_nothing;
-	Z_CheckHeap ();
 
 	paused = false;
 


### PR DESCRIPTION
Bugs like #337 are incredibly difficult to figure out due to the fact that we used the Doom Zone Heap, which pre-allocated a fixed-size buffer and dished out memory from it.  This meant that any bug in the use of Z_Malloc or Z_Free manifests not as a crash that we can debug, but as obscure messages like "Block does not have a proper ID".  And for all we know, that message might be caused by an oversight in the Zone itself.

Odamex had an existing implementation of a "Faux Heap" which was originally designed for debugging.  It has some of the unique Doom stuff, like tagging and ownership, but uses vanilla `malloc` and `free` under the hood instead of serving up portions of a fixed-size heap.  I dusted the thing off, added some missing pieces of functionality, and turned it into the only allocator.  I think we're much better off using it.  Neither I nor @rakohus has run into any similar crashes since the switchover.

If it turns out at some point in the future we need to improve how we allocate memory over malloc/free, I suspect we would be better served with a fresh perspective - perhaps using typed arenas - instead of going back to 1993.