### PR TITLE
Fix for g_coopthingfilter

### DIFF
--- a/common/doomdata.h
+++ b/common/doomdata.h
@@ -247,6 +247,10 @@ typedef struct MapThing
 #define MTF_COOPERATIVE		0x0200	// Thing appears in cooperative games
 #define MTF_DEATHMATCH		0x0400	// Thing appears in deathmatch games
 
+// Custom MapThing Flags
+#define MTF_FILTER_COOPWPN  0x0800  // Weapon thing is filtered with g_coopthingfilter 1.
+									// (Hate this method but it works...)
+
 
 // BOOM and DOOM compatible versions of some of the above
 

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2538,25 +2538,31 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 		return;
 
 	// don't spawn deathmatch weapons in offline single player mode
-	if (!multiplayer)
 	{
 		switch (i)
 		{
-			case MT_CHAINGUN:
-			case MT_SHOTGUN:
-			case MT_SUPERSHOTGUN:
-			case MT_MISC25: 		// BFG
-			case MT_MISC26: 		// chainsaw
-			case MT_MISC27: 		// rocket launcher
-			case MT_MISC28: 		// plasma gun
-				if ((mthing->flags & (MTF_DEATHMATCH|MTF_SINGLE)) == MTF_DEATHMATCH)
+		case MT_CHAINGUN:
+		case MT_SHOTGUN:
+		case MT_SUPERSHOTGUN:
+		case MT_MISC25: // BFG
+		case MT_MISC26: // chainsaw
+		case MT_MISC27: // rocket launcher
+		case MT_MISC28: // plasma gun
+			if (!multiplayer)
+			{
+				if ((mthing->flags & (MTF_DEATHMATCH | MTF_SINGLE)) == MTF_DEATHMATCH)
 					return;
-				break;
-			default:
-				break;
+			}
+			else
+			{
+				if ((mthing->flags & (MTF_FILTER_COOPWPN)))
+					return;
+			}
+			break;
+		default:
+			break;
 		}
 	}
-
 	// [csDoom] don't spawn any monsters
 	if (sv_nomonsters || !serverside)
 	{

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -616,8 +616,9 @@ void P_LoadThings (int lump)
 			#ifdef SERVER_APP
 			if (G_IsCoopGame())
 			{ 
-				if ((g_coopthingfilter.asInt() == 1 && mt2.flags & IT_WEAPON) ||
-				    (g_coopthingfilter.asInt() == 2))
+				if (g_coopthingfilter == 1)
+					mt2.flags |= MTF_FILTER_COOPWPN;
+				else if (g_coopthingfilter == 2)
 					mt2.flags &= ~MTF_COOPERATIVE;
 			}
 			else

--- a/common/p_teleport.cpp
+++ b/common/p_teleport.cpp
@@ -282,7 +282,7 @@ BOOL EV_LineTeleport (line_t *line, int side, AActor *thing)
 
 				fixed_t destz;
 
-				if (demoplayback && (gamemission == pack_tnt || gamemission == pack_plut))
+				if (demoplayback && (gamemission == pack_tnt || gamemission == pack_plut || gamemission == chex))
 					destz = m->z;	// Make sure we have the original Z-Height bug on Final Doom.
 				else
 					destz = (m->type == MT_TELEPORTMAN) ? P_FloorHeight(m) : m->z;

--- a/common/p_teleport.cpp
+++ b/common/p_teleport.cpp
@@ -282,7 +282,7 @@ BOOL EV_LineTeleport (line_t *line, int side, AActor *thing)
 
 				fixed_t destz;
 
-				if (demoplayback && (gamemission == pack_tnt || gamemission == pack_plut || gamemission == chex))
+				if (demoplayback && (gamemission == pack_tnt || gamemission == pack_plut))
 					destz = m->z;	// Make sure we have the original Z-Height bug on Final Doom.
 				else
 					destz = (m->type == MT_TELEPORTMAN) ? P_FloorHeight(m) : m->z;


### PR DESCRIPTION
This PR does the following:

* Fix `g_coopthingfilter` that actually filtered all MP things regardless of settings.
* Don't include Chex Quest for the teleporter bug when playbacking demos.