### PR TITLE
Fix occasional crashes caused by fuzz drawer OOB read

### DIFF
--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -120,9 +120,11 @@ public:
 	forceinline int getValue() const
 	{
 		// [SL] quickly convert the table value (-1 or 1) into (-pitch or pitch).
+		// [AM] Replaced with a multiply that returns accurate results.  Hopefully
+		//      we can find a way to improve upon an imul someday.
 		int pitch = R_GetRenderingSurface()->getPitchInPixels();
 		int value = table[pos];
-		return (pitch ^ value) + value;
+		return pitch * value;
 	}
 
 private:


### PR DESCRIPTION
The existing code that turned the fuzz offset into a pitch offset did not return results that were accurate.  This was causing an OOB read of the screen buffer when you had a spectre in the lower right corner of your vision, sometimes leading to a crash.

I replaced the old bit-twiddle cleverness with a multiply.  Maybe at some point I can come up with some branchless bit-twiddling will be faster, but this works okay for now.