### PR TITLE
Fix A_Mushroom codepointer

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -1643,25 +1643,28 @@ void A_FatAttack3 (AActor *actor)
 
 void A_Mushroom(AActor* actor)
 {
-	int n = actor->damage;
+	int n = actor->info->damage;
 
-	A_Explode(actor); // First make normal explosion
+	// Mushroom parameters are part of code pointer's state
+	fixed_t misc1 = actor->state->misc1 ? actor->state->misc1 : FRACUNIT * 4;
+	fixed_t misc2 = actor->state->misc2 ? actor->state->misc2 : FRACUNIT / 2;
 
-	// Now launch mushroom cloud
-	for (int i = -n; i <= n; i += 8)
+	A_Explode(actor); // make normal explosion
+
+	for (int i = -n; i <= n; i += 8) // launch mushroom cloud
 	{
 		for (int j = -n; j <= n; j += 8)
 		{
 			AActor* target = new AActor(actor->x, actor->y, actor->z, MT_UNKNOWNTHING);
 			target->x += i << FRACBITS; // Aim in many directions from source
 			target->y += j << FRACBITS;
-			target->z += P_AproxDistance(i, j) << (FRACBITS + 2);   // Aim up fairly high
+			target->z += P_AproxDistance(i, j) * misc1;     // Aim fairly high
 			AActor* mo = P_SpawnMissile(actor, target, MT_FATSHOT); // Launch fireball
 			if (mo != NULL)
 			{
-				mo->momx >>= 1;
-				mo->momy >>= 1; // Slow it down a bit
-				mo->momz >>= 1;
+				mo->momx = FixedMul(mo->momx, misc2);
+				mo->momy = FixedMul(mo->momy, misc2); // Slow down a bit
+				mo->momz = FixedMul(mo->momz, misc2);
 				mo->flags &= ~MF_NOGRAVITY; // Make debris fall under gravity
 			}
 			target->Destroy();

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -1641,41 +1641,32 @@ void A_FatAttack3 (AActor *actor)
 // Original idea: Linguica
 //
 
-void A_Mushroom (AActor *actor)
+void A_Mushroom(AActor* actor)
 {
-	int i, j, n = actor->damage;
+	int n = actor->damage;
 
-	A_Explode (actor);	// First make normal explosion
+	A_Explode(actor); // First make normal explosion
 
-	// FIXME FIXME FIXME FIXME FIXME FIXME FIXME
-	//
-	// THIS CODE BELOW CRASHES BECAUSE OF THINKERS!
-	// IT'S A SERIOUS BUG TO FIX!!
-	//
-	// FIXME FIXME FIXME FIXME FIXME FIXME FIXME
-
-	/*if(serverside)
+	// Now launch mushroom cloud
+	for (int i = -n; i <= n; i += 8)
 	{
-        // Now launch mushroom cloud
-        for (i = -n; i <= n; i += 8)
-        {
-            for (j = -n; j <= n; j += 8)
-            {
-                AActor target = *actor, *mo;
-                target.x += i << FRACBITS; // Aim in many directions from source
-                target.y += j << FRACBITS;
-                target.z += P_AproxDistance(i,j) << (FRACBITS+2); // Aim up fairly high
-                mo = P_SpawnMissile (actor, &target, MT_FATSHOT); // Launch fireball
-                if (mo != NULL)
-                {
-                    mo->momx >>= 1;
-                    mo->momy >>= 1;				  // Slow it down a bit
-                    mo->momz >>= 1;
-                    mo->flags &= ~MF_NOGRAVITY;   // Make debris fall under gravity
-                }
-            }
-        }
-	}*/
+		for (int j = -n; j <= n; j += 8)
+		{
+			AActor* target = new AActor(actor->x, actor->y, actor->z, MT_UNKNOWNTHING);
+			target->x += i << FRACBITS; // Aim in many directions from source
+			target->y += j << FRACBITS;
+			target->z += P_AproxDistance(i, j) << (FRACBITS + 2);   // Aim up fairly high
+			AActor* mo = P_SpawnMissile(actor, target, MT_FATSHOT); // Launch fireball
+			if (mo != NULL)
+			{
+				mo->momx >>= 1;
+				mo->momy >>= 1; // Slow it down a bit
+				mo->momz >>= 1;
+				mo->flags &= ~MF_NOGRAVITY; // Make debris fall under gravity
+			}
+			target->Destroy();
+		}
+	}
 }
 
 


### PR DESCRIPTION
This codepointer was half commented out because the commented-out bits were crashing the game.

The issue turned out to be the stack-allocation of the `AActor`.  That's not something you can safely do with the actor code in its current state.