### PR TITLE
Combine posts in imported graphics

### DIFF
--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -63,12 +63,7 @@
 	#endif
 
 	typedef unsigned char byte;
-#endif
-
-#ifdef __cplusplus
-	typedef bool dboolean;
-#else
-	typedef enum {false, true} dboolean;
+    typedef unsigned int uint;
 #endif
 
 #if defined(_MSC_VER) || defined(__WATCOMC__)

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -162,10 +162,7 @@ void R_ConvertPatch(patch_t* newpatch, patch_t* rawpatch, const unsigned int lum
 		{
 			// handle DeePsea tall patches where topdelta is treated as a relative
 			// offset instead of an absolute offset
-			if (rawpost->topdelta <= abs_offset)
-				abs_offset += rawpost->topdelta;
-			else
-				abs_offset = rawpost->topdelta;
+			abs_offset = rawpost->abs(abs_offset);
 
 			// watch for column overruns
 			int length = rawpost->length;

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -465,27 +465,58 @@ typedef struct node_s node_t;
 
 
 // posts are runs of non masked source pixels
-struct post_s
+struct post_t
 {
-	byte		topdelta;		// -1 is the last post in a column
-	byte		length; 		// length data bytes follows
+	byte topdelta; // -1 is the last post in a column
+	byte length;   // length data bytes follows
+
+	uint32_t size() const
+	{
+		return length + 3;
+	}
+	byte* data() const
+	{
+		return (byte*)(this) + 3;
+	}
+	post_t* next() const
+	{
+		return (post_t*)((byte*)this + length + 4);
+	}
+	bool end() const
+	{
+		return topdelta == 0xFF;
+	}
 };
-typedef struct post_s post_t;
 
 // column_t is a list of 0 or more post_t, (byte)-1 terminated
 typedef post_t	column_t;
 
-struct tallpost_s
+struct tallpost_t
 {
-	unsigned short		topdelta;
-	unsigned short		length;
-	
-	byte *data() const { return (byte*)(this) + 4; }
-	tallpost_s *next() const { return (tallpost_s*)((byte*)(this) + 4 + length); }
-	bool end() const { return topdelta == 0xFFFF; }
-	void writeend() { topdelta = 0xFFFF; }
+	unsigned short topdelta;
+	unsigned short length;
+
+	uint32_t size() const
+	{
+		return length + 4;
+	}
+	byte* data() const
+	{
+		return (byte*)(this) + 4;
+	}
+	tallpost_t* next() const
+	{
+		return (tallpost_t*)((byte*)(this) + 4 + length);
+	}
+	bool end() const
+	{
+		return topdelta == 0xFFFF;
+	}
+	void writeend()
+	{
+		topdelta = 0xFFFF;
+	}
 };
-typedef struct tallpost_s tallpost_t;
 
 //
 // OTHER TYPES
@@ -529,14 +560,41 @@ private:
 	short			_topoffset;		// pixels below the origin
 
 public:
-
-	short width() const { return LESHORT(_width); }
-	short height() const { return LESHORT(_height); }
-	short leftoffset() const { return LESHORT(_leftoffset); }
-	short topoffset() const { return LESHORT(_topoffset); }
-
 	int columnofs[8]; // only [width] used
 	// the [0] is &columnofs[width]
+
+	short width() const
+	{
+		return LESHORT(_width);
+	}
+	short height() const
+	{
+		return LESHORT(_height);
+	}
+	short leftoffset() const
+	{
+		return LESHORT(_leftoffset);
+	}
+	short topoffset() const
+	{
+		return LESHORT(_topoffset);
+	}
+	uint32_t* ofs() const
+	{
+		return (uint32_t*)((byte*)this + 8);
+	}
+	uint32_t datastart() const
+	{
+		return 8 + 4 * width();
+	}
+	post_t* post(const uint32_t ofs)
+	{
+		return (post_t*)((byte*)this + ofs);
+	}
+	tallpost_t* tallpost(const uint32_t ofs)
+	{
+		return (tallpost_t*)((byte*)this + ofs);
+	}
 };
 typedef struct patch_s patch_t;
 

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -470,18 +470,47 @@ struct post_t
 	byte topdelta; // -1 is the last post in a column
 	byte length;   // length data bytes follows
 
+	/**
+	 * @brief Return the post's absolute topdelta accounting for tall
+	 *        patches, which treat topdelta as relative.
+	 * 
+	 * @param lastAbs Last absolute topdelta.
+	 */
+	int abs(const int lastAbs) const
+	{
+		if (topdelta <= lastAbs)
+			return lastAbs + topdelta;
+		else
+			return topdelta;
+	}
+
+	/**
+	 * @brief Size of the post, including header.
+	 */
 	uint32_t size() const
 	{
 		return length + 3;
 	}
+	
+	/**
+	 * @brief Return a pointer to post data.
+	 */
 	byte* data() const
 	{
 		return (byte*)(this) + 3;
 	}
+
+	/**
+	 * @brief Return a pointer to the next post in the column.
+	 */
 	post_t* next() const
 	{
 		return (post_t*)((byte*)this + length + 4);
 	}
+
+	/**
+	 * @brief Check if the post ends the column.
+	 */
 	bool end() const
 	{
 		return topdelta == 0xFF;


### PR DESCRIPTION
There were some latent instances of tutti-frutti in the engine caused when a drawer that was designed for drawing a single post got graphic data with multiple posts in it.  Since it didn't skip over the post header, it displayed a strange band of color across some graphics.

![odamex_RRxIbre0Zq](https://user-images.githubusercontent.com/23563/128278389-2bfe26ec-00d1-4020-ad38-46ba8a9f2cef.png)

We have a function that converts patches to use our internal "tall post" format.  I simply adjusted the conversion routine to also combine two or more posts into one if the posts in the column leave no gaps between them.

![odamex_e9qObAJucG](https://user-images.githubusercontent.com/23563/128278715-dd754334-a276-442e-9138-e1148af1e3dd.png)

This should fix WADs like 32in24-17.wad that has some skies that contain multiple posts per column.  In fact the sky texture you see in the screenshot comes from MAP01 of the WAD.  I also did a lot of cleanup of that function as well as adding some helper functions to patches, posts, and tall posts.

I have not changed how much memory is allocated for the new graphic, since in all cases it's just going to be the same size minus the size of the headers of any posts that were merged, which is pretty trivial, a few dozen bytes at most.  At some point it would be nice to rewrite that function to use `realloc` but that requires actually implementing realloc (preferably [reallocarray](https://www.freebsd.org/cgi/man.cgi?query=reallocarray&sektion=3&manpath=freebsd-release-ports)) in the zone memory allocator, but that's a bigger change I want to save for later.