### PR TITLE
Write directory fixes - use bindir in portable Win32 mode, apply to default logfile

### DIFF
--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -145,7 +145,7 @@ EXTERN_CVAR (vid_widescreen)
 EXTERN_CVAR (vid_fullscreen)
 EXTERN_CVAR (vid_vsync)
 
-const char *LOG_FILE;
+std::string LOG_FILE;
 
 void M_RestoreVideoMode();
 void M_ModeFlashTestText();

--- a/common/c_dispatch.cpp
+++ b/common/c_dispatch.cpp
@@ -967,38 +967,46 @@ BEGIN_COMMAND (dumpactors)
 }
 END_COMMAND (dumpactors)
 
-BEGIN_COMMAND (logfile)
+BEGIN_COMMAND(logfile)
 {
 	time_t rawtime;
-	struct tm * timeinfo;
-	const char* DEFAULT_LOG_FILE = (serverside ? "odasrv.log" : "odamex.log");
+	struct tm* timeinfo;
+	const std::string default_logname =
+	    M_GetUserFileName(::serverside ? "odasrv.log" : "odamex.log");
 
-	if (LOG.is_open()) {
-		if ((argc == 1 && LOG_FILE == DEFAULT_LOG_FILE) || (argc > 1 && LOG_FILE == argv[1])) {
-			Printf (PRINT_HIGH, "Log file %s already in use\n", LOG_FILE);
+	if (::LOG.is_open())
+	{
+		if ((argc == 1 && ::LOG_FILE == default_logname) ||
+		    (argc > 1 && ::LOG_FILE == argv[1]))
+		{
+			Printf("Log file %s already in use\n", ::LOG_FILE.c_str());
 			return;
 		}
 
-    	time (&rawtime);
-    	timeinfo = localtime (&rawtime);
-    	Printf (PRINT_HIGH, "Log file %s closed on %s\n", LOG_FILE, asctime (timeinfo));
-		LOG.close();
+		time(&rawtime);
+		timeinfo = localtime(&rawtime);
+		Printf("Log file %s closed on %s\n", ::LOG_FILE.c_str(), asctime(timeinfo));
+		::LOG.close();
 	}
 
-	LOG_FILE = (argc > 1 ? argv[1] : DEFAULT_LOG_FILE);
-	LOG.open (LOG_FILE, std::ios::app);
+	::LOG_FILE = (argc > 1 ? argv[1] : default_logname);
+	::LOG.open(::LOG_FILE, std::ios::app);
 
-	if (!LOG.is_open())
-		Printf (PRINT_HIGH, "Unable to create logfile: %s\n", LOG_FILE);
-	else {
-		time (&rawtime);
-    	timeinfo = localtime (&rawtime);
-    	LOG.flush();
-    	LOG << std::endl;
-		Printf (PRINT_HIGH, "Logging in file %s started %s\n", LOG_FILE, asctime (timeinfo));
-    }
+	if (!::LOG.is_open())
+	{
+		Printf(PRINT_HIGH, "Unable to create logfile: %s\n", ::LOG_FILE.c_str());
+	}
+	else
+	{
+		time(&rawtime);
+		timeinfo = localtime(&rawtime);
+		::LOG.flush();
+		::LOG << std::endl;
+		Printf(PRINT_HIGH, "Logging in file %s started %s\n", ::LOG_FILE.c_str(),
+		       asctime(timeinfo));
+	}
 }
-END_COMMAND (logfile)
+END_COMMAND(logfile)
 
 BEGIN_COMMAND (stoplog)
 {

--- a/common/c_dispatch.cpp
+++ b/common/c_dispatch.cpp
@@ -1016,7 +1016,7 @@ BEGIN_COMMAND (stoplog)
 	if (LOG.is_open()) {
 		time (&rawtime);
     	timeinfo = localtime (&rawtime);
-		Printf (PRINT_HIGH, "Logging to file %s stopped %s\n", LOG_FILE, asctime (timeinfo));
+		Printf (PRINT_HIGH, "Logging to file %s stopped %s\n", LOG_FILE.c_str(), asctime (timeinfo));
 		LOG.close();
 	}
 }

--- a/common/c_dispatch.cpp
+++ b/common/c_dispatch.cpp
@@ -990,7 +990,7 @@ BEGIN_COMMAND(logfile)
 	}
 
 	::LOG_FILE = (argc > 1 ? argv[1] : default_logname);
-	::LOG.open(::LOG_FILE, std::ios::app);
+	::LOG.open(::LOG_FILE.c_str(), std::ios::app);
 
 	if (!::LOG.is_open())
 	{

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -26,6 +26,9 @@
 #ifndef __DOOMTYPE__
 #define __DOOMTYPE__
 
+// Standard libc/STL includes we use in countless places
+#include <string>
+
 #include "version.h"
 #include "errors.h"
 
@@ -248,7 +251,7 @@ void STACK_ARGS SV_BroadcastPrintf(int printlevel, const char* format, ...)
 #include <fstream>
 
 extern std::ofstream LOG;
-extern const char *LOG_FILE; //  Default is "odamex.log"
+extern std::string LOG_FILE; //  Default is "odamex.log"
 
 extern std::ifstream CON;
 

--- a/common/m_fileio_win32.cpp
+++ b/common/m_fileio_win32.cpp
@@ -116,8 +116,10 @@ std::string M_GetWriteDir()
 		}
 	}
 
-	// Our path is relative to the current working directory.
-	return M_CleanPath(M_GetCWD());
+	// Our path is relative to the binary directory.
+	// [AM] Don't change this back to CWD because this means your write dir
+	//      depends on where you launch it from, which is not great.
+	return M_CleanPath(M_GetBinaryDir());
 #endif
 }
 

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -101,7 +101,7 @@ char startmap[8];
 event_t events[MAXEVENTS];
 gamestate_t wipegamestate = GS_DEMOSCREEN;	// can be -1 to force a wipe
 
-const char *LOG_FILE;
+std::string LOG_FILE;
 
 //
 // D_DoomLoop


### PR DESCRIPTION
In 0.8.3, deciding where to write a file was a pain.  I rewrote a lot of that code for 0.9.0.  However, at the time, I had the idea to root the "Write Directory" for portable Win32 installations to be rooted in the CWD.  I think at the time I did it for noble reasons, since I had previously had some experiences with command line parameters not being parsed as expected.

However, I think I've realized by now that this change was a mistake.  The CWD often gets mutated in unexpected ways (dragging a WAD from a different directory, using doom builder, debugging from visual studio, etc.), and you want your persistent data to be in a reasonably stationary place.  The CWD ain't it.  So I changed it back to the binary directory.

While I was working on the fix, I came across an instance of something that wasn't writing to the write dir but really should be - the default logfile name.  I went and fixed the default logfile name to be relative to the write dir.