### PR TITLE
[BUGFIX] Fix 5 minute door, generalized perpetual lifts

### DIFF
--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -225,7 +225,7 @@ void DDoor::RunThink ()
 	case opening:
 		res = MoveCeiling(m_Speed, m_TopHeight, 1);
 		
-        if (m_LightTag && m_TopHeight - floorheight)
+        if (m_Line && m_LightTag && m_TopHeight - floorheight)
         {
             EV_LightTurnOnPartway(m_Line->id,
                 FixedDiv(ceilingheight - floorheight, m_TopHeight - floorheight));
@@ -258,7 +258,7 @@ void DDoor::RunThink ()
 			default:
 				break;
 			}
-			if (m_LightTag && m_TopHeight - floorheight)
+			if (m_Line && m_LightTag && m_TopHeight - floorheight)
             {
                 EV_LightTurnOnPartway(m_Line->id, FRACUNIT);
             }
@@ -695,13 +695,13 @@ void P_SpawnDoorRaiseIn5Mins (sector_t *sec)
 
 	sec->special = 0;
 
-	door->m_Type = DDoor::doorCloseWaitOpen;
+	door->m_Type = DDoor::doorRaiseIn5Mins;
 	door->m_Speed = FRACUNIT * 2;
 	door->m_TopHeight = P_FindLowestCeilingSurrounding (sec);
 	door->m_TopHeight -= 4*FRACUNIT;
 	door->m_TopWait = (150*TICRATE)/35;
 	door->m_TopCountdown = 5 * 60 * TICRATE;
-	door->m_Status = DDoor::waiting;
+	door->m_Status = DDoor::init;
 }
 
 BOOL EV_DoZDoomDoor(DDoor::EVlDoor type, line_t* line, AActor* mo, byte tag,

--- a/common/p_plats.cpp
+++ b/common/p_plats.cpp
@@ -426,7 +426,7 @@ DPlat::DPlat(sector_t* sec, int target, int delay, int speed, int trigger)
 		m_High = P_FindHighestFloorSurrounding(sec);
 		if (m_High < sec->floorheight)
 			m_High = sec->floorheight;
-		m_Status = (EPlatState)(P_Random() & 1);
+		m_Status = (EPlatState)(P_Random() & 1 ? DPlat::down : DPlat::up);
 		break;
 	default:
 		break;


### PR DESCRIPTION
The following fixes odahorde map13 (5 minute door crash when activating) and boomedit.wad (half the time, perpetual lifts would get in invalid state on activation and not work)