### PR TITLE
Demobar is now removed with max screenblocks. Addresses #515.

### DIFF
--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -1289,6 +1289,16 @@ bool R_StatusBarVisible()
 	return setblocks <= 10 || AM_ClassicAutomapVisible();
 }
 
+//
+// R_DemoBarVisible
+//
+// Returns true if the demo bar should not be drawn
+//
+bool R_DemoBarInvisible()
+{
+	return screenblocks == 12;
+}
+
 
 
 //

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -715,7 +715,7 @@ void drawNetdemo() {
 		return;
 	}
 
-	if (!hud_demobar)
+	if (!hud_demobar || R_DemoBarInvisible())
 		return;
 
 	int xscale = hud_scale ? CleanXfac : 1;

--- a/common/r_main.h
+++ b/common/r_main.h
@@ -200,6 +200,7 @@ IWindowSurface* R_GetRenderingSurface();
 
 bool R_BorderVisible();
 bool R_StatusBarVisible();
+bool R_DemoBarInvisible();
 
 int R_ViewWidth(int width, int height);
 int R_ViewHeight(int width, int height);


### PR DESCRIPTION
Maxing out the screen size/blocks now removes the demobar during local playback.