### PR TITLE
Fix bug with potential retrieval of non-existing spawn.

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2457,9 +2457,9 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 			if (otherplayernum == playernum)
 			{
 				// consider playerstarts[i] to be a voodoo doll start
+				M_RemoveWDLPlayerSpawn(&playerstarts[i]);
 				voodoostarts.push_back(playerstarts[i]);
 				playerstarts.erase(playerstarts.begin() + i);
-				M_RemoveWDLPlayerSpawn(&playerstarts[i]);
 				break;
 			}
 		}


### PR DESCRIPTION
This fixes a bug with removing a player spawn if it's a voodoo doll spawn. It was removing too late in the execution however, and could potentially point to a spawn that isn't the one that was supposed to be removed -- or worse, crash.