### PR TITLE
Add --version parameter to client and server

### DIFF
--- a/client/sdl/i_main.cpp
+++ b/client/sdl/i_main.cpp
@@ -134,6 +134,12 @@ int main(int argc, char *argv[])
 		// [ML] 2007/9/3: From Eternity (originally chocolate Doom) Thanks SoM & fraggle!
 		::Args.SetArgs(argc, argv);
 
+		if (::Args.CheckParm("--version"))
+		{
+			printf("Odamex %s\n", NiceVersion());
+			exit(EXIT_SUCCESS);
+		}
+
 		const char* crashdir = ::Args.CheckValue("-crashdir");
 		if (crashdir)
 		{

--- a/client/sdl/i_main.cpp
+++ b/client/sdl/i_main.cpp
@@ -136,7 +136,19 @@ int main(int argc, char *argv[])
 
 		if (::Args.CheckParm("--version"))
 		{
+#ifdef _WIN32
+			FILE* fh = fopen("odamex-version.txt", "w");
+			if (!fh)
+				exit(EXIT_FAILURE);
+
+			const int ok = fprintf(fh, "Odamex %s\n", NiceVersion());
+			if (!ok)
+				exit(EXIT_FAILURE);
+
+			fclose(fh);
+#else
 			printf("Odamex %s\n", NiceVersion());
+#endif
 			exit(EXIT_SUCCESS);
 		}
 

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -137,6 +137,12 @@ int __cdecl main(int argc, char *argv[])
 		// [ML] 2007/9/3: From Eternity (originally chocolate Doom) Thanks SoM & fraggle!
 		::Args.SetArgs(argc, argv);
 
+		if (::Args.CheckParm("--version"))
+		{
+			printf("Odamex %s\n", NiceVersion());
+			exit(EXIT_SUCCESS);
+		}
+
 		const char* crashdir = ::Args.CheckValue("-crashdir");
 		if (crashdir)
 		{
@@ -239,6 +245,12 @@ int main (int argc, char **argv)
 			perror(NULL);
 
 		::Args.SetArgs(argc, argv);
+
+		if (::Args.CheckParm("--version"))
+		{
+			printf("Odamex %s\n", NiceVersion());
+			exit(EXIT_SUCCESS);
+		}
 
 		const char* crashdir = ::Args.CheckValue("-crashdir");
 		if (crashdir)


### PR DESCRIPTION
Client and server get a new `--version` parameter.  On everything except the Win32 client, this version prints to stdout.  On the Win32 client, it outputs to a file in the CWD.