### PR TITLE
[BUGFIX] More bugfixes

### DIFF
--- a/common/p_ceiling.cpp
+++ b/common/p_ceiling.cpp
@@ -573,30 +573,8 @@ BOOL EV_DoZDoomCeiling(DCeiling::ECeiling type, line_t* line, byte tag, fixed_t 
                        fixed_t speed2, fixed_t height, int crush, byte silent, int change,
                        crushmode_e crushmode)
 {
-	sector_t* sec;
-	int secnum = -1;
-	BOOL retcode = 0;
-
-	height *= FRACUNIT;
-
-	// check if a manual trigger, if so do just the sector on the backside
-	if (tag == 0)
-	{
-		if (!line || !(sec = line->backsector))
-			return 0;
-
-		secnum = sec - sectors;
-		// [RH] Hack to let manual crushers be retriggerable, too
-		tag ^= secnum | 0x1000000;
-		P_ActivateInStasisCeiling(tag);
-
-		if (P_CeilingActive(sec))
-			return false;
-
-		P_SpawnZDoomCeiling(type, line, tag, speed, speed2, height, crush, silent,
+		return P_SpawnZDoomCeiling(type, line, tag, speed, speed2, height, crush, silent,
 		                    change, crushmode);
-		return true;
-	}
 }
 
 //
@@ -643,7 +621,7 @@ BOOL P_SpawnZDoomCeiling(DCeiling::ECeiling type, line_t* line, int tag, fixed_t
 		sec = &sectors[secnum];
 	manual_ceiling:
 		// if ceiling already moving, don't start a second function on it
-		if (sec->ceilingdata)
+		if (P_CeilingActive(sec))
 		{
 			if (co_boomphys && manual)
 				return false;

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -97,6 +97,8 @@ const int distfriend = 128;
 // killough 9/8/98: whether monsters are allowed to strafe or retreat
 const int monster_backing = 0;
 
+extern bool isFast;
+
 //
 // ENEMY THINKING
 // Enemies are always spawned
@@ -1339,7 +1341,6 @@ void A_SkelMissile (AActor *actor)
 
 fixed_t P_GetActorSpeed(AActor* actor)
 {
-	extern bool isFast;
 	int speed = actor->info->speed;
 
 	if (isFast)
@@ -1534,11 +1535,12 @@ void A_VileChase (AActor *actor)
 
 	if (actor->movedir != DI_NODIR)
 	{
-		fixed_t speed = P_GetActorSpeed(actor);
+		// [Blair] Ignore altspeed for vanilla demo comp purposes
+		//fixed_t speed = P_GetActorSpeed(actor);
 
 		// check for corpses to raise
-		viletryx = actor->x + speed * xspeed[actor->movedir];
-		viletryy = actor->y + speed * yspeed[actor->movedir];
+		viletryx = actor->x + actor->info->speed * xspeed[actor->movedir];
+		viletryy = actor->y + actor->info->speed * yspeed[actor->movedir];
 
 		xl = (viletryx - bmaporgx - MAXRADIUS*2)>>MAPBLOCKSHIFT;
 		xh = (viletryx - bmaporgx + MAXRADIUS*2)>>MAPBLOCKSHIFT;

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -60,7 +60,7 @@ BOOL EV_DoZDoomCeiling(DCeiling::ECeiling type, line_t* line, byte tag, fixed_t 
 // Returns true if the special for line will cause a DMovingFloor or
 // DMovingCeiling object to be created.
 //
-bool P_LineSpecialMovesSector(byte special)
+bool P_LineSpecialMovesSector(short special)
 {
 	static bool initialized = false;
 	static bool zdoomspecials[283];

--- a/common/p_lnspec.h
+++ b/common/p_lnspec.h
@@ -531,7 +531,7 @@ BOOL EV_DoZDoomDonut(int tag, line_t* line, fixed_t pillarspeed, fixed_t slimesp
 BOOL EV_ZDoomCeilingCrushStop(int tag, bool remove);
 BOOL EV_CompatibleTeleport(int tag, line_t* line, int side, AActor* thing, int flags);
 
-bool P_LineSpecialMovesSector(byte special);
+bool P_LineSpecialMovesSector(short special);
 bool P_CanActivateSpecials(AActor* mo, line_t* line);
 bool P_ActorInSpecialSector(AActor* actor);
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1931,7 +1931,7 @@ void P_ShootSpecialLine(AActor*	thing, line_t* line)
 
 	if(thing)
 	{
-		if (map_format.getZDoom() && !(line->flags == ML_SPAC_IMPACT))
+		if (map_format.getZDoom() && !(line->flags & ML_SPAC_IMPACT))
 			return;
 
 		if (thing->flags & MF_MISSILE)

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -124,7 +124,7 @@ void SexMessage (const char *from, char *to, int gender,
 	const char *victim, const char *killer);
 Players::iterator SV_RemoveDisconnectedPlayer(Players::iterator it);
 void P_PlayerLeavesGame(player_s* player);
-bool P_LineSpecialMovesSector(byte special);
+bool P_LineSpecialMovesSector(short special);
 
 void SV_UpdateShareKeys(player_t& player);
 std::string V_GetTeamColor(UserInfo userinfo);


### PR DESCRIPTION
The following things are fixed:

Archviles now again revive monsters. (Demo compatibility not affected)
ZDoom maps shootable switches are now functional (ZDCTFMP2 MAP11)
Use short for Boom special prediction function so generalized linedef actions can be predicted
ZDoom crushers work again