### PR TITLE
Fix cases where Spawninv and DEH weren't meshing

### DIFF
--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -51,6 +51,7 @@
 #include "c_console.h"
 #include "i_system.h"
 #include "g_game.h"
+#include "g_spawninv.h"
 #include "r_main.h"
 #include "d_main.h"
 #include "d_dehacked.h"
@@ -439,6 +440,9 @@ void D_LoadResolvedPatches()
 		    PRINT_WARNING,
 		    "Warning: chex.deh not loaded, experience may differ from the original!\n");
 	}
+
+	// Re-apply spawninv settings with our new DEH settings.
+	G_SetupSpawnInventory();
 }
 
 

--- a/common/g_spawninv.cpp
+++ b/common/g_spawninv.cpp
@@ -29,6 +29,8 @@
 #include "cmdlib.h"
 #include "doomstat.h"
 
+EXTERN_CVAR(g_spawninv);
+
 extern const char* weaponnames[];
 
 /**
@@ -396,14 +398,20 @@ static void SetupDefaultInv()
 	::gDefaultInv.backpack = false;
 }
 
-CVAR_FUNC_IMPL(g_spawninv)
+/**
+ * @brief Setup the default and actual spawn inventory.
+ *
+ * @details This must be called after either the default or actual spawn
+ *          inventory changes.  DeHackEd can change the default spawninv.
+ */
+void G_SetupSpawnInventory()
 {
 	SetupDefaultInv();
 
 	spawnInventory_t inv;
 
 	// Split value into comma-separated tokens.
-	const std::string& str = var.str();
+	const std::string& str = ::g_spawninv.str();
 	StringTokens tok = TokenizeString(str, " ");
 	for (StringTokens::iterator it = tok.begin(); it != tok.end(); ++it)
 	{
@@ -530,6 +538,11 @@ CVAR_FUNC_IMPL(g_spawninv)
 
 	// Commit our new inventory settings.
 	::gSpawnInv = inv;
+}
+
+CVAR_FUNC_IMPL(g_spawninv)
+{
+	G_SetupSpawnInventory();
 }
 
 static void SpawninvHelp()
@@ -732,6 +745,11 @@ BEGIN_COMMAND(spawninv)
 		if (!other.empty())
 			Printf("Other: %s\n", JoinStrings(other, ", ").c_str());
 
+		return;
+	}
+	else if (!stricmp(argv[1], "default"))
+	{
+		::g_spawninv.ForceSet("default");
 		return;
 	}
 	else if (argc == 2)

--- a/common/g_spawninv.h
+++ b/common/g_spawninv.h
@@ -26,6 +26,7 @@
 
 #include "d_player.h"
 
+void G_SetupSpawnInventory();
 void G_GiveSpawnInventory(player_t& player);
 void G_GiveBetweenInventory(player_t& player);
 


### PR DESCRIPTION
Before this bugfix, the default inventory was only modified when `g_spawninv` changed, which meant that it was possible to get out of sync if you switched WAD files until `g_spawninv` was run again.  Now, it updates the default inventory when DeHackEd is loaded.