### PR TITLE
[BUGFIX] Fix ZDoom Generalized Secrets

### DIFF
--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -932,7 +932,10 @@ void P_PlayerThink (player_t *player)
 	P_MovePlayer (player);
 	P_CalcHeight (player);
 
-	if (player->mo->subsector && (player->mo->subsector->sector->special || player->mo->subsector->sector->damageamount))
+	if (player->mo->subsector &&
+		(player->mo->subsector->sector->special ||
+		player->mo->subsector->sector->damageamount ||
+		player->mo->subsector->sector->flags & SECF_SECRET))
 		map_format.player_in_special_sector(player);
 
 	// Check for weapon change.


### PR DESCRIPTION
Added a condition to check if a player is in a secret sector to fix this, as both map formats have instances where sectors with the SECF_SECRET flag may not also have a damageamount or sector special to trigger `map_format.player_in_special_sector`. Fixes #586 (wad in that bug report works with this pull request.)