### PR TITLE
Write net_message data after the snapshot load

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -457,14 +457,15 @@ bool NetDemo::startRecording(const std::string &filename)
 		capture(&tempbuf);
 		writeMessages();
 
-		// Record any additional messages (usually a full update if auto-recording))
-		capture(&net_message);
-		writeMessages();
-		
 		SZ_Clear(&tempbuf);
 		MSG_WriteMarker(&tempbuf, svc_netdemoloadsnap);
 		capture(&tempbuf);
 		writeMessages();
+
+		// Record any additional messages (usually a full update if auto-recording))
+		// Do not write this message immediately because it needs to be written after
+		// the map snapshot.
+		capture(&net_message);
 	}
 
 	return true;


### PR DESCRIPTION
This fixes #316 , where there were instances where netdemo state was not being initialized properly causing broken demos, crashes, missing mobjs, and other fun bugs.

Netdemos are a recording of network commands, with "snapshots" of complete data spaced every so often.  When the demo starts recording, it takes an initial snapshot.  This works fine when you are already in the game and start recording, but when you start recording from the command line or from a cvar, the initial snapshot turns out to be almost empty.

But this is no big deal, because what follows after the snapshot is the network traffic that populates the game, so there's nothing to worry about, right?  Well, that data was not being written in the correct order.  When I started, that data was written BEFORE the command that tells the game to load the first snapshot, which blows all of that state away.

My initial attempt at fixing it swapped the "Load first snapshot" command to come before the data is written, but that merely caused the data to be skipped over because it was sandwiched between the "load snapshot" command and the first snapshot.  So the trick is to swap positions and capture the data, but don't write it immediately - instead letting it be written next tic after the snapshot.