### PR TITLE
Bug/fix local death exits

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -545,7 +545,7 @@ void G_DoLoadLevel (int position)
 	{
 		if (it->ingame())
 		{
-			if (it->playerstate == PST_REBORN)
+			if (it->playerstate == PST_DEAD || it->playerstate == PST_REBORN)
 				it->doreborn = true;
 			it->playerstate = PST_ENTER;
 		}


### PR DESCRIPTION
There was a problem with death exits done locally where it would not properly reborn you in the next level, resulting in a zombie player.