### PR TITLE
[BUGFIX] Fix A_FindTracer to switch targets if their current tracer is dead

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2230,8 +2230,13 @@ void A_FindTracer(AActor* actor)
 	angle_t fov;
 	int dist;
 
-	if (!actor || actor->tracer || !serverside)
+	if (!actor || (actor->tracer != AActor::AActorPtr() && actor->tracer->health > 0) ||
+	    !serverside)
 		return;
+
+	if (actor->tracer != AActor::AActorPtr() && actor->tracer->health <= 0)
+		actor->tracer = AActor::AActorPtr(); // [Blair] Clear tracer if it died, to keep
+		                                     // with MBF21 spec
 
 	fov = FixedToAngle(actor->state->args[0]);
 	dist = (actor->state->args[1]);


### PR DESCRIPTION
Alerted to this by Xaser in the #oda-development channel in Discord, xa-vesper.wad's Ichor Rifle should seek a new target once the current one has died. DSDA-Doom shows this behavior as well. I add this fix to mimic the same behavior.