### PR TITLE
Fix issues related to ceiling and floor

### DIFF
--- a/common/p_ceiling.cpp
+++ b/common/p_ceiling.cpp
@@ -384,7 +384,7 @@ manual_ceiling:
 
 		case DCeiling::ceilLowerToNearest:
 			targheight = ceiling->m_BottomHeight = P_FindNextLowestCeiling(sec);
-			ceiling->m_Direction = 1;
+			ceiling->m_Direction = -1;
 			break;
 
 		case DCeiling::ceilRaiseToNearest:

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -227,6 +227,8 @@ void DFloor::RunThink ()
 				}
 			}
 		}
+
+		P_SetFloorDestroy(this);
 	}
 }
 

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -334,8 +334,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 
 	case DFloor::floorLowerByTexture:
 		m_Direction = -1;
-		m_FloorDestHeight = floorheight -
-			P_FindShortestTextureAround (sec);
+		m_FloorDestHeight = floorheight - P_FindShortestTextureAround (sec);
 		break;
 
 	case DFloor::floorLowerToCeiling:
@@ -366,8 +365,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 
 	case DFloor::floorLowerAndChange:
 		m_Direction = -1;
-		m_FloorDestHeight =
-			P_FindLowestFloorSurrounding (sec);
+		m_FloorDestHeight = P_FindLowestFloorSurrounding (sec);
 		m_Texture = sec->floorpic;
 		// jff 1/24/98 make sure m_NewSpecial gets initialized
 		// in case no surrounding sector is at floordestheight
@@ -404,11 +402,11 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 			    floortype == DFloor::floorRaiseToCeiling ||
 			    floortype == DFloor::floorLowerToCeiling)
 			{
-				P_FindModelCeilingSector(m_FloorDestHeight, sec);
+				found = P_FindModelCeilingSector(m_FloorDestHeight, sec);
 			}
 			else
 			{
-				P_FindModelFloorSector(m_FloorDestHeight, sec);
+				found = P_FindModelFloorSector(m_FloorDestHeight, sec);
 			}
 
 			if (found != NULL)

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1003,16 +1003,15 @@ fixed_t P_FindShortestTextureAround (sector_t *sec)
 
 	for (i = 0; i < sec->linecount; i++)
 	{
-		if (twoSided (sec, i))
+		if (sec->lines[i]->flags & ML_TWOSIDED)
 		{
-			side = getSide (sec, i, 0);
-			if (side->bottomtexture >= 0)
-				if (textureheight[side->bottomtexture] < minsize)
-					minsize = textureheight[side->bottomtexture];
-			side = getSide (sec, i, 1);
-			if (side->bottomtexture >= 0)
-				if (textureheight[side->bottomtexture] < minsize)
-					minsize = textureheight[side->bottomtexture];
+			side = &sides[(sec->lines[i])->sidenum[0]];
+			if (side->bottomtexture >= 0 && textureheight[side->bottomtexture] < minsize)
+				minsize = textureheight[side->bottomtexture];
+
+			side = &sides[(sec->lines[i])->sidenum[1]];
+			if (side->bottomtexture >= 0 && textureheight[side->bottomtexture] < minsize)
+				minsize = textureheight[side->bottomtexture];
 		}
 	}
 	return minsize;
@@ -1038,16 +1037,15 @@ fixed_t P_FindShortestUpperAround (sector_t *sec)
 
 	for (i = 0; i < sec->linecount; i++)
 	{
-		if (twoSided (sec, i))
+		if (sec->lines[i]->flags & ML_TWOSIDED)
 		{
-			side = getSide (sec,i,0);
-			if (side->toptexture >= 0)
-				if (textureheight[side->toptexture] < minsize)
-					minsize = textureheight[side->toptexture];
-			side = getSide (sec,i,1);
-			if (side->toptexture >= 0)
-				if (textureheight[side->toptexture] < minsize)
-					minsize = textureheight[side->toptexture];
+			side = &sides[(sec->lines[i])->sidenum[0]];
+			if (side->toptexture >= 0 && textureheight[side->toptexture] < minsize)
+				minsize = textureheight[side->toptexture];
+
+			side = &sides[(sec->lines[i])->sidenum[1]];
+			if (side->toptexture >= 0 && textureheight[side->toptexture] < minsize)
+				minsize = textureheight[side->toptexture];
 		}
 	}
 	return minsize;

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -211,17 +211,6 @@ bool    P_PushSpecialLine (AActor* thing, line_t* line, int	side);
 void    P_PlayerInSpecialSector (player_t *player);
 
 //
-// getSide()
-// Will return a side_t*
-//	given the number of the current sector,
-//	the line number, and the side (0/1) that you want.
-//
-inline side_t *getSide (sector_t *sec, int line, int side)
-{
-	return &sides[ (sec->lines[line])->sidenum[side] ];
-}
-
-//
 // getSector()
 // Will return a sector_t*
 //	given the number of the current sector,
@@ -232,16 +221,6 @@ inline sector_t *getSector (int currentSector, int line, int side)
 	return sides[ (sectors[currentSector].lines[line])->sidenum[side] ].sector;
 }
 
-
-//
-// twoSided()
-// Given the sector number and the line number,
-//	it will tell you whether the line is two-sided or not.
-//
-inline int twoSided (sector_t *sec, int line)
-{
-	return (sec->lines[line])->flags & ML_TWOSIDED;
-}
 
 //
 // getNextSector()


### PR DESCRIPTION
This PR does the following:

* Fix the direction of ceilLowerToNearest (fix issues with Eviternity MAP30)
* Fix textures not changing in case of a generalized floor. (also fixes issues with Eviternity MAP30 and several other BOOM-maps)
* Optimized slightly functions related to P_FindShortestTextureAround  and P_FindShortestUpperAround (taken from ZDoom 1.23 and onward)
* Destroy the floor data the same frame it's finished (may fix 1tick desync issues related to them - haven't seen any but better safe than sorry).