### PR TITLE
Fix colored lighting being too bright

### DIFF
--- a/client/src/v_palette.cpp
+++ b/client/src/v_palette.cpp
@@ -1002,7 +1002,8 @@ fargb_t V_HSVtoRGB(const fahsv_t &color)
 /****** Colored Lighting Stuffs (Sorry, 8-bit only) ******/
 
 // Builds NUMCOLORMAPS colormaps lit with the specified color
-void BuildColoredLights(shademap_t* maps, int lr, int lg, int lb, int r, int g, int b)
+static void BuildColoredLights(shademap_t* maps, const int lr, const int lg, const int lb,
+                               const int fr, const int fg, const int fb)
 {
 	// The default palette is assumed to contain the maps for white light.
 	if (!maps)
@@ -1015,19 +1016,22 @@ void BuildColoredLights(shademap_t* maps, int lr, int lg, int lb, int r, int g, 
 	// build normal (but colored) light mappings
 	for (unsigned int l = 0; l < NUMCOLORMAPS; l++)
 	{
-		byte a = maps->ramp[l * 255 / NUMCOLORMAPS];
-
-		// Write directly to the shademap for blending:
-		argb_t* colors = maps->shademap + 256 * l;
-		V_DoBlending(colors, palette_colors, argb_t(a, r, g, b));
-
 		// Build the colormap and shademap:
-		palindex_t* colormap = maps->colormap + 256*l;
-		argb_t* shademap = maps->shademap + 256*l;
+		palindex_t* colormap = maps->colormap + 256 * l;
+		argb_t* shademap = maps->shademap + 256 * l;
 		for (unsigned int c = 0; c < 256; c++)
 		{
-			argb_t color(255, colors[c].getr() * lr / 255,
-						colors[c].getg() * lg / 255, colors[c].getb() * lb / 255);
+			unsigned int r = (palette_colors[c].getr() * (NUMCOLORMAPS - l) + fr * l +
+			                  NUMCOLORMAPS / 2) /
+			                 NUMCOLORMAPS;
+			unsigned int g = (palette_colors[c].getg() * (NUMCOLORMAPS - l) + fg * l +
+			                  NUMCOLORMAPS / 2) /
+			                 NUMCOLORMAPS;
+			unsigned int b = (palette_colors[c].getb() * (NUMCOLORMAPS - l) + fb * l +
+			                  NUMCOLORMAPS / 2) /
+			                 NUMCOLORMAPS;
+			argb_t color(255, r * lr / 255, g * lg / 255, b * lb / 255);
+
 			shademap[c] = V_GammaCorrect(color);
 			colormap[c] = V_BestColor(palette_colors, color);
 		}


### PR DESCRIPTION
During development of a mapset, I noticed that our colored lighting seemed a little bright compared to the light level.  Doing a little digging, I figured out that we did indeed have a problem.

![image](https://user-images.githubusercontent.com/23563/134752021-feeac7d1-7fa7-4f64-8de2-5bd261d6d25b.png)

Compared with ZDoom 2.8.1

![image](https://user-images.githubusercontent.com/23563/134752261-02c52cd1-fe6b-47f3-a1e5-04033620163a.png)

Below is a sample colormap comparison between a color multiply done in GIMP (top) vs what the colormap looked like in Odamex (bottom).  It's purple because I was using a different map to test.

![image](https://user-images.githubusercontent.com/23563/134751970-66300c37-b13d-4e0e-a389-d90511baf27c.png)

The trouble turned out to be that our base colors were too bright due to a different algorithm being used.  There might be a slicker way of fixing this problem, but I decided to simply copy the standard colormap generation function and add a multiply on top of that.  The result...

![image](https://user-images.githubusercontent.com/23563/134752333-ba0b9d05-74c0-4770-8a37-319a351f3b9f.png)