### PR TITLE
Enable LTO in MSVC release builds

### DIFF
--- a/cmake/modules/OdamexTargetSettings.cmake
+++ b/cmake/modules/OdamexTargetSettings.cmake
@@ -58,6 +58,7 @@ function(odamex_target_settings _TARGET)
   # https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html
   if(MSVC)
     checked_add_compile_flag(CHECKED_OPTIONS /wd26812 WD_26812)
+    checked_add_compile_flag(CHECKED_RELEASE_OPTIONS /GL MSVC_GL)
   else()
     checked_add_compile_flag(CHECKED_OPTIONS -Werror=format-security W_FORMAT_SECURITY)
     checked_add_compile_flag(CHECKED_OPTIONS -Wduplicated-cond W_DUPLICATED_COND)
@@ -69,7 +70,14 @@ function(odamex_target_settings _TARGET)
     checked_add_compile_flag(CHECKED_OPTIONS -Wno-unused-parameter W_NO_UNUSED_PARAMETER)
   endif()
   target_compile_options("${_TARGET}" PRIVATE ${CHECKED_OPTIONS})
-  
+  target_compile_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:${CHECKED_RELEASE_OPTIONS}>)
+
+  # Add link options - checked link options need at least 3.18.
+  if(MSVC)
+    target_link_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
+    target_link_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/LTCG>)
+  endif()
+
   # Ensure we get a useful stack trace on Linux.
   if(UNIX AND NOT APPLE)
     target_link_options("${_TARGET}" PRIVATE -rdynamic)


### PR DESCRIPTION
Pretty much what it says on the tin.  I'm not using CMake's built in LTO support because it didn't support MSVC until somewhat recently and even today its choice of LTO setting was not what was desired.