### PR TITLE
[BUGFIX] Multiple bugfixes

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -449,8 +449,7 @@ lineresult_s P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		if (EV_LineTeleport(line, side, thing))
 		{
 			result.lineexecuted = true;
-			// line->special = 0; // [Blair] Don't clear the line special,
-								  // we have other functions that handle that for teleports.
+			line->special = 0;
 		}						
 		break;
 

--- a/common/p_ceiling.cpp
+++ b/common/p_ceiling.cpp
@@ -36,7 +36,7 @@ EXTERN_CVAR(co_boomphys)
 extern bool predicting;
 
 void P_ResetTransferSpecial(newspecial_s* newspecial);
-void P_ResetSectorTransferFlags(unsigned int* flags);
+const unsigned int P_ResetSectorTransferFlags(const unsigned int flags);
 
 //
 // CEILINGS
@@ -447,8 +447,7 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int speed,
 					m_NewDamageRate = ns.damageamount;
 					m_NewDmgInterval = ns.damageinterval;
 					m_NewLeakRate = ns.damageleakrate;
-					m_NewFlags = chgsec->flags;
-					P_ResetSectorTransferFlags((unsigned int*)m_NewFlags);
+					m_NewFlags = P_ResetSectorTransferFlags(chgsec->flags);
 					m_Type = genCeilingChg0;
 					break;
 				case CChgTyp: // type is copied
@@ -484,8 +483,7 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int speed,
 				m_NewDamageRate = ns.damageamount;
 				m_NewDmgInterval = ns.damageinterval;
 				m_NewLeakRate = ns.damageleakrate;
-				m_NewFlags = line->frontsector->flags;
-				P_ResetSectorTransferFlags((unsigned int*)m_NewFlags);
+				m_NewFlags = P_ResetSectorTransferFlags(line->frontsector->flags);
 				m_Type = genCeilingChg0;
 				break;
 			case CChgTyp: // type is copied

--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -225,7 +225,7 @@ void DDoor::RunThink ()
 	case opening:
 		res = MoveCeiling(m_Speed, m_TopHeight, 1);
 		
-        if (m_LightTag && m_TopHeight - floorheight)
+        if (m_Line && m_LightTag && m_TopHeight - floorheight)
         {
             EV_LightTurnOnPartway(m_Line->id,
                 FixedDiv(ceilingheight - floorheight, m_TopHeight - floorheight));
@@ -258,7 +258,7 @@ void DDoor::RunThink ()
 			default:
 				break;
 			}
-			if (m_LightTag && m_TopHeight - floorheight)
+			if (m_Line && m_LightTag && m_TopHeight - floorheight)
             {
                 EV_LightTurnOnPartway(m_Line->id, FRACUNIT);
             }
@@ -695,13 +695,13 @@ void P_SpawnDoorRaiseIn5Mins (sector_t *sec)
 
 	sec->special = 0;
 
-	door->m_Type = DDoor::doorCloseWaitOpen;
+	door->m_Type = DDoor::doorRaiseIn5Mins;
 	door->m_Speed = FRACUNIT * 2;
 	door->m_TopHeight = P_FindLowestCeilingSurrounding (sec);
 	door->m_TopHeight -= 4*FRACUNIT;
 	door->m_TopWait = (150*TICRATE)/35;
 	door->m_TopCountdown = 5 * 60 * TICRATE;
-	door->m_Status = DDoor::waiting;
+	door->m_Status = DDoor::init;
 }
 
 BOOL EV_DoZDoomDoor(DDoor::EVlDoor type, line_t* line, AActor* mo, byte tag,

--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -70,7 +70,8 @@ void DDoor::Serialize (FArchive &arc)
 			<< m_TopHeight
 			<< m_Speed
 			<< m_TopWait
-			<< m_TopCountdown;
+			<< m_TopCountdown
+			<< m_LightTag;
 	}
 	else
 	{
@@ -79,7 +80,8 @@ void DDoor::Serialize (FArchive &arc)
 			>> m_TopHeight
 			>> m_Speed
 			>> m_TopWait
-			>> m_TopCountdown;
+			>> m_TopCountdown
+			>> m_LightTag;
 	}
 }
 
@@ -397,6 +399,7 @@ DDoor::DDoor(sector_t* sec, line_t* ln, int kind, int trigger, int speed)
 	m_TopWait = VDOORWAIT;
 	m_TopHeight = P_FindLowestCeilingSurrounding(sec) - 4 * FRACUNIT;
 	m_Status = opening;
+	m_TopCountdown = -1;
 
 	switch (speed)
 	{
@@ -428,6 +431,7 @@ DDoor::DDoor(sector_t* sec, line_t* ln, int delay, int kind, int trigger, int sp
     : DMovingCeiling(sec), m_Status(init)
 {
 	m_Line = ln;
+	m_TopCountdown = -1;
 
 	fixed_t ceilingheight = P_CeilingHeight(sec);
 

--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -165,9 +165,9 @@ void DDoor::RunThink ()
 	case closing:
 		res = MoveCeiling(m_Speed, floorheight, -1);
 		
-        if (m_Line && m_Line->id)
+        if (m_LightTag)
         {
-            EV_LightTurnOnPartway(m_Line->id,
+			EV_LightTurnOnPartway(m_LightTag,
                 FixedDiv(ceilingheight - floorheight, m_TopHeight - floorheight));
         }
 		if (res == pastdest)
@@ -198,9 +198,9 @@ void DDoor::RunThink ()
 			default:
 				break;
 			}
-            if (m_LightTag && m_TopHeight - m_Sector->floorheight)
+			if (m_LightTag && m_TopHeight - m_Sector->floorheight)
             {
-                EV_LightTurnOnPartway(m_Line->id, 0);
+				EV_LightTurnOnPartway(m_LightTag, 0);
             }
 		}
 		else if (res == crushed)
@@ -225,9 +225,9 @@ void DDoor::RunThink ()
 	case opening:
 		res = MoveCeiling(m_Speed, m_TopHeight, 1);
 		
-        if (m_Line && m_LightTag && m_TopHeight - floorheight)
+        if (m_LightTag && m_TopHeight - floorheight)
         {
-            EV_LightTurnOnPartway(m_Line->id,
+			EV_LightTurnOnPartway(m_LightTag,
                 FixedDiv(ceilingheight - floorheight, m_TopHeight - floorheight));
         }
 		if (res == pastdest)
@@ -258,9 +258,9 @@ void DDoor::RunThink ()
 			default:
 				break;
 			}
-			if (m_Line && m_LightTag && m_TopHeight - floorheight)
+			if (m_LightTag && m_TopHeight - floorheight)
             {
-                EV_LightTurnOnPartway(m_Line->id, FRACUNIT);
+				EV_LightTurnOnPartway(m_LightTag, FRACUNIT);
             }
 		}
 		break;
@@ -348,7 +348,17 @@ DDoor::DDoor (sector_t *sec, line_t *ln, EVlDoor type, fixed_t speed, int delay)
 	m_TopCountdown = -1;
 	m_Speed = speed;
     m_Line = ln;
-	m_LightTag = 0; /* killough 10/98: no light effects with tagged doors */
+	/* killough 10/98: use gradual lighting changes if nonzero tag given */
+	//door->lighttag = comp[comp_doorlight] ? 0 : line->tag;
+	// [Blair] Only certain door types are allowed to have LightTags.
+	if (m_Line && P_IsLightTagDoorType(m_Line->special))
+	{
+		m_LightTag = m_Line->id;
+	}
+	else
+	{
+		m_LightTag = 0; /* killough 10/98: no light effects with tagged doors */
+	}
 
 	fixed_t ceilingheight = P_CeilingHeight(sec);
 	

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -528,6 +528,11 @@ DFloor::DFloor(sector_t* sec, line_t* line, int speed,
 	m_NewLeakRate = sec->leakrate;
 	m_NewFlags = sec->flags;
 
+	if (m_Direction == 1)
+		m_Status = up;
+	else if (m_Direction == -1)
+		m_Status = down;
+
 	PlayFloorSound();
 
 	switch (speed)

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -31,7 +31,7 @@
 #include "tables.h"
 
 void P_ResetTransferSpecial(newspecial_s* newspecial);
-void P_ResetSectorTransferFlags(unsigned int* flags);
+const unsigned int P_ResetSectorTransferFlags(const unsigned int flags);
 
 EXTERN_CVAR(co_boomphys)
 
@@ -455,8 +455,7 @@ DFloor::DFloor(sector_t* sec, DFloor::EFloor floortype, line_t* line, fixed_t sp
 					m_NewDamageRate = ns.damageamount;
 					m_NewDmgInterval = ns.damageinterval;
 					m_NewLeakRate = ns.damageleakrate;
-					m_NewFlags = found->flags;
-					P_ResetSectorTransferFlags((unsigned int*)m_NewFlags);
+					m_NewFlags = P_ResetSectorTransferFlags(found->flags);
 					m_Type = DFloor::genFloorChg0;
 					break;
 				case 2:
@@ -487,8 +486,7 @@ DFloor::DFloor(sector_t* sec, DFloor::EFloor floortype, line_t* line, fixed_t sp
 				m_NewDamageRate = ns.damageamount;
 				m_NewDmgInterval = ns.damageinterval;
 				m_NewLeakRate = ns.damageleakrate;
-				m_NewFlags = line->frontsector->flags;
-				P_ResetSectorTransferFlags((unsigned int*)m_NewFlags);
+				m_NewFlags = P_ResetSectorTransferFlags(line->frontsector->flags);
 				m_Type = DFloor::genFloorChg0;
 				break;
 			case 2:
@@ -619,8 +617,7 @@ DFloor::DFloor(sector_t* sec, line_t* line, int speed,
 					m_NewDamageRate = ns.damageamount;
 					m_NewDmgInterval = ns.damageinterval;
 					m_NewLeakRate = ns.damageleakrate;
-					m_NewFlags = chgsec->flags;
-					P_ResetSectorTransferFlags((unsigned int*)m_NewFlags);
+					m_NewFlags = P_ResetSectorTransferFlags(chgsec->flags);
 					m_Type = genFloorChg0;
 					break;
 				case FChgTyp: // copy type
@@ -656,8 +653,7 @@ DFloor::DFloor(sector_t* sec, line_t* line, int speed,
 				m_NewDamageRate = ns.damageamount;
 				m_NewDmgInterval = ns.damageinterval;
 				m_NewLeakRate = ns.damageleakrate;
-				m_NewFlags = line->frontsector->flags;
-				P_ResetSectorTransferFlags((unsigned int*)m_NewFlags);
+				m_NewFlags = P_ResetSectorTransferFlags(line->frontsector->flags);
 				m_Type = genFloorChg0;
 				break;
 			case FChgTyp: // copy type

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3059,6 +3059,12 @@ void P_RadiusAttack(AActor *spot, AActor *source, int damage, int distance,
 	DamageSource = hurtSource;
 	bombmod = mod;
 
+	// [Blair] Prevent crash from barrels hit by crushers
+	if (bombsource == NULL && bombspot != NULL)
+	{
+		bombsource = bombspot;
+	}
+
 	// decide which radius attack function to use
 	BOOL (*pAttackFunc)(AActor*) = co_zdoomphys ?
 		PIT_ZDoomRadiusAttack : PIT_DoomRadiusAttack;

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -441,3 +441,24 @@ bool P_IsCompatibleYellowDoorLine(const short special)
 
 	return special == 27 || special == 34;
 }
+
+bool P_IsLightTagDoorType(const short special)
+{
+	switch (special)
+	{
+	case 1:  // Vertical Door
+	case 26: // Blue Door/Locked
+	case 27: // Yellow Door /Locked
+	case 28: // Red Door /Locked
+
+	case 31: // Manual door open
+	case 32: // Blue locked door open
+	case 33: // Red locked door open
+	case 34: // Yellow locked door open
+
+	case 117: // Blazing door raise
+	case 118: // Blazing door open
+		return true;
+	}
+	return false;
+}

--- a/common/p_mapformat.h
+++ b/common/p_mapformat.h
@@ -101,5 +101,6 @@ bool P_IsCompatibleLockedDoorLine(const short special);
 bool P_IsCompatibleBlueDoorLine(const short special);
 bool P_IsCompatibleRedDoorLine(const short special);
 bool P_IsCompatibleYellowDoorLine(const short special);
+bool P_IsLightTagDoorType(const short special);
 
 #endif

--- a/common/p_plats.cpp
+++ b/common/p_plats.cpp
@@ -426,7 +426,7 @@ DPlat::DPlat(sector_t* sec, int target, int delay, int speed, int trigger)
 		m_High = P_FindHighestFloorSurrounding(sec);
 		if (m_High < sec->floorheight)
 			m_High = sec->floorheight;
-		m_Status = (EPlatState)(P_Random() & 1);
+		m_Status = (EPlatState)(P_Random() & 1 ? DPlat::down : DPlat::up);
 		break;
 	default:
 		break;

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -141,9 +141,9 @@ int P_FindLineFromTag(int tag, int start)
 	return start;
 }
 
-void P_ResetSectorTransferFlags(unsigned int* flags)
+const unsigned int P_ResetSectorTransferFlags(const unsigned int flags)
 {
-	*flags &= ~SECF_TRANSFERMASK;
+	return (flags & ~SECF_TRANSFERMASK);
 }
 
 void P_ResetSectorSpecial(sector_t* sector)
@@ -152,7 +152,7 @@ void P_ResetSectorSpecial(sector_t* sector)
 	sector->damageamount = 0;
 	sector->damageinterval = 0;
 	sector->leakrate = 0;
-	P_ResetSectorTransferFlags(&sector->flags);
+	sector->flags = P_ResetSectorTransferFlags(sector->flags);
 }
 
 void P_CopySectorSpecial(sector_t* dest, sector_t* source)
@@ -170,7 +170,7 @@ void P_ResetTransferSpecial(newspecial_s* newspecial)
 	newspecial->damageamount = 0;
 	newspecial->damageinterval = 0;
 	newspecial->damageleakrate = 0;
-	P_ResetSectorTransferFlags(&newspecial->flags);
+	newspecial->flags = P_ResetSectorTransferFlags(newspecial->flags);
 }
 
 void P_TransferSectorFlags(unsigned int* dest, unsigned int source)

--- a/common/p_zdoomhexspec.cpp
+++ b/common/p_zdoomhexspec.cpp
@@ -88,6 +88,22 @@ lineresult_s P_ActivateZDoomLine(line_t* line, AActor* mo, int side,
 	result.lineexecuted = false;
 	result.switchchanged = false;
 
+	// Err...
+	// Use the back sides of VERY SPECIAL lines...
+	if (side && (line->flags & (ML_SPAC_PUSH | ML_SPAC_USE)))
+	{
+		switch (line->special)
+		{
+		case Exit_Secret:
+			// Sliding door open&close
+			// UNUSED?
+			break;
+
+		default:
+			return result;
+		}
+	}
+
 	if (!P_TestActivateZDoomLine(line, mo, side, activationType) ||
 	    !P_CanActivateSpecials(mo, line))
 	{


### PR DESCRIPTION
The following GitHub issues are fixed with this pull request:

#559 (MBF Smooth Lighting not working)
#553 (5 minute door crashes on activation)
#551 - This was actually caused by a crusher blowing up a barrel and then damaging an AActor when co_blockmapfix was on. Fixed.

I also fix a bug not listed here, that had to do with generalized sectors that use model sectors, but don't copy sector flags, only reset.

Also a bugfix with perpetual genlifts getting into an invalid state and not activating. Noticeable on boomedit.wad.

Finally, I re-added the side test for ZDoom format maps for use and push line types, so you can no longer activate lifts and such from the opposite side.