### PR TITLE
Fix crashes discoverd via OZone switch

### DIFF
--- a/client/sdl/i_music.h
+++ b/client/sdl/i_music.h
@@ -24,13 +24,17 @@
 #define __I_MUSIC_H__
 
 #include <SDL_mixer.h>
-#include "doomstat.h"
 
-typedef struct
+#include "doomstat.h"
+#include "m_memio.h"
+
+struct MusicHandler_t
 {
-    Mix_Music *Track;
-    SDL_RWops *Data;
-} MusicHandler_t;
+	Mix_Music* Track;
+	SDL_RWops* Data;
+	MEMFILE* Mem;
+	MusicHandler_t() : Track(NULL), Data(NULL), Mem(NULL) { }
+};
 
 typedef enum
 {

--- a/client/sdl/i_musicsystem.cpp
+++ b/client/sdl/i_musicsystem.cpp
@@ -284,6 +284,11 @@ void SdlMixerMusicSystem::_UnregisterSong()
 		
 	mRegisteredSong.Track = NULL;
 	mRegisteredSong.Data = NULL;
+	if (mRegisteredSong.Mem != NULL)
+	{
+		mem_fclose(mRegisteredSong.Mem);
+		mRegisteredSong.Mem = NULL;
+	}
 }
 
 //
@@ -299,16 +304,20 @@ void SdlMixerMusicSystem::_RegisterSong(byte* data, size_t length)
 	if (S_MusicIsMus(data, length))
 	{
 		MEMFILE *mus = mem_fopen_read(data, length);
-		MEMFILE *midi = mem_fopen_write();
+		mRegisteredSong.Mem = mem_fopen_write();
 	
-		int result = mus2mid(mus, midi);
+		int result = mus2mid(mus, mRegisteredSong.Mem);
 		if (result == 0)
-			mRegisteredSong.Data = SDL_RWFromMem(mem_fgetbuf(midi), mem_fsize(midi));
+		{
+			mRegisteredSong.Data = SDL_RWFromMem(mem_fgetbuf(mRegisteredSong.Mem),
+			                                     mem_fsize(mRegisteredSong.Mem));
+		}
 		else
+		{
 			Printf(PRINT_WARNING, "MUS is not valid\n");
+		}
 
 		mem_fclose(mus);
-		mem_fclose(midi);		
 	}
 	else
 	{

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -314,8 +314,7 @@ static void getsfx (struct sfxinfo_struct *sfx)
 	chunk = (Mix_Chunk *)Z_Malloc(sizeof(Mix_Chunk), PU_STATIC, NULL);
     chunk->allocated = 1;
     chunk->alen = expanded_length;
-    chunk->abuf 
-        = (Uint8 *)Z_Malloc(expanded_length, PU_STATIC, &chunk->abuf);
+	chunk->abuf = (Uint8*)Z_Malloc(expanded_length, PU_STATIC, NULL);
     chunk->volume = MIX_MAX_VOLUME;
 
     ExpandSoundData((byte*)data + 8, samplerate, 8, length, chunk);

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -21,7 +21,7 @@
 //
 //-----------------------------------------------------------------------------
 
-
+#include <map>
 #include <stdlib.h>
 
 #include "z_zone.h"
@@ -104,10 +104,10 @@ class OZone
 		OFileLine fileLine; // __FILE__, __LINE__
 	};
 
-	typedef OHashTable<void*, MemoryBlockInfo> MemoryBlockTable;
+	typedef std::map<void*, MemoryBlockInfo> MemoryBlockTable;
 	MemoryBlockTable m_heap;
 
-	void dealloc(MemoryBlockTable::iterator& block)
+	MemoryBlockTable::iterator dealloc(MemoryBlockTable::iterator& block)
 	{
 		if (block->second.user)
 		{
@@ -117,11 +117,11 @@ class OZone
 		void* imFree = block->first;
 
 		free(imFree);
-		m_heap.erase(block);
+		return m_heap.erase(block);
 	}
 
   public:
-	OZone() : m_heap(4096)
+	OZone()
 	{
 	}
 
@@ -132,14 +132,11 @@ class OZone
 
 	void clear()
 	{
-		// Free the memory first.
-		for (MemoryBlockTable::iterator it = m_heap.begin(); it != m_heap.end(); ++it)
+		// Free all memory.
+		for (MemoryBlockTable::iterator it = m_heap.begin(); it != m_heap.end();)
 		{
-			dealloc(it);
+			it = dealloc(it);
 		}
-
-		// Now clear the heap.
-		m_heap.clear();
 	}
 
 	void* alloc(size_t size, zoneTag_e tag, void* user, const OFileLine& info)
@@ -233,14 +230,15 @@ class OZone
 	 */
 	void deallocTags(const int lowtag, const int hightag)
 	{
-		for (MemoryBlockTable::iterator it = m_heap.begin(); it != m_heap.end(); ++it)
+		for (MemoryBlockTable::iterator it = m_heap.begin();it != m_heap.end();)
 		{
 			if (it->second.tag < lowtag || it->second.tag > hightag)
 			{
+				++it;
 				continue;
 			}
 
-			dealloc(it);
+			it = dealloc(it);
 		}
 	}
 

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -117,7 +117,11 @@ class OZone
 		void* imFree = block->first;
 
 		free(imFree);
-		return m_heap.erase(block);
+
+		MemoryBlockTable::iterator next = block;
+		++next;
+		m_heap.erase(block);
+		return next;
 	}
 
   public:


### PR DESCRIPTION
0.9.1 took the Faux Zone and graduated it to be OZone, the only implementation of Zone Memory.  This change turned out to reveal several insidious bugs now that the memory backing allocations was actually being properly freed upon request.

- SDL_Mixer had to convert MUS music to MIDI.  The buffer this was done in turned out to be freed immediately after conversion, even though the functions used to load the music were adament that the music was not being copied, merely "viewed".
- When playing sound effects, the expanded sound buffer was allocated with an "owner".  This owner is basically the address of the pointer variable, which is used to NULL the pointer upon free.  The trouble is that both the sound chunk and the expanded buffer were both allocated with zone memory, which meant that there was coinflip odds that whenever the zone was cleared the chunk would be freed before the buffer itself, which means the freeing function would try to NULL a pointer variable contained in freed memory.  And that's coinflip odds per sound chunk.  Whoops.

There was also a bug in the zone itself caused by improper use of iterators.  Switching to the STL type `std::map` laid my sins bare with a nice assert.