### PR TITLE
Bring back the classic intermission screen to Odamex.

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -180,7 +180,7 @@ CVAR_RANGE_FUNC_DECL(msgmidcolor, "5", "Color used for centered messages.",
 // ------------
 
 // Determines whether to draw the scores on intermission.
-CVAR(				wi_newintermission, "0", "Draw the scores on intermission",
+CVAR(				wi_newintermission, "0", "Use Odamex's intermission screen if there are 4 players or less on cooperative gamemodes.",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
 

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1179,7 +1179,7 @@ void WI_drawNetgameStats(void)
 		if (!demoplayback)
 		{
 			std::string str;
-			StrFormat(str, "%s", it->userinfo.netname);			
+			StrFormat(str, "%s", it->userinfo.netname.c_str());			
 			WI_DrawSmallName(str.c_str(), x+10, y+24);
 		}
 


### PR DESCRIPTION
This was done originally with #80 but I rewrote it since it broke compilation with no apparent reason.

This commits reenables `wi_newintermission`'s original functionality that was disabled long ago.

It also partially fixes coop movies that were desynced due to Odamex's intermission's timer method.

Also, it is disabled automatically whenever 5+ players are playing at the same time online.

COOP demo:
![image](https://user-images.githubusercontent.com/2938006/127654644-3da67e63-b2b5-4671-abcf-e721c3f06c39.png)

Online: 
![image](https://user-images.githubusercontent.com/2938006/127654673-570b00b7-2ca6-40c9-bef8-02f4a83fa671.png)
