### PR TITLE
Fix several MAPINFO/UMAPINFO problems

### DIFF
--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -58,7 +58,7 @@ EXTERN_CVAR(co_realactorheight)
 
 // Construct from array of levelinfos, ending with an "empty" level
 LevelInfos::LevelInfos(const level_info_t* levels) :
-	_defaultInfos(levels)
+	m_defaultInfos(levels)
 {
 	//addDefaults();
 }
@@ -74,20 +74,20 @@ void LevelInfos::addDefaults()
 {
 	for (size_t i = 0;; i++)
 	{
-		const level_info_t& level = _defaultInfos[i];
+		const level_info_t& level = m_defaultInfos[i];
 		if (!level.exists())
 			break;
 
 		// Copied, so it can be mutated.
 		level_pwad_info_t info(level);
-		_infos.push_back(info);
+		m_infos.push_back(info);
 	}
 }
 
 // Get a specific info index
 level_pwad_info_t& LevelInfos::at(size_t i)
 {
-	return _infos.at(i);
+	return m_infos.at(i);
 }
 
 // Clear all cluster definitions
@@ -95,13 +95,13 @@ void LevelInfos::clear()
 {
 	clearSnapshots();
 	zapDeferreds();
-	_infos.clear();
+	m_infos.clear();
 }
 
 // Clear all stored snapshots
 void LevelInfos::clearSnapshots()
 {
-	for (_LevelInfoArray::iterator it = _infos.begin(); it != _infos.end(); ++it)
+	for (_LevelInfoArray::iterator it = m_infos.begin(); it != m_infos.end(); ++it)
 	{
 		if (it->snapshot)
 		{
@@ -114,14 +114,14 @@ void LevelInfos::clearSnapshots()
 // Add a new levelinfo and return it by reference
 level_pwad_info_t& LevelInfos::create()
 {
-	_infos.push_back(level_pwad_info_t());
-	return _infos.back();
+	m_infos.push_back(level_pwad_info_t());
+	return m_infos.back();
 }
 
 // Find a levelinfo by mapname
 level_pwad_info_t& LevelInfos::findByName(const char* mapname)
 {
-	for (_LevelInfoArray::iterator it = _infos.begin(); it != _infos.end(); ++it)
+	for (_LevelInfoArray::iterator it = m_infos.begin(); it != m_infos.end(); ++it)
 	{
 		if (it->mapname == mapname)
 		{
@@ -133,7 +133,7 @@ level_pwad_info_t& LevelInfos::findByName(const char* mapname)
 
 level_pwad_info_t& LevelInfos::findByName(const std::string &mapname)
 {
-	for (_LevelInfoArray::iterator it = _infos.begin(); it != _infos.end(); ++it)
+	for (_LevelInfoArray::iterator it = m_infos.begin(); it != m_infos.end(); ++it)
 	{
 		if (it->mapname == mapname)
 		{
@@ -145,7 +145,7 @@ level_pwad_info_t& LevelInfos::findByName(const std::string &mapname)
 
 level_pwad_info_t& LevelInfos::findByName(const OLumpName& mapname)
 {
-	for (_LevelInfoArray::iterator it = _infos.begin(); it != _infos.end(); ++it)
+	for (_LevelInfoArray::iterator it = m_infos.begin(); it != m_infos.end(); ++it)
 	{
 		if (it->mapname == mapname)
 		{
@@ -158,7 +158,7 @@ level_pwad_info_t& LevelInfos::findByName(const OLumpName& mapname)
 // Find a levelinfo by mapnum
 level_pwad_info_t& LevelInfos::findByNum(int levelnum)
 {
-	for (_LevelInfoArray::iterator it = _infos.begin(); it != _infos.end(); ++it)
+	for (_LevelInfoArray::iterator it = m_infos.begin(); it != m_infos.end(); ++it)
 	{
 		if (it->levelnum == levelnum && W_CheckNumForName(it->mapname.c_str()) != -1)
 		{
@@ -171,13 +171,13 @@ level_pwad_info_t& LevelInfos::findByNum(int levelnum)
 // Number of info entries.
 size_t LevelInfos::size()
 {
-	return _infos.size();
+	return m_infos.size();
 }
 
 // Zap all deferred ACS scripts
 void LevelInfos::zapDeferreds()
 {
-	for (_LevelInfoArray::iterator it = _infos.begin(); it != _infos.end(); ++it)
+	for (_LevelInfoArray::iterator it = m_infos.begin(); it != m_infos.end(); ++it)
 	{
 		acsdefered_t* def = it->defered;
 		while (def) {
@@ -195,7 +195,7 @@ void LevelInfos::zapDeferreds()
 
 // Construct from array of clusterinfos, ending with an "empty" cluster.
 ClusterInfos::ClusterInfos(const cluster_info_t* clusters) :
-	_defaultInfos(clusters)
+	m_defaultInfos(clusters)
 {
 	//addDefaults();
 }
@@ -211,48 +211,48 @@ void ClusterInfos::addDefaults()
 {
 	for (size_t i = 0;; i++)
 	{
-		const cluster_info_t& cluster = _defaultInfos[i];
+		const cluster_info_t& cluster = m_defaultInfos[i];
 		if (cluster.cluster == 0)
 		{
 			break;
 		}
 
 		// Copied, so it can be mutated.
-		_infos.push_back(cluster);
+		m_infos.push_back(cluster);
 	}
 }
 
 // Get a specific info index
 cluster_info_t& ClusterInfos::at(size_t i)
 {
-	return _infos.at(i);
+	return m_infos.at(i);
 }
 
 // Clear all cluster definitions
 void ClusterInfos::clear()
 {
 	// Free all strings.
-	for (_ClusterInfoArray::iterator it = _infos.begin(); it != _infos.end(); ++it)
+	for (_ClusterInfoArray::iterator it = m_infos.begin(); it != m_infos.end(); ++it)
 	{
 		free(it->exittext);
 		it->exittext = NULL;
 		free(it->entertext);
 		it->entertext = NULL;
 	}
-	return _infos.clear();
+	return m_infos.clear();
 }
 
 // Add a new levelinfo and return it by reference
 cluster_info_t& ClusterInfos::create()
 {
-	_infos.push_back(cluster_info_t());
-	return _infos.back();
+	m_infos.push_back(cluster_info_t());
+	return m_infos.back();
 }
 
 // Find a clusterinfo by mapname
 cluster_info_t& ClusterInfos::findByCluster(int i)
 {
-	for (_ClusterInfoArray::iterator it = _infos.begin();it != _infos.end();++it)
+	for (_ClusterInfoArray::iterator it = m_infos.begin();it != m_infos.end();++it)
 	{
 		if (it->cluster == i)
 		{
@@ -265,7 +265,7 @@ cluster_info_t& ClusterInfos::findByCluster(int i)
 // Number of info entries.
 size_t ClusterInfos::size() const
 {
-	return _infos.size();
+	return m_infos.size();
 }
 
 void P_RemoveDefereds()

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -645,10 +645,10 @@ void G_ClearSnapshots()
 	getLevelInfos().clearSnapshots();
 }
 
-static void writeSnapShot(FArchive &arc, level_info_t *i)
+static void writeSnapShot(FArchive &arc, level_pwad_info_t& info)
 {
-	arc.Write (i->mapname.c_str(), 8);
-	i->snapshot->Serialize (arc);
+	arc.Write(info.mapname.c_str(), 8);
+	info.snapshot->Serialize(arc);
 }
 
 void G_SerializeSnapshots(FArchive &arc)
@@ -662,7 +662,7 @@ void G_SerializeSnapshots(FArchive &arc)
 			level_pwad_info_t& level = levels.at(i);
 			if (level.snapshot)
 			{
-				writeSnapShot(arc, reinterpret_cast<level_info_t*>(&level));
+				writeSnapShot(arc, level);
 			}
 		}
 
@@ -690,10 +690,10 @@ void G_SerializeSnapshots(FArchive &arc)
 	}
 }
 
-static void writeDefereds(FArchive &arc, level_info_t *i)
+static void writeDefereds(FArchive &arc, level_pwad_info_t& info)
 {
-	arc.Write (i->mapname.c_str(), 8);
-	arc << i->defered;
+	arc.Write(info.mapname.c_str(), 8);
+	arc << info.defered;
 }
 
 void P_SerializeACSDefereds(FArchive &arc)
@@ -707,7 +707,7 @@ void P_SerializeACSDefereds(FArchive &arc)
 			level_pwad_info_t& level = levels.at(i);
 			if (level.defered)
 			{
-				writeDefereds(arc, reinterpret_cast<level_info_t*>(&level));
+				writeDefereds(arc, level);
 			}
 		}
 

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -46,6 +46,9 @@
 
 level_locals_t level;			// info about current level
 
+level_pwad_info_t g_EmptyLevel;
+cluster_info_t g_EmptyCluster;
+
 EXTERN_CVAR(co_allowdropoff)
 EXTERN_CVAR(co_realactorheight)
 
@@ -76,8 +79,7 @@ void LevelInfos::addDefaults()
 			break;
 
 		// Copied, so it can be mutated.
-		level_pwad_info_t info = _empty;
-		memcpy(&info, &level, sizeof(level));
+		level_pwad_info_t info(level);
 		_infos.push_back(info);
 	}
 }
@@ -113,7 +115,6 @@ void LevelInfos::clearSnapshots()
 level_pwad_info_t& LevelInfos::create()
 {
 	_infos.push_back(level_pwad_info_t());
-	_infos.back() = _empty;
 	return _infos.back();
 }
 
@@ -127,7 +128,7 @@ level_pwad_info_t& LevelInfos::findByName(const char* mapname)
 			return *it;
 		}
 	}
-	return _empty;
+	return ::g_EmptyLevel;
 }
 
 level_pwad_info_t& LevelInfos::findByName(const std::string &mapname)
@@ -139,7 +140,7 @@ level_pwad_info_t& LevelInfos::findByName(const std::string &mapname)
 			return *it;
 		}
 	}
-	return _empty;
+	return ::g_EmptyLevel;
 }
 
 level_pwad_info_t& LevelInfos::findByName(const OLumpName& mapname)
@@ -151,7 +152,7 @@ level_pwad_info_t& LevelInfos::findByName(const OLumpName& mapname)
 			return *it;
 		}
 	}
-	return _empty;
+	return ::g_EmptyLevel;
 }
 
 // Find a levelinfo by mapnum
@@ -164,7 +165,7 @@ level_pwad_info_t& LevelInfos::findByNum(int levelnum)
 			return *it;
 		}
 	}
-	return _empty;
+	return ::g_EmptyLevel;
 }
 
 // Number of info entries.
@@ -187,36 +188,6 @@ void LevelInfos::zapDeferreds()
 		it->defered = NULL;
 	}
 }
-
-// Empty levelinfo.
-level_pwad_info_t LevelInfos::_empty = {
-	"",   // mapname
-	0,    // levelnum
-	"",   // level_name
-	"",   // pname
-	"",   // nextmap
-	"",   // secretmap
-	0,    // partime
-	"",   // skypic
-	"",   // music
-	0,    // flags
-	0,    // cluster
-	NULL, // snapshot
-	NULL, // defered
-	{ 0, 0, 0, 0 },    // fadeto_color
-	{ 0xFF, 0, 0, 0 }, // outsidefog_color, 0xFF000000 is special token signaling to not handle it specially
-	"COLORMAP",        // fadetable
-	"",   // skypic2
-	0.0,  // gravity
-	0.0,  // aircontrol
-    "",	  // exitpic
-	"",	  // enterpic
-	"",	  // endpic
-    "",   // intertext
-    "",   // intertextsecret
-    "",   // interbackdrop
-    "",   // intermusic
-	};
 
 //
 // ClusterInfos methods
@@ -275,7 +246,6 @@ void ClusterInfos::clear()
 cluster_info_t& ClusterInfos::create()
 {
 	_infos.push_back(cluster_info_t());
-	_infos.back() = _empty;
 	return _infos.back();
 }
 
@@ -289,7 +259,7 @@ cluster_info_t& ClusterInfos::findByCluster(int i)
 			return *it;
 		}
 	}
-	return _empty;
+	return ::g_EmptyCluster;
 }
 
 // Number of info entries.
@@ -297,16 +267,6 @@ size_t ClusterInfos::size() const
 {
 	return _infos.size();
 }
-
-// Empty clusterinfo.
-cluster_info_t ClusterInfos::_empty = {
-	0,    // cluster
-	"",   // messagemusic
-	"",   // finaleflat
-	NULL, // exittext
-	NULL, // entertext
-	0,    // flags
-};
 
 void P_RemoveDefereds()
 {

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -224,6 +224,8 @@ struct level_pwad_info_t
 		std::copy(other.bossactions.begin(), other.bossactions.end(),
 		          bossactions.begin());
 		bossactions_donothing = other.bossactions_donothing;
+
+		return *this;
 	}
 
 	bool exists() const

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -39,43 +39,49 @@
 #define NUM_WORLDVARS			256
 #define NUM_GLOBALVARS			64
 
-enum OLevelFlags : unsigned int
-{
-	LEVEL_NOINTERMISSION = 0x00000001, 
-	LEVEL_DOUBLESKY = 0x00000004,
-	LEVEL_NOSOUNDCLIPPING = 0x00000008,
+/**
+ * @brief Level flag bitfield.
+ */
+typedef uint32_t levelFlags_t;
 
-	LEVEL_MAP07SPECIAL = 0x00000010,
-	LEVEL_BRUISERSPECIAL = 0x00000020,
-	LEVEL_CYBORGSPECIAL = 0x00000040,
-	LEVEL_SPIDERSPECIAL = 0x00000080,
+const static levelFlags_t LEVEL_NOINTERMISSION = BIT(0);
+const static levelFlags_t LEVEL_DOUBLESKY = BIT(2);
+const static levelFlags_t LEVEL_NOSOUNDCLIPPING = BIT(3);
 
-	LEVEL_SPECLOWERFLOOR = 0x00000100,
-	LEVEL_SPECOPENDOOR = 0x00000200,
-	LEVEL_SPECACTIONSMASK =0x00000300,
+const static levelFlags_t LEVEL_MAP07SPECIAL = BIT(4);
+const static levelFlags_t LEVEL_BRUISERSPECIAL = BIT(5);
+const static levelFlags_t LEVEL_CYBORGSPECIAL = BIT(6);
+const static levelFlags_t LEVEL_SPIDERSPECIAL = BIT(7);
 
-	LEVEL_MONSTERSTELEFRAG = 0x00000400,
-	LEVEL_EVENLIGHTING = 0x00000800,
-	LEVEL_SNDSEQTOTALCTRL = 0x00001000,
-	LEVEL_FORCENOSKYSTRETCH = 0x00002000,
+const static levelFlags_t LEVEL_SPECLOWERFLOOR = BIT(8);
+const static levelFlags_t LEVEL_SPECOPENDOOR = BIT(9);
+const static levelFlags_t LEVEL_SPECACTIONSMASK = BIT_MASK(LEVEL_SPECLOWERFLOOR, LEVEL_SPECOPENDOOR);
+const static levelFlags_t LEVEL_MONSTERSTELEFRAG = BIT(10);
+const static levelFlags_t LEVEL_EVENLIGHTING = BIT(11);
 
-	LEVEL_JUMP_NO = 0x00004000,
-	LEVEL_JUMP_YES = 0x00008000,
-	LEVEL_FREELOOK_NO = 0x00010000,
-	LEVEL_FREELOOK_YES = 0x00020000,
+const static levelFlags_t LEVEL_SNDSEQTOTALCTRL = BIT(12);
+const static levelFlags_t LEVEL_FORCENOSKYSTRETCH = BIT(13);
+const static levelFlags_t LEVEL_JUMP_NO = BIT(14);
+const static levelFlags_t LEVEL_JUMP_YES = BIT(15);
 
-	LEVEL_COMPAT_DROPOFF = 0x00040000,
-	LEVEL_COMPAT_NOPASSOVER = 0x00080000,
+const static levelFlags_t LEVEL_FREELOOK_NO = BIT(16);
+const static levelFlags_t LEVEL_FREELOOK_YES = BIT(17);
+const static levelFlags_t LEVEL_COMPAT_DROPOFF = BIT(18);
+const static levelFlags_t LEVEL_COMPAT_NOPASSOVER = BIT(19);
 
-	LEVEL_STARTLIGHTNING = 0x01000000,	// Automatically start lightning
-	LEVEL_FILTERSTARTS = 0x02000000,	// Apply mapthing filtering to player starts
-	LEVEL_LOBBYSPECIAL = 0x04000000,	// That level is a lobby, and has a few priorities
+ // Automatically start lightning
+const static levelFlags_t LEVEL_STARTLIGHTNING = BIT(24);
+// Apply mapthing filtering to player starts
+const static levelFlags_t LEVEL_FILTERSTARTS = BIT(25);
+// That level is a lobby, and has a few priorities
+const static levelFlags_t LEVEL_LOBBYSPECIAL = BIT(26);
 
-	LEVEL_DEFINEDINMAPINFO = 0x20000000, // Level was defined in a MAPINFO lump
-	LEVEL_CHANGEMAPCHEAT = 0x40000000,	// Don't display cluster messages
-	LEVEL_VISITED = 0x80000000,			// Used for intermission map
-
-};
+ // Level was defined in a MAPINFO lump
+const static levelFlags_t LEVEL_DEFINEDINMAPINFO = BIT(29);
+// Don't display cluster messages
+const static levelFlags_t LEVEL_CHANGEMAPCHEAT = BIT(30);
+// Used for intermission map
+const static levelFlags_t LEVEL_VISITED = BIT(31);
 
 struct acsdefered_s;
 class FBehavior;

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -325,8 +325,8 @@ extern level_locals_t level;
 class LevelInfos
 {
 	typedef std::vector<level_pwad_info_t> _LevelInfoArray;
-	const level_info_t* _defaultInfos;
-	std::vector<level_pwad_info_t> _infos;
+	const level_info_t* m_defaultInfos;
+	std::vector<level_pwad_info_t> m_infos;
 public:
 	LevelInfos(const level_info_t* levels);
 	~LevelInfos();
@@ -346,8 +346,8 @@ public:
 class ClusterInfos
 {
 	typedef std::vector<cluster_info_t> _ClusterInfoArray;
-	const cluster_info_t* _defaultInfos;
-	std::vector<cluster_info_t> _infos;
+	const cluster_info_t* m_defaultInfos;
+	std::vector<cluster_info_t> m_infos;
 public:
 	ClusterInfos(const cluster_info_t* clusters);
 	~ClusterInfos();

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -295,8 +295,10 @@ struct level_locals_t
 	
 };
 
-#define CLUSTER_HUB            0x00000001u
-#define CLUSTER_EXITTEXTISLUMP 0x00000002u
+typedef uint32_t clusterFlags_t;
+
+const static clusterFlags_t CLUSTER_HUB = BIT(0);
+const static clusterFlags_t CLUSTER_EXITTEXTISLUMP = BIT(1);
 
 struct OBossAction
 {

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -901,6 +901,20 @@ void MIType_LumpName(OScanner& os, bool doEquals, void* data, unsigned int flags
 	*static_cast<OLumpName*>(data) = os.getToken();
 }
 
+// Handle lump names that can also be intermission scripts
+void MIType_InterLumpName(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                          unsigned int flags2)
+{
+	ParseMapInfoHelper<std::string>(os, doEquals);
+	std::string tok = os.getToken();
+	if (!tok.empty() && tok.at(0) == '$')
+	{
+		// Intermission scripts are not supported.
+		return;
+	}
+	*static_cast<OLumpName*>(data) = tok;
+}
+
 // Sets the inputted data as an OLumpName, checking LANGUAGE for the actual OLumpName
 void MIType_$LumpName(OScanner& os, bool doEquals, void* data, unsigned int flags,
                       unsigned int flags2)
@@ -1192,9 +1206,9 @@ struct MapInfoDataSetter<level_pwad_info_t>
 		ENTRY2("intermusic", &MIType_EatNext)
 		ENTRY3("par", &MIType_Int, &ref.partime)
 		ENTRY2("sucktime", &MIType_EatNext)
-		ENTRY3("enterpic", &MIType_LumpName,
+		ENTRY3("enterpic", &MIType_InterLumpName,
 		       &ref.enterpic) // todo: add intermission script support
-		ENTRY3("exitpic", &MIType_LumpName,
+		ENTRY3("exitpic", &MIType_InterLumpName,
 		       &ref.exitpic) // todo: add intermission script support
 		ENTRY2("interpic", &MIType_EatNext)
 		ENTRY2("translator", &MIType_EatNext)

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -162,21 +162,21 @@ T GetToken(OScanner& os)
 template <>
 int GetToken<int>(OScanner& os)
 {
-	return os.getTokenAsBool();
+	return os.getTokenBool();
 }
 
 // return token as float
 template <>
 float GetToken<float>(OScanner& os)
 {
-	return os.getTokenAsFloat();
+	return os.getTokenFloat();
 }
 
 // return token as bool
 template <>
 bool GetToken<bool>(OScanner& os)
 {
-	return os.getTokenAsBool();
+	return os.getTokenBool();
 }
 
 // return token as std::string
@@ -216,35 +216,35 @@ void MustGet(OScanner& os)
 template <>
 void MustGet<int>(OScanner& os)
 {
-	os.mustGetInt();
+	os.mustScanInt();
 }
 
 // ensure token is float
 template <>
 void MustGet<float>(OScanner& os)
 {
-	os.mustGetFloat();
+	os.mustScanFloat();
 }
 
 // ensure token is bool
 template <>
 void MustGet<bool>(OScanner& os)
 {
-	os.mustGetBool();
+	os.mustScanBool();
 }
 
 // ensure token is std::string
 template <>
 void MustGet<std::string>(OScanner& os)
 {
-	os.mustGetString();
+	os.mustScan();
 }
 
 // ensure token is OLumpName
 template <>
 void MustGet<OLumpName>(OScanner& os)
 {
-	os.mustGetString();
+	os.mustScan();
 
 	if (os.getToken().length() > 8)
 	{

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -162,7 +162,7 @@ T GetToken(OScanner& os)
 template <>
 int GetToken<int>(OScanner& os)
 {
-	return os.getTokenBool();
+	return os.getTokenInt();
 }
 
 // return token as float

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -20,12 +20,12 @@
 
 #include "cmdlib.h"
 #include "doomdef.h"
-#include "doomtype.h"
 #include "doomstat.h"
-#include "gi.h"
-#include "gstrings.h"
+#include "doomtype.h"
 #include "g_episode.h"
 #include "g_level.h"
+#include "gi.h"
+#include "gstrings.h"
 #include "i_system.h"
 #include "oscanner.h"
 #include "p_setup.h"
@@ -39,1718 +39,1601 @@ BOOL HexenHack;
 
 namespace
 {
-	// [DE] used for UMAPINFO's boss actions
-	const char* const ActorNames[] =
-	{
-		"DoomPlayer",
-		"ZombieMan",
-		"ShotgunGuy",
-		"Archvile",
-		"ArchvileFire",
-		"Revenant",
-		"RevenantTracer",
-		"RevenantTracerSmoke",
-		"Fatso",
-		"FatShot",
-		"ChaingunGuy",
-		"DoomImp",
-		"Demon",
-		"Spectre",
-		"Cacodemon",
-		"BaronOfHell",
-		"BaronBall",
-		"HellKnight",
-		"LostSoul",
-		"SpiderMastermind",
-		"Arachnotron",
-		"Cyberdemon",
-		"PainElemental",
-		"WolfensteinSS",
-		"CommanderKeen",
-		"BossBrain",
-		"BossEye",
-		"BossTarget",
-		"SpawnShot",
-		"SpawnFire",
-		"ExplosiveBarrel",
-		"DoomImpBall",
-		"CacodemonBall",
-		"Rocket",
-		"PlasmaBall",
-		"BFGBall",
-		"ArachnotronPlasma",
-		"BulletPuff",
-		"Blood",
-		"TeleportFog",
-		"ItemFog",
-		"TeleportDest",
-		"BFGExtra",
-		"GreenArmor",
-		"BlueArmor",
-		"HealthBonus",
-		"ArmorBonus",
-		"BlueCard",
-		"RedCard",
-		"YellowCard",
-		"YellowSkull",
-		"RedSkull",
-		"BlueSkull",
-		"Stimpack",
-		"Medikit",
-		"Soulsphere",
-		"InvulnerabilitySphere",
-		"Berserk",
-		"BlurSphere",
-		"RadSuit",
-		"Allmap",
-		"Infrared",
-		"Megasphere",
-		"Clip",
-		"ClipBox",
-		"RocketAmmo",
-		"RocketBox",
-		"Cell",
-		"CellPack",
-		"Shell",
-		"ShellBox",
-		"Backpack",
-		"BFG9000",
-		"Chaingun",
-		"Chainsaw",
-		"RocketLauncher",
-		"PlasmaRifle",
-		"Shotgun",
-		"SuperShotgun",
-		"TechLamp",
-		"TechLamp2",
-		"Column",
-		"TallGreenColumn",
-		"ShortGreenColumn",
-		"TallRedColumn",
-		"ShortRedColumn",
-		"SkullColumn",
-		"HeartColumn",
-		"EvilEye",
-		"FloatingSkull",
-		"TorchTree",
-		"BlueTorch",
-		"GreenTorch",
-		"RedTorch",
-		"ShortBlueTorch",
-		"ShortGreenTorch",
-		"ShortRedTorch",
-		"Stalagtite",
-		"TechPillar",
-		"CandleStick",
-		"Candelabra",
-		"BloodyTwitch",
-		"Meat2",
-		"Meat3",
-		"Meat4",
-		"Meat5",
-		"NonsolidMeat2",
-		"NonsolidMeat4",
-		"NonsolidMeat3",
-		"NonsolidMeat5",
-		"NonsolidTwitch",
-		"DeadCacodemon",
-		"DeadMarine",
-		"DeadZombieMan",
-		"DeadDemon",
-		"DeadLostSoul",
-		"DeadDoomImp",
-		"DeadShotgunGuy",
-		"GibbedMarine",
-		"GibbedMarineExtra",
-		"HeadsOnAStick",
-		"Gibs",
-		"HeadOnAStick",
-		"HeadCandles",
-		"DeadStick",
-		"LiveStick",
-		"BigTree",
-		"BurningBarrel",
-		"HangNoGuts",
-		"HangBNoBrain",
-		"HangTLookingDown",
-		"HangTSkull",
-		"HangTLookingUp",
-		"HangTNoBrain",
-		"ColonGibs",
-		"SmallBloodPool",
-		"BrainStem",
-		//Boom/MBF additions
-		"PointPusher",
-		"PointPuller",
-		"MBFHelperDog",
-		"PlasmaBall1",
-		"PlasmaBall2",
-		"EvilSceptre",
-		"UnholyBible",
-		NULL
-	};
+// [DE] used for UMAPINFO's boss actions
+const char* const ActorNames[] = {
+    "DoomPlayer", "ZombieMan", "ShotgunGuy", "Archvile", "ArchvileFire", "Revenant",
+    "RevenantTracer", "RevenantTracerSmoke", "Fatso", "FatShot", "ChaingunGuy", "DoomImp",
+    "Demon", "Spectre", "Cacodemon", "BaronOfHell", "BaronBall", "HellKnight", "LostSoul",
+    "SpiderMastermind", "Arachnotron", "Cyberdemon", "PainElemental", "WolfensteinSS",
+    "CommanderKeen", "BossBrain", "BossEye", "BossTarget", "SpawnShot", "SpawnFire",
+    "ExplosiveBarrel", "DoomImpBall", "CacodemonBall", "Rocket", "PlasmaBall", "BFGBall",
+    "ArachnotronPlasma", "BulletPuff", "Blood", "TeleportFog", "ItemFog", "TeleportDest",
+    "BFGExtra", "GreenArmor", "BlueArmor", "HealthBonus", "ArmorBonus", "BlueCard",
+    "RedCard", "YellowCard", "YellowSkull", "RedSkull", "BlueSkull", "Stimpack",
+    "Medikit", "Soulsphere", "InvulnerabilitySphere", "Berserk", "BlurSphere", "RadSuit",
+    "Allmap", "Infrared", "Megasphere", "Clip", "ClipBox", "RocketAmmo", "RocketBox",
+    "Cell", "CellPack", "Shell", "ShellBox", "Backpack", "BFG9000", "Chaingun",
+    "Chainsaw", "RocketLauncher", "PlasmaRifle", "Shotgun", "SuperShotgun", "TechLamp",
+    "TechLamp2", "Column", "TallGreenColumn", "ShortGreenColumn", "TallRedColumn",
+    "ShortRedColumn", "SkullColumn", "HeartColumn", "EvilEye", "FloatingSkull",
+    "TorchTree", "BlueTorch", "GreenTorch", "RedTorch", "ShortBlueTorch",
+    "ShortGreenTorch", "ShortRedTorch", "Stalagtite", "TechPillar", "CandleStick",
+    "Candelabra", "BloodyTwitch", "Meat2", "Meat3", "Meat4", "Meat5", "NonsolidMeat2",
+    "NonsolidMeat4", "NonsolidMeat3", "NonsolidMeat5", "NonsolidTwitch", "DeadCacodemon",
+    "DeadMarine", "DeadZombieMan", "DeadDemon", "DeadLostSoul", "DeadDoomImp",
+    "DeadShotgunGuy", "GibbedMarine", "GibbedMarineExtra", "HeadsOnAStick", "Gibs",
+    "HeadOnAStick", "HeadCandles", "DeadStick", "LiveStick", "BigTree", "BurningBarrel",
+    "HangNoGuts", "HangBNoBrain", "HangTLookingDown", "HangTSkull", "HangTLookingUp",
+    "HangTNoBrain", "ColonGibs", "SmallBloodPool", "BrainStem",
+    // Boom/MBF additions
+    "PointPusher", "PointPuller", "MBFHelperDog", "PlasmaBall1", "PlasmaBall2",
+    "EvilSceptre", "UnholyBible", NULL};
 
-	void SetLevelDefaults(level_pwad_info_t& levelinfo)
+void SetLevelDefaults(level_pwad_info_t& levelinfo)
+{
+	levelinfo = level_pwad_info_t();
+}
+
+//
+// Assumes that you have munched the last parameter you know how to handle,
+// but have not yet munched a comma.
+//
+void SkipUnknownParams(OScanner& os)
+{
+	// Every loop, try to burn a comma.
+	while (os.scan())
 	{
-		levelinfo = level_pwad_info_t();
-	}
-	
-	//
-	// Assumes that you have munched the last parameter you know how to handle,
-	// but have not yet munched a comma.
-	//
-	void SkipUnknownParams(OScanner& os)
-	{
-		// Every loop, try to burn a comma.
-		while (os.scan())
-		{
-			if (!os.compareToken(","))
-			{
-				os.unScan();
-				return;
-			}
-	
-			// Burn the parameter.
-			os.scan();
-		}
-	}
-	
-	//
-	// Assumes that you have already munched the unknown type name, and just need
-	// to much parameters, if any.
-	//
-	void SkipUnknownType(OScanner& os)
-	{
-		os.scan();
-		if (!os.compareToken("="))
+		if (!os.compareToken(","))
 		{
 			os.unScan();
 			return;
 		}
-	
-		os.scan(); // Get the first parameter
-		SkipUnknownParams(os);
-	}
-	
-	//
-	// Assumes you have already munched the first opening brace.
-	//
-	// This function does not work with old-school ZDoom MAPINFO.
-	//
-	void SkipUnknownBlock(OScanner& os)
-	{
-		int stack = 0;
-	
-		while (os.scan())
-		{
-			if (os.compareToken("{"))
-			{
-				// Found another block
-				stack++;
-			}
-			else if (os.compareToken("}"))
-			{
-				stack--;
-				if (stack <= 0)
-				{
-					// Done with all blocks
-					break;
-				}
-			}
-		}
-	}
 
-	// [DE] Below are helper functions for UMAPINFO and Z/MAPINFO parsing, partially to stand
-	// in for
-	// the way sc_man did things before
-
-	bool UpperCompareToken(OScanner& os, const char* str)
-    {
-	    return iequals(os.getToken(), str);
-    }
-
-	//////////////////////////////////////////////////////////////////////
-	/// GetToken
-
-	template <typename T>
-    T GetToken(OScanner& os)
-	{
-	    I_FatalError("Templated function GetToken templated with non-existant specialized type!");
-	}
-
-    // return token as int
-	template <>
-	int GetToken<int>(OScanner& os)
-	{
-	    return os.getTokenAsBool();
-	}
-	
-	// return token as float
-	template <>
-	float GetToken<float>(OScanner& os)
-	{
-		return os.getTokenAsFloat();
-	}
-
-	// return token as bool
-	template <>
-	bool GetToken<bool>(OScanner& os)
-    {
-	    return os.getTokenAsBool();
-    }
-
-	// return token as std::string
-	template <>
-    std::string GetToken<std::string>(OScanner& os)
-	{
-	    return os.getToken();
-	}
-
-	// return token as OLumpName
-    template <>
-    OLumpName GetToken<OLumpName>(OScanner& os)
-    {
-	    return os.getToken();
-    }
-
-	//////////////////////////////////////////////////////////////////////
-    /// MustGet
-
-	// ensure token is string
-    void MustGetString(OScanner& os)
-    {
-	    if (!os.scan())
-	    {
-		    I_Error("Missing string (unexpected end of file).");
-	    }
-    }
-
-	template <typename T>
-    void MustGet(OScanner &os)
-	{
-	    I_FatalError("Templated function MustGet templated with non-existant specialized type!");
-	}
-
-	// ensure token is int
-	template <>
-	void MustGet<int>(OScanner& os)
-	{
-	    os.mustGetInt();
-	}
-
-	// ensure token is float
-	template <>
-	void MustGet<float>(OScanner& os)
-	{
-	    os.mustGetFloat();
-	}
-
-	// ensure token is bool
-	template <>
-	void MustGet<bool>(OScanner& os)
-    {
-	    os.mustGetBool();
-    }
-
-	// ensure token is std::string
-	template <>
-    void MustGet<std::string>(OScanner& os)
-    {
-	    os.mustGetString();
-    }
-
-    // ensure token is OLumpName
-    template <>
-    void MustGet<OLumpName>(OScanner& os)
-    {
-	    os.mustGetString();
-
-		if (os.getToken().length() > 8)
-	    {
-		    I_Error("Lump name \"%s\" too long. Maximum size is 8 characters.", os.getToken().c_str());
-	    }
-    }
-
-	//////////////////////////////////////////////////////////////////////
-    /// Misc
-
-	bool IsIdentifier(OScanner& os)
-	{
-		const char &ch = os.getToken()[0];
-	
-		return (ch == '_' || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z'));
-	}
-	
-	void MustGetIdentifier(OScanner& os)
-	{
-		MustGetString(os);
-		if (!IsIdentifier(os))
-		{
-			I_Error("Expected identifier (unexpected end of file).");
-		}
-	}
-	
-	bool ContainsMapInfoTopLevel(OScanner& os)
-	{
-		return UpperCompareToken(os, "map") ||
-			   UpperCompareToken(os, "defaultmap") ||
-		       UpperCompareToken(os, "cluster") ||
-			   UpperCompareToken(os, "clusterdef") ||
-		       UpperCompareToken(os, "episode") ||
-			   UpperCompareToken(os, "clearepisodes") ||
-		       UpperCompareToken(os, "skill") ||
-			   UpperCompareToken(os, "clearskills") ||
-		       UpperCompareToken(os, "gameinfo") ||
-			   UpperCompareToken(os, "intermission") ||
-		       UpperCompareToken(os, "automap");
-	}
-	
-	void MustGetStringName(OScanner& os, const char* name)
-	{
-		MustGetString(os);
-		if (UpperCompareToken(os, name) == false)
-		{
-			I_Error("Expected '%s', got '%s'.", name, os.getToken().c_str());
-		}
-	}
-	
-	// used for munching the strings in UMAPINFO
-	char* ParseMultiString(OScanner& os)
-	{
-		char* build = NULL;
-	
+		// Burn the parameter.
 		os.scan();
-		// TODO: properly identify identifiers so clear can be separated from regular strings
-		if (!os.isQuotedString())
-		{
-			if (UpperCompareToken(os, "clear"))
-			{
-				return strdup("-"); // this was explicitly deleted to override the default.
-			}
-	
-			// I_Error("Either 'clear' or string constant expected");
-		}
+	}
+}
+
+//
+// Assumes that you have already munched the unknown type name, and just need
+// to much parameters, if any.
+//
+void SkipUnknownType(OScanner& os)
+{
+	os.scan();
+	if (!os.compareToken("="))
+	{
 		os.unScan();
-	
+		return;
+	}
+
+	os.scan(); // Get the first parameter
+	SkipUnknownParams(os);
+}
+
+//
+// Assumes you have already munched the first opening brace.
+//
+// This function does not work with old-school ZDoom MAPINFO.
+//
+void SkipUnknownBlock(OScanner& os)
+{
+	int stack = 0;
+
+	while (os.scan())
+	{
+		if (os.compareToken("{"))
+		{
+			// Found another block
+			stack++;
+		}
+		else if (os.compareToken("}"))
+		{
+			stack--;
+			if (stack <= 0)
+			{
+				// Done with all blocks
+				break;
+			}
+		}
+	}
+}
+
+// [DE] Below are helper functions for UMAPINFO and Z/MAPINFO parsing, partially to stand
+// in for
+// the way sc_man did things before
+
+bool UpperCompareToken(OScanner& os, const char* str)
+{
+	return iequals(os.getToken(), str);
+}
+
+//////////////////////////////////////////////////////////////////////
+/// GetToken
+
+template <typename T>
+T GetToken(OScanner& os)
+{
+	I_FatalError(
+	    "Templated function GetToken templated with non-existant specialized type!");
+}
+
+// return token as int
+template <>
+int GetToken<int>(OScanner& os)
+{
+	return os.getTokenAsBool();
+}
+
+// return token as float
+template <>
+float GetToken<float>(OScanner& os)
+{
+	return os.getTokenAsFloat();
+}
+
+// return token as bool
+template <>
+bool GetToken<bool>(OScanner& os)
+{
+	return os.getTokenAsBool();
+}
+
+// return token as std::string
+template <>
+std::string GetToken<std::string>(OScanner& os)
+{
+	return os.getToken();
+}
+
+// return token as OLumpName
+template <>
+OLumpName GetToken<OLumpName>(OScanner& os)
+{
+	return os.getToken();
+}
+
+//////////////////////////////////////////////////////////////////////
+/// MustGet
+
+// ensure token is string
+void MustGetString(OScanner& os)
+{
+	if (!os.scan())
+	{
+		I_Error("Missing string (unexpected end of file).");
+	}
+}
+
+template <typename T>
+void MustGet(OScanner& os)
+{
+	I_FatalError(
+	    "Templated function MustGet templated with non-existant specialized type!");
+}
+
+// ensure token is int
+template <>
+void MustGet<int>(OScanner& os)
+{
+	os.mustGetInt();
+}
+
+// ensure token is float
+template <>
+void MustGet<float>(OScanner& os)
+{
+	os.mustGetFloat();
+}
+
+// ensure token is bool
+template <>
+void MustGet<bool>(OScanner& os)
+{
+	os.mustGetBool();
+}
+
+// ensure token is std::string
+template <>
+void MustGet<std::string>(OScanner& os)
+{
+	os.mustGetString();
+}
+
+// ensure token is OLumpName
+template <>
+void MustGet<OLumpName>(OScanner& os)
+{
+	os.mustGetString();
+
+	if (os.getToken().length() > 8)
+	{
+		I_Error("Lump name \"%s\" too long. Maximum size is 8 characters.",
+		        os.getToken().c_str());
+	}
+}
+
+//////////////////////////////////////////////////////////////////////
+/// Misc
+
+bool IsIdentifier(OScanner& os)
+{
+	const char& ch = os.getToken()[0];
+
+	return (ch == '_' || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z'));
+}
+
+void MustGetIdentifier(OScanner& os)
+{
+	MustGetString(os);
+	if (!IsIdentifier(os))
+	{
+		I_Error("Expected identifier (unexpected end of file).");
+	}
+}
+
+bool ContainsMapInfoTopLevel(OScanner& os)
+{
+	return UpperCompareToken(os, "map") || UpperCompareToken(os, "defaultmap") ||
+	       UpperCompareToken(os, "cluster") || UpperCompareToken(os, "clusterdef") ||
+	       UpperCompareToken(os, "episode") || UpperCompareToken(os, "clearepisodes") ||
+	       UpperCompareToken(os, "skill") || UpperCompareToken(os, "clearskills") ||
+	       UpperCompareToken(os, "gameinfo") || UpperCompareToken(os, "intermission") ||
+	       UpperCompareToken(os, "automap");
+}
+
+void MustGetStringName(OScanner& os, const char* name)
+{
+	MustGetString(os);
+	if (UpperCompareToken(os, name) == false)
+	{
+		I_Error("Expected '%s', got '%s'.", name, os.getToken().c_str());
+	}
+}
+
+// used for munching the strings in UMAPINFO
+char* ParseMultiString(OScanner& os)
+{
+	char* build = NULL;
+
+	os.scan();
+	// TODO: properly identify identifiers so clear can be separated from regular strings
+	if (!os.isQuotedString())
+	{
+		if (UpperCompareToken(os, "clear"))
+		{
+			return strdup("-"); // this was explicitly deleted to override the default.
+		}
+
+		// I_Error("Either 'clear' or string constant expected");
+	}
+	os.unScan();
+
+	do
+	{
+		MustGetString(os);
+
+		if (build == NULL)
+			build = strdup(os.getToken().c_str());
+		else
+		{
+			size_t newlen = strlen(build) + os.getToken().length() +
+			                2; // strlen for both the existing text and the new line, plus
+			                   // room for one \n and one \0
+			build = (char*)realloc(
+			    build, newlen);  // Prepare the destination memory for the below strcats
+			strcat(build, "\n"); // Replace the existing text's \0 terminator with a \n
+			strcat(
+			    build,
+			    os.getToken().c_str()); // Concatenate the new line onto the existing text
+		}
+		os.scan();
+	} while (os.compareToken(","));
+	os.unScan();
+
+	return build;
+}
+
+void ParseOLumpName(OScanner& os, OLumpName& buffer)
+{
+	MustGet<OLumpName>(os);
+	buffer = os.getToken();
+}
+
+int ValidateMapName(const OLumpName& mapname, int* pEpi = NULL, int* pMap = NULL)
+{
+	// Check if the given map name can be expressed as a gameepisode/gamemap pair and be
+	// reconstructed from it.
+	char lumpname[9];
+	int epi = -1, map = -1;
+
+	if (gamemode != commercial)
+	{
+		if (sscanf(mapname.c_str(), "E%dM%d", &epi, &map) != 2)
+			return 0;
+		snprintf(lumpname, 9, "E%dM%d", epi, map);
+	}
+	else
+	{
+		if (sscanf(mapname.c_str(), "MAP%d", &map) != 1)
+			return 0;
+		snprintf(lumpname, 9, "MAP%02d", map);
+		epi = 1;
+	}
+	if (pEpi)
+		*pEpi = epi;
+	if (pMap)
+		*pMap = map;
+	return !strcmp(mapname.c_str(), lumpname);
+}
+
+int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
+{
+	// find the next line with content.
+	// this line is no property.
+
+	if (!IsIdentifier(os))
+	{
+		I_Error("Expected identifier");
+	}
+	char* pname = strdup(os.getToken().c_str());
+	MustGetStringName(os, "=");
+
+	if (!stricmp(pname, "levelname"))
+	{
+		MustGetString(os);
+		mape->level_name = strdup(os.getToken().c_str());
+	}
+	else if (!stricmp(pname, "next"))
+	{
+		ParseOLumpName(os, mape->nextmap);
+		if (!ValidateMapName(mape->nextmap.c_str()))
+		{
+			I_Error("Invalid map name %s.", mape->nextmap.c_str());
+			return 0;
+		}
+	}
+	else if (!stricmp(pname, "nextsecret"))
+	{
+		ParseOLumpName(os, mape->secretmap);
+		if (!ValidateMapName(mape->secretmap.c_str()))
+		{
+			I_Error("Invalid map name %s", mape->nextmap.c_str());
+			return 0;
+		}
+	}
+	else if (!stricmp(pname, "levelpic"))
+	{
+		ParseOLumpName(os, mape->pname);
+	}
+	else if (!stricmp(pname, "skytexture"))
+	{
+		ParseOLumpName(os, mape->skypic);
+	}
+	else if (!stricmp(pname, "music"))
+	{
+		ParseOLumpName(os, mape->music);
+	}
+	else if (!stricmp(pname, "endpic"))
+	{
+		ParseOLumpName(os, mape->endpic);
+		mape->nextmap = "EndGame1";
+	}
+	else if (!stricmp(pname, "endcast"))
+	{
+		MustGet<bool>(os);
+		if (GetToken<bool>(os))
+			mape->nextmap = "EndGameC";
+		else
+			mape->endpic.clear();
+	}
+	else if (!stricmp(pname, "endbunny"))
+	{
+		MustGet<bool>(os);
+		if (GetToken<bool>(os))
+			mape->nextmap = "EndGame3";
+		else
+			mape->endpic.clear();
+	}
+	else if (!stricmp(pname, "endgame"))
+	{
+		MustGet<bool>(os);
+		if (GetToken<bool>(os))
+		{
+			mape->endpic = "!";
+		}
+		else
+		{
+			mape->endpic.clear();
+		}
+	}
+	else if (!stricmp(pname, "exitpic"))
+	{
+		ParseOLumpName(os, mape->exitpic);
+	}
+	else if (!stricmp(pname, "enterpic"))
+	{
+		ParseOLumpName(os, mape->enterpic);
+	}
+	else if (!stricmp(pname, "nointermission"))
+	{
+		MustGet<bool>(os);
+		if (GetToken<bool>(os))
+		{
+			mape->flags |= LEVEL_NOINTERMISSION;
+		}
+	}
+	else if (!stricmp(pname, "partime"))
+	{
+		MustGet<int>(os);
+		mape->partime = TICRATE * GetToken<int>(os);
+	}
+	else if (!stricmp(pname, "intertext"))
+	{
+		char* lname = ParseMultiString(os);
+		if (!lname)
+			return 0;
+		mape->intertext = lname;
+	}
+	else if (!stricmp(pname, "intertextsecret"))
+	{
+		char* lname = ParseMultiString(os);
+		if (!lname)
+			return 0;
+		mape->intertextsecret = lname;
+	}
+	else if (!stricmp(pname, "interbackdrop"))
+	{
+		ParseOLumpName(os, mape->interbackdrop);
+	}
+	else if (!stricmp(pname, "intermusic"))
+	{
+		ParseOLumpName(os, mape->intermusic);
+	}
+	else if (!stricmp(pname, "episode"))
+	{
+		if (!episodes_modified && gamemode == commercial)
+		{
+			episodenum = 0;
+			episodes_modified = true;
+		}
+
+		char* lname = ParseMultiString(os);
+		if (!lname)
+			return 0;
+
+		if (*lname == '-') // means "clear"
+		{
+			episodenum = 0;
+		}
+		else
+		{
+			const char* gfx = std::strtok(lname, "\n");
+			const char* txt = std::strtok(NULL, "\n");
+			const char* alpha = std::strtok(NULL, "\n");
+
+			if (episodenum >= 8)
+			{
+				return 0;
+			}
+
+			strncpy(EpisodeMaps[episodenum], mape->mapname.c_str(), 8);
+			EpisodeInfos[episodenum].name = gfx;
+			EpisodeInfos[episodenum].fulltext = false;
+			EpisodeInfos[episodenum].noskillmenu = false;
+			EpisodeInfos[episodenum].key = alpha ? *alpha : 0;
+			++episodenum;
+		}
+	}
+	else if (!stricmp(pname, "bossaction"))
+	{
+		MustGetIdentifier(os);
+
+		if (!stricmp(os.getToken().c_str(), "clear"))
+		{
+			// mark level free of boss actions
+			mape->bossactions.clear();
+			mape->bossactions_donothing = true;
+		}
+		else
+		{
+			int i;
+
+			// remove comma from token
+			std::string actor_name = os.getToken();
+			actor_name[actor_name.length() - 1] = '\0';
+
+			for (i = 0; ActorNames[i]; i++)
+			{
+				if (!stricmp(actor_name.c_str(), ActorNames[i]))
+					break;
+			}
+			if (ActorNames[i] == NULL)
+			{
+				I_Error("Unknown thing type %s", os.getToken().c_str());
+				return 0;
+			}
+
+			// skip comma token
+			// MustGetStringName(os, ",");
+			MustGet<int>(os);
+			const int special = GetToken<int>(os);
+			// MustGetStringName(os, ",");
+			MustGet<int>(os);
+			const int tag = GetToken<int>(os);
+			// allow no 0-tag specials here, unless a level exit.
+			if (tag != 0 || special == 11 || special == 51 || special == 52 ||
+			    special == 124)
+			{
+				if (mape->bossactions_donothing == true)
+					mape->bossactions_donothing = false;
+
+				OBossAction new_bossaction;
+
+				maplinedef_t mld;
+				mld.special = static_cast<short>(special);
+				mld.tag = static_cast<short>(tag);
+				P_TranslateLineDef(&new_bossaction.ld, &mld);
+
+				new_bossaction.type = i;
+
+				mape->bossactions.push_back(new_bossaction);
+			}
+		}
+	}
+	else
+	{
 		do
 		{
-			MustGetString(os);
-	
-			if (build == NULL)
-				build = strdup(os.getToken().c_str());
-			else
-			{
-				size_t newlen = strlen(build) + os.getToken().length() +
-				                2; // strlen for both the existing text and the new line, plus
-				                   // room for one \n and one \0
-				build = (char*)realloc(
-				    build, newlen);  // Prepare the destination memory for the below strcats
-				strcat(build, "\n"); // Replace the existing text's \0 terminator with a \n
-				strcat(
-				    build,
-				    os.getToken().c_str()); // Concatenate the new line onto the existing text
-			}
-			os.scan();
+			if (!IsRealNum(os.getToken().c_str()))
+				os.scan();
+
 		} while (os.compareToken(","));
-		os.unScan();
-	
-		return build;
 	}
-	
-	void ParseOLumpName(OScanner& os, OLumpName& buffer)
+	free(pname);
+	os.scan();
+
+	return 1;
+}
+
+void MapNameToLevelNum(level_pwad_info_t& info)
+{
+	if (info.mapname[0] == 'E' && info.mapname[2] == 'M')
 	{
+		// Convert a char into its equivalent integer.
+		const int e = info.mapname[1] - '0';
+		const int m = info.mapname[3] - '0';
+		if (e >= 0 && e <= 9 && m >= 0 && m <= 9)
+		{
+			// Copypasted from the ZDoom wiki.
+			info.levelnum = (e - 1) * 10 + m;
+		}
+	}
+	else if (strnicmp(info.mapname.c_str(), "MAP", 3) == 0)
+	{
+		// Try and turn the trailing digits after the "MAP" into a
+		// level number.
+		int mapnum = std::atoi(info.mapname.c_str() + 3);
+		if (mapnum >= 0 && mapnum <= 99)
+		{
+			info.levelnum = mapnum;
+		}
+	}
+}
+
+void ParseUMapInfoLump(int lump, const char* lumpname)
+{
+	LevelInfos& levels = getLevelInfos();
+
+	level_pwad_info_t defaultinfo;
+	SetLevelDefaults(defaultinfo);
+
+	const char* buffer = static_cast<char*>(W_CacheLumpNum(lump, PU_STATIC));
+
+	OScannerConfig config = {
+	    lumpname, // lumpName
+	    false,    // semiComments
+	    true,     // cComments
+	};
+	OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));
+
+	while (os.scan())
+	{
+		if (!UpperCompareToken(os, "map"))
+		{
+			I_Error("Expected map definition, got %s", os.getToken().c_str());
+		}
+
 		MustGet<OLumpName>(os);
-		buffer = os.getToken();
-	}
-	
-	int ValidateMapName(const OLumpName& mapname, int* pEpi = NULL, int* pMap = NULL)
-	{
-		// Check if the given map name can be expressed as a gameepisode/gamemap pair and be
-		// reconstructed from it.
-		char lumpname[9];
-		int epi = -1, map = -1;
-	
-		if (gamemode != commercial)
+		OLumpName mapname = GetToken<OLumpName>(os);
+
+		if (!ValidateMapName(mapname))
 		{
-		    if (sscanf(mapname.c_str(), "E%dM%d", &epi, &map) != 2)
-				return 0;
-			snprintf(lumpname, 9, "E%dM%d", epi, map);
+			I_Error("Invalid map name %s", mapname.c_str());
 		}
-		else
-		{
-		    if (sscanf(mapname.c_str(), "MAP%d", &map) != 1)
-				return 0;
-			snprintf(lumpname, 9, "MAP%02d", map);
-			epi = 1;
-		}
-		if (pEpi)
-			*pEpi = epi;
-		if (pMap)
-			*pMap = map;
-	    return !strcmp(mapname.c_str(), lumpname);
-	}
-	
-	int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
-	{
-		// find the next line with content.
-		// this line is no property.
-	
-		if (!IsIdentifier(os))
-		{
-			I_Error("Expected identifier");
-		}
-		char* pname = strdup(os.getToken().c_str());
-		MustGetStringName(os, "=");
-	
-		if (!stricmp(pname, "levelname"))
-		{
-			MustGetString(os);
-			mape->level_name = strdup(os.getToken().c_str());
-		}
-		else if (!stricmp(pname, "next"))
-		{
-			ParseOLumpName(os, mape->nextmap);
-			if (!ValidateMapName(mape->nextmap.c_str()))
-			{
-				I_Error("Invalid map name %s.", mape->nextmap.c_str());
-				return 0;
-			}
-		}
-		else if (!stricmp(pname, "nextsecret"))
-		{
-			ParseOLumpName(os, mape->secretmap);
-			if (!ValidateMapName(mape->secretmap.c_str()))
-			{
-				I_Error("Invalid map name %s", mape->nextmap.c_str());
-				return 0;
-			}
-		}
-		else if (!stricmp(pname, "levelpic"))
-		{
-			ParseOLumpName(os, mape->pname);
-		}
-		else if (!stricmp(pname, "skytexture"))
-		{
-			ParseOLumpName(os, mape->skypic);
-		}
-		else if (!stricmp(pname, "music"))
-		{
-			ParseOLumpName(os, mape->music);
-		}
-		else if (!stricmp(pname, "endpic"))
-		{
-			ParseOLumpName(os, mape->endpic);
-			mape->nextmap = "EndGame1";
-		}
-		else if (!stricmp(pname, "endcast"))
-		{
-			MustGet<bool>(os);
-		    if (GetToken<bool>(os))
-				mape->nextmap = "EndGameC";
-			else
-				mape->endpic.clear();
-		}
-		else if (!stricmp(pname, "endbunny"))
-		{
-			MustGet<bool>(os);
-		    if (GetToken<bool>(os))
-				mape->nextmap = "EndGame3";
-			else
-				mape->endpic.clear();
-		}
-		else if (!stricmp(pname, "endgame"))
-		{
-			MustGet<bool>(os);
-		    if (GetToken<bool>(os))
-			{
-				mape->endpic = "!";
-			}
-			else
-			{
-				mape->endpic.clear();
-			}
-		}
-		else if (!stricmp(pname, "exitpic"))
-		{
-			ParseOLumpName(os, mape->exitpic);
-		}
-		else if (!stricmp(pname, "enterpic"))
-		{
-			ParseOLumpName(os, mape->enterpic);
-		}
-		else if (!stricmp(pname, "nointermission"))
-		{
-			MustGet<bool>(os);
-			if (GetToken<bool>(os))
-			{
-				mape->flags |= LEVEL_NOINTERMISSION;
-			}
-		}
-		else if (!stricmp(pname, "partime"))
-		{
-			MustGet<int>(os);
-			mape->partime = TICRATE * GetToken<int>(os);
-		}
-		else if (!stricmp(pname, "intertext"))
-		{
-			char* lname = ParseMultiString(os);
-			if (!lname)
-				return 0;
-			mape->intertext = lname;
-		}
-		else if (!stricmp(pname, "intertextsecret"))
-		{
-			char* lname = ParseMultiString(os);
-			if (!lname)
-				return 0;
-			mape->intertextsecret = lname;
-		}
-		else if (!stricmp(pname, "interbackdrop"))
-		{
-			ParseOLumpName(os, mape->interbackdrop);
-		}
-		else if (!stricmp(pname, "intermusic"))
-		{
-			ParseOLumpName(os, mape->intermusic);
-		}
-		else if (!stricmp(pname, "episode"))
-		{
-			if (!episodes_modified && gamemode == commercial)
-			{
-				episodenum = 0;
-				episodes_modified = true;
-			}
-	
-			char* lname = ParseMultiString(os);
-			if (!lname)
-				return 0;
-	
-			if (*lname == '-') // means "clear"
-			{
-				episodenum = 0;
-			}
-			else
-			{
-				const char* gfx = std::strtok(lname, "\n");
-				const char* txt = std::strtok(NULL, "\n");
-				const char* alpha = std::strtok(NULL, "\n");
-	
-				if (episodenum >= 8)
-				{
-					return 0;
-				}
-	
-				strncpy(EpisodeMaps[episodenum], mape->mapname.c_str(), 8);
-				EpisodeInfos[episodenum].name = gfx;
-				EpisodeInfos[episodenum].fulltext = false;
-				EpisodeInfos[episodenum].noskillmenu = false;
-				EpisodeInfos[episodenum].key = alpha ? *alpha : 0;
-				++episodenum;
-			}
-		}
-		else if (!stricmp(pname, "bossaction"))
-		{
-			MustGetIdentifier(os);
-	
-			if (!stricmp(os.getToken().c_str(), "clear"))
-			{
-				// mark level free of boss actions
-				mape->bossactions.clear();
-				mape->bossactions_donothing = true;
-			}
-			else
-			{
-				int i;
-	
-				// remove comma from token
-				std::string actor_name = os.getToken();
-				actor_name[actor_name.length() - 1] = '\0';
-	
-				for (i = 0; ActorNames[i]; i++)
-				{
-					if (!stricmp(actor_name.c_str(), ActorNames[i]))
-						break;
-				}
-				if (ActorNames[i] == NULL)
-				{
-					I_Error("Unknown thing type %s", os.getToken().c_str());
-					return 0;
-				}
-	
-				// skip comma token
-				// MustGetStringName(os, ",");
-				MustGet<int>(os);
-				const int special = GetToken<int>(os);
-				// MustGetStringName(os, ",");
-				MustGet<int>(os);
-				const int tag = GetToken<int>(os);
-				// allow no 0-tag specials here, unless a level exit.
-				if (tag != 0 || special == 11 || special == 51 || special == 52 ||
-				    special == 124)
-				{
-					if (mape->bossactions_donothing == true)
-						mape->bossactions_donothing = false;
-	
-					OBossAction new_bossaction;
-	
-					maplinedef_t mld;
-					mld.special = static_cast<short>(special);
-					mld.tag = static_cast<short>(tag);
-					P_TranslateLineDef(&new_bossaction.ld, &mld);
-	
-					new_bossaction.type = i;
-	
-					mape->bossactions.push_back(new_bossaction);
-				}
-			}
-		}
-		else
-		{
-			do
-			{
-				if (!IsRealNum(os.getToken().c_str()))
-					os.scan();
-	
-			} while (os.compareToken(","));
-		}
-		free(pname);
+
+		// Find the level.
+		level_pwad_info_t& info = (levels.findByName(mapname).exists())
+		                              ? levels.findByName(mapname)
+		                              : levels.create();
+
+		// Free the level name string before we pave over it.
+		info.level_name.clear();
+
+		info = defaultinfo;
+		info.mapname = mapname;
+
+		MapNameToLevelNum(info);
+
+		MustGetStringName(os, "{");
 		os.scan();
-	
-		return 1;
-	}
-	
-	void MapNameToLevelNum(level_pwad_info_t& info)
-	{
-		if (info.mapname[0] == 'E' && info.mapname[2] == 'M')
+		while (!os.compareToken("}"))
 		{
-			// Convert a char into its equivalent integer.
-			const int e = info.mapname[1] - '0';
-			const int m = info.mapname[3] - '0';
-			if (e >= 0 && e <= 9 && m >= 0 && m <= 9)
-			{
-				// Copypasted from the ZDoom wiki.
-				info.levelnum = (e - 1) * 10 + m;
-			}
+			ParseStandardUmapInfoProperty(os, &info);
 		}
-		else if (strnicmp(info.mapname.c_str(), "MAP", 3) == 0)
+
+		// Set default level progression here to simplify the checks elsewhere.
+		// Doing this lets us skip all normal code for this if nothing has been defined.
+		if (!info.nextmap[0] && !info.endpic[0])
 		{
-			// Try and turn the trailing digits after the "MAP" into a
-			// level number.
-			int mapnum = std::atoi(info.mapname.c_str() + 3);
-			if (mapnum >= 0 && mapnum <= 99)
+			if (info.mapname == "MAP30")
 			{
-				info.levelnum = mapnum;
+				info.endpic = "$CAST";
+				info.nextmap = "EndGameC";
 			}
-		}
-	}
-	
-	void ParseUMapInfoLump(int lump, const char* lumpname)
-	{
-		LevelInfos& levels = getLevelInfos();
-	
-		level_pwad_info_t defaultinfo;
-		SetLevelDefaults(defaultinfo);
-	
-		const char* buffer = static_cast<char*>(W_CacheLumpNum(lump, PU_STATIC));
-	
-		OScannerConfig config = {
-		    lumpname, // lumpName
-		    false,    // semiComments
-		    true,     // cComments
-		};
-		OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));
-	
-		while (os.scan())
-		{
-			if (!UpperCompareToken(os, "map"))
+			else if (info.mapname == "E1M8")
 			{
-				I_Error("Expected map definition, got %s", os.getToken().c_str());
+				info.endpic = gamemode == retail ? "CREDIT" : "HELP2";
+				info.nextmap = "EndGameC";
 			}
-	
-			MustGet<OLumpName>(os);
-		    OLumpName mapname = GetToken<OLumpName>(os);
-			
-			if (!ValidateMapName(mapname))
+			else if (info.mapname == "E2M8")
 			{
-			    I_Error("Invalid map name %s", mapname.c_str());
+				info.endpic = "VICTORY";
+				info.nextmap = "EndGame2";
 			}
-	
-			// Find the level.
-		    level_pwad_info_t& info = (levels.findByName(mapname).exists())
-		                                  ? levels.findByName(mapname)
-			                              : levels.create();
-	
-			// Free the level name string before we pave over it.
-			info.level_name.clear();
-	
-			info = defaultinfo;
-			info.mapname = mapname;
-	
-			MapNameToLevelNum(info);
-	
-			MustGetStringName(os, "{");
-			os.scan();
-			while (!os.compareToken("}"))
+			else if (info.mapname == "E3M8")
 			{
-				ParseStandardUmapInfoProperty(os, &info);
+				info.endpic = "$BUNNY";
+				info.nextmap = "EndGame3";
 			}
-	
-			// Set default level progression here to simplify the checks elsewhere.
-			// Doing this lets us skip all normal code for this if nothing has been defined.
-			if (!info.nextmap[0] && !info.endpic[0])
+			else if (info.mapname == "E4M8")
 			{
-				if (info.mapname == "MAP30")
+				info.endpic = "ENDPIC";
+				info.nextmap = "EndGame4";
+			}
+			else if (gamemission == chex && info.mapname == "E1M5")
+			{
+				info.endpic = "CREDIT";
+				info.nextmap = "EndGame1";
+			}
+			else
+			{
+				char arr[9] = "";
+				int ep, map;
+				ValidateMapName(info.mapname.c_str(), &ep, &map);
+				map++;
+				if (gamemode == commercial)
 				{
-					info.endpic = "$CAST";
-					info.nextmap = "EndGameC";
-				}
-				else if (info.mapname == "E1M8")
-				{
-					info.endpic = gamemode == retail ? "CREDIT" : "HELP2";
-					info.nextmap = "EndGameC";
-				}
-				else if (info.mapname == "E2M8")
-				{
-					info.endpic = "VICTORY";
-					info.nextmap = "EndGame2";
-				}
-				else if (info.mapname == "E3M8")
-				{
-					info.endpic = "$BUNNY";
-					info.nextmap = "EndGame3";
-				}
-				else if (info.mapname == "E4M8")
-				{
-					info.endpic = "ENDPIC";
-					info.nextmap = "EndGame4";
-				}
-				else if (gamemission == chex && info.mapname == "E1M5")
-				{
-					info.endpic = "CREDIT";
-					info.nextmap = "EndGame1";
+					sprintf(arr, "MAP%02d", map);
 				}
 				else
 				{
-				    char arr[9] = "";
-					int ep, map;
-					ValidateMapName(info.mapname.c_str(), &ep, &map);
-					map++;
-					if (gamemode == commercial)
-					{
-						sprintf(arr, "MAP%02d", map);
-					}
-					else
-					{
-					    sprintf(arr, "E%dM%d", ep, map);
-					}
-					info.nextmap = arr;
+					sprintf(arr, "E%dM%d", ep, map);
 				}
+				info.nextmap = arr;
 			}
 		}
 	}
+}
 
-	
-	template <typename T>
-    void ParseMapInfoHelper(OScanner& os, bool doEquals)
-    {
-	    if (doEquals)
-	    {
-		    MustGetStringName(os, "=");
-	    }
-
-	    MustGet<T>(os);
-    }
-
-	template <>
-    void ParseMapInfoHelper<void>(OScanner& os, bool doEquals)
+template <typename T>
+void ParseMapInfoHelper(OScanner& os, bool doEquals)
+{
+	if (doEquals)
 	{
-		// do nothing
+		MustGetStringName(os, "=");
 	}
 
+	MustGet<T>(os);
+}
 
-	//////////////////////////////////////////////////////////////////////
-	/// MapInfo type functions
+template <>
+void ParseMapInfoHelper<void>(OScanner& os, bool doEquals)
+{
+	// do nothing
+}
 
-	// Eats the next block and does nothing with the data
-    void MIType_EatNext(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                        unsigned int flags2)
-    {
-	    ParseMapInfoHelper<std::string>(os, doEquals);
-    }
+//////////////////////////////////////////////////////////////////////
+/// MapInfo type functions
 
-	// Sets the inputted data as an int
-    void MIType_Int(OScanner& os, bool doEquals, void* data, unsigned int flags,
+// Eats the next block and does nothing with the data
+void MIType_EatNext(OScanner& os, bool doEquals, void* data, unsigned int flags,
                     unsigned int flags2)
-    {
-	    ParseMapInfoHelper<int>(os, doEquals);
+{
+	ParseMapInfoHelper<std::string>(os, doEquals);
+}
 
-	    *static_cast<int*>(data) = GetToken<int>(os);
-    }
+// Sets the inputted data as an int
+void MIType_Int(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                unsigned int flags2)
+{
+	ParseMapInfoHelper<int>(os, doEquals);
 
-	// Sets the inputted data as a float
-    void MIType_Float(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                      unsigned int flags2)
-    {
-	    ParseMapInfoHelper<float>(os, doEquals);
+	*static_cast<int*>(data) = GetToken<int>(os);
+}
 
-	    *static_cast<float*>(data) = GetToken<float>(os);
-    }
+// Sets the inputted data as a float
+void MIType_Float(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                  unsigned int flags2)
+{
+	ParseMapInfoHelper<float>(os, doEquals);
 
-	// Sets the inputted data as a color
-    void MIType_Color(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                      unsigned int flags2)
-    {
-	    ParseMapInfoHelper<std::string>(os, doEquals);
+	*static_cast<float*>(data) = GetToken<float>(os);
+}
 
-	    argb_t color(V_GetColorFromString(os.getToken()));
-	    uint8_t* ptr = static_cast<uint8_t*>(data);
-	    ptr[0] = color.geta();
-	    ptr[1] = color.getr();
-	    ptr[2] = color.getg();
-	    ptr[3] = color.getb();
-    }
+// Sets the inputted data as a color
+void MIType_Color(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                  unsigned int flags2)
+{
+	ParseMapInfoHelper<std::string>(os, doEquals);
 
-	// Sets the inputted data as an OLumpName map name
-    void MIType_MapName(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                        unsigned int flags2)
-    {
-		ParseMapInfoHelper<OLumpName>(os, doEquals);
-		
-	    if (os.isQuotedString())
-	    {
-		    char map_name[9];
-		    strncpy(map_name, os.getToken().c_str(), 8);
+	argb_t color(V_GetColorFromString(os.getToken()));
+	uint8_t* ptr = static_cast<uint8_t*>(data);
+	ptr[0] = color.geta();
+	ptr[1] = color.getr();
+	ptr[2] = color.getg();
+	ptr[3] = color.getb();
+}
 
-		    if (IsNum(map_name))
-		    {
-			    int map = std::atoi(map_name);
-			    sprintf(map_name, "MAP%02d", map);
-		    }
-		    else if(UpperCompareToken(os, "EndBunny"))
-		    {
-			    *static_cast<OLumpName*>(data) = "EndGame3";
-			    return;
-		    }
-
-		    *static_cast<OLumpName*>(data) = map_name;
-	    }
-	    else
-	    {
-	    	// endgame block
-		    if (UpperCompareToken(os, "endgame"))
-	    	{
-			    MustGetStringName(os, "{");
-		    	
-				while (os.scan())
-			    {
-				    if (UpperCompareToken(os, "}"))
-				    {
-					    break;
-				    }
-					
-					if (UpperCompareToken(os, "pic"))
-					{
-					    ParseMapInfoHelper<OLumpName>(os, doEquals);
-
-					    // todo
-					}
-					else if (UpperCompareToken(os, "hscroll"))
-					{
-					    ParseMapInfoHelper<std::string>(os, doEquals);
-
-					    // todo
-					}
-					else if (UpperCompareToken(os, "vscroll"))
-					{
-					    ParseMapInfoHelper<std::string>(os, doEquals);
-
-					    // todo
-					}
-					else if (UpperCompareToken(os, "cast"))
-					{
-					    *static_cast<OLumpName*>(data) = "EndGameC";
-					}
-				    if (UpperCompareToken(os, "music"))
-				    {
-					    ParseMapInfoHelper<OLumpName>(os, doEquals);
-
-				    	// todo
-					    os.scan();
-					    if (UpperCompareToken(os, ","))
-					    {
-						    MustGet<float>(os);
-					    	// todo
-					    }
-					    else
-					    {
-						    os.unScan();
-					    }
-				    }
-				}
-	    	}
-		    else if (UpperCompareToken(os, "EndPic"))
-		    {
-			    MustGetStringName(os, ",");
-			    MustGetString(os);
-
-		    	// todo
-		    }
-		    else if (UpperCompareToken(os, "EndPic,"))
-		    {
-			    MustGetString(os);
-
-		    	// todo
-		    }
-		    else if (UpperCompareToken(os, "EndSequence"))
-		    {
-			    MustGetStringName(os, ",");
-			    MustGetString(os);
-
-		    	// todo
-		    }
-		    else if (UpperCompareToken(os, "EndSequence,"))
-		    {
-			    MustGetString(os);
-
-		    	// todo
-		    }
-	    }
-    }
-
-	// Sets the inputted data as an OLumpName
-    void MIType_LumpName(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                         unsigned int flags2)
-    {
-	    ParseMapInfoHelper<OLumpName>(os, doEquals);
-
-	    *static_cast<OLumpName*>(data) = os.getToken();
-    }
-
-	// Sets the inputted data as an OLumpName, checking LANGUAGE for the actual OLumpName
-    void MIType_$LumpName(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                          unsigned int flags2)
-    {
-	    ParseMapInfoHelper<std::string>(os, doEquals);
-		
-	    if (os.getToken()[0] == '$')
-	    {
-		    // It is possible to pass a DeHackEd string
-		    // prefixed by a $.
-		    const OString& s = GStrings(os.getToken().c_str() + 1);
-		    if (s.empty())
-		    {
-			    I_Error("Unknown lookup string \"%s\"", os.getToken().c_str());
-		    }
-		    *static_cast<OLumpName*>(data) = s;
-	    }
-	    else
-	    {
-		    *static_cast<OLumpName*>(data) = os.getToken();
-	    }
-    }
-
-	// Sets the inputted data as an OLumpName, checking LANGUAGE for the actual OLumpName (Music variant)
-    void MIType_MusicLumpName(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                              unsigned int flags2)
-    {
-	    ParseMapInfoHelper<std::string>(os, doEquals);
-		
-	    if (os.getToken()[0] == '$')
-	    {
-		    // It is possible to pass a DeHackEd string
-		    // prefixed by a $.
-		    const OString& s = GStrings(os.getToken().c_str() + 1);
-		    if (s.empty())
-		    {
-			    I_Error("Unknown lookup string \"%s\"", s.c_str());
-		    }
-
-		    // Music lumps in the stringtable do not begin
-		    // with a D_, so we must add it.
-		    char lumpname[9];
-		    snprintf(lumpname, ARRAY_LENGTH(lumpname), "D_%s", s.c_str());
-		    *static_cast<OLumpName*>(data) = lumpname;
-	    }
-	    else
-	    {
-		    *static_cast<OLumpName*>(data) = os.getToken();
-	    }
-    }
-
-	// Sets the sky texture with an OLumpName
-    void MIType_Sky(OScanner& os, bool doEquals, void* data, unsigned int flags,
+// Sets the inputted data as an OLumpName map name
+void MIType_MapName(OScanner& os, bool doEquals, void* data, unsigned int flags,
                     unsigned int flags2)
-    {
-	    ParseMapInfoHelper<OLumpName>(os, doEquals);
-		
-		*static_cast<OLumpName*>(data) = os.getToken();
-		
-	    // Scroll speed
-	    if (doEquals)
-	    {
-		    os.scan();
-		    if (!os.compareToken(","))
-		    {
-			    os.unScan();
-			    return;
-		    }
-	    }
-		MustGet<float>(os);
-		/*if (HexenHack)
-		{
-		    *((fixed_t *)(info + handler->data2)) = sc_Number << 8;
-		}
-		 else
-		{
-		    *((fixed_t *)(info + handler->data2)) = (fixed_t)(sc_Float * 65536.0f);
-		}*/
-    }
+{
+	ParseMapInfoHelper<OLumpName>(os, doEquals);
 
-	// Sets a flag
-    void MIType_SetFlag(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                        unsigned int flags2)
-    {
-	    *static_cast<DWORD *>(data) |= flags;
-    }
-
-	// Sets an SC flag
-    void MIType_SCFlags(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                        unsigned int flags2)
-    {
-	    *static_cast<DWORD*>(data) = (*static_cast<DWORD *>(data) & flags2) | flags;
-    }
-
-	// Sets a cluster
-    void MIType_Cluster(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                        unsigned int flags2)
-    {
-	    ParseMapInfoHelper<int>(os, doEquals);
-
-	    *static_cast<int*>(data) = GetToken<int>(os);
-	    if (HexenHack)
-	    {
-		    ClusterInfos& clusters = getClusterInfos();
-		    cluster_info_t& clusterH = clusters.findByCluster(GetToken<int>(os));
-		    if (clusterH.cluster != 0)
-		    {
-			    clusterH.flags |= CLUSTER_HUB;
-		    }
-	    }
-    }
-
-	// Sets a cluster string
-    void MIType_ClusterString(OScanner& os, bool doEquals, void* data, unsigned int flags,
-                              unsigned int flags2)
-    {
-	    ParseMapInfoHelper<std::string>(os, doEquals);
-		
-	    char** text = static_cast<char**>(data);
-		
-	    if (doEquals)
-	    {
-		    if (UpperCompareToken(os, "lookup,"))
-		    {
-			    MustGetString(os);
-			    const OString& s = GStrings(os.getToken());
-			    if (s.empty())
-			    {
-				    I_Error("Unknown lookup string \"%s\"", os.getToken().c_str());
-			    }
-			    free(*text);
-			    *text = strdup(s.c_str());
-		    }
-		    else
-		    {
-			    // One line per string.
-			    std::string ctext;
-			    os.unScan();
-			    do
-			    {
-				    MustGetString(os);
-				    ctext += os.getToken();
-				    ctext += "\n";
-				    os.scan();
-			    } while (os.compareToken(","));
-			    os.unScan();
-
-			    // Trim trailing newline.
-			    if (ctext.length() > 0)
-			    {
-				    ctext.resize(ctext.length() - 1);
-			    }
-
-			    free(*text);
-			    *text = strdup(ctext.c_str());
-		    }
-	    }
-	    else
-	    {
-		    if (UpperCompareToken(os, "lookup"))
-		    {
-			    MustGetString(os);
-			    const OString& s = GStrings(os.getToken());
-			    if (s.empty())
-			    {
-				    I_Error("Unknown lookup string \"%s\"", os.getToken().c_str());
-			    }
-
-			    free(*text);
-			    *text = strdup(s.c_str());
-		    }
-		    else
-		    {
-			    free(*text);
-			    *text = strdup(os.getToken().c_str());
-		    }
-	    }
-    }
-
-	//////////////////////////////////////////////////////////////////////
-    /// MapInfoData
-
-	typedef void (*MITypeFunctionPtr)(OScanner&, bool, void*, unsigned int, unsigned int);
-
-	// data structure containing all of the information needed to set a value from mapinfo
-	struct MapInfoData
+	if (os.isQuotedString())
 	{
-	    const char* name;
-	    MITypeFunctionPtr fn;
-	    void* data;
-	    unsigned int flags;
-	    unsigned int flags2;
+		char map_name[9];
+		strncpy(map_name, os.getToken().c_str(), 8);
 
-		MapInfoData
-		(
-			const char* _name,
-			MITypeFunctionPtr _fn = NULL,
-			void* _data = NULL,
-			unsigned int _flags = 0,
-			unsigned int _flags2 = 0
-		)
-	        : name(_name), fn(_fn), data(_data), flags(_flags), flags2(_flags2)
-	    {
-	    }
-	};
+		if (IsNum(map_name))
+		{
+			int map = std::atoi(map_name);
+			sprintf(map_name, "MAP%02d", map);
+		}
+		else if (UpperCompareToken(os, "EndBunny"))
+		{
+			*static_cast<OLumpName*>(data) = "EndGame3";
+			return;
+		}
 
-	// container holding all MapInfoData types
-	typedef std::vector<MapInfoData> MapInfoDataContainer;
+		*static_cast<OLumpName*>(data) = map_name;
+	}
+	else
+	{
+		// endgame block
+		if (UpperCompareToken(os, "endgame"))
+		{
+			MustGetStringName(os, "{");
 
-	// base class for MapInfoData; also used when there's no data to process (unimplemented blocks)
-	template <typename T>
-	struct MapInfoDataSetter
-    {
-	    MapInfoDataContainer mapInfoDataContainer;
-		
-	    MapInfoDataSetter()
-			: mapInfoDataContainer()
-	    {
-	    }
-    };
+			while (os.scan())
+			{
+				if (UpperCompareToken(os, "}"))
+				{
+					break;
+				}
+
+				if (UpperCompareToken(os, "pic"))
+				{
+					ParseMapInfoHelper<OLumpName>(os, doEquals);
+
+					// todo
+				}
+				else if (UpperCompareToken(os, "hscroll"))
+				{
+					ParseMapInfoHelper<std::string>(os, doEquals);
+
+					// todo
+				}
+				else if (UpperCompareToken(os, "vscroll"))
+				{
+					ParseMapInfoHelper<std::string>(os, doEquals);
+
+					// todo
+				}
+				else if (UpperCompareToken(os, "cast"))
+				{
+					*static_cast<OLumpName*>(data) = "EndGameC";
+				}
+				if (UpperCompareToken(os, "music"))
+				{
+					ParseMapInfoHelper<OLumpName>(os, doEquals);
+
+					// todo
+					os.scan();
+					if (UpperCompareToken(os, ","))
+					{
+						MustGet<float>(os);
+						// todo
+					}
+					else
+					{
+						os.unScan();
+					}
+				}
+			}
+		}
+		else if (UpperCompareToken(os, "EndPic"))
+		{
+			MustGetStringName(os, ",");
+			MustGetString(os);
+
+			// todo
+		}
+		else if (UpperCompareToken(os, "EndPic,"))
+		{
+			MustGetString(os);
+
+			// todo
+		}
+		else if (UpperCompareToken(os, "EndSequence"))
+		{
+			MustGetStringName(os, ",");
+			MustGetString(os);
+
+			// todo
+		}
+		else if (UpperCompareToken(os, "EndSequence,"))
+		{
+			MustGetString(os);
+
+			// todo
+		}
+	}
+}
+
+// Sets the inputted data as an OLumpName
+void MIType_LumpName(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                     unsigned int flags2)
+{
+	ParseMapInfoHelper<OLumpName>(os, doEquals);
+
+	*static_cast<OLumpName*>(data) = os.getToken();
+}
+
+// Sets the inputted data as an OLumpName, checking LANGUAGE for the actual OLumpName
+void MIType_$LumpName(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                      unsigned int flags2)
+{
+	ParseMapInfoHelper<std::string>(os, doEquals);
+
+	if (os.getToken()[0] == '$')
+	{
+		// It is possible to pass a DeHackEd string
+		// prefixed by a $.
+		const OString& s = GStrings(os.getToken().c_str() + 1);
+		if (s.empty())
+		{
+			I_Error("Unknown lookup string \"%s\"", os.getToken().c_str());
+		}
+		*static_cast<OLumpName*>(data) = s;
+	}
+	else
+	{
+		*static_cast<OLumpName*>(data) = os.getToken();
+	}
+}
+
+// Sets the inputted data as an OLumpName, checking LANGUAGE for the actual OLumpName
+// (Music variant)
+void MIType_MusicLumpName(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                          unsigned int flags2)
+{
+	ParseMapInfoHelper<std::string>(os, doEquals);
+
+	if (os.getToken()[0] == '$')
+	{
+		// It is possible to pass a DeHackEd string
+		// prefixed by a $.
+		const OString& s = GStrings(os.getToken().c_str() + 1);
+		if (s.empty())
+		{
+			I_Error("Unknown lookup string \"%s\"", s.c_str());
+		}
+
+		// Music lumps in the stringtable do not begin
+		// with a D_, so we must add it.
+		char lumpname[9];
+		snprintf(lumpname, ARRAY_LENGTH(lumpname), "D_%s", s.c_str());
+		*static_cast<OLumpName*>(data) = lumpname;
+	}
+	else
+	{
+		*static_cast<OLumpName*>(data) = os.getToken();
+	}
+}
+
+// Sets the sky texture with an OLumpName
+void MIType_Sky(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                unsigned int flags2)
+{
+	ParseMapInfoHelper<OLumpName>(os, doEquals);
+
+	*static_cast<OLumpName*>(data) = os.getToken();
+
+	// Scroll speed
+	if (doEquals)
+	{
+		os.scan();
+		if (!os.compareToken(","))
+		{
+			os.unScan();
+			return;
+		}
+	}
+	MustGet<float>(os);
+	/*if (HexenHack)
+	{
+	    *((fixed_t *)(info + handler->data2)) = sc_Number << 8;
+	}
+	 else
+	{
+	    *((fixed_t *)(info + handler->data2)) = (fixed_t)(sc_Float * 65536.0f);
+	}*/
+}
+
+// Sets a flag
+void MIType_SetFlag(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                    unsigned int flags2)
+{
+	*static_cast<DWORD*>(data) |= flags;
+}
+
+// Sets an SC flag
+void MIType_SCFlags(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                    unsigned int flags2)
+{
+	*static_cast<DWORD*>(data) = (*static_cast<DWORD*>(data) & flags2) | flags;
+}
+
+// Sets a cluster
+void MIType_Cluster(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                    unsigned int flags2)
+{
+	ParseMapInfoHelper<int>(os, doEquals);
+
+	*static_cast<int*>(data) = GetToken<int>(os);
+	if (HexenHack)
+	{
+		ClusterInfos& clusters = getClusterInfos();
+		cluster_info_t& clusterH = clusters.findByCluster(GetToken<int>(os));
+		if (clusterH.cluster != 0)
+		{
+			clusterH.flags |= CLUSTER_HUB;
+		}
+	}
+}
+
+// Sets a cluster string
+void MIType_ClusterString(OScanner& os, bool doEquals, void* data, unsigned int flags,
+                          unsigned int flags2)
+{
+	ParseMapInfoHelper<std::string>(os, doEquals);
+
+	char** text = static_cast<char**>(data);
+
+	if (doEquals)
+	{
+		if (UpperCompareToken(os, "lookup,"))
+		{
+			MustGetString(os);
+			const OString& s = GStrings(os.getToken());
+			if (s.empty())
+			{
+				I_Error("Unknown lookup string \"%s\"", os.getToken().c_str());
+			}
+			free(*text);
+			*text = strdup(s.c_str());
+		}
+		else
+		{
+			// One line per string.
+			std::string ctext;
+			os.unScan();
+			do
+			{
+				MustGetString(os);
+				ctext += os.getToken();
+				ctext += "\n";
+				os.scan();
+			} while (os.compareToken(","));
+			os.unScan();
+
+			// Trim trailing newline.
+			if (ctext.length() > 0)
+			{
+				ctext.resize(ctext.length() - 1);
+			}
+
+			free(*text);
+			*text = strdup(ctext.c_str());
+		}
+	}
+	else
+	{
+		if (UpperCompareToken(os, "lookup"))
+		{
+			MustGetString(os);
+			const OString& s = GStrings(os.getToken());
+			if (s.empty())
+			{
+				I_Error("Unknown lookup string \"%s\"", os.getToken().c_str());
+			}
+
+			free(*text);
+			*text = strdup(s.c_str());
+		}
+		else
+		{
+			free(*text);
+			*text = strdup(os.getToken().c_str());
+		}
+	}
+}
+
+//////////////////////////////////////////////////////////////////////
+/// MapInfoData
+
+typedef void (*MITypeFunctionPtr)(OScanner&, bool, void*, unsigned int, unsigned int);
+
+// data structure containing all of the information needed to set a value from mapinfo
+struct MapInfoData
+{
+	const char* name;
+	MITypeFunctionPtr fn;
+	void* data;
+	unsigned int flags;
+	unsigned int flags2;
+
+	MapInfoData(const char* _name, MITypeFunctionPtr _fn = NULL, void* _data = NULL,
+	            unsigned int _flags = 0, unsigned int _flags2 = 0)
+	    : name(_name), fn(_fn), data(_data), flags(_flags), flags2(_flags2)
+	{
+	}
+};
+
+// container holding all MapInfoData types
+typedef std::vector<MapInfoData> MapInfoDataContainer;
+
+// base class for MapInfoData; also used when there's no data to process (unimplemented
+// blocks)
+template <typename T>
+struct MapInfoDataSetter
+{
+	MapInfoDataContainer mapInfoDataContainer;
+
+	MapInfoDataSetter() : mapInfoDataContainer()
+	{
+	}
+};
 
 // macro to make up for lack of initializer lists in C++98
 #define ENTRY1(x1) mapInfoDataContainer.push_back(MapInfoData(x1));
 #define ENTRY2(x1, x2) mapInfoDataContainer.push_back(MapInfoData(x1, x2));
 #define ENTRY3(x1, x2, x3) mapInfoDataContainer.push_back(MapInfoData(x1, x2, x3));
-#define ENTRY4(x1, x2, x3, x4) mapInfoDataContainer.push_back(MapInfoData(x1, x2, x3, x4));
-#define ENTRY5(x1, x2, x3, x4, x5) mapInfoDataContainer.push_back(MapInfoData(x1, x2, x3, x4, x5));
+#define ENTRY4(x1, x2, x3, x4) \
+	mapInfoDataContainer.push_back(MapInfoData(x1, x2, x3, x4));
+#define ENTRY5(x1, x2, x3, x4, x5) \
+	mapInfoDataContainer.push_back(MapInfoData(x1, x2, x3, x4, x5));
 
-	// level_pwad_info_t
-	template <>
-	struct MapInfoDataSetter<level_pwad_info_t>
+// level_pwad_info_t
+template <>
+struct MapInfoDataSetter<level_pwad_info_t>
+{
+	MapInfoDataContainer mapInfoDataContainer;
+
+	MapInfoDataSetter(level_pwad_info_t& ref)
 	{
-	    MapInfoDataContainer mapInfoDataContainer;
-		
-	    MapInfoDataSetter(level_pwad_info_t& ref)
-	    {
-		    mapInfoDataContainer.reserve(70); // [DE] some random number, i'm not counting all these
-	    	
-			ENTRY3("levelnum",					&MIType_Int,			&ref.levelnum)
-			ENTRY3("next",						&MIType_MapName,		&ref.nextmap)
-			ENTRY3("secretnext",				&MIType_MapName,		&ref.secretmap)
-			ENTRY3("secret",					&MIType_MapName,		&ref.secretmap)
-			ENTRY3("cluster",					&MIType_Cluster,		&ref.cluster)
-			ENTRY3("sky1",						&MIType_Sky,			&ref.skypic)
-			ENTRY3("sky2",						&MIType_Sky,			&ref.skypic2)
-			ENTRY3("fade",						&MIType_Color,			&ref.fadeto_color)
-			ENTRY3("outsidefog",				&MIType_Color,			&ref.outsidefog_color)
-			ENTRY3("titlepatch",				&MIType_LumpName,		&ref.pname)
-			ENTRY3("par",						&MIType_Int,			&ref.partime)
-			ENTRY3("music",						&MIType_MusicLumpName,	&ref.music)
-			ENTRY4("nointermission",			&MIType_SetFlag,		&ref.flags,				LEVEL_NOINTERMISSION)
-			ENTRY4("doublesky",					&MIType_SetFlag,		&ref.flags,				LEVEL_DOUBLESKY)
-			ENTRY4("nosoundclipping",			&MIType_SetFlag,		&ref.flags,				LEVEL_NOSOUNDCLIPPING)
-			ENTRY4("allowmonstertelefrags",		&MIType_SetFlag,		&ref.flags,				LEVEL_MONSTERSTELEFRAG)
-			ENTRY4("map07special",				&MIType_SetFlag,		&ref.flags,				LEVEL_MAP07SPECIAL)
-			ENTRY4("baronspecial",				&MIType_SetFlag,		&ref.flags,				LEVEL_BRUISERSPECIAL)
-			ENTRY4("cyberdemonspecial",			&MIType_SetFlag,		&ref.flags,				LEVEL_CYBORGSPECIAL)
-			ENTRY4("spidermastermindspecial",	&MIType_SetFlag,		&ref.flags,				LEVEL_SPIDERSPECIAL)
-			ENTRY5("specialaction_exitlevel",	&MIType_SCFlags,		&ref.flags,				0,							~LEVEL_SPECACTIONSMASK)
-			ENTRY5("specialaction_opendoor",	&MIType_SCFlags,		&ref.flags,				LEVEL_SPECOPENDOOR,			~LEVEL_SPECACTIONSMASK)
-			ENTRY5("specialaction_lowerfloor",	&MIType_SCFlags,		&ref.flags,				LEVEL_SPECLOWERFLOOR,		~LEVEL_SPECACTIONSMASK)
-			ENTRY1("lightning")
-			ENTRY3("fadetable",					&MIType_LumpName,		&ref.fadetable)
-			ENTRY4("evenlighting",				&MIType_SetFlag,		&ref.flags,				LEVEL_EVENLIGHTING)
-			ENTRY4("noautosequences",			&MIType_SetFlag,		&ref.flags,				LEVEL_SNDSEQTOTALCTRL)
-			ENTRY4("forcenoskystretch",			&MIType_SetFlag,		&ref.flags,				LEVEL_FORCENOSKYSTRETCH)
-			ENTRY5("allowfreelook",				&MIType_SCFlags,		&ref.flags,				LEVEL_FREELOOK_YES,			~LEVEL_FREELOOK_NO)
-			ENTRY5("nofreelook",				&MIType_SCFlags,		&ref.flags,				LEVEL_FREELOOK_NO,			~LEVEL_FREELOOK_YES)
-			ENTRY5("allowjump",					&MIType_SCFlags,		&ref.flags,				LEVEL_JUMP_YES,				~LEVEL_JUMP_NO)
-			ENTRY5("nojump",					&MIType_SCFlags,		&ref.flags,				LEVEL_JUMP_NO,				~LEVEL_JUMP_YES)
-			ENTRY2("cdtrack",					&MIType_EatNext)
-			ENTRY2("cd_start_track",			&MIType_EatNext)
-			ENTRY2("cd_end1_track",				&MIType_EatNext)
-			ENTRY2("cd_end2_track",				&MIType_EatNext)
-			ENTRY2("cd_end3_track",				&MIType_EatNext)
-			ENTRY2("cd_intermission_track",		&MIType_EatNext)
-			ENTRY2("cd_title_track",			&MIType_EatNext)
-			ENTRY2("warptrans",					&MIType_EatNext)
-			ENTRY3("gravity",					&MIType_Float,			&ref.gravity)
-			ENTRY3("aircontrol",				&MIType_Float,			&ref.aircontrol)
-			ENTRY4("islobby",					&MIType_SetFlag,		&ref.flags,				LEVEL_LOBBYSPECIAL)
-			ENTRY4("lobby",						&MIType_SetFlag,		&ref.flags,				LEVEL_LOBBYSPECIAL)
-			ENTRY1("nocrouch")
-			ENTRY2("intermusic",				&MIType_EatNext)
-			ENTRY3("par",						&MIType_Int,			&ref.partime)
-			ENTRY2("sucktime",					&MIType_EatNext)
-			ENTRY3("enterpic",					&MIType_LumpName,		&ref.enterpic) // todo: add intermission script support
-			ENTRY3("exitpic",					&MIType_LumpName,		&ref.exitpic)  // todo: add intermission script support
-			ENTRY2("interpic",					&MIType_EatNext)
-			ENTRY2("translator",				&MIType_EatNext)
-			ENTRY2("compat_shorttex",			&MIType_EatNext)
-			ENTRY2("compat_limitpain",			&MIType_EatNext)
-			ENTRY4("compat_dropoff",			&MIType_SetFlag,		&ref.flags,				LEVEL_COMPAT_DROPOFF)
-			ENTRY2("compat_trace",				&MIType_EatNext)
-			ENTRY2("compat_boomscroll",			&MIType_EatNext)
-			ENTRY2("compat_sectorsounds",		&MIType_EatNext)
-			ENTRY4("compat_nopassover", 		&MIType_SetFlag,		&ref.flags,				LEVEL_COMPAT_NOPASSOVER)
-	    }
-	};
+		mapInfoDataContainer.reserve(
+		    70); // [DE] some random number, i'm not counting all these
 
-	// cluster_info_t
-	template <>
-    struct MapInfoDataSetter<cluster_info_t>
-    {
-	    MapInfoDataContainer mapInfoDataContainer;
+		ENTRY3("levelnum", &MIType_Int, &ref.levelnum)
+		ENTRY3("next", &MIType_MapName, &ref.nextmap)
+		ENTRY3("secretnext", &MIType_MapName, &ref.secretmap)
+		ENTRY3("secret", &MIType_MapName, &ref.secretmap)
+		ENTRY3("cluster", &MIType_Cluster, &ref.cluster)
+		ENTRY3("sky1", &MIType_Sky, &ref.skypic)
+		ENTRY3("sky2", &MIType_Sky, &ref.skypic2)
+		ENTRY3("fade", &MIType_Color, &ref.fadeto_color)
+		ENTRY3("outsidefog", &MIType_Color, &ref.outsidefog_color)
+		ENTRY3("titlepatch", &MIType_LumpName, &ref.pname)
+		ENTRY3("par", &MIType_Int, &ref.partime)
+		ENTRY3("music", &MIType_MusicLumpName, &ref.music)
+		ENTRY4("nointermission", &MIType_SetFlag, &ref.flags, LEVEL_NOINTERMISSION)
+		ENTRY4("doublesky", &MIType_SetFlag, &ref.flags, LEVEL_DOUBLESKY)
+		ENTRY4("nosoundclipping", &MIType_SetFlag, &ref.flags, LEVEL_NOSOUNDCLIPPING)
+		ENTRY4("allowmonstertelefrags", &MIType_SetFlag, &ref.flags,
+		       LEVEL_MONSTERSTELEFRAG)
+		ENTRY4("map07special", &MIType_SetFlag, &ref.flags, LEVEL_MAP07SPECIAL)
+		ENTRY4("baronspecial", &MIType_SetFlag, &ref.flags, LEVEL_BRUISERSPECIAL)
+		ENTRY4("cyberdemonspecial", &MIType_SetFlag, &ref.flags, LEVEL_CYBORGSPECIAL)
+		ENTRY4("spidermastermindspecial", &MIType_SetFlag, &ref.flags,
+		       LEVEL_SPIDERSPECIAL)
+		ENTRY5("specialaction_exitlevel", &MIType_SCFlags, &ref.flags, 0,
+		       ~LEVEL_SPECACTIONSMASK)
+		ENTRY5("specialaction_opendoor", &MIType_SCFlags, &ref.flags, LEVEL_SPECOPENDOOR,
+		       ~LEVEL_SPECACTIONSMASK)
+		ENTRY5("specialaction_lowerfloor", &MIType_SCFlags, &ref.flags,
+		       LEVEL_SPECLOWERFLOOR, ~LEVEL_SPECACTIONSMASK)
+		ENTRY1("lightning")
+		ENTRY3("fadetable", &MIType_LumpName, &ref.fadetable)
+		ENTRY4("evenlighting", &MIType_SetFlag, &ref.flags, LEVEL_EVENLIGHTING)
+		ENTRY4("noautosequences", &MIType_SetFlag, &ref.flags, LEVEL_SNDSEQTOTALCTRL)
+		ENTRY4("forcenoskystretch", &MIType_SetFlag, &ref.flags, LEVEL_FORCENOSKYSTRETCH)
+		ENTRY5("allowfreelook", &MIType_SCFlags, &ref.flags, LEVEL_FREELOOK_YES,
+		       ~LEVEL_FREELOOK_NO)
+		ENTRY5("nofreelook", &MIType_SCFlags, &ref.flags, LEVEL_FREELOOK_NO,
+		       ~LEVEL_FREELOOK_YES)
+		ENTRY5("allowjump", &MIType_SCFlags, &ref.flags, LEVEL_JUMP_YES, ~LEVEL_JUMP_NO)
+		ENTRY5("nojump", &MIType_SCFlags, &ref.flags, LEVEL_JUMP_NO, ~LEVEL_JUMP_YES)
+		ENTRY2("cdtrack", &MIType_EatNext)
+		ENTRY2("cd_start_track", &MIType_EatNext)
+		ENTRY2("cd_end1_track", &MIType_EatNext)
+		ENTRY2("cd_end2_track", &MIType_EatNext)
+		ENTRY2("cd_end3_track", &MIType_EatNext)
+		ENTRY2("cd_intermission_track", &MIType_EatNext)
+		ENTRY2("cd_title_track", &MIType_EatNext)
+		ENTRY2("warptrans", &MIType_EatNext)
+		ENTRY3("gravity", &MIType_Float, &ref.gravity)
+		ENTRY3("aircontrol", &MIType_Float, &ref.aircontrol)
+		ENTRY4("islobby", &MIType_SetFlag, &ref.flags, LEVEL_LOBBYSPECIAL)
+		ENTRY4("lobby", &MIType_SetFlag, &ref.flags, LEVEL_LOBBYSPECIAL)
+		ENTRY1("nocrouch")
+		ENTRY2("intermusic", &MIType_EatNext)
+		ENTRY3("par", &MIType_Int, &ref.partime)
+		ENTRY2("sucktime", &MIType_EatNext)
+		ENTRY3("enterpic", &MIType_LumpName,
+		       &ref.enterpic) // todo: add intermission script support
+		ENTRY3("exitpic", &MIType_LumpName,
+		       &ref.exitpic) // todo: add intermission script support
+		ENTRY2("interpic", &MIType_EatNext)
+		ENTRY2("translator", &MIType_EatNext)
+		ENTRY2("compat_shorttex", &MIType_EatNext)
+		ENTRY2("compat_limitpain", &MIType_EatNext)
+		ENTRY4("compat_dropoff", &MIType_SetFlag, &ref.flags, LEVEL_COMPAT_DROPOFF)
+		ENTRY2("compat_trace", &MIType_EatNext)
+		ENTRY2("compat_boomscroll", &MIType_EatNext)
+		ENTRY2("compat_sectorsounds", &MIType_EatNext)
+		ENTRY4("compat_nopassover", &MIType_SetFlag, &ref.flags, LEVEL_COMPAT_NOPASSOVER)
+	}
+};
 
-	    MapInfoDataSetter(cluster_info_t &ref)
-	    {
-		    mapInfoDataContainer.reserve(7);
-	    	
-		    ENTRY3("entertext",			&MIType_ClusterString,	&ref.entertext)
-			ENTRY3("exittext",			&MIType_ClusterString,	&ref.exittext)
-			ENTRY4("exittextislump",	&MIType_SetFlag,		&ref.flags,			CLUSTER_EXITTEXTISLUMP)
-			ENTRY3("music",				&MIType_MusicLumpName,	&ref.messagemusic)
-			ENTRY3("flat",				&MIType_$LumpName,		&ref.finaleflat)
-			ENTRY4("hub",				&MIType_SetFlag,		&ref.flags,			CLUSTER_HUB)
-			ENTRY3("pic",				&MIType_$LumpName,		&ref.finalepic)
-	    }
-    };
+// cluster_info_t
+template <>
+struct MapInfoDataSetter<cluster_info_t>
+{
+	MapInfoDataContainer mapInfoDataContainer;
 
-	// gameinfo_t
-	template <>
-	struct MapInfoDataSetter<gameinfo_t>
+	MapInfoDataSetter(cluster_info_t& ref)
 	{
-	    MapInfoDataContainer mapInfoDataContainer;
+		mapInfoDataContainer.reserve(7);
 
-	    MapInfoDataSetter()
-	    {
-		    mapInfoDataContainer.reserve(7);
+		ENTRY3("entertext", &MIType_ClusterString, &ref.entertext)
+		ENTRY3("exittext", &MIType_ClusterString, &ref.exittext)
+		ENTRY4("exittextislump", &MIType_SetFlag, &ref.flags, CLUSTER_EXITTEXTISLUMP)
+		ENTRY3("music", &MIType_MusicLumpName, &ref.messagemusic)
+		ENTRY3("flat", &MIType_$LumpName, &ref.finaleflat)
+		ENTRY4("hub", &MIType_SetFlag, &ref.flags, CLUSTER_HUB)
+		ENTRY3("pic", &MIType_$LumpName, &ref.finalepic)
+	}
+};
 
-		    ENTRY3("advisorytime",		&MIType_Float,		&gameinfo.advisoryTime)
-		    //ENTRY3("chatsound",			)
-		    ENTRY3("pagetime",			&MIType_Float,		&gameinfo.pageTime)
-		    ENTRY3("finaleflat",		&MIType_LumpName,	&gameinfo.finaleFlat)
-		    ENTRY3("finalemusic",		&MIType_$LumpName,	&gameinfo.finaleMusic)
-		    ENTRY3("titlemusic",		&MIType_$LumpName,	&gameinfo.titleMusic)
-		    ENTRY3("titlepage",			&MIType_LumpName,	&gameinfo.titlePage)
-		    ENTRY3("titletime",			&MIType_Float,		&gameinfo.titleTime)
-	    }
-	};
+// gameinfo_t
+template <>
+struct MapInfoDataSetter<gameinfo_t>
+{
+	MapInfoDataContainer mapInfoDataContainer;
 
-	//
-    // Parse a MAPINFO block
-    //
-    // NULL pointers can be passed if the block is unimplemented.  However, if
-    // the block you want to stub out is compatible with old MAPINFO, you need
-    // to parse the block anyway, even if you throw away the values.  This is
-    // done by passing in a strings pointer, and leaving the others NULL.
-    //
-	template <typename T>
-    void ParseMapInfoLower(OScanner& os, MapInfoDataSetter<T>& mapInfoDataSetter)
+	MapInfoDataSetter()
 	{
-	    // 0 if old mapinfo, positive number if new MAPINFO, the exact
-	    // number represents current brace depth.
-	    int newMapInfoStack = 0;
+		mapInfoDataContainer.reserve(7);
 
-		while (os.scan())
-	    {
-		    if (os.compareToken("{"))
-		    {
-			    // Detected new-style MAPINFO
-			    newMapInfoStack++;
-			    continue;
-		    }
-		    if (os.compareToken("}"))
-		    {
-			    newMapInfoStack--;
-			    if (newMapInfoStack <= 0)
-			    {
-				    // MAPINFO block is done
-				    break;
-			    }
-		    }
+		ENTRY3("advisorytime", &MIType_Float, &gameinfo.advisoryTime)
+		// ENTRY3("chatsound",			)
+		ENTRY3("pagetime", &MIType_Float, &gameinfo.pageTime)
+		ENTRY3("finaleflat", &MIType_LumpName, &gameinfo.finaleFlat)
+		ENTRY3("finalemusic", &MIType_$LumpName, &gameinfo.finaleMusic)
+		ENTRY3("titlemusic", &MIType_$LumpName, &gameinfo.titleMusic)
+		ENTRY3("titlepage", &MIType_LumpName, &gameinfo.titlePage)
+		ENTRY3("titletime", &MIType_Float, &gameinfo.titleTime)
+	}
+};
 
-		    if (newMapInfoStack <= 0 && ContainsMapInfoTopLevel(os) &&
-		        // "cluster" is a valid map block type and is also
-		        // a valid top-level type.
-		        !UpperCompareToken(os, "cluster"))
-		    {
-			    // Old-style MAPINFO is done
-			    os.unScan();
-			    break;
-		    }
+//
+// Parse a MAPINFO block
+//
+// NULL pointers can be passed if the block is unimplemented.  However, if
+// the block you want to stub out is compatible with old MAPINFO, you need
+// to parse the block anyway, even if you throw away the values.  This is
+// done by passing in a strings pointer, and leaving the others NULL.
+//
+template <typename T>
+void ParseMapInfoLower(OScanner& os, MapInfoDataSetter<T>& mapInfoDataSetter)
+{
+	// 0 if old mapinfo, positive number if new MAPINFO, the exact
+	// number represents current brace depth.
+	int newMapInfoStack = 0;
 
-			MapInfoDataContainer& mapInfoDataContainer = mapInfoDataSetter.mapInfoDataContainer;
-
-			// find the matching string and use its corresponding function
-		    MapInfoDataContainer::iterator it = mapInfoDataContainer.begin();
-		    for (; it != mapInfoDataContainer.end(); ++it)
+	while (os.scan())
+	{
+		if (os.compareToken("{"))
+		{
+			// Detected new-style MAPINFO
+			newMapInfoStack++;
+			continue;
+		}
+		if (os.compareToken("}"))
+		{
+			newMapInfoStack--;
+			if (newMapInfoStack <= 0)
 			{
-			    if (UpperCompareToken(os, it->name))
-			    {
-				    if (it->fn)
-				    {
-					    it->fn(os, newMapInfoStack > 0, it->data, it->flags, it->flags2);
-					    break;
-				    }
-			    }
+				// MAPINFO block is done
+				break;
 			}
-			
-			if (it == mapInfoDataContainer.end())
+		}
+
+		if (newMapInfoStack <= 0 && ContainsMapInfoTopLevel(os) &&
+		    // "cluster" is a valid map block type and is also
+		    // a valid top-level type.
+		    !UpperCompareToken(os, "cluster"))
+		{
+			// Old-style MAPINFO is done
+			os.unScan();
+			break;
+		}
+
+		MapInfoDataContainer& mapInfoDataContainer =
+		    mapInfoDataSetter.mapInfoDataContainer;
+
+		// find the matching string and use its corresponding function
+		MapInfoDataContainer::iterator it = mapInfoDataContainer.begin();
+		for (; it != mapInfoDataContainer.end(); ++it)
+		{
+			if (UpperCompareToken(os, it->name))
 			{
-				if (newMapInfoStack <= 0)
+				if (it->fn)
 				{
-					// Old MAPINFO is up a creek, we need to be
-					// able to parse all types even if we can't
-					// do anything with them.
-					//
-					I_Error("Unknown MAPINFO token \"%s\"", os.getToken().c_str());
+					it->fn(os, newMapInfoStack > 0, it->data, it->flags, it->flags2);
+					break;
 				}
-	
-				// New MAPINFO is capable of skipping past unknown
-				// types.
-				SkipUnknownType(os);
 			}
-	    }
+		}
+
+		if (it == mapInfoDataContainer.end())
+		{
+			if (newMapInfoStack <= 0)
+			{
+				// Old MAPINFO is up a creek, we need to be
+				// able to parse all types even if we can't
+				// do anything with them.
+				//
+				I_Error("Unknown MAPINFO token \"%s\"", os.getToken().c_str());
+			}
+
+			// New MAPINFO is capable of skipping past unknown
+			// types.
+			SkipUnknownType(os);
+		}
+	}
+}
+
+// todo: parse episode info like the others? (but how?)
+void ParseEpisodeInfo(OScanner& os)
+{
+	int new_mapinfo = false; // is int instead of bool for template purposes
+	OLumpName map;
+	std::string pic;
+	bool picisgfx = false;
+	bool remove = false;
+	char key = 0;
+	bool noskillmenu = false;
+	bool optional = false;
+	bool extended = false;
+
+	MustGetString(os); // Map lump
+	map = os.getToken();
+
+	MustGetString(os);
+	if (UpperCompareToken(os, "teaser"))
+	{
+		// Teaser lump
+		MustGetString(os);
+		if (gameinfo.flags & GI_SHAREWARE)
+		{
+			map = os.getToken();
+		}
+		MustGetString(os);
+	}
+	else
+	{
+		os.unScan();
 	}
 
-	// todo: parse episode info like the others? (but how?)
-	void ParseEpisodeInfo(OScanner& os)
+	if (os.compareToken("{"))
 	{
-		int new_mapinfo = false; // is int instead of bool for template purposes
-		OLumpName map;
-		std::string pic;
-		bool picisgfx = false;
-		bool remove = false;
-		char key = 0;
-		bool noskillmenu = false;
-		bool optional = false;
-		bool extended = false;
-	
-		MustGetString(os); // Map lump
-		map = os.getToken();
-	
-		MustGetString(os);
-		if (UpperCompareToken(os, "teaser"))
+		// Detected new-style MAPINFO
+		new_mapinfo = true;
+	}
+
+	MustGetString(os);
+	while (os.scan())
+	{
+		if (os.compareToken("{"))
 		{
-			// Teaser lump
-			MustGetString(os);
-			if (gameinfo.flags & GI_SHAREWARE)
+			// Detected new-style MAPINFO
+			I_Error(
+			    "Detected incorrectly placed curly brace in MAPINFO episode definiton");
+		}
+		else if (os.compareToken("}"))
+		{
+			if (new_mapinfo == false)
 			{
-				map = os.getToken();
+				I_Error("Detected incorrectly placed curly brace in MAPINFO episode "
+				        "definiton");
 			}
-			MustGetString(os);
+			else
+			{
+				break;
+			}
+		}
+		else if (UpperCompareToken(os, "name"))
+		{
+			ParseMapInfoHelper<std::string>(os, new_mapinfo);
+
+			if (picisgfx == false)
+			{
+				pic = os.getToken();
+			}
+		}
+		else if (UpperCompareToken(os, "lookup"))
+		{
+			ParseMapInfoHelper<std::string>(os, new_mapinfo);
+
+			// Not implemented
+		}
+		else if (UpperCompareToken(os, "picname"))
+		{
+			ParseMapInfoHelper<std::string>(os, new_mapinfo);
+
+			pic = os.getToken();
+			picisgfx = true;
+		}
+		else if (UpperCompareToken(os, "key"))
+		{
+			ParseMapInfoHelper<std::string>(os, new_mapinfo);
+
+			key = os.getToken()[0];
+		}
+		else if (UpperCompareToken(os, "remove"))
+		{
+			remove = true;
+		}
+		else if (UpperCompareToken(os, "noskillmenu"))
+		{
+			noskillmenu = true;
+		}
+		else if (UpperCompareToken(os, "optional"))
+		{
+			optional = true;
+		}
+		else if (UpperCompareToken(os, "extended"))
+		{
+			extended = true;
 		}
 		else
 		{
 			os.unScan();
+			break;
 		}
-	
-		if (os.compareToken("{"))
+	}
+
+	int i;
+	for (i = 0; i < episodenum; ++i)
+	{
+		if (map == EpisodeMaps[i])
+			break;
+	}
+
+	if (remove || (optional && W_CheckNumForName(map.c_str()) == -1) ||
+	    (extended && W_CheckNumForName("EXTENDED") == -1))
+	{
+		// If the remove property is given for an episode, remove it.
+		if (i < episodenum)
 		{
-			// Detected new-style MAPINFO
-			new_mapinfo = true;
+			if (i + 1 < episodenum)
+			{
+				memmove(&EpisodeMaps[i], &EpisodeMaps[i + 1],
+				        sizeof(EpisodeMaps[0]) * (episodenum - i - 1));
+				memmove(&EpisodeInfos[i], &EpisodeInfos[i + 1],
+				        sizeof(EpisodeInfos[0]) * (episodenum - i - 1));
+			}
+			episodenum--;
 		}
-	
-		MustGetString(os);
-		while (os.scan())
+	}
+	else
+	{
+		if (pic.empty())
 		{
-			if (os.compareToken("{"))
+			pic = map.c_str();
+			picisgfx = false;
+		}
+
+		if (i == episodenum)
+		{
+			if (episodenum == MAX_EPISODES)
 			{
-				// Detected new-style MAPINFO
-				I_Error(
-				    "Detected incorrectly placed curly brace in MAPINFO episode definiton");
-			}
-			else if (os.compareToken("}"))
-			{
-				if (new_mapinfo == false)
-				{
-					I_Error("Detected incorrectly placed curly brace in MAPINFO episode "
-					        "definiton");
-				}
-				else
-				{
-					break;
-				}
-			}
-			else if (UpperCompareToken(os, "name"))
-			{
-				ParseMapInfoHelper<std::string>(os, new_mapinfo);
-				
-				if (picisgfx == false)
-				{
-					pic = os.getToken();
-				}
-			}
-			else if (UpperCompareToken(os, "lookup"))
-			{
-			    ParseMapInfoHelper<std::string>(os, new_mapinfo);
-	
-				// Not implemented
-			}
-			else if (UpperCompareToken(os, "picname"))
-			{
-			    ParseMapInfoHelper<std::string>(os, new_mapinfo);
-				
-				pic = os.getToken();
-				picisgfx = true;
-			}
-			else if (UpperCompareToken(os, "key"))
-			{
-			    ParseMapInfoHelper<std::string>(os, new_mapinfo);
-				
-				key = os.getToken()[0];
-			}
-			else if (UpperCompareToken(os, "remove"))
-			{
-				remove = true;
-			}
-			else if (UpperCompareToken(os, "noskillmenu"))
-			{
-				noskillmenu = true;
-			}
-			else if (UpperCompareToken(os, "optional"))
-			{
-				optional = true;
-			}
-			else if (UpperCompareToken(os, "extended"))
-			{
-				extended = true;
+				i = episodenum - 1;
 			}
 			else
 			{
-				os.unScan();
-				break;
+				i = episodenum++;
 			}
 		}
-	
-		int i;
-		for (i = 0; i < episodenum; ++i)
+
+		EpisodeInfos[i].name = pic;
+		EpisodeInfos[i].key = tolower(key);
+		EpisodeInfos[i].fulltext = !picisgfx;
+		EpisodeInfos[i].noskillmenu = noskillmenu;
+		strncpy(EpisodeMaps[i], map.c_str(), 8);
+	}
+}
+
+void ParseMapInfoLump(int lump, const char* lumpname)
+{
+	LevelInfos& levels = getLevelInfos();
+	ClusterInfos& clusters = getClusterInfos();
+
+	level_pwad_info_t defaultinfo;
+	SetLevelDefaults(defaultinfo);
+
+	const char* buffer = static_cast<char*>(W_CacheLumpNum(lump, PU_STATIC));
+
+	OScannerConfig config = {
+	    lumpname, // lumpName
+	    false,    // semiComments
+	    true,     // cComments
+	};
+	OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));
+
+	while (os.scan())
+	{
+		if (UpperCompareToken(os, "defaultmap"))
 		{
-			if (map == EpisodeMaps[i])
-				break;
+			SetLevelDefaults(defaultinfo);
+
+			MapInfoDataSetter<level_pwad_info_t> defaultsetter(defaultinfo);
+			ParseMapInfoLower<level_pwad_info_t>(os, defaultsetter);
 		}
-	
-		if (remove || (optional && W_CheckNumForName(map.c_str()) == -1) ||
-		    (extended && W_CheckNumForName("EXTENDED") == -1))
+		else if (UpperCompareToken(os, "map"))
 		{
-			// If the remove property is given for an episode, remove it.
-			if (i < episodenum)
+			uint32_t& levelflags = defaultinfo.flags;
+			MustGetString(os);
+
+			char map_name[9];
+			strncpy(map_name, os.getToken().c_str(), 8);
+
+			if (IsNum(map_name))
 			{
-				if (i + 1 < episodenum)
-				{
-					memmove(&EpisodeMaps[i], &EpisodeMaps[i + 1],
-					        sizeof(EpisodeMaps[0]) * (episodenum - i - 1));
-					memmove(&EpisodeInfos[i], &EpisodeInfos[i + 1],
-					        sizeof(EpisodeInfos[0]) * (episodenum - i - 1));
-				}
-				episodenum--;
+				// MAPNAME is a number, assume a Hexen wad
+				const int map = std::atoi(map_name);
+
+				sprintf(map_name, "MAP%02d", map);
+				SKYFLATNAME[5] = 0;
+				HexenHack = true;
+				// Hexen levels are automatically nointermission
+				// and even lighting and no auto sound sequences
+				levelflags |=
+				    LEVEL_NOINTERMISSION | LEVEL_EVENLIGHTING | LEVEL_SNDSEQTOTALCTRL;
 			}
+
+			// Find the level.
+			level_pwad_info_t& info = (levels.findByName(map_name).exists())
+			                              ? levels.findByName(map_name)
+			                              : levels.create();
+
+			info = defaultinfo;
+			info.mapname = map_name;
+
+			// Map name.
+			MustGetString(os);
+			if (UpperCompareToken(os, "lookup"))
+			{
+				MustGetString(os);
+				const OString& s = GStrings(os.getToken());
+				if (s.empty())
+				{
+					I_Error("Unknown lookup string \"%s\"", os.getToken().c_str());
+				}
+				info.level_name = strdup(s.c_str());
+			}
+			else
+			{
+				info.level_name = strdup(os.getToken().c_str());
+			}
+
+			MapInfoDataSetter<level_pwad_info_t> setter(info);
+			ParseMapInfoLower<level_pwad_info_t>(os, setter);
+
+			// If the level info was parsed and no levelnum was applied,
+			// try and synthesize one from the level name.
+			if (info.levelnum == 0)
+			{
+				MapNameToLevelNum(info);
+			}
+		}
+		else if (UpperCompareToken(os, "cluster") || UpperCompareToken(os, "clusterdef"))
+		{
+			MustGet<int>(os);
+
+			// Find the cluster.
+			cluster_info_t& info =
+			    (clusters.findByCluster(GetToken<int>(os)).cluster != 0)
+			        ? clusters.findByCluster(GetToken<int>(os))
+			        : clusters.create();
+
+			info.cluster = GetToken<int>(os);
+
+			MapInfoDataSetter<cluster_info_t> setter(info);
+			ParseMapInfoLower<cluster_info_t>(os, setter);
+		}
+		else if (UpperCompareToken(os, "episode"))
+		{
+			ParseEpisodeInfo(os);
+		}
+		else if (UpperCompareToken(os, "clearepisodes"))
+		{
+			episodenum = 0;
+			// Set this for UMAPINFOs sake (UMAPINFO doesn't consider Doom 2's episode a
+			// real episode)
+			episodes_modified = false;
+		}
+		else if (UpperCompareToken(os, "skill"))
+		{
+			// Not implemented
+			MustGetString(os); // Name
+
+			MapInfoDataSetter<void> setter;
+			ParseMapInfoLower<void>(os, setter);
+		}
+		else if (UpperCompareToken(os, "clearskills"))
+		{
+			// Not implemented
+		}
+		else if (UpperCompareToken(os, "gameinfo"))
+		{
+			MapInfoDataSetter<gameinfo_t> setter;
+			ParseMapInfoLower<gameinfo_t>(os, setter);
+		}
+		else if (UpperCompareToken(os, "intermission"))
+		{
+			// Not implemented
+			MustGetString(os); // Name
+
+			MapInfoDataSetter<void> setter;
+			ParseMapInfoLower<void>(os, setter);
+		}
+		else if (UpperCompareToken(os, "automap"))
+		{
+			// Not implemented
+			MapInfoDataSetter<void> setter;
+			ParseMapInfoLower<void>(os, setter);
 		}
 		else
 		{
-			if (pic.empty())
-			{
-				pic = map.c_str();
-				picisgfx = false;
-			}
-	
-			if (i == episodenum)
-			{
-				if (episodenum == MAX_EPISODES)
-				{
-					i = episodenum - 1;
-				}
-				else
-				{
-					i = episodenum++;
-				}
-			}
-	
-			EpisodeInfos[i].name = pic;
-			EpisodeInfos[i].key = tolower(key);
-			EpisodeInfos[i].fulltext = !picisgfx;
-			EpisodeInfos[i].noskillmenu = noskillmenu;
-			strncpy(EpisodeMaps[i], map.c_str(), 8);
+			I_Error("Unimplemented top-level type \"%s\"", os.getToken().c_str());
 		}
 	}
-
-	void ParseMapInfoLump(int lump, const char* lumpname)
-	{
-		LevelInfos& levels = getLevelInfos();
-		ClusterInfos& clusters = getClusterInfos();
-	
-		level_pwad_info_t defaultinfo;
-		SetLevelDefaults(defaultinfo);
-	
-		const char* buffer = static_cast<char*>(W_CacheLumpNum(lump, PU_STATIC));
-	
-		OScannerConfig config = {
-		    lumpname, // lumpName
-		    false,    // semiComments
-		    true,     // cComments
-		};
-		OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));
-	
-		while (os.scan())
-		{
-			if (UpperCompareToken(os, "defaultmap"))
-			{
-				SetLevelDefaults(defaultinfo);
-				
-				MapInfoDataSetter<level_pwad_info_t> defaultsetter(defaultinfo);
-				ParseMapInfoLower<level_pwad_info_t>(os, defaultsetter);
-			}
-			else if (UpperCompareToken(os, "map"))
-			{
-				uint32_t &levelflags = defaultinfo.flags;
-				MustGetString(os);
-	
-				char map_name[9];
-				strncpy(map_name, os.getToken().c_str(), 8);
-	
-				if (IsNum(map_name))
-				{
-					// MAPNAME is a number, assume a Hexen wad
-					const int map = std::atoi(map_name);
-	
-					sprintf(map_name, "MAP%02d", map);
-					SKYFLATNAME[5] = 0;
-					HexenHack = true;
-					// Hexen levels are automatically nointermission
-					// and even lighting and no auto sound sequences
-					levelflags |=
-					    LEVEL_NOINTERMISSION | LEVEL_EVENLIGHTING | LEVEL_SNDSEQTOTALCTRL;
-				}
-	
-				// Find the level.
-				level_pwad_info_t& info = (levels.findByName(map_name).exists())
-				                              ? levels.findByName(map_name)
-				                              : levels.create();
-	
-				info = defaultinfo;
-				info.mapname = map_name;
-	
-				// Map name.
-				MustGetString(os);
-				if (UpperCompareToken(os, "lookup"))
-				{
-					MustGetString(os);
-					const OString& s = GStrings(os.getToken());
-					if (s.empty())
-					{
-						I_Error("Unknown lookup string \"%s\"", os.getToken().c_str());
-					}
-					info.level_name = strdup(s.c_str());
-				}
-				else
-				{
-					info.level_name = strdup(os.getToken().c_str());
-				}
-
-				MapInfoDataSetter<level_pwad_info_t> setter(info);
-				ParseMapInfoLower<level_pwad_info_t>(os, setter);
-	
-				// If the level info was parsed and no levelnum was applied,
-				// try and synthesize one from the level name.
-				if (info.levelnum == 0)
-				{
-					MapNameToLevelNum(info);
-				}
-			}
-			else if (UpperCompareToken(os, "cluster") || UpperCompareToken(os, "clusterdef"))
-			{
-				MustGet<int>(os);
-	
-				// Find the cluster.
-				cluster_info_t& info =
-				    (clusters.findByCluster(GetToken<int>(os)).cluster != 0)
-				        ? clusters.findByCluster(GetToken<int>(os))
-				        : clusters.create();
-	
-				info.cluster = GetToken<int>(os);
-
-				MapInfoDataSetter<cluster_info_t> setter(info);
-			    ParseMapInfoLower<cluster_info_t>(os, setter);
-			}
-			else if (UpperCompareToken(os, "episode"))
-			{
-				ParseEpisodeInfo(os);
-			}
-			else if (UpperCompareToken(os, "clearepisodes"))
-			{
-				episodenum = 0;
-				// Set this for UMAPINFOs sake (UMAPINFO doesn't consider Doom 2's episode a
-				// real episode)
-				episodes_modified = false;
-			}
-			else if (UpperCompareToken(os, "skill"))
-			{
-				// Not implemented
-				MustGetString(os); // Name
-
-				MapInfoDataSetter<void> setter;
-				ParseMapInfoLower<void>(os, setter);
-			}
-			else if (UpperCompareToken(os, "clearskills"))
-			{
-				// Not implemented
-			}
-			else if (UpperCompareToken(os, "gameinfo"))
-			{
-			    MapInfoDataSetter<gameinfo_t> setter;
-			    ParseMapInfoLower<gameinfo_t>(os, setter);
-			}
-			else if (UpperCompareToken(os, "intermission"))
-			{
-				// Not implemented
-				MustGetString(os); // Name
-
-				MapInfoDataSetter<void> setter;
-			    ParseMapInfoLower<void>(os, setter);
-			}
-			else if (UpperCompareToken(os, "automap"))
-			{
-				// Not implemented
-				MapInfoDataSetter<void> setter;
-			    ParseMapInfoLower<void>(os, setter);
-			}
-			else
-			{
-				I_Error("Unimplemented top-level type \"%s\"", os.getToken().c_str());
-			}
-		}
-	}
+}
 } // namespace
 
 //

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -190,15 +190,9 @@ namespace
 		NULL
 	};
 
-	void SetLevelDefaults(level_pwad_info_t* levelinfo)
+	void SetLevelDefaults(level_pwad_info_t& levelinfo)
 	{
-		memset(levelinfo, 0, sizeof(*levelinfo));
-		levelinfo->snapshot = NULL;
-		levelinfo->outsidefog_color[0] = 255;
-		levelinfo->outsidefog_color[1] = 0;
-		levelinfo->outsidefog_color[2] = 0;
-		levelinfo->outsidefog_color[3] = 0;
-		levelinfo->fadetable = "COLORMAP";
+		levelinfo = level_pwad_info_t();
 	}
 	
 	//
@@ -755,7 +749,7 @@ namespace
 		LevelInfos& levels = getLevelInfos();
 	
 		level_pwad_info_t defaultinfo;
-		SetLevelDefaults(&defaultinfo);
+		SetLevelDefaults(defaultinfo);
 	
 		const char* buffer = static_cast<char*>(W_CacheLumpNum(lump, PU_STATIC));
 	
@@ -1617,7 +1611,7 @@ namespace
 		ClusterInfos& clusters = getClusterInfos();
 	
 		level_pwad_info_t defaultinfo;
-		SetLevelDefaults(&defaultinfo);
+		SetLevelDefaults(defaultinfo);
 	
 		const char* buffer = static_cast<char*>(W_CacheLumpNum(lump, PU_STATIC));
 	
@@ -1632,14 +1626,14 @@ namespace
 		{
 			if (UpperCompareToken(os, "defaultmap"))
 			{
-				SetLevelDefaults(&defaultinfo);
+				SetLevelDefaults(defaultinfo);
 				
 				MapInfoDataSetter<level_pwad_info_t> defaultsetter(defaultinfo);
 				ParseMapInfoLower<level_pwad_info_t>(os, defaultsetter);
 			}
 			else if (UpperCompareToken(os, "map"))
 			{
-				DWORD &levelflags = defaultinfo.flags;
+				uint32_t &levelflags = defaultinfo.flags;
 				MustGetString(os);
 	
 				char map_name[9];

--- a/common/oscanner.cpp
+++ b/common/oscanner.cpp
@@ -473,6 +473,14 @@ bool OScanner::compareToken(const char* string) const
 }
 
 //
+// Compare the most recent token with the passed string, case-insensitive.
+//
+bool OScanner::compareTokenNoCase(const char* string) const
+{
+	return iequals(m_token, string);
+}
+
+//
 // Print given error message.
 //
 void OScanner::error(const char* message) const

--- a/common/oscanner.cpp
+++ b/common/oscanner.cpp
@@ -302,10 +302,9 @@ void OScanner::mustScanInt()
 
 	if (IsNum(str.c_str()) == false && str != "MAXINT")
 	{
-		std::string errorMessage = "Expected integer, got \"";
-		errorMessage += str + '\"';
-
-		error(errorMessage.c_str());
+		std::string err;
+		StrFormat(err, "Expected integer, got \"%s\".", m_token.c_str());
+		error(err.c_str());
 	}
 }
 
@@ -316,7 +315,7 @@ void OScanner::mustScanFloat()
 {
 	if (!scan())
 	{
-		error("Missing floating-point number (unexpected end of file).");
+		error("Missing float (unexpected end of file).");
 	}
 
 	// fix for parser reading in commas
@@ -330,10 +329,9 @@ void OScanner::mustScanFloat()
 
 	if (IsRealNum(str.c_str()) == false)
 	{
-		std::string errorMessage = "Expected floating-point number, got \"";
-		errorMessage += str + '\"';
-
-		error(errorMessage.c_str());
+		std::string err;
+		StrFormat(err, "Expected float, got \"%s\".", m_token.c_str());
+		error(err.c_str());
 	}
 }
 
@@ -349,10 +347,9 @@ void OScanner::mustScanBool()
 
 	if (!iequals(m_token, "true") && !iequals(m_token, "false"))
 	{
-		std::string errorMessage = "Expected boolean, got \"";
-		errorMessage += m_token + '\"';
-
-		error(errorMessage.c_str());
+		std::string err;
+		StrFormat(err, "Expected boolean, got \"%s\".", m_token.c_str());
+		error(err.c_str());
 	}
 }
 
@@ -366,8 +363,7 @@ void OScanner::unScan()
 {
 	if (m_unScan == true)
 	{
-		I_Error("Script Error: %d:%s: Tried to unScan twice in a row", m_lineNumber,
-		        m_config.lumpName);
+		error("Tried to unScan twice in a row.");
 	}
 
 	m_unScan = true;
@@ -406,7 +402,9 @@ int OScanner::getTokenInt() const
 
 	if (*stopper != 0)
 	{
-		I_Error("Bad numeric constant \"%s\".", str.c_str());
+		std::string err;
+		StrFormat(err, "Bad integer constant \"%s\".", m_token.c_str());
+		error(err.c_str());
 	}
 
 	return num;
@@ -432,7 +430,9 @@ float OScanner::getTokenFloat() const
 
 	if (*stopper != 0)
 	{
-		I_Error("Bad numeric constant \"%s\".", str.c_str());
+		std::string err;
+		StrFormat(err, "Bad float constant \"%s\".", m_token.c_str());
+		error(err.c_str());
 	}
 
 	return static_cast<float>(num);
@@ -461,8 +461,10 @@ void OScanner::assertTokenIs(const char* string) const
 {
 	if (m_token.compare(string) != 0)
 	{
-		I_Error("Script Error: %d:%s: Unexpected Token (expected '%s' actual '%s')",
-		        m_lineNumber, m_config.lumpName, string, m_token.c_str());
+		std::string err;
+		StrFormat(err, "Unexpected Token (expected \"%s\" actual \"%s\").", string,
+		          m_token.c_str());
+		error(err.c_str());
 	}
 }
 
@@ -477,9 +479,9 @@ bool OScanner::compareToken(const char* string) const
 //
 // Print given error message.
 //
-void OScanner::error(const char* message)
+void OScanner::error(const char* message) const
 {
-	I_Error("%s", message);
+	I_Error("Script Error: %s:%d: %s", m_config.lumpName, m_lineNumber, message);
 }
 
 VERSION_CONTROL(sc_oman_cpp, "$Id$")

--- a/common/oscanner.cpp
+++ b/common/oscanner.cpp
@@ -99,10 +99,6 @@ bool OScanner::munchQuotedString()
 		if (m_position[0] == '"')
 			return true;
 
-		// Ran off the end of the line, this is a problem.
-		if (m_position[0] == '\n')
-			return false;
-
 		m_position += 1;
 	}
 

--- a/common/oscanner.cpp
+++ b/common/oscanner.cpp
@@ -34,7 +34,7 @@
 
 #include "i_system.h"
 
-#define SINGLE_CHAR_TOKENS "$();=[]{}"
+static const char* SINGLE_CHAR_TOKENS = "$(),;=[]{}";
 
 bool OScanner::checkPair(char a, char b)
 {

--- a/common/oscanner.cpp
+++ b/common/oscanner.cpp
@@ -34,48 +34,47 @@
 
 #include "i_system.h"
 
-
 #define SINGLE_CHAR_TOKENS "$();=[]{}"
 
 bool OScanner::checkPair(char a, char b)
 {
-	return _position[0] == a && _position + 1 < _scriptEnd && _position[1] == b;
+	return m_position[0] == a && m_position + 1 < m_scriptEnd && m_position[1] == b;
 }
 
 void OScanner::skipWhitespace()
 {
-	while (_position < _scriptEnd && _position[0] <= ' ')
+	while (m_position < m_scriptEnd && m_position[0] <= ' ')
 	{
-		if (_position[0] == '\n')
-			_lineNumber += 1;
+		if (m_position[0] == '\n')
+			m_lineNumber += 1;
 
-		_position += 1;
+		m_position += 1;
 	}
 }
 
 void OScanner::skipToNextLine()
 {
-	while (_position < _scriptEnd && _position[0] != '\n')
-		_position += 1;
+	while (m_position < m_scriptEnd && m_position[0] != '\n')
+		m_position += 1;
 
-	_position += 1;
-	_lineNumber += 1;
+	m_position += 1;
+	m_lineNumber += 1;
 }
 
 void OScanner::skipPastPair(char a, char b)
 {
-	while (_position < _scriptEnd)
+	while (m_position < m_scriptEnd)
 	{
 		if (checkPair(a, b))
 		{
-			_position += 2;
+			m_position += 2;
 			return;
 		}
 
-		if (_position[0] == '\n')
-			_lineNumber += 1;
+		if (m_position[0] == '\n')
+			m_lineNumber += 1;
 
-		_position += 1;
+		m_position += 1;
 	}
 }
 
@@ -87,24 +86,24 @@ void OScanner::skipPastPair(char a, char b)
 //
 bool OScanner::munchQuotedString()
 {
-	while (_position < _scriptEnd)
+	while (m_position < m_scriptEnd)
 	{
 		// Found an escape character quotation mark in string.
-		if (_position[0] == '\\' && _position + 1 < _scriptEnd && _position[1] == '"')
+		if (m_position[0] == '\\' && m_position + 1 < m_scriptEnd && m_position[1] == '"')
 		{
-			_removeEscapeCharacter = true;
-			_position += 2;
+			m_removeEscapeCharacter = true;
+			m_position += 2;
 		}
-		
+
 		// Found ending quote.
-		if (_position[0] == '"')
+		if (m_position[0] == '"')
 			return true;
 
 		// Ran off the end of the line, this is a problem.
-		if (_position[0] == '\n')
+		if (m_position[0] == '\n')
 			return false;
 
-		_position += 1;
+		m_position += 1;
 	}
 
 	// Ran off the end of the script, this is also a problem.
@@ -113,29 +112,29 @@ bool OScanner::munchQuotedString()
 
 void OScanner::munchString()
 {
-	while (_position < _scriptEnd)
+	while (m_position < m_scriptEnd)
 	{
 		// Munch until whitespace.
-		if (_position[0] <= ' ')
+		if (m_position[0] <= ' ')
 			return;
 
 		// There are some tokens that can end the string without whitespace.
-		if (_position[0] == '"')
-			return;
-		
-		if (_config.semiComments && _position[0] == ';')
+		if (m_position[0] == '"')
 			return;
 
-		if (_config.cComments && checkPair('/', '/'))
+		if (m_config.semiComments && m_position[0] == ';')
 			return;
 
-		if (_config.cComments && checkPair('/', '*'))
+		if (m_config.cComments && checkPair('/', '/'))
 			return;
 
-		if (strchr(SINGLE_CHAR_TOKENS, _position[0]) != NULL)
+		if (m_config.cComments && checkPair('/', '*'))
 			return;
 
-		_position += 1;
+		if (strchr(SINGLE_CHAR_TOKENS, m_position[0]) != NULL)
+			return;
+
+		m_position += 1;
 	}
 }
 
@@ -146,41 +145,41 @@ void OScanner::munchString()
 //
 void OScanner::pushToken(const char* string, size_t length)
 {
-	_token.assign(string, length);
+	m_token.assign(string, length);
 
-	if (_removeEscapeCharacter)
+	if (m_removeEscapeCharacter)
 	{
-		size_t pos = _token.find("\\\"", 0);
-		
+		size_t pos = m_token.find("\\\"", 0);
+
 		while (pos != std::string::npos)
 		{
-			_token.replace(pos, 2, "\"");
+			m_token.replace(pos, 2, "\"");
 			pos += 2;
-			
-			pos = _token.find("\\\"", pos);
+
+			pos = m_token.find("\\\"", pos);
 		}
 
-		_removeEscapeCharacter = false;
+		m_removeEscapeCharacter = false;
 	}
 }
 
 void OScanner::pushToken(const std::string& string)
 {
-	_token = string;
+	m_token = string;
 
-	if (_removeEscapeCharacter)
+	if (m_removeEscapeCharacter)
 	{
-		size_t pos = _token.find("\\\"", 0);
+		size_t pos = m_token.find("\\\"", 0);
 
 		while (pos != std::string::npos)
 		{
-			_token.replace(pos, 2, "\"");
+			m_token.replace(pos, 2, "\"");
 			pos += 2;
 
-			pos = _token.find("\\\"", pos);
+			pos = m_token.find("\\\"", pos);
 		}
 
-		_removeEscapeCharacter = false;
+		m_removeEscapeCharacter = false;
 	}
 }
 
@@ -191,9 +190,9 @@ OScanner OScanner::openBuffer(const OScannerConfig& config, const char* start,
                               const char* end)
 {
 	OScanner os = OScanner(config);
-	os._scriptStart = start;
-	os._scriptEnd = end;
-	os._position = start;
+	os.m_scriptStart = start;
+	os.m_scriptEnd = end;
+	os.m_position = start;
 	return os;
 }
 
@@ -202,73 +201,159 @@ OScanner OScanner::openBuffer(const OScannerConfig& config, const char* start,
 //
 bool OScanner::scan()
 {
-	if (_unScan)
+	if (m_unScan)
 	{
-		_unScan = false;
+		m_unScan = false;
 		return true;
 	}
 
-	_isQuotedString = false;
+	m_isQuotedString = false;
 
-	while (_position < _scriptEnd)
+	while (m_position < m_scriptEnd)
 	{
 		// What are we looking at?
-		if (_position[0] <= ' ')
+		if (m_position[0] <= ' ')
 		{
 			skipWhitespace();
 			continue;
 		}
-		if (_config.semiComments && _position[0] == ';')
+		if (m_config.semiComments && m_position[0] == ';')
 		{
 			skipToNextLine();
 			continue;
 		}
-		else if (_config.cComments && checkPair('/', '/'))
+		else if (m_config.cComments && checkPair('/', '/'))
 		{
 			skipToNextLine();
 			continue;
 		}
-		else if (_config.cComments && checkPair('/', '*'))
+		else if (m_config.cComments && checkPair('/', '*'))
 		{
 			skipPastPair('*', '/');
 			continue;
 		}
 
 		// We found an interesting token.  What is it?
-		const char* single = strchr(SINGLE_CHAR_TOKENS, _position[0]);
+		const char* single = strchr(SINGLE_CHAR_TOKENS, m_position[0]);
 		if (single != NULL)
 		{
 			// Found a single char token.
 			pushToken(single, 1);
 
-			_position += 1;
+			m_position += 1;
 			return true;
 		}
-		else if (_position[0] == '"')
+		else if (m_position[0] == '"')
 		{
 			// Found a quoted string.
-			_isQuotedString = true;
-			
-			_position += 1;
-			const char* begin = _position;
+			m_isQuotedString = true;
+
+			m_position += 1;
+			const char* begin = m_position;
 			if (munchQuotedString() == false)
 				return false;
-			const char* end = _position;
+			const char* end = m_position;
 			pushToken(begin, end - begin);
 
-			_position += 1;
+			m_position += 1;
 			return true;
 		}
 
 		// Found a bare string.
-		const char* begin = _position;
+		const char* begin = m_position;
 		munchString();
-		const char* end = _position;
+		const char* end = m_position;
 		pushToken(begin, end - begin);
 		return true;
 	}
 
 	return false;
+}
+
+//
+// Ensure next token is a string.
+//
+void OScanner::mustScan()
+{
+	if (!scan())
+	{
+		error("Missing string (unexpected end of file).");
+	}
+}
+
+//
+// Ensure next token is an int.
+//
+void OScanner::mustScanInt()
+{
+	if (!scan())
+	{
+		error("Missing integer (unexpected end of file).");
+	}
+
+	// fix for parser reading in commas
+	std::string str = m_token;
+
+	// remove comma if necessary
+	if (*(str.end() - 1) == ',')
+	{
+		str.resize(str.size() - 1);
+	}
+
+	if (IsNum(str.c_str()) == false && str != "MAXINT")
+	{
+		std::string errorMessage = "Expected integer, got \"";
+		errorMessage += str + '\"';
+
+		error(errorMessage.c_str());
+	}
+}
+
+//
+// Ensure next token is a float.
+//
+void OScanner::mustScanFloat()
+{
+	if (!scan())
+	{
+		error("Missing floating-point number (unexpected end of file).");
+	}
+
+	// fix for parser reading in commas
+	std::string str = m_token;
+
+	// remove comma if necessary
+	if (*(str.end() - 1) == ',')
+	{
+		str.resize(str.size() - 1);
+	}
+
+	if (IsRealNum(str.c_str()) == false)
+	{
+		std::string errorMessage = "Expected floating-point number, got \"";
+		errorMessage += str + '\"';
+
+		error(errorMessage.c_str());
+	}
+}
+
+//
+// Ensure next token is a bool.
+//
+void OScanner::mustScanBool()
+{
+	if (!scan())
+	{
+		error("Missing boolean (unexpected end of file).");
+	}
+
+	if (!iequals(m_token, "true") && !iequals(m_token, "false"))
+	{
+		std::string errorMessage = "Expected boolean, got \"";
+		errorMessage += m_token + '\"';
+
+		error(errorMessage.c_str());
+	}
 }
 
 //
@@ -279,13 +364,13 @@ bool OScanner::scan()
 //
 void OScanner::unScan()
 {
-	if (_unScan == true)
+	if (m_unScan == true)
 	{
-		I_Error("Script Error: %d:%s: Tried to unScan twice in a row",
-			_lineNumber, _config.lumpName);
+		I_Error("Script Error: %d:%s: Tried to unScan twice in a row", m_lineNumber,
+		        m_config.lumpName);
 	}
 
-	_unScan = true;
+	m_unScan = true;
 }
 
 //
@@ -293,52 +378,16 @@ void OScanner::unScan()
 //
 std::string OScanner::getToken() const
 {
-	return _token;
-}
-
-//
-// Assert token is equal to the passed string, or error.
-//
-void OScanner::assertTokenIs(const char* string) const
-{
-	if (_token.compare(string) != 0)
-	{
-		I_Error("Script Error: %d:%s: Unexpected Token (expected '%s' actual '%s')",
-		        _lineNumber, _config.lumpName, string, _token.c_str());
-	}
-}
-
-//
-// Compare the most recent token with the passed string.
-//
-bool OScanner::compareToken(const char* string) const
-{
-	return _token.compare(string) == 0;
-}
-
-//
-// Print given error message.
-//
-void OScanner::error(const char* message)
-{
-	I_Error("%s", message);
-}
-
-//
-// Check if last token read in was a quoted string.
-//
-bool OScanner::isQuotedString() const
-{
-	return _isQuotedString;
+	return m_token;
 }
 
 //
 // Get token as an int.
 //
-int OScanner::getTokenAsInt() const
+int OScanner::getTokenInt() const
 {
 	// fix for parser reading in commas
-	std::string str = _token;
+	std::string str = m_token;
 
 	// remove comma if necessary
 	if (*(str.end() - 1) == ',')
@@ -350,7 +399,7 @@ int OScanner::getTokenAsInt() const
 
 	if (str == "MAXINT")
 	{
-		return MAXINT;//INT32_MAX;
+		return MAXINT; // INT32_MAX;
 	}
 
 	const int num = strtol(str.c_str(), &stopper, 0);
@@ -366,10 +415,10 @@ int OScanner::getTokenAsInt() const
 //
 // Get token as a float.
 //
-float OScanner::getTokenAsFloat() const
+float OScanner::getTokenFloat() const
 {
 	// fix for parser reading in commas
-	std::string str = _token;
+	std::string str = m_token;
 
 	// remove comma if necessary
 	if (*(str.end() - 1) == ',')
@@ -392,95 +441,45 @@ float OScanner::getTokenAsFloat() const
 //
 // Get token as a bool.
 //
-bool OScanner::getTokenAsBool() const
+bool OScanner::getTokenBool() const
 {
-	return iequals(_token, "true");
+	return iequals(m_token, "true");
 }
 
 //
-// Ensure next token is a string.
+// Check if last token read in was a quoted string.
 //
-void OScanner::mustGetString()
+bool OScanner::isQuotedString() const
 {
-	if (!scan())
-	{
-		error("Missing string (unexpected end of file).");
-	}
+	return m_isQuotedString;
 }
 
 //
-// Ensure next token is an int.
+// Assert token is equal to the passed string, or error.
 //
-void OScanner::mustGetInt()
+void OScanner::assertTokenIs(const char* string) const
 {
-	if (!scan())
+	if (m_token.compare(string) != 0)
 	{
-		error("Missing integer (unexpected end of file).");
-	}
-
-	// fix for parser reading in commas
-	std::string str = _token;
-
-	// remove comma if necessary
-	if (*(str.end() - 1) == ',')
-	{
-		str.resize(str.size() - 1);
-	}
-
-	if (IsNum(str.c_str()) == false && str != "MAXINT")
-	{
-		std::string errorMessage = "Expected integer, got \"";
-		errorMessage += str + '\"';
-
-		error(errorMessage.c_str());
+		I_Error("Script Error: %d:%s: Unexpected Token (expected '%s' actual '%s')",
+		        m_lineNumber, m_config.lumpName, string, m_token.c_str());
 	}
 }
 
 //
-// Ensure next token is a float.
+// Compare the most recent token with the passed string.
 //
-void OScanner::mustGetFloat()
+bool OScanner::compareToken(const char* string) const
 {
-	if (!scan())
-	{
-		error("Missing floating-point number (unexpected end of file).");
-	}
-
-	// fix for parser reading in commas
-	std::string str = _token;
-
-	// remove comma if necessary
-	if (*(str.end() - 1) == ',')
-	{
-		str.resize(str.size() - 1);
-	}
-
-	if (IsRealNum(str.c_str()) == false)
-	{
-		std::string errorMessage = "Expected floating-point number, got \"";
-		errorMessage += str + '\"';
-
-		error(errorMessage.c_str());
-	}
+	return m_token.compare(string) == 0;
 }
 
 //
-// Ensure next token is a bool.
+// Print given error message.
 //
-void OScanner::mustGetBool()
+void OScanner::error(const char* message)
 {
-	if (!scan())
-	{
-		error("Missing boolean (unexpected end of file).");
-	}
-	
-	if (!iequals(_token, "true") && !iequals(_token, "false"))
-	{
-		std::string errorMessage = "Expected boolean, got \"";
-		errorMessage += _token + '\"';
-
-		error(errorMessage.c_str());
-	}
+	I_Error("%s", message);
 }
 
 VERSION_CONTROL(sc_oman_cpp, "$Id$")

--- a/common/oscanner.h
+++ b/common/oscanner.h
@@ -35,15 +35,15 @@ struct OScannerConfig
 
 class OScanner
 {
-	OScannerConfig _config;
-	const char* _scriptStart;
-	const char* _scriptEnd;
-	const char* _position;
-	int _lineNumber;
-	std::string _token;
-	bool _unScan;
-	bool _removeEscapeCharacter;
-	bool _isQuotedString;
+	OScannerConfig m_config;
+	const char* m_scriptStart;
+	const char* m_scriptEnd;
+	const char* m_position;
+	int m_lineNumber;
+	std::string m_token;
+	bool m_unScan;
+	bool m_removeEscapeCharacter;
+	bool m_isQuotedString;
 
 	bool checkPair(char a, char b);
 	void skipWhitespace();
@@ -56,30 +56,31 @@ class OScanner
 
   public:
 	OScanner(const OScannerConfig& config)
-	    : _config(config), _scriptStart(NULL), _scriptEnd(NULL), _position(NULL),
-	      _lineNumber(0), _token(""), _unScan(false), _removeEscapeCharacter(false),
-		  _isQuotedString(false){}
+	    : m_config(config), m_scriptStart(NULL), m_scriptEnd(NULL), m_position(NULL),
+	      m_lineNumber(0), m_token(""), m_unScan(false), m_removeEscapeCharacter(false),
+	      m_isQuotedString(false)
+	{
+	}
 
 	static OScanner openBuffer(const OScannerConfig& config, const char* start,
 	                           const char* end);
+
 	bool scan();
+	void mustScan();
+	void mustScanInt();
+	void mustScanFloat();
+	void mustScanBool();
 	void unScan();
+
 	std::string getToken() const;
+	int getTokenInt() const;
+	float getTokenFloat() const;
+	bool getTokenBool() const;
+
+	bool isQuotedString() const;
 	void assertTokenIs(const char* string) const;
 	bool compareToken(const char* string) const;
 	void error(const char* message);
-	bool isQuotedString() const;
-
-	// get token as specific type
-	int getTokenAsInt() const;
-	float getTokenAsFloat() const;
-	bool getTokenAsBool() const;
-
-	// check token is specific type (calls OScanner::scan() and then checks the type)
-	void mustGetString();
-	void mustGetInt();
-	void mustGetFloat();
-	void mustGetBool();
 };
 
 #endif // __OSCANNER_H__

--- a/common/oscanner.h
+++ b/common/oscanner.h
@@ -80,6 +80,7 @@ class OScanner
 	bool isQuotedString() const;
 	void assertTokenIs(const char* string) const;
 	bool compareToken(const char* string) const;
+	bool compareTokenNoCase(const char* string) const;
 	void error(const char* message) const;
 };
 

--- a/common/oscanner.h
+++ b/common/oscanner.h
@@ -80,7 +80,7 @@ class OScanner
 	bool isQuotedString() const;
 	void assertTokenIs(const char* string) const;
 	bool compareToken(const char* string) const;
-	void error(const char* message);
+	void error(const char* message) const;
 };
 
 #endif // __OSCANNER_H__

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -406,16 +406,16 @@ static void P_InitAnimDefs ()
 			}
 			else if (os.compareToken("warp"))
 			{
-				os.mustGetString();
+				os.mustScan();
 				if (os.compareToken("flat"))
 				{
-					os.mustGetString();
+					os.mustScan();
 					flatwarp[R_FlatNumForName(os.getToken().c_str())] = true;
 				}
 				else if (os.compareToken("texture"))
 				{
 					// TODO: Make texture warping work with wall textures
-					os.mustGetString();
+					os.mustScan();
 					R_TextureNumForName(os.getToken().c_str());
 				}
 				else
@@ -434,7 +434,7 @@ static void ParseAnim(OScanner &os, byte istex)
 	anim_t *place;
 	byte min, max;
 
-	os.mustGetString();
+	os.mustScan();
 	picnum = istex ? R_CheckTextureNumForName(os.getToken().c_str())
 		: W_CheckNumForName(os.getToken().c_str(), ns_flats) - firstflat;
 
@@ -501,21 +501,21 @@ static void ParseAnim(OScanner &os, byte istex)
 
 		min = max = 1;	// Shut up, GCC
 
-		os.mustGetInt();
-		const int frame = os.getTokenAsInt();
-		os.mustGetString();
+		os.mustScanInt();
+		const int frame = os.getTokenInt();
+		os.mustScan();
 		if (os.compareToken("tics"))
 		{
-			os.mustGetInt();
-			min = max = clamp(os.getTokenAsInt(), 0, 255);
+			os.mustScanInt();
+			min = max = clamp(os.getTokenInt(), 0, 255);
 		}
 		else if (os.compareToken("rand"))
 		{
-			os.mustGetInt();
-			int num = os.getTokenAsInt();
+			os.mustScanInt();
+			int num = os.getTokenInt();
 			min = num >= 0 ? num : 0;
-			os.mustGetInt();
-			num = os.getTokenAsInt();
+			os.mustScanInt();
+			num = os.getTokenInt();
 			max = num <= 255 ? num : 255;
 		}
 		else

--- a/common/res_texture.cpp
+++ b/common/res_texture.cpp
@@ -574,7 +574,7 @@ void TextureManager::readAnimDefLump()
 				if (os.compareToken("flat"))
 					texture_type = Texture::TEX_FLAT;
 
-				os.mustGetString();
+				os.mustScan();
 				anim.basepic = texturemanager.getHandle(os.getToken(), texture_type);
 
 				anim.curframe = 0;
@@ -595,20 +595,20 @@ void TextureManager::readAnimDefLump()
 
 					byte min = 1, max = 1;
 					
-					os.mustGetInt();
-					const int frame = os.getTokenAsInt();
-					os.mustGetString();
+					os.mustScanInt();
+					const int frame = os.getTokenInt();
+					os.mustScan();
 					if (os.compareToken("tics"))
 					{
-						os.mustGetInt();
-						min = max = clamp(os.getTokenAsInt(), 0, 255);
+						os.mustScanInt();
+						min = max = clamp(os.getTokenInt(), 0, 255);
 					}
 					else if (os.compareToken("rand"))
 					{
-						os.mustGetInt();
-						min = MAX(os.getTokenAsInt(), 0);
-						os.mustGetInt();
-						max = MIN(os.getTokenAsInt(), 255);
+						os.mustScanInt();
+						min = MAX(os.getTokenInt(), 0);
+						os.mustScanInt();
+						max = MIN(os.getTokenInt(), 255);
 						if (min > max)
 							min = max = 1;
 					}
@@ -636,14 +636,14 @@ void TextureManager::readAnimDefLump()
 			}
 			else if (os.compareToken("warp"))
 			{
-				os.mustGetString();
+				os.mustScan();
 				if (os.compareToken("flat") || os.compareToken("texture"))
 				{
 					Texture::TextureSourceType texture_type = Texture::TEX_WALLTEXTURE;
 					if (os.compareToken("flat"))
 						texture_type = Texture::TEX_FLAT;
 
-					os.mustGetString();
+					os.mustScan();
 
 					const texhandle_t texhandle = texturemanager.getHandle(os.getToken(), texture_type);
 					if (texhandle == TextureManager::NOT_FOUND_TEXTURE_HANDLE ||


### PR DESCRIPTION
The main thrust of this commit is to fix the recent UMAPINFO branch so it runs properly on CentOS 7.  However, in the process, a number of other issues were found that applied to all platforms.

- Don't treat level information structs as C structs that can be memcpy-ed.
- Integers were being improperly parsed as boolean values, now no longer.
- Next/Secret map parsing was different depending on if it was a quoted string or not.
- Convert level flags to use a non-enum type and define the flags in terms of `BIT` macros.
- General code clean-ups, especially inside of `OScanner`.
