### PR TITLE
[BUGFIX] Mask extended flags to preserve compatibility on E2M7

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -3458,10 +3458,8 @@ const unsigned int P_TranslateCompatibleLineFlags(const unsigned int flags, cons
 
 	unsigned int filter;
 
-	if (demoplayback)
+	if (demoplayback || reserved)
 		filter = 0x01ff;
-	else if (reserved)
-		filter = 0x03ff;
 	else
 		filter = 0x3fff;
 

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -3447,7 +3447,7 @@ lineresult_s P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 	return result;
 }
 
-const unsigned int P_TranslateCompatibleLineFlags(const unsigned int flags)
+const unsigned int P_TranslateCompatibleLineFlags(const unsigned int flags, const bool reserved)
 {
 	/*
 	if (mbf21)
@@ -3460,6 +3460,8 @@ const unsigned int P_TranslateCompatibleLineFlags(const unsigned int flags)
 
 	if (demoplayback)
 		filter = 0x01ff;
+	else if (reserved)
+		filter = 0x03ff;
 	else
 		filter = 0x3fff;
 

--- a/common/p_boomfspec.h
+++ b/common/p_boomfspec.h
@@ -30,7 +30,7 @@ void P_DamageMobj(AActor* target, AActor* inflictor, AActor* source, int damage,
                   int flags);
 lineresult_s P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
                                           bool bossaction);
-const unsigned int P_TranslateCompatibleLineFlags(const unsigned int flags);
+const unsigned int P_TranslateCompatibleLineFlags(const unsigned int flags, const bool reserved);
 void P_ApplyGeneralizedSectorDamage(player_t* player, int bits);
 void P_CollectSecretBoom(sector_t* sector, player_t* player);
 void P_PlayerInCompatibleSector(player_t* player);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -50,6 +50,7 @@
 #include "p_setup.h"
 #include "p_hordespawn.h"
 #include "p_mapformat.h"
+#include <cinttypes>
 
 void SV_PreservePlayer(player_t &player);
 void P_SpawnMapThing (mapthing2_t *mthing, int position);
@@ -897,7 +898,8 @@ void P_LoadLineDefs (const int lump)
 	                        (uint64_t)(::level.level_fingerprint[14]) << 48 |
 	                        (uint64_t)(::level.level_fingerprint[15]) << 56;
 
-	StrFormat(levelHash, "%16llx%16llx", reconsthash1, reconsthash2);
+	StrFormat(levelHash, "%" PRIx64 "%" PRIx64, reconsthash1,
+	          reconsthash2);
 
 	bool isE2M7 = (levelHash == e2m7hash);
 

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -50,7 +50,6 @@
 #include "p_setup.h"
 #include "p_hordespawn.h"
 #include "p_mapformat.h"
-#include <cinttypes>
 
 void SV_PreservePlayer(player_t &player);
 void P_SpawnMapThing (mapthing2_t *mthing, int position);
@@ -898,8 +897,7 @@ void P_LoadLineDefs (const int lump)
 	                        (uint64_t)(::level.level_fingerprint[14]) << 48 |
 	                        (uint64_t)(::level.level_fingerprint[15]) << 56;
 
-	StrFormat(levelHash, "%" PRIx64 "%" PRIx64, reconsthash1,
-	          reconsthash2);
+	StrFormat(levelHash, "%16llx%16llx", reconsthash1, reconsthash2);
 
 	bool isE2M7 = (levelHash == e2m7hash);
 

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -874,11 +874,9 @@ void P_LoadLineDefs (const int lump)
 	// E2M7 has flags masked in that interfere with MBF21 flags.
 	// Boom fixes this with the comp flag comp_reservedlineflag
 	// We'll fix this for now by just checking for the E2M7 FarmHash
-	const char e2m7hash[33] = "43ffa244f5ae923b7df59dbf511c0468";
+	const std::string e2m7hash = "43ffa244f5ae923b7df59dbf511c0468";
 
-	char levelHash[33];
-
-	ArrayInit(levelHash, '0');
+	std::string levelHash;
 
 	// [Blair] Serialize the hashes before reading.
 	uint64_t reconsthash1 = (uint64_t)(::level.level_fingerprint[0]) |
@@ -899,9 +897,9 @@ void P_LoadLineDefs (const int lump)
 	                        (uint64_t)(::level.level_fingerprint[14]) << 48 |
 	                        (uint64_t)(::level.level_fingerprint[15]) << 56;
 
-	sprintf(levelHash, "%16llx%16llx", reconsthash1, reconsthash2);
+	StrFormat(levelHash, "%16llx%16llx", reconsthash1, reconsthash2);
 
-	bool isE2M7 = std::equal(levelHash, levelHash + sizeof levelHash / sizeof *levelHash, e2m7hash);
+	bool isE2M7 = (levelHash == e2m7hash);
 
 	ld = lines;
 	for (i=0 ; i<numlines ; i++, ld++)


### PR DESCRIPTION
This is a workaround to fix a bug report in Doomworld post https://www.doomworld.com/forum/post/2462959

This bug is caused by linedef flags being masked with 0xFE00 on E2M7 and E2M7 only. DSDA has a flag called comp_reservedlineflag that handles these erroneous flags from early maps. How I decided to solve it, since E2M7 is the only map this is known to happen, I've created a check that occurs once to see if the E2M7 FarmHash fingerprint exists, and if so, apply the reserved flag.