### PR TITLE
Fix musl build by checking whether execinfo.h's backtrace is present

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -6,3 +6,12 @@ configure_file(git_describe.h.in "${CMAKE_CURRENT_BINARY_DIR}/git_describe.h")
 add_library(odamex-common INTERFACE)
 target_sources(odamex-common INTERFACE ${COMMON_SOURCES} ${COMMON_HEADERS})
 target_include_directories(odamex-common INTERFACE . ${CMAKE_CURRENT_BINARY_DIR})
+
+if(UNIX)
+  include(CheckSymbolExists)
+  check_symbol_exists(backtrace "execinfo.h" HAVE_BACKTRACE)
+
+  if(HAVE_BACKTRACE)
+    target_compile_definitions(odamex-common INTERFACE HAVE_BACKTRACE)
+  endif()
+endif()

--- a/common/i_crash_noop.cpp
+++ b/common/i_crash_noop.cpp
@@ -23,7 +23,7 @@
 
 
 #if defined _WIN32 && !defined _XBOX && defined _MSC_VER && !defined _DEBUG
-#elif defined UNIX && !defined GEKKO
+#elif defined UNIX && defined HAVE_BACKTRACE && !defined GEKKO
 #else
 
 #include "odamex.h"

--- a/common/i_crash_posix.cpp
+++ b/common/i_crash_posix.cpp
@@ -22,7 +22,7 @@
 //-----------------------------------------------------------------------------
 
 
-#if defined UNIX && !defined GCONSOLE
+#if defined UNIX && defined HAVE_BACKTRACE && !defined GCONSOLE
 
 #include "odamex.h"
 


### PR DESCRIPTION
Admittedly I haven't tested it with musl, as I don't have it readily available, but I have tested without execinfo.h present, checking that it definitely used the "noop" implementation and vice-versa.

I noticed that the condition in `i_crash_noop.cpp` has `!defined GEKKO` whereas the condition in `i_crash_posix.cpp` has `!defined GCONSOLE`. I get the impression they should be the same, so is that a mistake?

Closes: https://github.com/odamex/odamex/issues/533