### PR TITLE
Fix odasrv logs not being colorstripped.

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1212,12 +1212,6 @@ static int VPrintf(int printlevel, const char* color_code, const char* format, v
 				outlinelog[i] = '=';
 		}
 
-		if (LOG.is_open())
-		{
-			LOG << outlinelog;
-			LOG.flush();
-		}
-
 		// Up the row buffer for the console.
 		// This is incremented here so that any time we
 		// print something we know about it.  This feels pretty hacky!
@@ -1240,6 +1234,17 @@ static int VPrintf(int printlevel, const char* color_code, const char* format, v
 		StripColorCodes(sanitized_str);
 
 	C_PrintString(printlevel, color_code, sanitized_str.c_str());
+
+	// Once done, log 
+	if (LOG.is_open())
+	{
+		// Strip if not already done
+		if (con_coloredmessages)
+			StripColorCodes(sanitized_str);
+
+		LOG << sanitized_str;
+		LOG.flush();
+	}
 
 #if defined (_WIN32) && defined(_DEBUG)
 	// [AM] Since we don't have stdout/stderr in a non-console Win32 app,

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -139,11 +139,6 @@ int VPrintf(int printlevel, const char* format, va_list parms)
 		}
 	}
 
-	if (LOG.is_open()) {
-		LOG << str;
-		LOG.flush();
-	}
-
 	return PrintString(printlevel, str.c_str());
 }
 

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -81,6 +81,12 @@ int PrintString(int printlevel, char const* str)
 	printf("%s", sanitized_str.c_str());
 	fflush(stdout);
 
+	if (LOG.is_open())
+	{
+		LOG << sanitized_str;
+		LOG.flush();
+	}
+
 	return sanitized_str.length();
 }
 


### PR DESCRIPTION
In Odamex/Odasrv, every string is logged before being color-stripped.
As a result, gibberish characters appear next to usually colored strings in the logs.

This PR fixes this issue by logging after stripping the colors, not before.