### PR TITLE
[BUGFIX] Fix damage end sectors for Doom

### DIFF
--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -40,6 +40,7 @@
 #include "svc_message.h"
 #include "p_horde.h"
 #include "com_misc.h"
+#include "p_mapformat.h"
 
 #ifdef SERVER_APP
 #include "sv_main.h"
@@ -2097,10 +2098,16 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 	// player specific
 	if (player)
 	{
+		short special = 11;
+		if (map_format.getZDoom())
+		{
+			special = dDamage_End;
+		}
+
 		// end of game hell hack
 		if (sv_gametype == GM_COOP || sv_allowexit)
 		{
-			if ((target->subsector->sector->special & 255) == dDamage_End
+			if ((target->subsector->sector->special & 255) == special
 				&& damage >= target->health)
 			{
 				damage = target->health - 1;


### PR DESCRIPTION
This fixes an occasional death in sector 11 (E1M8), when sector 11 is supposed to keep you at 1hp. This now works for Doom and ZDoom maps.