### PR TITLE
[BUGFIX] Fix automap crashes

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -1305,11 +1305,10 @@ void AM_drawWalls(void)
 		{
 			if ((lines[i].flags & ML_DONTDRAW) && !am_cheating)
 				continue;
-            if (!lines[i].backsector &&
-                (((am_usecustomcolors || viewactive) &&
-                P_IsExitLine(lines[i].special)) ||
-                (!am_usecustomcolors && !viewactive)))
-            {
+			if (!lines[i].backsector &&
+				((am_usecustomcolors || viewactive) ||
+				(!am_usecustomcolors && !viewactive)))
+			{
 				AM_drawMline(&l, WallColor);
 			}
 			else


### PR DESCRIPTION
This bugfix _du jour_ fixes bug #554. This was caused by a check for backsector not properly being made, and this would allow the automap loop to fall to a condition that would allow a crash. This is fixed by removing the condition that would always make linedefs without backsectors never ring true.