### PR TITLE
Don't restart music when restarting the level

### DIFF
--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -299,7 +299,9 @@ void S_Stop (void)
 //
 void S_Start (void)
 {
-	S_Stop();
+	// Kill all sound channels - but don't stop music.
+	for (size_t i = 0; i < numChannels; i++)
+		S_StopChannel(i);
 
 	// start new music for the level
 	mus_paused = 0;


### PR DESCRIPTION
In most ports, if you are starting the level and it has the same music track as what was playing previously - so, in other words, after a death, idclev to same map, or load game to same level, the music track is not supposed to start from the beginning.

Odamex did not have this behavior because it combined sound effect channel clearing and music stoppage into one function, which was desirable in most cases, but not on level load.

I use the past tense because this commit fixes that.