### PR TITLE
Quit if we attempt to load a corrupt patch

### DIFF
--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -138,7 +138,7 @@ size_t R_CalculateNewPatchSize(patch_t *patch, size_t length)
 //
 // Converts a patch that uses post_t posts into a patch that uses tallpost_t.
 //
-void R_ConvertPatch(patch_t *newpatch, patch_t *rawpatch)
+void R_ConvertPatch(patch_t* newpatch, patch_t* rawpatch, const unsigned int lump)
 {
 	if (!rawpatch || !newpatch)
 		return;
@@ -171,6 +171,12 @@ void R_ConvertPatch(patch_t *newpatch, patch_t *rawpatch)
 			int length = rawpost->length;
 			if (abs_offset + length > rawpatch->height())
 				length = rawpatch->height() - abs_offset;
+
+			if (length < 0)
+			{
+				I_Error("%s: Patch %s appears to be corrupted.", __FUNCTION__,
+				        W_LumpName(lump).c_str());
+			}
 
 			// copy the pixels in the post
 			memcpy(newpost->data(), (byte*)(rawpost) + 3, length);

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -604,6 +604,19 @@ int W_GetNumForName(const char* name, int namespc)
 	return i;
 }
 
+/**
+ * @brief Return the name of a lump number.
+ * 
+ * @detail You likely only need this for debugging, since a name can be
+ *         ambiguous.
+ */
+std::string W_LumpName(unsigned lump)
+{
+	if (lump >= ::numlumps)
+		I_Error("%s: %i >= numlumps", __FUNCTION__, lump);
+
+	return std::string(::lumpinfo[lump].name, ARRAY_LENGTH(::lumpinfo[lump].name));
+}
 
 //
 // W_LumpLength
@@ -737,7 +750,7 @@ void* W_CacheLumpName(const char* name, const zoneTag_e tag)
 }
 
 size_t R_CalculateNewPatchSize(patch_t *patch, size_t length);
-void R_ConvertPatch(patch_t *rawpatch, patch_t *newpatch);
+void R_ConvertPatch(patch_t* rawpatch, patch_t* newpatch, const unsigned int lumpnum);
 
 //
 // W_CachePatch
@@ -768,7 +781,7 @@ patch_t* W_CachePatch(unsigned lumpnum, const zoneTag_e tag)
 			patch_t *newpatch = (patch_t*)lumpcache[lumpnum];
 			*((unsigned char*)lumpcache[lumpnum] + newlumplen) = 0;
 
-			R_ConvertPatch(newpatch, rawpatch);
+			R_ConvertPatch(newpatch, rawpatch, lumpnum);
 		}
 		else
 		{

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -120,6 +120,7 @@ int W_HandleToLump(const lumpHandle_t handle);
 int		W_CheckNumForName (const char *name, int ns = ns_global);
 int		W_GetNumForName (const char *name, int ns = ns_global);
 
+std::string W_LumpName(unsigned lump);
 unsigned	W_LumpLength (unsigned lump);
 void		W_ReadLump (unsigned lump, void *dest);
 unsigned	W_ReadChunk (const char *file, unsigned offs, unsigned len, void *dest, unsigned &filelen);


### PR DESCRIPTION
Got a crash from someone trying to load a WAD with a corrupt patch.  Did a little digging and it turned out to be that the graphic was corrupt, causing the `memcpy` inside our patch conversion routine to copy negative bytes and things quickly went south from there.

So, they needed to fix their WAD, but we should attempt to gracefully quit if we realize the patch is nonsense.