### PR TITLE
Fix Z-Teleport on vanilla demo playback

### DIFF
--- a/common/p_teleport.cpp
+++ b/common/p_teleport.cpp
@@ -280,7 +280,12 @@ BOOL EV_LineTeleport (line_t *line, int side, AActor *thing)
 				oldy = thing->y;
 				oldz = thing->z;
 
-				fixed_t destz = (m->type == MT_TELEPORTMAN) ? P_FloorHeight(m) : m->z;
+				fixed_t destz;
+
+				if (demoplayback && (gamemission == pack_tnt || gamemission == pack_plut || gamemission == chex))
+					destz = m->z;	// Make sure we have the original Z-Height bug on Final Doom.
+				else
+					destz = (m->type == MT_TELEPORTMAN) ? P_FloorHeight(m) : m->z;
 
 				if (!P_TeleportMove (thing, m->x, m->y, destz, false))
 					return false;


### PR DESCRIPTION
On TNT/Plutonia, playing back vanillademos caused a desync, because the z destination was always on the ground, which definitely wasn't the proper behaviour.

This PR attempts to fix the issue by making a special case while playbacking a demo only.