### PR TITLE
Fix Teamchats & filters as a spectator.

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2135,14 +2135,16 @@ void CL_Say()
 	}
 
 	const char* name = player.userinfo.netname.c_str();
+	printlevel_t publicmsg = filtermessage ? PRINT_FILTERCHAT : PRINT_CHAT;
+	printlevel_t publicteammsg = filtermessage ? PRINT_FILTERCHAT : PRINT_TEAMCHAT;
+
 
 	if (message_visibility == 0)
 	{
 		if (strnicmp(message, "/me ", 4) == 0)
-			Printf(filtermessage ? PRINT_FILTERCHAT : PRINT_CHAT, "* %s %s\n", name, &message[4]);
+			Printf(publicmsg, "* %s %s\n", name, &message[4]);
 		else
-			Printf(filtermessage ? PRINT_FILTERCHAT : PRINT_CHAT, "%s: %s\n", name,
-			       message);
+			Printf(publicmsg, "%s: %s\n", name, message);
 
 		if (show_messages && !filtermessage)
 		{	
@@ -2153,11 +2155,11 @@ void CL_Say()
 	else if (message_visibility == 1)
 	{
 		if (strnicmp(message, "/me ", 4) == 0)
-			Printf(PRINT_TEAMCHAT, "* %s %s\n", name, &message[4]);
+			Printf(publicteammsg, "* %s %s\n", name, &message[4]);
 		else
-			Printf(PRINT_TEAMCHAT, "%s: %s\n", name, message);
+			Printf(publicteammsg, "%s: %s\n", name, message);
 
-		if (show_messages && cl_chatsounds)
+		if ((show_messages && cl_chatsounds) && !filtermessage)
 			S_Sound(CHAN_INTERFACE, "misc/teamchat", 1, ATTN_NONE);
 	}
 }

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2159,7 +2159,7 @@ void CL_Say()
 		else
 			Printf(publicteammsg, "%s: %s\n", name, message);
 
-		if ((show_messages && cl_chatsounds) && !filtermessage)
+		if (!filtermessage && show_messages && cl_chatsounds)
 			S_Sound(CHAN_INTERFACE, "misc/teamchat", 1, ATTN_NONE);
 	}
 }


### PR DESCRIPTION
This PR corrects an oversight with the spectator filter.

Despite properly being able to mute other spectators (useful for streams), it could have been bypassed by sending a team_chat message.