### PR TITLE
Create QoL for lobby maps 

### DIFF
--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -195,9 +195,8 @@ void G_ChangeMap() {
 		maplist_entry_t lobby_entry;
 		lobby_entry = Maplist::instance().get_lobbymap();
 
-		if (lobby_entry.map != "")
+		if (!Maplist::instance().lobbyempty())
 		{
-
 			std::string wadstr;
 			for (size_t i = 0; i < lobby_entry.wads.size(); i++)
 			{

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -192,29 +192,51 @@ void G_ChangeMap() {
 	}
 	else
 	{
-		size_t next_index;
-		if (!Maplist::instance().get_next_index(next_index)) {
-			// We don't have a maplist, so grab the next 'natural' map lump.
-			std::string next = G_NextMap();
-			G_DeferedInitNew((char *)next.c_str());
-		}
-		else {
-			maplist_entry_t maplist_entry;
-			Maplist::instance().get_map_by_index(next_index, maplist_entry);
+		maplist_entry_t lobby_entry;
+		lobby_entry = Maplist::instance().get_lobbymap();
+
+		if (lobby_entry.map != "")
+		{
 
 			std::string wadstr;
-			for (size_t i = 0; i < maplist_entry.wads.size(); i++)
+			for (size_t i = 0; i < lobby_entry.wads.size(); i++)
 			{
 				if (i != 0)
 				{
 					wadstr += " ";
 				}
-				wadstr += C_QuoteString(maplist_entry.wads.at(i));
+				wadstr += C_QuoteString(lobby_entry.wads.at(i));
 			}
-			G_LoadWadString(wadstr, maplist_entry.map);
+			G_LoadWadString(wadstr, lobby_entry.map);
+		}
+		else
+		{
+			size_t next_index;
+			if (!Maplist::instance().get_next_index(next_index))
+			{
+				// We don't have a maplist, so grab the next 'natural' map lump.
+				std::string next = G_NextMap();
+				G_DeferedInitNew((char*)next.c_str());
+			}
+			else
+			{
+				maplist_entry_t maplist_entry;
+				Maplist::instance().get_map_by_index(next_index, maplist_entry);
 
-			// Set the new map as the current map
-			Maplist::instance().set_index(next_index);
+				std::string wadstr;
+				for (size_t i = 0; i < maplist_entry.wads.size(); i++)
+				{
+					if (i != 0)
+					{
+						wadstr += " ";
+					}
+					wadstr += C_QuoteString(maplist_entry.wads.at(i));
+				}
+				G_LoadWadString(wadstr, maplist_entry.map);
+
+				// Set the new map as the current map
+				Maplist::instance().set_index(next_index);
+			}
 		}
 
 		// run script at the end of each map

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4756,15 +4756,34 @@ void SV_RunTics()
 		// [SL] Ordinarily we should call G_DeferedInitNew but this is called
 		// at the end of a gametic and the level reset should take place now
 		// rather than at the start of the next gametic.
+		maplist_entry_t lobby_entry;
+		lobby_entry = Maplist::instance().get_lobbymap();
 
-		// [SL] create a copy of level.mapname because G_InitNew uses strncpy
-		// to copy the mapname parameter to level.mapname, which is undefined
-		// behavior.
-		char mapname[9];
-		strncpy(mapname, level.mapname, 8);
-		mapname[8] = 0;
+		if (lobby_entry.map != "")
+		{
 
-		G_InitNew(mapname);
+			std::string wadstr;
+			for (size_t i = 0; i < lobby_entry.wads.size(); i++)
+			{
+				if (i != 0)
+				{
+					wadstr += " ";
+				}
+				wadstr += C_QuoteString(lobby_entry.wads.at(i));
+			}
+			G_LoadWadString(wadstr, lobby_entry.map);
+		}
+		else
+		{
+			// [SL] create a copy of level.mapname because G_InitNew uses strncpy
+			// to copy the mapname parameter to level.mapname, which is undefined
+			// behavior.
+			char mapname[9];
+			strncpy(mapname, level.mapname, 8);
+			mapname[8] = 0;
+
+			G_InitNew(mapname);
+		}
 	}
 	last_player_count = players.size();
 }

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4759,7 +4759,7 @@ void SV_RunTics()
 		maplist_entry_t lobby_entry;
 		lobby_entry = Maplist::instance().get_lobbymap();
 
-		if (lobby_entry.map != "")
+		if (!Maplist::instance().lobbyempty())
 		{
 
 			std::string wadstr;

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -474,6 +474,19 @@ void Maplist::set_lobbymap(maplist_entry_t map)
 	this->lobbymap = map;
 }
 
+void Maplist::clear_lobbymap()
+{
+	maplist_entry_t maplist_empty;
+	this->lobbymap = maplist_empty;
+}
+
+bool Maplist::lobbyempty()
+{
+	if (this->lobbymap.map != "")
+		return false;
+	return true;
+}
+
 //////// COMMANDS TO CLIENT ////////
 
 // Clue the client in on if the maplist is outdated or not and if they're
@@ -876,8 +889,15 @@ BEGIN_COMMAND(setlobbymap)
 	Maplist::instance().set_lobbymap(maplist_entry);
 
 	// Successfully warn the server a map has been added.
-	Printf(PRINT_HIGH, "Setting %s as the Lobby map (WAD%s : %s)", arguments[0].c_str(),
+	Printf(PRINT_HIGH, "Setting %s as the Lobby map (WAD%s : %s)\n", arguments[0].c_str(),
 	       (arguments.size() > 2) ? "s" : "",
 	       JoinStrings(maplist_entry.wads, " ").c_str());
 }
 END_COMMAND(setlobbymap)
+
+BEGIN_COMMAND(clearlobbymap)
+{
+	Maplist::instance().clear_lobbymap();
+	Printf("Lobby map cleared.\n");
+}
+END_COMMAND(clearlobbymap)

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -850,7 +850,7 @@ BEGIN_COMMAND (randmap) {
 
 // LOBBY FUNCTIONS
 
-BEGIN_COMMAND(setlobby)
+BEGIN_COMMAND(setlobbymap)
 {
 	if (argc < 2)
 	{
@@ -880,4 +880,4 @@ BEGIN_COMMAND(setlobby)
 	       (arguments.size() > 2) ? "s" : "",
 	       JoinStrings(maplist_entry.wads, " ").c_str());
 }
-END_COMMAND(setlobby)
+END_COMMAND(setlobbymap)

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -461,6 +461,19 @@ void Maplist::clear_timeout(const int index) {
 	this->timeout.erase(index);
 }
 
+
+// LOBBY FUNCS
+// Return the current map index.
+maplist_entry_t Maplist::get_lobbymap()
+{
+	return this->lobbymap;
+}
+
+void Maplist::set_lobbymap(maplist_entry_t map)
+{
+	this->lobbymap = map;
+}
+
 //////// COMMANDS TO CLIENT ////////
 
 // Clue the client in on if the maplist is outdated or not and if they're
@@ -833,3 +846,38 @@ BEGIN_COMMAND (randmap) {
 		Printf(PRINT_HIGH, "%s\n", error.c_str());
 	}
 } END_COMMAND (randmap)
+
+
+// LOBBY FUNCTIONS
+
+BEGIN_COMMAND(setlobby)
+{
+	if (argc < 2)
+	{
+		Printf(PRINT_HIGH, "Usage: setlobby <map lump> [wad name] [...]\n");
+		Printf(PRINT_HIGH,
+		       "There can only be one map with the lobby.\n");
+		return;
+	}
+
+	std::vector<std::string> arguments = VectorArgs(argc, argv);
+
+	// Grab the map lump.
+	maplist_entry_t maplist_entry;
+	maplist_entry.map = arguments[0];
+
+	// If we specified any WAD files, grab them too.
+	if (arguments.size() > 1)
+	{
+		maplist_entry.wads.resize(arguments.size() - 1);
+		std::copy(arguments.begin() + 1, arguments.end(), maplist_entry.wads.begin());
+	}
+
+	Maplist::instance().set_lobbymap(maplist_entry);
+
+	// Successfully warn the server a map has been added.
+	Printf(PRINT_HIGH, "Setting %s as the Lobby map (WAD%s : %s)", arguments[0].c_str(),
+	       (arguments.size() > 2) ? "s" : "",
+	       JoinStrings(maplist_entry.wads, " ").c_str());
+}
+END_COMMAND(setlobby)

--- a/server/src/sv_maplist.h
+++ b/server/src/sv_maplist.h
@@ -80,6 +80,8 @@ public:
 	// Lobby
 	void set_lobbymap(maplist_entry_t map);
 	maplist_entry_t get_lobbymap();
+	void clear_lobbymap();
+	bool lobbyempty();
 };
 
 void SV_Maplist(player_t &player);

--- a/server/src/sv_maplist.h
+++ b/server/src/sv_maplist.h
@@ -45,6 +45,9 @@ private:
 	byte version;
 	void shuffle(void);
 	void update_shuffle_index(void);
+
+	maplist_entry_t lobbymap;
+
 public:
 	Maplist() : entered_once(false), error(""), index(0),
 				in_maplist(false), shuffled(false), s_index(0), version(0) { };
@@ -54,6 +57,7 @@ public:
 	bool insert(const size_t &position, maplist_entry_t &maplist_entry);
 	bool remove(const size_t &position);
 	bool clear(void);
+
 	// Elements
 	bool empty(void);
 	std::string get_error(void);
@@ -72,6 +76,10 @@ public:
 	bool pid_cached(const int index);
 	void set_timeout(const int index);
 	void clear_timeout(const int index);
+
+	// Lobby
+	void set_lobbymap(maplist_entry_t map);
+	maplist_entry_t get_lobbymap();
 };
 
 void SV_Maplist(player_t &player);


### PR DESCRIPTION
This PR does the following:
- Create a `SetLobby` command that works exactly like `addmap` : ```setlobby MAP <wads>``` . It only has 1 entry, and will be overwritten it you use it again.
- If all players left on a map, the server goes back to the selected lobby map.
- Once a map is completed (ie intermission), the server goes back to the selected lobby map.

As a result, it will allow server creators to not add "addmap MAP00" between two maps, simplifying the configs.