### PR TITLE
Fix lostepis.wad crashing on load

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -894,6 +894,7 @@ void MIType_InterLumpName(OScanner& os, bool doEquals, void* data, unsigned int 
 	const std::string tok = os.getToken();
 	if (!tok.empty() && tok.at(0) == '$')
 	{
+		os.mustScan();
 		// Intermission scripts are not supported.
 		return;
 	}


### PR DESCRIPTION
enterpic and exitpic no longer crash if an intermission lump is detected