### PR TITLE
Add options for pistol-starting every level

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -69,7 +69,7 @@ EXTERN_CVAR(sv_fastmonsters)
 EXTERN_CVAR(sv_monstersrespawn)
 EXTERN_CVAR(sv_gravity)
 EXTERN_CVAR(sv_aircontrol)
-EXTERN_CVAR(g_resetinv)
+EXTERN_CVAR(g_resetinvonexit)
 
 // Start time for timing demos
 dtime_t starttime;
@@ -545,7 +545,7 @@ void G_DoLoadLevel (int position)
 	{
 		if (it->ingame())
 		{
-			if (::g_resetinv || it->playerstate == PST_DEAD ||
+			if (::g_resetinvonexit || it->playerstate == PST_DEAD ||
 			    it->playerstate == PST_REBORN)
 			{
 				it->doreborn = true;

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -69,6 +69,7 @@ EXTERN_CVAR(sv_fastmonsters)
 EXTERN_CVAR(sv_monstersrespawn)
 EXTERN_CVAR(sv_gravity)
 EXTERN_CVAR(sv_aircontrol)
+EXTERN_CVAR(g_resetinv)
 
 // Start time for timing demos
 dtime_t starttime;
@@ -544,8 +545,11 @@ void G_DoLoadLevel (int position)
 	{
 		if (it->ingame())
 		{
-			if (it->playerstate == PST_DEAD || it->playerstate == PST_REBORN)
+			if (::g_resetinv || it->playerstate == PST_DEAD ||
+			    it->playerstate == PST_REBORN)
+			{
 				it->doreborn = true;
+			}
 			it->playerstate = PST_ENTER;
 		}
 

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -143,6 +143,7 @@ EXTERN_CVAR (vid_32bpp)
 EXTERN_CVAR (vid_widescreen)
 EXTERN_CVAR (vid_fullscreen)
 EXTERN_CVAR (vid_vsync)
+EXTERN_CVAR (g_resetinvonexit)
 
 std::string LOG_FILE;
 
@@ -811,6 +812,9 @@ void D_DoomMain()
 
 	// Fast
 	sv_fastmonsters = Args.CheckParm("-fast");
+
+	// Pistol start
+	g_resetinvonexit = Args.CheckParm("-pistolstart");
 
 	// get skill / episode / map from parms
 	strcpy(startmap, (gameinfo.flags & GI_MAPxx) ? "MAP01" : "E1M1");

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -56,6 +56,8 @@
 #include "i_xbox.h"
 #endif
 
+EXTERN_CVAR(g_resetinvonexit)
+
 // temp for screenblocks (0-9)
 int 				screenSize;
 
@@ -303,6 +305,7 @@ enum newgame_t
 	hurtme,
 	violence,
 	nightmare,
+	pistolstart,
 	newg_end
 } newgame_e;
 
@@ -312,7 +315,8 @@ oldmenuitem_t NewGameMenu[]=
 	{1,"M_ROUGH",		M_ChooseSkill, 'h'},
 	{1,"M_HURT",		M_ChooseSkill, 'h'},
 	{1,"M_ULTRA",		M_ChooseSkill, 'u'},
-	{1,"M_NMARE",		M_ChooseSkill, 'n'}
+	{1,"M_NMARE",		M_ChooseSkill, 'n'},
+	{1,"\0",			M_ChooseSkill, 'p'}
 };
 
 oldmenu_t NewDef =
@@ -928,8 +932,17 @@ void M_DrawMainMenu()
 
 void M_DrawNewGame()
 {
-	screen->DrawPatchClean ((patch_t *)W_CachePatch("M_NEWG"), 96, 14);
-	screen->DrawPatchClean ((patch_t *)W_CachePatch("M_SKILL"), 54, 38);
+	screen->DrawPatchClean((patch_t*)W_CachePatch("M_NEWG"), 96, 14);
+	screen->DrawPatchClean((patch_t*)W_CachePatch("M_SKILL"), 54, 38);
+
+	const int SMALLFONT_OFFSET = 8; // Line up with the skull
+
+	const char* pslabel = "Pistol Start Each Level ";
+	const int psy = NewDef.y + (LINEHEIGHT * 5) + SMALLFONT_OFFSET;
+
+	screen->DrawTextCleanMove(CR_RED, NewDef.x, psy, pslabel);
+	screen->DrawTextCleanMove(CR_GREY, NewDef.x + V_StringWidth(pslabel), psy,
+	                          g_resetinvonexit ? "ON" : "OFF");
 }
 
 namespace
@@ -1052,7 +1065,12 @@ void M_StartGame(int choice)
 
 void M_ChooseSkill(int choice)
 {
-	if (choice == nightmare)
+	if (choice == pistolstart)
+	{
+		g_resetinvonexit = !g_resetinvonexit;
+		return;
+	}
+	else if (choice == nightmare)
 	{
 		M_StartMessage(GStrings(NIGHTMARE),M_VerifyNightmare,true);
 		return;

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -249,8 +249,9 @@ CVAR_RANGE(g_coopthingfilter, "0", "Removes cooperative things of the map. Value
            CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE | CVAR_LATCH,
            0.0f, 2.0f)
 
-CVAR(g_resetinv, "0", "Always reset players to their starting inventory on level switch",
-     CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+CVAR(g_resetinvonexit, "0",
+     "Always reset players to their starting inventory on level exit", CVARTYPE_BOOL,
+     CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
 
 CVAR(g_horde_waves, "5", "Number of horde waves per map", CVARTYPE_INT,
      CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -249,6 +249,9 @@ CVAR_RANGE(g_coopthingfilter, "0", "Removes cooperative things of the map. Value
            CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE | CVAR_LATCH,
            0.0f, 2.0f)
 
+CVAR(g_resetinv, "0", "Always reset players to their starting inventory on level switch",
+     CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
 CVAR(g_horde_waves, "5", "Number of horde waves per map", CVARTYPE_INT,
      CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
 

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -73,7 +73,7 @@ EXTERN_CVAR (sv_intermissionlimit)
 EXTERN_CVAR (sv_warmup)
 EXTERN_CVAR (sv_timelimit)
 EXTERN_CVAR (sv_teamsinplay)
-EXTERN_CVAR(g_resetinv)
+EXTERN_CVAR(g_resetinvonexit)
 
 extern int mapchange;
 
@@ -737,7 +737,7 @@ void G_DoLoadLevel (int position)
 
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{
-		if (it->ingame() && (::g_resetinv || it->playerstate == PST_DEAD))
+		if (it->ingame() && (::g_resetinvonexit || it->playerstate == PST_DEAD))
 			it->playerstate = PST_REBORN;
 
 		// Properly reset Cards, Powerups, and scores.

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -73,6 +73,7 @@ EXTERN_CVAR (sv_intermissionlimit)
 EXTERN_CVAR (sv_warmup)
 EXTERN_CVAR (sv_timelimit)
 EXTERN_CVAR (sv_teamsinplay)
+EXTERN_CVAR(g_resetinv)
 
 extern int mapchange;
 
@@ -736,7 +737,7 @@ void G_DoLoadLevel (int position)
 
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{
-		if (it->ingame() && it->playerstate == PST_DEAD)
+		if (it->ingame() && (::g_resetinv || it->playerstate == PST_DEAD))
 			it->playerstate = PST_REBORN;
 
 		// Properly reset Cards, Powerups, and scores.

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -119,6 +119,7 @@ EXTERN_CVAR(sv_sharekeys)
 EXTERN_CVAR(sv_teamsinplay)
 EXTERN_CVAR(g_winnerstays)
 EXTERN_CVAR(debug_disconnect)
+EXTERN_CVAR(g_resetinv)
 
 void SexMessage (const char *from, char *to, int gender,
 	const char *victim, const char *killer);
@@ -4634,7 +4635,7 @@ void SV_PreservePlayer(player_t &player)
 	if (!serverside || sv_gametype != GM_COOP || !validplayer(player) || !player.ingame())
 		return;
 
-	if(!unnatural_level_progression)
+	if(!::unnatural_level_progression && !::g_resetinv)
 		player.playerstate = PST_LIVE; // denis - carry weapons and keys over to next level
 
 	G_DoReborn(player);

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -119,7 +119,7 @@ EXTERN_CVAR(sv_sharekeys)
 EXTERN_CVAR(sv_teamsinplay)
 EXTERN_CVAR(g_winnerstays)
 EXTERN_CVAR(debug_disconnect)
-EXTERN_CVAR(g_resetinv)
+EXTERN_CVAR(g_resetinvonexit)
 
 void SexMessage (const char *from, char *to, int gender,
 	const char *victim, const char *killer);
@@ -4635,8 +4635,11 @@ void SV_PreservePlayer(player_t &player)
 	if (!serverside || sv_gametype != GM_COOP || !validplayer(player) || !player.ingame())
 		return;
 
-	if(!::unnatural_level_progression && !::g_resetinv)
-		player.playerstate = PST_LIVE; // denis - carry weapons and keys over to next level
+	if (!::unnatural_level_progression && !::g_resetinvonexit)
+	{
+		// denis - carry weapons and keys over to next level
+		player.playerstate = PST_LIVE;
+	}
 
 	G_DoReborn(player);
 


### PR DESCRIPTION
Pistol-starting levels is an incredibly common thing to do, to the point where most doom content is balanced around a pistol start while carrying over inventory is usually an afterthought.

#479 was a feature request for a `-pistrolstart` parameter.  I added that and then some.

1. A `g_resetinvonexit` cvar - named because our spawn inventory system means you might get more than a pistol and cvar names should be pedantic for clarity.
2. A `-pistrolstart` parameter for compatibility with other ports.
3. A brand new menu item in the difficulty selection that allows you to turn on or off pistol starting before starting a single-player playthrough.

![image](https://user-images.githubusercontent.com/23563/142967231-2d28bd33-1683-408c-ae85-1d1df9f33874.png)

Tested off and online.