### PR TITLE
Allow avatars to telefrag

### DIFF
--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -212,7 +212,8 @@ BOOL P_TeleportMove (AActor *thing, fixed_t x, fixed_t y, fixed_t z, BOOL telefr
 	validcount++;
 	spechit.clear();
 
-	StompAlwaysFrags = tmthing->player || (level.flags & LEVEL_MONSTERSTELEFRAG) || telefrag;
+	StompAlwaysFrags = tmthing->player || tmthing->type == MT_AVATAR ||
+	                   (level.flags & LEVEL_MONSTERSTELEFRAG) || telefrag;
 
 	// stomp on any things contacted
 	xl = (tmbbox[BOXLEFT] - bmaporgx - MAXRADIUS)>>MAPBLOCKSHIFT;


### PR DESCRIPTION
Fixes #469 .

It doesn't damage players, so death exits that take items away still don't work as intended in coop, but getting those to work right in standard coop is already quite dicey since players can respawn out of the dead state.  Will think of a better solution for those instances.