### PR TITLE
Allow finer mouse sensitivity tweaks in the settings menu

### DIFF
--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -448,8 +448,8 @@ void M_ResetMouseValues()
 
 static menuitem_t MouseItems[] =
 {
-	{ slider,	"Overall Sensitivity"			, {&mouse_sensitivity},	{0.25},	{2.5},		{0.1},		{NULL}},
-	{ slider,	"Freelook Sensitivity"			, {&m_pitch},			{0.25},	{2.5},		{0.1},		{NULL}},
+	{ slider,	"Overall Sensitivity"			, {&mouse_sensitivity},	{0.05},	{2.5},		{0.05},		{NULL}},
+	{ slider,	"Freelook Sensitivity"			, {&m_pitch},			{0.05},	{2.5},		{0.05},		{NULL}},
 
 	{ redtext,	" "								, {NULL},				{0.0},	{0.0},		{0.0},		{NULL}},
 	{ discrete,	"Always FreeLook"				, {&cl_mouselook},		{2.0},	{0.0},		{0.0},		{OnOff}},


### PR DESCRIPTION
This is useful for mice with particularly high DPI settings. Here, I need to use 0.1 to get a good sensitivity value on my Logitech G903 Lightspeed on Linux (flat acceleration profile).