### PR TITLE
Add an alternate PWO system.

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -218,7 +218,7 @@ CVAR_RANGE			(cl_chatsounds, "1", "Plays a sound when a chat message appears (0 
 
 CVAR_RANGE(			cl_switchweapon, "1", "Switch upon weapon pickup (0 = never, 1 = always, " \
 					"2 = use weapon preferences)",
-					CVARTYPE_BYTE, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
+					CVARTYPE_BYTE, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 3.0f)
 
 CVAR_RANGE(			cl_weaponpref_fst, "0", "Weapon preference level for fists",
 					CVARTYPE_BYTE, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 8.0f)

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -217,7 +217,7 @@ CVAR_RANGE			(cl_chatsounds, "1", "Plays a sound when a chat message appears (0 
 					CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
 
 CVAR_RANGE(			cl_switchweapon, "1", "Switch upon weapon pickup (0 = never, 1 = always, " \
-					"2 = use weapon preferences)",
+					"2 = use weapon preferences, 3 = use PWO but holding fire cancels it)",
 					CVARTYPE_BYTE, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 3.0f)
 
 CVAR_RANGE(			cl_weaponpref_fst, "0", "Weapon preference level for fists",

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -172,8 +172,8 @@ void D_SetupUserInfo(void)
 	coninfo->predict_weapons	= (cl_predictweapons != 0);
 
 	// sanitize the weapon switching choice
-	if (cl_switchweapon < 0 || cl_switchweapon > 2)
-		cl_switchweapon.ForceSet(float(WPSW_ALWAYS));
+	if (cl_switchweapon >= WPSW_NUMTYPES || cl_switchweapon < 0)
+		cl_switchweapon.ForceSet(WPSW_ALWAYS);
 	coninfo->switchweapon	= (weaponswitch_t)cl_switchweapon.asInt();
 
 	// Copies the updated cl_weaponpref* cvars to coninfo->weapon_prefs[]

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -675,14 +675,15 @@ menu_t NetworkMenu = {
 static value_t WeapSwitch[] = {
 	{ 0.0,			"Never" },
 	{ 1.0,			"Always" },
-	{ 2.0,			"By Preference" }
+	{ 2.0,			"By Preference" },
+    { 3.0,			"Dynamic PWO"}
 };
 
 extern const char *weaponnames[];
 
 static menuitem_t WeaponItems[] = {
 	{bricktext, "Weapon Preferences",  {NULL},               {0.0}, {0.0}, {0.0}, {NULL}},
-	{discrete,  "Switch on pickup",    {&cl_switchweapon},   {3.0}, {0.0}, {0.0}, {WeapSwitch}},
+	{discrete,  "Switch on pickup",    {&cl_switchweapon},   {4.0}, {0.0}, {0.0}, {WeapSwitch}},
 	{redtext,   " ",                   {NULL},               {0.0}, {0.0}, {0.0}, {NULL}},
 	{bricktext, "Weapon Switch Order", {NULL},               {0.0}, {0.0}, {0.0}, {NULL}},
 	{slider,    weaponnames[0],        {&cl_weaponpref_fst}, {0.0}, {8.0}, {1.0}, {NULL}},

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -676,7 +676,7 @@ static value_t WeapSwitch[] = {
 	{ 0.0,			"Never" },
 	{ 1.0,			"Always" },
 	{ 2.0,			"By Preference" },
-    { 3.0,			"Dynamic PWO"}
+    { 3.0,			"Attack Cancels PWO"}
 };
 
 extern const char *weaponnames[];

--- a/common/d_netinf.h
+++ b/common/d_netinf.h
@@ -45,6 +45,7 @@ enum weaponswitch_t
 	WPSW_NEVER,
 	WPSW_ALWAYS,
 	WPSW_PWO,
+	WPSW_PWO_ALT,	// PWO but never switch if holding +attack
 
 	WPSW_NUMTYPES
 };

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -392,7 +392,13 @@ bool P_CheckSwitchWeapon(player_t *player, weapontype_t weapon)
 	// Use player's weapon preferences
 	byte *prefs = player->userinfo.weapon_prefs;
 	if (prefs[weapon] > prefs[currentweapon])
+	{
+		if (player->userinfo.switchweapon == WPSW_PWO_ALT &&
+			player->cmd.buttons & BT_ATTACK)
+			return false;
+
 		return true;
+	}
 
 	return false;
 }


### PR DESCRIPTION
Odamex properly supports PWO, however some people noticed in other MP ports that weapon switching was "ignored" if they were holding `+fire` while picking up a new weapon. 

This PR adds a new, alternate PWO value called `Dynamic PWO` that follows that idea.