### PR TITLE
Fix (again) vanilla demoplaybacks

### DIFF
--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -1834,6 +1834,8 @@ void G_DoPlayDemo(bool justStreamInput)
 			}
 		}
 
+		demoplayback = true;
+
 		if (!justStreamInput)
 		{
 			player_t &con = idplayer(who + 1);
@@ -1889,12 +1891,9 @@ void G_DoPlayDemo(bool justStreamInput)
 			}
 
 			sv_respawnsuper.Set(0.0f);
-			G_InitNew(mapname);
 
 			usergame = false;
 		}
-
-		demoplayback = true;
 
 		// Set up the colors and names for the demo players
 		for (Players::iterator it = players.begin(); it != players.end(); ++it)
@@ -1911,6 +1910,10 @@ void G_DoPlayDemo(bool justStreamInput)
 			sprintf(tmpname, "Player %i", it->id);
 			it->userinfo.netname = tmpname;
 		}
+
+		if (!justStreamInput)
+			G_InitNew(mapname);
+
 	}
 	else
 	{

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -264,7 +264,6 @@ void G_InitNew (const char *mapname)
 
 	usergame = true;				// will be set false if a demo
 	paused = false;
-	demoplayback = false;
 	viewactive = true;
 
 	D_SetupUserInfo();

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -237,7 +237,8 @@ CVAR_RANGE(g_coopthingfilter, "0", "Removes cooperative things of the map. Value
 	"// 0 - All Coop things are retained (default).\n" \
 	"// 1 - Only Coop weapons are removed.\n" \
         "// 2 - All Coop things are removed.",
-	CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
+           CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE | CVAR_LATCH,
+           0.0f, 2.0f)
 
 // Game mode options commonized from the server
 //     At some point, replace "sv_" with "g_"

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -207,6 +207,9 @@ bool G_CanScoreChange()
  */
 bool G_CanShowFightMessage()
 {
+	if (demoplayback)
+		return false;
+
 	// Don't show a call-to-action when there's nobody ingame to answer.
 	PlayerResults pr = PlayerQuery().execute();
 	if (pr.count <= 0)

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -613,14 +613,15 @@ void P_LoadThings (int lump)
 		mt2.flags = (short)((flags & 0xf) | 0x7e0);
 		if (flags & BTF_NOTSINGLE)
 		{
-			if (multiplayer && G_IsCoopGame())
+			#ifdef SERVER_APP
+			if (G_IsCoopGame())
 			{ 
-				
 				if ((g_coopthingfilter.asInt() == 1 && mt2.flags & IT_WEAPON) ||
 				    (g_coopthingfilter.asInt() == 2))
 					mt2.flags &= ~MTF_COOPERATIVE;
 			}
 			else
+			#endif
 				mt2.flags &= ~MTF_SINGLE;
 		}
 		if (flags & BTF_NOTDEATHMATCH)		mt2.flags &= ~MTF_DEATHMATCH;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -613,8 +613,9 @@ void P_LoadThings (int lump)
 		mt2.flags = (short)((flags & 0xf) | 0x7e0);
 		if (flags & BTF_NOTSINGLE)
 		{
-			if (G_IsCoopGame())
+			if (multiplayer && G_IsCoopGame())
 			{ 
+				
 				if ((g_coopthingfilter.asInt() == 1 && mt2.flags & IT_WEAPON) ||
 				    (g_coopthingfilter.asInt() == 2))
 					mt2.flags &= ~MTF_COOPERATIVE;


### PR DESCRIPTION
Since I added the g_coopthingfilter CVAR, Vanilla demos were suddenly desyncing (DEMO1 spawning the cyberdemon for instance).

Besides, multiplayer vanilla demos crashed suddenly as it was trying to populate data that never existed.

This PR corrects both issues by:
- Tweaking the g_coopthingfilter CVAR with SERVERINFO & LATCH;
- Make that CVAR server_app only, to avoid clients to desync demos;
- Fix vanilla coop demo playback.

However, it still has one last issue with coop demos: all players are "(null)" and they all have the default colors, but I'm unsure when it was introduced. 