### PR TITLE
Correct sv_weapondrop bfg. Fixes issue mentioned in #314 comment

### DIFF
--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -1625,7 +1625,7 @@ void P_KillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill
 				    break;
 
 			    case wp_bfg:
-				    item = MT_BFG;
+				    item = MT_MISC25; // [RV] BFG.
 				    break;
 
 			    case wp_chainsaw:


### PR DESCRIPTION
Fixes broken BFG pickup when `sv_weapondrop` is enabled. 