### PR TITLE
Rename the wi_intermission CVAR.

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -180,7 +180,7 @@ CVAR_RANGE_FUNC_DECL(msgmidcolor, "5", "Color used for centered messages.",
 // ------------
 
 // Determines whether to draw the scores on intermission.
-CVAR(				wi_newintermission, "0", "Use Odamex's intermission screen if there are 4 players or less on cooperative gamemodes.",
+CVAR(				wi_oldintermission, "0", "Use Vanilla's intermission screen if there are 4 players or less on cooperative gamemodes.",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -112,7 +112,7 @@ EXTERN_CVAR (hud_transparency)
 EXTERN_CVAR (hud_revealsecrets)
 EXTERN_CVAR (co_allowdropoff)
 EXTERN_CVAR (co_realactorheight)
-EXTERN_CVAR (wi_newintermission)
+EXTERN_CVAR (wi_oldintermission)
 EXTERN_CVAR (co_zdoomphys)
 EXTERN_CVAR (co_zdoomsound)
 EXTERN_CVAR (co_fixweaponimpacts)
@@ -242,8 +242,8 @@ static value_t FlagHelds[] =
 
 static value_t DoomOrOdamex[2] =
 {
-	{ 0.0, "Doom" },
-	{ 1.0, "Odamex" }
+	{ 0.0, "Odamex" },
+	{ 1.0, "Doom" }
 };
 
 menu_t  *CurrentMenu;
@@ -849,7 +849,7 @@ static menuitem_t VideoItems[] = {
 	{ discrete, "Stretch short skies",	    {&r_stretchsky},	   	{3.0}, {0.0},	{0.0},  {OnOffAuto} },
 	{ discrete, "Invuln changes skies",		{&r_skypalette},		{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Screen wipe style",	    {&r_wipetype},			{4.0}, {0.0},	{0.0},  {Wipes} },
-	{ discrete, "Multiplayer Intermissions",{&wi_newintermission},	{2.0}, {0.0},	{0.0},  {DoomOrOdamex} },
+	{ discrete, "Multiplayer Intermissions",{&wi_oldintermission},	{2.0}, {0.0},	{0.0},  {DoomOrOdamex} },
 	{ discrete, "Show loading disk icon",	{&r_loadicon},			{2.0}, {0.0},	{0.0},	{OnOff} },
     { discrete,	"Show DOS ending screen" ,  {&r_showendoom},		{2.0}, {0.0},	{0.0},  {OnOff} },
 

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -362,7 +362,7 @@ static const char*		lnametexts[2];
 static IWindowSurface*	background_surface;
 
 EXTERN_CVAR (sv_maxplayers)
-EXTERN_CVAR (wi_newintermission)
+EXTERN_CVAR (wi_oldintermission)
 EXTERN_CVAR (cl_autoscreenshot)
 //
 // CODE
@@ -1355,7 +1355,7 @@ void WI_checkForAccelerate(void)
 {
 	if (!serverside)
 		return;
-
+		
 	// check for button presses to skip delays
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{
@@ -1413,7 +1413,7 @@ void WI_Ticker (void)
 				}
 			    else
 			    {
-				    if (sv_gametype == 0 && !wi_newintermission && P_NumPlayersInGame() < 5)
+				    if (sv_gametype == 0 && wi_oldintermission && P_NumPlayersInGame() < 5)
 					    WI_updateNetgameStats();
 				    else
 					    WI_updateNoState();
@@ -1691,7 +1691,7 @@ void WI_Drawer (void)
 				}
 				else
 				{
-					if (sv_gametype == 0 && !wi_newintermission && P_NumPlayersInGame() < 5)
+					if (sv_gametype == 0 && wi_oldintermission && P_NumPlayersInGame() < 5)
 						WI_drawNetgameStats();
 					else
 						WI_drawDeathmatchStats();


### PR DESCRIPTION
This PR only changes the CVAR so that Odamex's scoreboard is still the default one.