### PR TITLE
SNDINFO Improvements

### DIFF
--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -427,7 +427,7 @@ void I_UpdateSoundParams (int handle, float vol, int sep, int pitch)
 	Mix_SetPanning(handle, sep, 255-sep);
 }
 
-void I_LoadSound (struct sfxinfo_struct *sfx)
+void I_LoadSound (sfxinfo_struct *sfx)
 {
 	if (!sound_initialized)
 		return;

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1229,10 +1229,9 @@ void M_QuitResponse(int ch)
 	
 	if (!multiplayer)
 	{
-		if (gameinfo.quitSounds)
+		if (gameinfo.quitSound[0])
 		{
-			S_Sound(CHAN_INTERFACE,
-					gameinfo.quitSounds[(gametic>>2)&7], 1, ATTN_NONE);
+			S_Sound(CHAN_INTERFACE, gameinfo.quitSound, 1, ATTN_NONE);
 			I_WaitVBL (105);
 		}
 	}

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -585,14 +585,20 @@ static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 
 	sfxinfo_t* sfxinfo = &S_sfx[sfx_id];
 
-	if (sfxinfo->link != sfxinfo_t::NO_LINK)
+	while (sfxinfo->link != sfxinfo_t::NO_LINK)
+	{
+		sfx_id = sfxinfo->link;
 		sfxinfo = &S_sfx[sfxinfo->link];
+	}
 
 	if (!sfxinfo->data)
 	{
 		I_LoadSound(sfxinfo);
-		if (sfxinfo->link != sfxinfo_t::NO_LINK)
+		while (sfxinfo->link != sfxinfo_t::NO_LINK)
+		{
+			sfx_id = sfxinfo->link;
 			sfxinfo = &S_sfx[sfxinfo->link];
+		}
 	}
 
   	// check for bogus sound lump
@@ -1186,7 +1192,7 @@ int S_AddSoundLump(const char *logicalname, int lump)
 	new_sfx.data = NULL;
 	new_sfx.link = sfxinfo_t::NO_LINK;
 	new_sfx.lumpnum = lump;
-	return S_sfx.size();
+	return S_sfx.size() - 1;
 }
 
 void S_ClearSoundLumps()
@@ -1398,7 +1404,7 @@ void S_ParseSndInfo()
 					if (list.size() == 1)
 					{
 						// only one sound; treat as alias
-						S_sfx[owner - 1].link = list[0];
+						S_sfx[owner].link = list[0];
 					}
 					else if (list.size() > 1)
 					{

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -45,6 +45,7 @@
 #include "m_vectors.h"
 #include "m_fileio.h"
 #include "gi.h"
+#include "oscanner.h"
 
 #define NORM_PITCH		128
 #define NORM_PRIORITY	64
@@ -120,7 +121,7 @@ CVAR_FUNC_IMPL (snd_channels)
 
 
 // whether songs are mus_paused
-static BOOL		mus_paused;
+static BOOL mus_paused;
 
 // music currently being played
 static struct mus_playing_t
@@ -138,7 +139,7 @@ size_t			numChannels;
 //
 // [RH] Print sound debug info. Called from D_Display()
 //
-void S_NoiseDebug (void)
+void S_NoiseDebug()
 {
 	fixed_t ox, oy;
 	unsigned int i;
@@ -236,7 +237,7 @@ static bool S_UseMap8Volume()
 //
 // Internals.
 //
-static void S_StopChannel (unsigned int cnum);
+static void S_StopChannel(unsigned int cnum);
 
 
 //
@@ -244,7 +245,7 @@ static void S_StopChannel (unsigned int cnum);
 // Sets channels, SFX and music volume,
 // allocates channel buffer, sets S_sfx lookup.
 //
-void S_Init (float sfxVolume, float musicVolume)
+void S_Init(float sfxVolume, float musicVolume)
 {
 	SoundCurve = (byte *)W_CacheLumpNum(W_GetNumForName("SNDCURVE"), PU_STATIC);
 
@@ -281,7 +282,7 @@ void S_Deinit()
 //
 // Kills playing sounds
 //
-void S_Stop (void)
+void S_Stop()
 {
 	// kill all playing sounds at start of level
 	//	(trust me - a good idea)
@@ -297,7 +298,7 @@ void S_Stop (void)
 // Kills playing sounds at start of level,
 // determines music if any, changes music.
 //
-void S_Start (void)
+void S_Start()
 {
 	// Kill all sound channels - but don't stop music.
 	for (size_t i = 0; i < numChannels; i++)
@@ -570,7 +571,7 @@ int S_CalculateSoundPriority(const fixed_t* pt, int channel, int attenuation)
 // a bit of a whore of a funtion but she works ok
 //
 static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
-	                  int sfx_id, float volume, int attenuation, bool looping)
+	                     int sfx_id, float volume, int attenuation, bool looping)
 {
 	int		sep;
 
@@ -687,17 +688,17 @@ static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 	Channel[cnum].start_time = gametic;
 }
 
-void S_SoundID (int channel, int sound_id, float volume, int attenuation)
+void S_SoundID(int channel, int sound_id, float volume, int attenuation)
 {
-	S_StartSound ((fixed_t *)NULL, 0, 0, channel, sound_id, volume, attenuation, false);
+	S_StartSound((fixed_t *)NULL, 0, 0, channel, sound_id, volume, attenuation, false);
 }
 
-void S_SoundID (fixed_t x, fixed_t y, int channel, int sound_id, float volume, int attenuation)
+void S_SoundID(fixed_t x, fixed_t y, int channel, int sound_id, float volume, int attenuation)
 {
-	S_StartSound ((fixed_t *)NULL, x, y, channel, sound_id, volume, attenuation, false);
+	S_StartSound((fixed_t *)NULL, x, y, channel, sound_id, volume, attenuation, false);
 }
 
-void S_SoundID (AActor *ent, int channel, int sound_id, float volume, int attenuation)
+void S_SoundID(AActor *ent, int channel, int sound_id, float volume, int attenuation)
 {
 	if (!ent)
 		return;
@@ -708,12 +709,12 @@ void S_SoundID (AActor *ent, int channel, int sound_id, float volume, int attenu
 	S_StartSound (&ent->x, 0, 0, channel, sound_id, volume, attenuation, false);
 }
 
-void S_SoundID (fixed_t *pt, int channel, int sound_id, float volume, int attenuation)
+void S_SoundID(fixed_t *pt, int channel, int sound_id, float volume, int attenuation)
 {
-	S_StartSound (pt, 0, 0, channel, sound_id, volume, attenuation, false);
+	S_StartSound(pt, 0, 0, channel, sound_id, volume, attenuation, false);
 }
 
-void S_LoopedSoundID (AActor *ent, int channel, int sound_id, float volume, int attenuation)
+void S_LoopedSoundID(AActor *ent, int channel, int sound_id, float volume, int attenuation)
 {
 	if (!ent)
 		return;
@@ -721,16 +722,16 @@ void S_LoopedSoundID (AActor *ent, int channel, int sound_id, float volume, int 
 	if (ent->subsector && ent->subsector->sector &&
 		ent->subsector->sector->MoreFlags & SECF_SILENT)
 		return;
-	S_StartSound (&ent->x, 0, 0, channel, sound_id, volume, attenuation, true);
+	S_StartSound(&ent->x, 0, 0, channel, sound_id, volume, attenuation, true);
 }
 
-void S_LoopedSoundID (fixed_t *pt, int channel, int sound_id, float volume, int attenuation)
+void S_LoopedSoundID(fixed_t *pt, int channel, int sound_id, float volume, int attenuation)
 {
-	S_StartSound (pt, 0, 0, channel, sound_id, volume, attenuation, true);
+	S_StartSound(pt, 0, 0, channel, sound_id, volume, attenuation, true);
 }
 
-static void S_StartNamedSound (AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, int channel,
-                               const char *name, float volume, int attenuation, bool looping)
+static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, int channel,
+                              const char *name, float volume, int attenuation, bool looping)
 {
 	int sfx_id = -1;
 
@@ -778,21 +779,21 @@ static void S_StartNamedSound (AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, i
 		DPrintf ("Unknown sound %s\n", name);
 
 	if (ent && ent != (AActor *)(~0))
-		S_StartSound (&ent->x, x, y, channel, sfx_id, volume, attenuation, looping);
+		S_StartSound(&ent->x, x, y, channel, sfx_id, volume, attenuation, looping);
 	else if (pt)
-		S_StartSound (pt, x, y, channel, sfx_id, volume, attenuation, looping);
+		S_StartSound(pt, x, y, channel, sfx_id, volume, attenuation, looping);
 	else
-		S_StartSound ((fixed_t *)ent, x, y, channel, sfx_id, volume, attenuation, looping);
+		S_StartSound((fixed_t *)ent, x, y, channel, sfx_id, volume, attenuation, looping);
 }
 
 // [Russell] - Hack to stop multiple plat stop sounds
-void S_PlatSound (fixed_t *pt, int channel, const char *name, float volume, int attenuation)
+void S_PlatSound(fixed_t *pt, int channel, const char *name, float volume, int attenuation)
 {
     if (!predicting)
         S_StartNamedSound (NULL, pt, 0, 0, channel, name, volume, attenuation, false);
 }
 
-void S_Sound (int channel, const char *name, float volume, int attenuation)
+void S_Sound(int channel, const char *name, float volume, int attenuation)
 {
 	// [SL] 2011-05-27 - This particular S_Sound() function is only used for sounds
 	// that should be full volume regardless of location.  Ignore the specified
@@ -800,30 +801,30 @@ void S_Sound (int channel, const char *name, float volume, int attenuation)
 	S_StartNamedSound ((AActor *)NULL, NULL, 0, 0, channel, name, volume, ATTN_NONE, false);
 }
 
-void S_Sound (AActor *ent, int channel, const char *name, float volume, int attenuation)
+void S_Sound(AActor *ent, int channel, const char *name, float volume, int attenuation)
 {
 	if(!co_globalsound && channel == CHAN_ITEM && ent != listenplayer().camera)
 		return;
 
-	S_StartNamedSound (ent, NULL, 0, 0, channel, name, volume, attenuation, false);
+	S_StartNamedSound(ent, NULL, 0, 0, channel, name, volume, attenuation, false);
 }
 
-void S_Sound (fixed_t *pt, int channel, const char *name, float volume, int attenuation)
+void S_Sound(fixed_t *pt, int channel, const char *name, float volume, int attenuation)
 {
-	S_StartNamedSound (NULL, pt, 0, 0, channel, name, volume, attenuation, false);
+	S_StartNamedSound(NULL, pt, 0, 0, channel, name, volume, attenuation, false);
 }
 
-void S_LoopedSound (AActor *ent, int channel, const char *name, float volume, int attenuation)
+void S_LoopedSound(AActor *ent, int channel, const char *name, float volume, int attenuation)
 {
 	S_StartNamedSound (ent, NULL, 0, 0, channel, name, volume, attenuation, true);
 }
 
-void S_LoopedSound (fixed_t *pt, int channel, const char *name, float volume, int attenuation)
+void S_LoopedSound(fixed_t *pt, int channel, const char *name, float volume, int attenuation)
 {
 	S_StartNamedSound (NULL, pt, 0, 0, channel, name, volume, attenuation, true);
 }
 
-void S_Sound (fixed_t x, fixed_t y, int channel, const char *name, float volume, int attenuation)
+void S_Sound(fixed_t x, fixed_t y, int channel, const char *name, float volume, int attenuation)
 {
 	S_StartNamedSound ((AActor *)(~0), NULL, x, y, channel, name, volume, attenuation, false);
 }
@@ -852,7 +853,7 @@ static void S_StopChannel(unsigned int cnum)
 }
 
 
-void S_StopSound (fixed_t *pt)
+void S_StopSound(fixed_t *pt)
 {
 	for (unsigned int i = 0; i < numChannels; i++)
 		if (Channel[i].sfxinfo && (Channel[i].pt == pt))
@@ -861,7 +862,7 @@ void S_StopSound (fixed_t *pt)
 		}
 }
 
-void S_StopSound (fixed_t *pt, int channel)
+void S_StopSound(fixed_t *pt, int channel)
 {
 	if (::Channel == NULL)
 		return;
@@ -873,12 +874,12 @@ void S_StopSound (fixed_t *pt, int channel)
 			S_StopChannel(i);
 }
 
-void S_StopSound (AActor *ent, int channel)
+void S_StopSound(AActor *ent, int channel)
 {
 	S_StopSound (&ent->x, channel);
 }
 
-void S_StopAllChannels(void)
+void S_StopAllChannels()
 {
 	for (size_t i = 0; i < numChannels; i++)
 		S_StopChannel(i);
@@ -887,7 +888,7 @@ void S_StopAllChannels(void)
 
 // Moves all the sounds from one thing to another. If the destination is
 // NULL, then the sound becomes a positioned sound.
-void S_RelinkSound (AActor *from, AActor *to)
+void S_RelinkSound(AActor *from, AActor *to)
 {
 	if (::Channel == NULL)
 		return;
@@ -909,7 +910,7 @@ void S_RelinkSound (AActor *from, AActor *to)
 	}
 }
 
-bool S_GetSoundPlayingInfo (fixed_t *pt, int sound_id)
+bool S_GetSoundPlayingInfo(fixed_t *pt, int sound_id)
 {
 	unsigned int i;
 
@@ -921,7 +922,7 @@ bool S_GetSoundPlayingInfo (fixed_t *pt, int sound_id)
 	return false;
 }
 
-bool S_GetSoundPlayingInfo (AActor *ent, int sound_id)
+bool S_GetSoundPlayingInfo(AActor *ent, int sound_id)
 {
 	return S_GetSoundPlayingInfo (ent ? &ent->x : NULL, sound_id);
 }
@@ -929,7 +930,7 @@ bool S_GetSoundPlayingInfo (AActor *ent, int sound_id)
 //
 // Stop and resume music, during game PAUSE.
 //
-void S_PauseSound (void)
+void S_PauseSound()
 {
 	if (!mus_paused)
 	{
@@ -938,7 +939,7 @@ void S_PauseSound (void)
 	}
 }
 
-void S_ResumeSound (void)
+void S_ResumeSound()
 {
 	if (mus_paused)
 	{
@@ -1034,7 +1035,7 @@ void S_UpdateMusic()
 	I_UpdateMusic();
 }
 
-void S_SetMusicVolume (float volume)
+void S_SetMusicVolume(float volume)
 {
 	if (volume < 0.0 || volume > 1.0)
 		Printf (PRINT_HIGH, "Attempt to set music volume at %f\n", volume);
@@ -1042,7 +1043,7 @@ void S_SetMusicVolume (float volume)
 		I_SetMusicVolume (volume);
 }
 
-void S_SetSfxVolume (float volume)
+void S_SetSfxVolume(float volume)
 {
 	if (volume < 0.0 || volume > 1.0)
 		Printf (PRINT_HIGH, "Attempt to set sfx volume at %f\n", volume);
@@ -1053,14 +1054,14 @@ void S_SetSfxVolume (float volume)
 //
 // Starts some music with the music id found in sounds.h.
 //
-void S_StartMusic (const char *m_id)
+void S_StartMusic(const char *m_id)
 {
 	S_ChangeMusic (m_id, false);
 }
 
 // [RH] S_ChangeMusic() now accepts the name of the music lump.
 // It's up to the caller to figure out what that name is.
-void S_ChangeMusic (std::string musicname, int looping)
+void S_ChangeMusic(std::string musicname, int looping)
 {
 	
 	// [SL] Avoid caching music lumps if we're not playing music
@@ -1097,7 +1098,6 @@ void S_ChangeMusic (std::string musicname, int looping)
     }
     else
 	{
-		lumpnum = -1;
 		length = M_FileLength(f);
 		data = static_cast<byte*>(Malloc(length));
 		size_t result = fread(data, length, 1, f);
@@ -1111,7 +1111,7 @@ void S_ChangeMusic (std::string musicname, int looping)
 	mus_playing.name = musicname;
 }
 
-void S_StopMusic (void)
+void S_StopMusic()
 {
 	I_StopSong();
 
@@ -1145,7 +1145,7 @@ static struct AmbientSound {
 #define POSITIONAL	4
 #define SURROUND	16
 
-void S_HashSounds (void)
+void S_HashSounds()
 {
 	int i;
 	unsigned j;
@@ -1162,7 +1162,7 @@ void S_HashSounds (void)
 	}
 }
 
-int S_FindSound (const char *logicalname)
+int S_FindSound(const char *logicalname)
 {
 	if(!numsfx)
 		return -1;
@@ -1175,7 +1175,7 @@ int S_FindSound (const char *logicalname)
 	return i;
 }
 
-int S_FindSoundByLump (int lump)
+int S_FindSoundByLump(int lump)
 {
 	if (lump != -1) {
 		int i;
@@ -1187,7 +1187,7 @@ int S_FindSoundByLump (int lump)
 	return -1;
 }
 
-int S_AddSoundLump (char *logicalname, int lump)
+int S_AddSoundLump(char *logicalname, int lump)
 {
 	if (numsfx == maxsfx) {
 		maxsfx = maxsfx ? maxsfx*2 : 128;
@@ -1210,7 +1210,7 @@ void S_ClearSoundLumps()
 	maxsfx = 0;
 }
 
-int S_AddSound (char *logicalname, char *lumpname)
+int S_AddSound(char *logicalname, const char *lumpname)
 {
 	int sfxid;
 
@@ -1232,134 +1232,161 @@ int S_AddSound (char *logicalname, char *lumpname)
 
 // S_ParseSndInfo
 // Parses all loaded SNDINFO lumps.
-void S_ParseSndInfo (void)
+void S_ParseSndInfo()
 {
-	char *sndinfo;
-	char *data;
-
-	S_ClearSoundLumps ();
+	S_ClearSoundLumps();
 
 	int lump = -1;
-	while ((lump = W_FindLump ("SNDINFO", lump)) != -1)
+	while ((lump = W_FindLump("SNDINFO", lump)) != -1)
 	{
-		sndinfo = (char *)W_CacheLumpNum (lump, PU_CACHE);
+		char* buffer = static_cast<char*>(W_CacheLumpNum(lump, PU_CACHE));
 
-		while ( (data = COM_Parse (sndinfo)) ) {
-			if (com_token[0] == ';') {
-				// Handle comments from Hexen MAPINFO lumps
-				while (*sndinfo && *sndinfo != ';')
-					sndinfo++;
-				while (*sndinfo && *sndinfo != '\n')
-					sndinfo++;
-				continue;
-			}
-			sndinfo = data;
-			if (com_token[0] == '$') {
-				// com_token is a command
+		const OScannerConfig config = {
+		    "SNDINFO", // lumpName
+		    true,      // semiComments
+		    true,      // cComments
+		};
+		OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));
 
-				if (!stricmp (com_token + 1, "ambient")) {
-					// $ambient <num> <logical name> [point [atten]|surround] <type> [secs] <relative volume>
-					struct AmbientSound *ambient, dummy;
-					int index;
+		while (os.scan())
+		{
+			std::string tok = os.getToken();
 
-					sndinfo = COM_Parse (sndinfo);
-					index = atoi (com_token);
-					if (index < 0 || index > 255) {
-						Printf (PRINT_HIGH, "Bad ambient index (%d)\n", index);
+			// check if token is a command
+			if (tok[0] == '$')
+			{
+				os.mustScan();
+				if (os.compareTokenNoCase("ambient"))
+				{
+					// $ambient <num> <logical name> [point [atten]|surround] <type>
+					// [secs] <relative volume>
+					AmbientSound *ambient, dummy;
+
+					os.mustScanInt();
+					const int index = os.getTokenInt();
+					if (index < 0 || index > 255)
+					{
+						Printf(PRINT_HIGH, "Bad ambient index (%d)\n", index);
 						ambient = &dummy;
-					} else {
+					}
+					else
+					{
 						ambient = Ambients + index;
 					}
-                    
-                    ambient->type = 0;
-                    ambient->periodmin = 0;
-                    ambient->periodmax = 0;
-                    ambient->volume = 0.0f;
 
-					sndinfo = COM_Parse (sndinfo);
-					strncpy (ambient->sound, com_token, MAX_SNDNAME);
+					ambient->type = 0;
+					ambient->periodmin = 0;
+					ambient->periodmax = 0;
+					ambient->volume = 0.0f;
+
+					os.mustScan();
+					strncpy(ambient->sound, os.getToken().c_str(), MAX_SNDNAME);
 					ambient->sound[MAX_SNDNAME] = 0;
 					ambient->attenuation = 0.0f;
 
-					sndinfo = COM_Parse (sndinfo);
-					if (!stricmp (com_token, "point")) {
-						float attenuation;
-
+					os.mustScan();
+					if (os.compareTokenNoCase("point"))
+					{
 						ambient->type = POSITIONAL;
-						sndinfo = COM_Parse (sndinfo);
-						attenuation = (float)atof (com_token);
+						os.mustScanFloat();
+						const float attenuation = os.getTokenFloat();
 						if (attenuation > 0)
 						{
 							ambient->attenuation = attenuation;
-							sndinfo = COM_Parse (sndinfo);
+							os.mustScan();
 						}
 						else
 						{
 							ambient->attenuation = 1;
 						}
-					} else if (!stricmp (com_token, "surround")) {
+					}
+					else if (os.compareTokenNoCase("surround"))
+					{
 						ambient->type = SURROUND;
-						sndinfo = COM_Parse (sndinfo);
+						os.mustScan();
 						ambient->attenuation = -1;
 					}
 
-					if (!stricmp (com_token, "continuous")) {
+					if (os.compareTokenNoCase("continuous"))
+					{
 						ambient->type |= CONTINUOUS;
-					} else if (!stricmp (com_token, "random")) {
+					}
+					else if (os.compareTokenNoCase("random"))
+					{
 						ambient->type |= RANDOM;
-						sndinfo = COM_Parse (sndinfo);
-						ambient->periodmin = (int)(atof (com_token) * TICRATE);
-						sndinfo = COM_Parse (sndinfo);
-						ambient->periodmax = (int)(atof (com_token) * TICRATE);
-					} else if (!stricmp (com_token, "periodic")) {
+						os.mustScanFloat();
+						ambient->periodmin = static_cast<int>(os.getTokenFloat() * TICRATE);
+						os.mustScanFloat();
+						ambient->periodmax = static_cast<int>(os.getTokenFloat() * TICRATE);
+					}
+					else if (os.compareTokenNoCase("periodic"))
+					{
 						ambient->type |= PERIODIC;
-						sndinfo = COM_Parse (sndinfo);
-						ambient->periodmin = (int)(atof (com_token) * TICRATE);
-					} else {
-						Printf (PRINT_HIGH, "Unknown ambient type (%s)\n", com_token);
+						os.mustScanFloat();
+						ambient->periodmin = static_cast<int>(os.getTokenFloat() * TICRATE);
+					}
+					else
+					{
+						os.warning("Unknown ambient type (%s)\n", os.getToken().c_str());
 					}
 
-					sndinfo = COM_Parse (sndinfo);
-					ambient->volume = (float)atof (com_token);
+					os.mustScanFloat();
+					ambient->volume = os.getTokenFloat();
 					if (ambient->volume > 1)
 						ambient->volume = 1;
 					else if (ambient->volume < 0)
 						ambient->volume = 0;
-				} else if (!stricmp (com_token + 1, "map")) {
+				}
+				else if (os.compareTokenNoCase("map"))
+				{
 					// Hexen-style $MAP command
-					sndinfo = COM_Parse (sndinfo);
-					sprintf (com_token, "MAP%02d", atoi (com_token));
-					level_pwad_info_t& info = getLevelInfos().findByName(com_token);
-					sndinfo = COM_Parse (sndinfo);
+					char* mapname = NULL;
+
+					os.mustScanInt();
+					sprintf(mapname, "MAP%02d", os.getTokenInt());
+					level_pwad_info_t& info = getLevelInfos().findByName(mapname);
+					os.mustScan();
 					if (info.mapname[0])
 					{
-						info.music = com_token; // denis - todo -string limit?
+						info.music = os.getToken();
 					}
-				} else {
-					Printf (PRINT_WARNING, "Unknown SNDINFO command %s\n", com_token);
-					while (*sndinfo != '\n' && *sndinfo != '\0')
-						sndinfo++;
 				}
-			} else {
-				// com_token is a logical sound mapping
-				char name[MAX_SNDNAME+1];
+				/*else if (os.compareTokenNoCase("random"))
+				{
+					
+				}*/
+				else
+				{
+					os.warning("Unknown SNDINFO command %s\n", os.getToken().c_str());
+					while (os.scan())
+						if (os.crossed())
+						{
+							os.unScan();
+							break;
+						}
+				}
+			}
+			else
+			{
+				// token is a logical sound mapping
+				char name[MAX_SNDNAME + 1];
 
-				strncpy (name, com_token, MAX_SNDNAME);
+				strncpy(name, tok.c_str(), MAX_SNDNAME);
 				name[MAX_SNDNAME] = 0;
-				sndinfo = COM_Parse (sndinfo);
-				S_AddSound (name, com_token);
+				os.mustScan();
+				S_AddSound(name, os.getToken().c_str());
 			}
 		}
 	}
-	S_HashSounds ();
+	S_HashSounds();
 
-	sfx_empty = W_CheckNumForName ("dsempty");
-	sfx_noway = S_FindSoundByLump (W_CheckNumForName ("dsnoway"));
-	sfx_oof = S_FindSoundByLump (W_CheckNumForName ("dsoof"));
+	sfx_empty = W_CheckNumForName("dsempty");
+	sfx_noway = S_FindSoundByLump(W_CheckNumForName("dsnoway"));
+	sfx_oof = S_FindSoundByLump(W_CheckNumForName("dsoof"));
 }
 
 
-static void SetTicker (int *tics, struct AmbientSound *ambient)
+static void SetTicker(int *tics, AmbientSound *ambient)
 {
 	if ((ambient->type & CONTINUOUS) == CONTINUOUS)
 	{
@@ -1382,12 +1409,12 @@ static void SetTicker (int *tics, struct AmbientSound *ambient)
 		*tics = 1;
 }
 
-void A_Ambient (AActor *actor)
+void A_Ambient(AActor *actor)
 {
 	if (!actor)
 		return;
 
-	struct AmbientSound *ambient = &Ambients[actor->args[0]];
+	AmbientSound *ambient = &Ambients[actor->args[0]];
 
 	if ((ambient->type & CONTINUOUS) == CONTINUOUS)
 	{
@@ -1422,12 +1449,12 @@ void A_Ambient (AActor *actor)
 	}
 }
 
-void S_ActivateAmbient (AActor *origin, int ambient)
+void S_ActivateAmbient(AActor *origin, int ambient)
 {
 	if (!origin)
 		return;
 
-	struct AmbientSound *amb = &Ambients[ambient];
+	AmbientSound *amb = &Ambients[ambient];
 
 	if (!(amb->type & 3) && !amb->periodmin)
 	{
@@ -1516,7 +1543,7 @@ END_COMMAND (changemus)
 // UV_SoundAvoidCl
 // Sends a sound to clients, but doesn't send it to client 'player'.
 //
-void UV_SoundAvoidPlayer (AActor *mo, byte channel, const char *name, byte attenuation)
+void UV_SoundAvoidPlayer(AActor *mo, byte channel, const char *name, byte attenuation)
 {
 	S_Sound(mo, channel, name, 1, attenuation);
 }

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -134,7 +134,7 @@ EXTERN_CVAR (co_globalsound)
 EXTERN_CVAR (co_zdoomsound)
 EXTERN_CVAR (snd_musicsystem)
 
-size_t			numChannels;
+size_t numChannels;
 
 //
 // [RH] Print sound debug info. Called from D_Display()
@@ -142,11 +142,8 @@ size_t			numChannels;
 void S_NoiseDebug()
 {
 	fixed_t ox, oy;
-	unsigned int i;
-	int y;
-	int color;
 
-	y = 32 * CleanYfac;
+	int y = 32 * CleanYfac;
 	if (gametic & 16)
 		screen->DrawText (CR_TAN, 0, y, "*** SOUND DEBUG INFO ***");
 	y += 8;
@@ -160,7 +157,7 @@ void S_NoiseDebug()
 	screen->DrawText (CR_GREY, 280, y, "chan");
 	y += 8;
 
-	for (i = 0;((i < numChannels) && (y < I_GetVideoHeight() - 16)); i++, y += 8)
+	for (unsigned int i = 0; ((i < numChannels) && (y < I_GetVideoHeight() - 16)); i++, y += 8)
 	{
 		if (Channel[i].sfxinfo)
 		{
@@ -182,7 +179,7 @@ void S_NoiseDebug()
 				ox = Channel[i].x;
 				oy = Channel[i].y;
 			}
-			color = Channel[i].loop ? CR_BROWN : CR_GREY;
+			const int color = Channel[i].loop ? CR_BROWN : CR_GREY;
 			strcpy (temp, lumpinfo[Channel[i].sfxinfo->lumpnum].name);
 			temp[8] = 0;
 			screen->DrawText (color, 0, y, temp);
@@ -251,10 +248,10 @@ void S_Init(float sfxVolume, float musicVolume)
 
 	// [RH] Read in sound sequences
 	NumSequences = 0;
-	S_ParseSndSeq ();
+	S_ParseSndSeq();
 
-	S_SetSfxVolume (sfxVolume);
-	S_SetMusicVolume (musicVolume);
+	S_SetSfxVolume(sfxVolume);
+	S_SetMusicVolume(musicVolume);
 
 	// Allocating the internal channels for mixing
 	// (the maximum numer of sounds rendered
@@ -264,7 +261,7 @@ void S_Init(float sfxVolume, float musicVolume)
 	for (size_t i = 0; i < numChannels; i++)
 		Channel[i].clear();
 
-	I_SetChannels (numChannels);
+	I_SetChannels(numChannels);
 
 	// no sounds are playing, and they are not mus_paused
 	mus_paused = 0;
@@ -286,7 +283,7 @@ void S_Stop()
 {
 	// kill all playing sounds at start of level
 	//	(trust me - a good idea)
-	for (size_t i = 0; i < numChannels; i++)
+	for (unsigned i = 0; i < numChannels; i++)
 		S_StopChannel(i);
 
 	S_StopMusic();
@@ -301,7 +298,7 @@ void S_Stop()
 void S_Start()
 {
 	// Kill all sound channels - but don't stop music.
-	for (size_t i = 0; i < numChannels; i++)
+	for (unsigned i = 0; i < numChannels; i++)
 		S_StopChannel(i);
 
 	// start new music for the level
@@ -361,7 +358,7 @@ int S_GetChannel(sfxinfo_t* sfxinfo, float volume, int priority, unsigned max_in
 	tempchan.volume = volume;
 	tempchan.start_time = gametic;
 
-	int sound_id = S_FindSound(sfxinfo->name);
+	const int sound_id = S_FindSound(sfxinfo->name);
 
 	// Limit the number of identical sounds playing at once
 	// tries to keep the plasma rifle from hogging all the channels
@@ -402,7 +399,7 @@ static void AdjustSoundParamsZDoom(const AActor* listener, fixed_t x, fixed_t y,
 {
 	static const fixed_t MAX_SND_DIST = 2025 * FRACUNIT;
 	static const fixed_t MIN_SND_DIST = 1 * FRACUNIT;
-	int approx_dist = P_AproxDistance(listener->x - x, listener->y - y);
+	const int approx_dist = P_AproxDistance(listener->x - x, listener->y - y);
 
 	if (approx_dist > MAX_SND_DIST)
 	{
@@ -416,7 +413,7 @@ static void AdjustSoundParamsZDoom(const AActor* listener, fixed_t x, fixed_t y,
 	}
 	else
 	{
-		float attenuation = float(SoundCurve[approx_dist >> FRACBITS]) / 128.0f;
+		const float attenuation = static_cast<float>(SoundCurve[approx_dist >> FRACBITS]) / 128.0f;
 		
 		*vol = snd_sfxvolume * attenuation;
 
@@ -573,8 +570,6 @@ int S_CalculateSoundPriority(const fixed_t* pt, int channel, int attenuation)
 static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 	                     int sfx_id, float volume, int attenuation, bool looping)
 {
-	int		sep;
-
 	if (volume <= 0.0f)
 		return;
 
@@ -582,7 +577,7 @@ static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 		return;
 
   	// check for bogus sound #
-	if (sfx_id < 1 || sfx_id > numsfx)
+	if (sfx_id < 1 || sfx_id > S_sfx.size() - 1)
 	{
 		DPrintf("Bad sfx #: %d\n", sfx_id);
 		return;
@@ -591,7 +586,7 @@ static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 	sfxinfo_t* sfxinfo = &S_sfx[sfx_id];
 
   	// check for bogus sound lump
-	if (sfxinfo->lumpnum < 0 || sfxinfo->lumpnum > (int)numlumps)
+	if (sfxinfo->lumpnum < 0 || sfxinfo->lumpnum > static_cast<int>(numlumps))
 	{
 		DPrintf("Bad sfx lump #: %d\n", sfxinfo->lumpnum);
 		return;
@@ -620,6 +615,8 @@ static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 	if (sfxinfo->lumpnum == sfx_empty)
 		return;
 
+	int sep;
+
 	if (listenplayer().camera && attenuation != ATTN_NONE)
 	{
   		// Check to see if it is audible, and if not, modify the params
@@ -636,7 +633,7 @@ static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 			volume = snd_sfxvolume;
 	}
 
-	int priority = S_CalculateSoundPriority(pt, channel, attenuation);
+	const int priority = S_CalculateSoundPriority(pt, channel, attenuation);
 
 	// joek - hack for silent bfg - stop player's weapon sounds if grunting
 	if (sfx_id == sfx_noway || sfx_id == sfx_oof)
@@ -656,10 +653,10 @@ static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 
 	// How many instances of the same sfx can be playing concurrently
 	// Allow 3 of all sounds except announcer sfx
-	unsigned int max_instances = (channel == CHAN_ANNOUNCER) ? 1 : 3;
+	const unsigned int max_instances = (channel == CHAN_ANNOUNCER) ? 1 : 3;
 
 	// try to find a channel
-	int cnum = S_GetChannel(sfxinfo, volume, priority, max_instances);
+	const int cnum = S_GetChannel(sfxinfo, volume, priority, max_instances);
 
 	// no channel found
 	if (cnum < 0)
@@ -668,7 +665,7 @@ static void S_StartSound(fixed_t* pt, fixed_t x, fixed_t y, int channel,
 	// make sure the channel isn't playing anything
 	S_StopChannel(cnum);
 
-	int handle = I_StartSound(sfx_id, volume, sep, NORM_PITCH, looping);
+	const int handle = I_StartSound(sfx_id, volume, sep, NORM_PITCH, looping);
 
 	// I_StartSound can not find an empty channel
 	if (handle < 0)
@@ -733,8 +730,6 @@ void S_LoopedSoundID(fixed_t *pt, int channel, int sound_id, float volume, int a
 static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, int channel,
                               const char *name, float volume, int attenuation, bool looping)
 {
-	int sfx_id = -1;
-
 	if (!consoleplayer().mo && channel != CHAN_INTERFACE)
 		return;
 
@@ -744,6 +739,8 @@ static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, in
 	{
 		return;
 	}
+
+	int sfx_id = -1;
 
 	if (*name == '*')
 	{
@@ -763,17 +760,17 @@ static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, in
 			if (sfx_id == -1)
 			{
 				sprintf(nametemp, templat, genders[player->userinfo.gender], name + 1);
-				sfx_id = S_FindSound (nametemp);
+				sfx_id = S_FindSound(nametemp);
 			}
 		}
 		if (sfx_id == -1)
 		{
 			sprintf(nametemp, templat, "male", name + 1);
-			sfx_id = S_FindSound (nametemp);
+			sfx_id = S_FindSound(nametemp);
 		}
 	}
 	else
-		sfx_id = S_FindSound (name);
+		sfx_id = S_FindSound(name);
 
 	if (sfx_id == -1)
 		DPrintf ("Unknown sound %s\n", name);
@@ -790,7 +787,7 @@ static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, in
 void S_PlatSound(fixed_t *pt, int channel, const char *name, float volume, int attenuation)
 {
     if (!predicting)
-        S_StartNamedSound (NULL, pt, 0, 0, channel, name, volume, attenuation, false);
+        S_StartNamedSound(NULL, pt, 0, 0, channel, name, volume, attenuation, false);
 }
 
 void S_Sound(int channel, const char *name, float volume, int attenuation)
@@ -798,7 +795,7 @@ void S_Sound(int channel, const char *name, float volume, int attenuation)
 	// [SL] 2011-05-27 - This particular S_Sound() function is only used for sounds
 	// that should be full volume regardless of location.  Ignore the specified
 	// attenuation and use ATTN_NONE instead.
-	S_StartNamedSound ((AActor *)NULL, NULL, 0, 0, channel, name, volume, ATTN_NONE, false);
+	S_StartNamedSound((AActor *)NULL, NULL, 0, 0, channel, name, volume, ATTN_NONE, false);
 }
 
 void S_Sound(AActor *ent, int channel, const char *name, float volume, int attenuation)
@@ -816,17 +813,17 @@ void S_Sound(fixed_t *pt, int channel, const char *name, float volume, int atten
 
 void S_LoopedSound(AActor *ent, int channel, const char *name, float volume, int attenuation)
 {
-	S_StartNamedSound (ent, NULL, 0, 0, channel, name, volume, attenuation, true);
+	S_StartNamedSound(ent, NULL, 0, 0, channel, name, volume, attenuation, true);
 }
 
 void S_LoopedSound(fixed_t *pt, int channel, const char *name, float volume, int attenuation)
 {
-	S_StartNamedSound (NULL, pt, 0, 0, channel, name, volume, attenuation, true);
+	S_StartNamedSound(NULL, pt, 0, 0, channel, name, volume, attenuation, true);
 }
 
 void S_Sound(fixed_t x, fixed_t y, int channel, const char *name, float volume, int attenuation)
 {
-	S_StartNamedSound ((AActor *)(~0), NULL, x, y, channel, name, volume, attenuation, false);
+	S_StartNamedSound((AActor *)(~0), NULL, x, y, channel, name, volume, attenuation, false);
 }
 
 
@@ -876,12 +873,12 @@ void S_StopSound(fixed_t *pt, int channel)
 
 void S_StopSound(AActor *ent, int channel)
 {
-	S_StopSound (&ent->x, channel);
+	S_StopSound(&ent->x, channel);
 }
 
 void S_StopAllChannels()
 {
-	for (size_t i = 0; i < numChannels; i++)
+	for (unsigned i = 0; i < numChannels; i++)
 		S_StopChannel(i);
 }
 
@@ -893,16 +890,16 @@ void S_RelinkSound(AActor *from, AActor *to)
 	if (::Channel == NULL)
 		return;
 
-	unsigned int i;
-
 	if (!from)
 		return;
 
-	fixed_t *frompt = &from->x;
+	const fixed_t *frompt = &from->x;
 	fixed_t *topt = to ? &to->x : NULL;
 
-	for (i = 0; i < numChannels; i++) {
-		if (Channel[i].pt == frompt) {
+	for (unsigned int i = 0; i < numChannels; i++)
+	{
+		if (Channel[i].pt == frompt)
+		{
 			Channel[i].pt = topt;
 			Channel[i].x = frompt[0];
 			Channel[i].y = frompt[1];
@@ -912,9 +909,7 @@ void S_RelinkSound(AActor *from, AActor *to)
 
 bool S_GetSoundPlayingInfo(fixed_t *pt, int sound_id)
 {
-	unsigned int i;
-
-	for (i = 0; i < numChannels; i++)
+	for (unsigned int i = 0; i < numChannels; i++)
 	{
 		if (Channel[i].pt == pt && Channel[i].sound_id == sound_id)
 			return true;
@@ -960,8 +955,8 @@ void S_UpdateSounds(void* listener_p)
 	AActor* listener = (AActor*)listener_p;
 	for (int cnum = 0; cnum < (int)numChannels; cnum++)
 	{
-		channel_t* c = &Channel[cnum];
-		sfxinfo_t* sfx = c->sfxinfo;
+		const channel_t* c = &Channel[cnum];
+		const sfxinfo_t* sfx = c->sfxinfo;
 
 		if (c->sfxinfo)
 		{
@@ -1063,7 +1058,6 @@ void S_StartMusic(const char *m_id)
 // It's up to the caller to figure out what that name is.
 void S_ChangeMusic(std::string musicname, int looping)
 {
-	
 	// [SL] Avoid caching music lumps if we're not playing music
 	if (snd_musicsystem == MS_NONE)
 		return;
@@ -1074,18 +1068,17 @@ void S_ChangeMusic(std::string musicname, int looping)
 	if (!musicname.length() || musicname[0] == 0)
 	{
 		// Don't choke if the map doesn't have a song attached
-		S_StopMusic ();
+		S_StopMusic();
 		return;
 	}
 
 	byte* data = NULL;
 	size_t length = 0;
-	int lumpnum;
 	FILE *f;
-
 
 	if (!(f = fopen (musicname.c_str(), "rb")))
 	{
+		int lumpnum;
 		if ((lumpnum = W_CheckNumForName (musicname.c_str())) == -1)
 		{
 			Printf (PRINT_HIGH, "Music lump \"%s\" not found\n", musicname.c_str());
@@ -1100,7 +1093,7 @@ void S_ChangeMusic(std::string musicname, int looping)
 	{
 		length = M_FileLength(f);
 		data = static_cast<byte*>(Malloc(length));
-		size_t result = fread(data, length, 1, f);
+		const size_t result = fread(data, length, 1, f);
 		fclose(f);
 
 		if (result == 1)
@@ -1126,9 +1119,7 @@ void S_StopMusic()
 //
 // =============================== [RH]
 
-sfxinfo_t *S_sfx;	// [RH] This is no longer defined in sounds.c
-static int maxsfx;	// [RH] Current size of S_sfx array.
-int numsfx;			// [RH] Current number of sfx defined.
+std::vector<sfxinfo_t> S_sfx;	// [RH] This is no longer defined in sounds.c
 
 static struct AmbientSound {
 	unsigned	type;		// type of ambient sound
@@ -1147,16 +1138,14 @@ static struct AmbientSound {
 
 void S_HashSounds()
 {
-	int i;
-	unsigned j;
-
 	// Mark all buckets as empty
-	for (i = 0; i < numsfx; i++)
+	for (unsigned i = 0; i < S_sfx.size(); i++)
 		S_sfx[i].index = ~0;
 
 	// Now set up the chains
-	for (i = 0; i < numsfx; i++) {
-		j = MakeKey (S_sfx[i].name) % (unsigned)numsfx;
+	for (unsigned i = 0; i < S_sfx.size(); i++)
+	{
+		const unsigned j = MakeKey(S_sfx[i].name) % static_cast<unsigned>(S_sfx.size() - 1);
 		S_sfx[i].next = S_sfx[j].index;
 		S_sfx[j].index = i;
 	}
@@ -1164,12 +1153,12 @@ void S_HashSounds()
 
 int S_FindSound(const char *logicalname)
 {
-	if(!numsfx)
+	if (S_sfx.empty())
 		return -1;
 
-	int i = S_sfx[MakeKey (logicalname) % (unsigned)numsfx].index;
+	int i = S_sfx[MakeKey(logicalname) % static_cast<unsigned>(S_sfx.size() - 1)].index;
 
-	while ((i != -1) && strnicmp (S_sfx[i].name, logicalname, MAX_SNDNAME))
+	while ((i != -1) && strnicmp(S_sfx[i].name, logicalname, MAX_SNDNAME))
 		i = S_sfx[i].next;
 
 	return i;
@@ -1177,53 +1166,47 @@ int S_FindSound(const char *logicalname)
 
 int S_FindSoundByLump(int lump)
 {
-	if (lump != -1) {
-		int i;
-
-		for (i = 0; i < numsfx; i++)
+	if (lump != -1)
+	{
+		for (unsigned i = 0; i < S_sfx.size(); i++)
 			if (S_sfx[i].lumpnum == lump)
 				return i;
 	}
 	return -1;
 }
 
-int S_AddSoundLump(char *logicalname, int lump)
+int S_AddSoundLump(const char *logicalname, int lump)
 {
-	if (numsfx == maxsfx) {
-		maxsfx = maxsfx ? maxsfx*2 : 128;
-		S_sfx = (sfxinfo_struct *)Realloc (S_sfx, maxsfx * sizeof(*S_sfx));
-	}
+	S_sfx.push_back(sfxinfo_t());
+	sfxinfo_t& new_sfx = S_sfx[S_sfx.size() - 1];
 
 	// logicalname MUST be < MAX_SNDNAME chars long
-	strcpy (S_sfx[numsfx].name, logicalname);
-	S_sfx[numsfx].data = NULL;
-	S_sfx[numsfx].link = NULL;
-	S_sfx[numsfx].lumpnum = lump;
-	return numsfx++;
+	strcpy(new_sfx.name, logicalname);
+	new_sfx.data = NULL;
+	new_sfx.link = NULL;
+	new_sfx.lumpnum = lump;
+	return S_sfx.size();
 }
 
 void S_ClearSoundLumps()
 {
-	M_Free(S_sfx);
-
-	numsfx = 0;
-	maxsfx = 0;
+	S_sfx.clear();
 }
 
-int S_AddSound(char *logicalname, const char *lumpname)
+int S_AddSound(const char *logicalname, const char *lumpname)
 {
 	int sfxid;
 
 	// If the sound has already been defined, change the old definition.
-	for (sfxid = 0; sfxid < numsfx; sfxid++)
-		if (0 == stricmp(logicalname, S_sfx[sfxid].name))
+	for (sfxid = 0; sfxid < S_sfx.size(); sfxid++)
+		if (iequals(logicalname, S_sfx[sfxid].name))
 			break;
 
-	const int lump = W_CheckNumForName (lumpname);
+	const int lump = W_CheckNumForName(lumpname);
 
 	// Otherwise, prepare a new one.
-	if (sfxid == numsfx)
-		sfxid = S_AddSoundLump (logicalname, lump);
+	if (sfxid == S_sfx.size())
+		sfxid = S_AddSoundLump(logicalname, lump);
 	else
 		S_sfx[sfxid].lumpnum = lump;
 
@@ -1351,10 +1334,26 @@ void S_ParseSndInfo()
 						info.music = os.getToken();
 					}
 				}
-				/*else if (os.compareTokenNoCase("random"))
+				else if (os.compareTokenNoCase("alias"))
 				{
-					
-				}*/
+					os.mustScan();
+					std::string alias = os.getToken();
+					S_AddSound(os.getToken().c_str(), NULL);
+					os.mustScan();
+					std::string orig = os.getToken();
+				}
+				else if (os.compareTokenNoCase("random"))
+				{
+					os.mustScan();
+					// do thing
+
+					os.mustScan();
+					os.assertTokenIs("{");
+					while (os.scan() && !os.compareToken("}"))
+					{
+						
+					}
+				}
 				else
 				{
 					os.warning("Unknown SNDINFO command %s\n", os.getToken().c_str());
@@ -1458,11 +1457,11 @@ void S_ActivateAmbient(AActor *origin, int ambient)
 
 	if (!(amb->type & 3) && !amb->periodmin)
 	{
-		int sndnum = S_FindSound(amb->sound);
+		const int sndnum = S_FindSound(amb->sound);
 		if (sndnum == 0)
 			return;
 
-		sfxinfo_t *sfx = S_sfx + sndnum;
+		sfxinfo_t *sfx = &S_sfx[sndnum];
 
 		// Make sure the sound has been loaded so we know how long it is
 		if (!sfx->data)
@@ -1479,10 +1478,9 @@ void S_ActivateAmbient(AActor *origin, int ambient)
 BEGIN_COMMAND (snd_soundlist)
 {
 	char lumpname[9];
-	int i;
 
 	lumpname[8] = 0;
-	for (i = 0; i < numsfx; i++)
+	for (unsigned i = 0; i < S_sfx.size(); i++)
 		if (S_sfx[i].lumpnum != -1)
 		{
 			strncpy (lumpname, lumpinfo[S_sfx[i].lumpnum].name, 8);
@@ -1495,9 +1493,7 @@ END_COMMAND (snd_soundlist)
 
 BEGIN_COMMAND (snd_soundlinks)
 {
-	int i;
-
-	for (i = 0; i < numsfx; i++)
+	for (unsigned i = 0; i < S_sfx.size(); i++)
 		if (S_sfx[i].link)
 			Printf (PRINT_HIGH, "%s -> %s\n", S_sfx[i].name, S_sfx[i].link->name);
 }
@@ -1512,8 +1508,6 @@ END_COMMAND (snd_restart)
 
 BEGIN_COMMAND (changemus)
 {
-	int loopmus;
-
 	if (argc == 1)
 	{
 	    Printf(PRINT_HIGH, "Usage: changemus lumpname [loop]");
@@ -1529,7 +1523,7 @@ BEGIN_COMMAND (changemus)
 
 	if (argc > 2)
 	{
-		loopmus = (atoi(argv[2]) != 0);
+		const int loopmus = (atoi(argv[2]) != 0);
 		S_ChangeMusic(musicname, loopmus);
 	}
 	else if (argc == 2)

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -1264,6 +1264,7 @@ int S_AddSound(const char *logicalname, const char *lumpname)
 void S_AddRandomSound(int owner, std::vector<int>& list)
 {
 	S_rnd[owner] = list;
+	S_sfx[owner].link = owner;
 	S_sfx[owner].israndom = true;
 }
 

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -1142,7 +1142,7 @@ void S_StopMusic()
 // =============================== [RH]
 
 std::vector<sfxinfo_t> S_sfx;	// [RH] This is no longer defined in sounds.c
-std::map<int, std::vector<int>> S_rnd;
+std::map<int, std::vector<int> > S_rnd;
 
 static struct AmbientSound {
 	unsigned	type;		// type of ambient sound

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1740,7 +1740,7 @@ void ParseMapInfoLump(int lump, const char* lumpname)
 
 	const OScannerConfig config = {
 	    lumpname, // lumpName
-	    false,    // semiComments
+	    true,     // semiComments
 	    true,     // cComments
 	};
 	OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));

--- a/common/gi.cpp
+++ b/common/gi.cpp
@@ -28,30 +28,6 @@
 
 gameinfo_t gameinfo;
 
-static const char *quitsounds[8] =
-{
-	"player/male/death1",
-	"demon/pain",
-	"grunt/pain",
-	"misc/gibbed",
-	"misc/teleport",
-	"grunt/sight1",
-	"grunt/sight3",
-	"demon/melee"
-};
-
-static const char *quitsounds2[8] =
-{
-	"vile/active",
-	"misc/p_pkup",
-	"brain/cube",
-	"misc/gibbed",
-	"skeleton/swing",
-	"knight/death",
-	"baby/active",
-	"demon/melee"
-};
-
 static gameborder_t DoomBorder =
 {
 	8, 8,
@@ -77,7 +53,7 @@ gameinfo_t SharewareGameInfo =
 	{ 'V','I','C','T','O','R','Y','2' },
 	"ENDPIC",
 	{ { "HELP1", "HELP2", "CREDIT" } },
-	quitsounds,
+	"menu/quit1",
 	1,
 	{ 'F','L','O','O','R','7','_','2' },
 	&DoomBorder,
@@ -101,7 +77,7 @@ gameinfo_t RegisteredGameInfo =
 	{ 'V','I','C','T','O','R','Y','2' },
 	"ENDPIC",
 	{ { "HELP1", "HELP2", "CREDIT" } },
-	quitsounds,
+	"menu/quit1",
 	2,
 	{ 'F','L','O','O','R','7','_','2' },
 	&DoomBorder,
@@ -125,7 +101,7 @@ gameinfo_t RetailGameInfo =
 	{ 'V','I','C','T','O','R','Y','2' },
 	"ENDPIC",
 	{ { "HELP1", "CREDIT", "CREDIT"  } },
-	quitsounds,
+	"menu/quit1",
 	2,
 	{ 'F','L','O','O','R','7','_','2' },
 	&DoomBorder,
@@ -149,7 +125,7 @@ gameinfo_t RetailBFGGameInfo =
 	{ 'V','I','C','T','O','R','Y','2' },
 	"ENDPIC",
 	{ { "HELP1", "CREDIT", "CREDIT"  } },
-	quitsounds,
+	"menu/quit1",
 	2,
 	{ 'F','L','O','O','R','7','_','2' },
 	&DoomBorder,
@@ -173,7 +149,7 @@ gameinfo_t CommercialGameInfo =
 	"CREDIT",
 	"CREDIT",
 	{ { "HELP", "CREDIT", "CREDIT" } },
-	quitsounds2,
+	"menu/quit2",
 	3,
 	"GRNROCK",
 	&DoomBorder,
@@ -197,7 +173,7 @@ gameinfo_t CommercialBFGGameInfo =
 	"CREDIT",
 	"CREDIT",
 	{ { "HELP", "CREDIT", "CREDIT" } },
-	quitsounds2,
+	"menu/quit2",
 	3,
 	"GRNROCK",
 	&DoomBorder,

--- a/common/gi.h
+++ b/common/gi.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "olumpname.h"
+#include "s_sound.h"
 
 #define GI_MAPxx				0x00000001
 #define GI_PAGESARERAW			0x00000002
@@ -60,7 +61,7 @@ typedef struct
 	float titleTime;
 	float advisoryTime;
 	float pageTime;
-	char chatSound[16];
+	char chatSound[MAX_SNDNAME + 1];
 	OLumpName finaleMusic;
 	OLumpName finaleFlat;
 	char finalePage1[8];

--- a/common/gi.h
+++ b/common/gi.h
@@ -76,7 +76,7 @@ typedef struct
 			int numPages;
 		} indexed;
 	} info;
-	const char **quitSounds;
+	char quitSound[MAX_SNDNAME + 1];
 	int maxSwitch;
 	char borderFlat[8];
 	gameborder_t *border;

--- a/common/s_sound.h
+++ b/common/s_sound.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -21,12 +21,11 @@
 //
 //-----------------------------------------------------------------------------
 
-
 #pragma once
 
 #include "m_fixed.h"
 
-#define MAX_SNDNAME			63
+#define MAX_SNDNAME 63
 
 class AActor;
 class player_s;
@@ -39,22 +38,22 @@ typedef struct sfxinfo_struct sfxinfo_t;
 
 struct sfxinfo_struct
 {
-	char		name[MAX_SNDNAME+1];	// [RH] Sound name defined in SNDINFO
-	unsigned	normal;					// Normal sample handle
-	unsigned	looping;				// Looping sample handle
-	void*		data;
+	char name[MAX_SNDNAME + 1]; // [RH] Sound name defined in SNDINFO
+	unsigned normal;            // Normal sample handle
+	unsigned looping;           // Looping sample handle
+	void* data;
 
-	struct sfxinfo_struct *link;
+	sfxinfo_struct* link;
 
-	int 		lumpnum;				// lump number of sfx
-	unsigned int ms;					// [RH] length of sfx in milliseconds
-	unsigned int next, index;			// [RH] For hashing
-	unsigned int frequency;				// [RH] Preferred playback rate
-	unsigned int length;				// [RH] Length of the sound in bytes
+	int lumpnum;              // lump number of sfx
+	unsigned int ms;          // [RH] length of sfx in milliseconds
+	unsigned int next, index; // [RH] For hashing
+	unsigned int frequency;   // [RH] Preferred playback rate
+	unsigned int length;      // [RH] Length of the sound in bytes
 };
 
 // the complete set of sound effects
-extern sfxinfo_t *S_sfx;
+extern std::vector<sfxinfo_t> S_sfx;
 
 // [RH] Number of defined sounds
 extern int numsfx;
@@ -63,112 +62,115 @@ extern int numsfx;
 // Sets channels, SFX and music volume,
 //	allocates channel buffer, sets S_sfx lookup.
 //
-void S_Init (float sfxVolume, float musicVolume);
+void S_Init(float sfxVolume, float musicVolume);
 void S_Deinit();
 
 // Per level startup code.
 // Kills playing sounds at start of level,
 //	determines music if any, changes music.
 //
-void S_Stop(void);
-void S_Start(void);
+void S_Stop();
+void S_Start();
 
 // Start sound for thing at <ent>
-void S_Sound (int channel, const char *name, float volume, int attenuation);
-void S_Sound (AActor *ent, int channel, const char *name, float volume, int attenuation);
-void S_Sound (fixed_t *pt, int channel, const char *name, float volume, int attenuation);
-void S_Sound (fixed_t x, fixed_t y, int channel, const char *name, float volume, int attenuation);
-void S_PlatSound (fixed_t *pt, int channel, const char *name, float volume, int attenuation); // [Russell] - Hack to stop multiple plat stop sounds
-void S_LoopedSound (AActor *ent, int channel, const char *name, float volume, int attenuation);
-void S_LoopedSound (fixed_t *pt, int channel, const char *name, float volume, int attenuation);
-void S_SoundID (int channel, int sfxid, float volume, int attenuation);
-void S_SoundID (fixed_t x, fixed_t y, int channel, int sound_id, float volume, int attenuation);
-void S_SoundID (AActor *ent, int channel, int sfxid, float volume, int attenuation);
-void S_SoundID (fixed_t *pt, int channel, int sfxid, float volume, int attenuation);
-void S_LoopedSoundID (AActor *ent, int channel, int sfxid, float volume, int attenuation);
-void S_LoopedSoundID (fixed_t *pt, int channel, int sfxid, float volume, int attenuation);
+void S_Sound(int channel, const char* name, float volume, int attenuation);
+void S_Sound(AActor* ent, int channel, const char* name, float volume, int attenuation);
+void S_Sound(fixed_t* pt, int channel, const char* name, float volume, int attenuation);
+void S_Sound(fixed_t x, fixed_t y, int channel, const char* name, float volume,
+             int attenuation);
+void S_PlatSound(fixed_t* pt, int channel, const char* name, float volume,
+                 int attenuation); // [Russell] - Hack to stop multiple plat stop sounds
+void S_LoopedSound(AActor* ent, int channel, const char* name, float volume,
+                   int attenuation);
+void S_LoopedSound(fixed_t* pt, int channel, const char* name, float volume,
+                   int attenuation);
+void S_SoundID(int channel, int sfxid, float volume, int attenuation);
+void S_SoundID(fixed_t x, fixed_t y, int channel, int sound_id, float volume,
+               int attenuation);
+void S_SoundID(AActor* ent, int channel, int sfxid, float volume, int attenuation);
+void S_SoundID(fixed_t* pt, int channel, int sfxid, float volume, int attenuation);
+void S_LoopedSoundID(AActor* ent, int channel, int sfxid, float volume, int attenuation);
+void S_LoopedSoundID(fixed_t* pt, int channel, int sfxid, float volume, int attenuation);
 
 // sound channels
 // channel 0 never willingly overrides
 // other channels (1-8) always override a playing sound on that channel
-#define CHAN_AUTO				0
-#define CHAN_WEAPON				1
-#define CHAN_VOICE				2
-#define CHAN_ITEM				3
-#define CHAN_BODY				4
-#define CHAN_ANNOUNCER			5
-#define CHAN_GAMEINFO			6
-#define CHAN_INTERFACE			7
+#define CHAN_AUTO 0
+#define CHAN_WEAPON 1
+#define CHAN_VOICE 2
+#define CHAN_ITEM 3
+#define CHAN_BODY 4
+#define CHAN_ANNOUNCER 5
+#define CHAN_GAMEINFO 6
+#define CHAN_INTERFACE 7
 
 // modifier flags
-//#define CHAN_NO_PHS_ADD		8	// send to all clients, not just ones in PHS (ATTN 0 will also do this)
-//#define CHAN_RELIABLE			16	// send by reliable message, not datagram
-
+//#define CHAN_NO_PHS_ADD		8	// send to all clients, not just ones in PHS (ATTN 0 will
+//also do this) #define CHAN_RELIABLE			16	// send by reliable message, not
+//datagram
 
 // sound attenuation values
-#define ATTN_NONE				0	// full volume the entire level
-#define ATTN_NORM				1
-#define ATTN_IDLE				2
-#define ATTN_STATIC				3	// diminish very rapidly with distance
+#define ATTN_NONE 0 // full volume the entire level
+#define ATTN_NORM 1
+#define ATTN_IDLE 2
+#define ATTN_STATIC 3 // diminish very rapidly with distance
 
 // Stops a sound emanating from one of an entity's channels
-void S_StopSound (AActor *ent, int channel);
-void S_StopSound (fixed_t *pt, int channel);
-void S_StopSound (fixed_t *pt);
+void S_StopSound(AActor* ent, int channel);
+void S_StopSound(fixed_t* pt, int channel);
+void S_StopSound(fixed_t* pt);
 
 // Stop sound for all channels
-void S_StopAllChannels (void);
+void S_StopAllChannels();
 
 // Is the sound playing on one of the entity's channels?
-bool S_GetSoundPlayingInfo (AActor *ent, int sound_id);
-bool S_GetSoundPlayingInfo (fixed_t *pt, int sound_id);
+bool S_GetSoundPlayingInfo(AActor* ent, int sound_id);
+bool S_GetSoundPlayingInfo(fixed_t* pt, int sound_id);
 
 // Moves all sounds from one mobj to another
-void S_RelinkSound (AActor *from, AActor *to);
+void S_RelinkSound(AActor* from, AActor* to);
 
 // Start music using <music_name>
-void S_StartMusic (const char *music_name);
+void S_StartMusic(const char* music_name);
 
 // Start music using <music_name>, and set whether looping
-void S_ChangeMusic (std::string music_name, int looping);
+void S_ChangeMusic(std::string music_name, int looping);
 
 // Stops the music fer sure.
-void S_StopMusic (void);
+void S_StopMusic();
 
 // Stop and resume music, during game PAUSE.
-void S_PauseSound (void);
-void S_ResumeSound (void);
-
+void S_PauseSound();
+void S_ResumeSound();
 
 //
 // Updates music & sounds
 //
-void S_UpdateSounds (void *listener);
+void S_UpdateSounds(void* listener);
 void S_UpdateMusic();
 
-void S_SetMusicVolume (float volume);
-void S_SetSfxVolume (float volume);
+void S_SetMusicVolume(float volume);
+void S_SetSfxVolume(float volume);
 
 // [RH] Activates an ambient sound. Called when the thing is added to the map.
 //		(0-biased)
-void S_ActivateAmbient (AActor *mobj, int ambient);
-
+void S_ActivateAmbient(AActor* mobj, int ambient);
 
 // [RH] S_sfx "maintenance" routines
-void S_ParseSndInfo (void);
+void S_ParseSndInfo();
 
-void S_HashSounds (void);
-int S_FindSound (const char *logicalname);
-int S_FindSoundByLump (int lump);
-int S_AddSound (char *logicalname, char *lumpname);	// Add sound by lumpname
-int S_AddSoundLump (char *logicalname, int lump);	// Add sound by lump index
-void S_ClearSoundLumps (void);
+void S_HashSounds();
+int S_FindSound(const char* logicalname);
+int S_FindSoundByLump(int lump);
+int S_AddSound(const char* logicalname, const char* lumpname); // Add sound by lumpname
+int S_AddSoundLump(char* logicalname, int lump);         // Add sound by lump index
+void S_ClearSoundLumps();
 
-void UV_SoundAvoidPlayer (AActor *mo, byte channel, const char *name, byte attenuation);
+void UV_SoundAvoidPlayer(AActor* mo, byte channel, const char* name, byte attenuation);
 
 // [RH] Prints sound debug info to the screen.
 //		Modelled after Hexen's noise cheat.
-void S_NoiseDebug (void);
+void S_NoiseDebug();
 
 // The following functions work seamlessly on local clients and networked games.
 

--- a/common/s_sound.h
+++ b/common/s_sound.h
@@ -58,7 +58,7 @@ struct sfxinfo_struct
 extern std::vector<sfxinfo_t> S_sfx;
 
 // map of every sound id for sounds that have randomized variants
-extern std::map<int, std::vector<int>> S_rnd;
+extern std::map<int, std::vector<int> > S_rnd;
 
 // Initializes sound stuff, including volume
 // Sets channels, SFX and music volume,

--- a/common/s_sound.h
+++ b/common/s_sound.h
@@ -43,7 +43,8 @@ struct sfxinfo_struct
 	unsigned looping;           // Looping sample handle
 	void* data;
 
-	sfxinfo_struct* link;
+	unsigned int link = NO_LINK;
+	enum { NO_LINK = 0xffffffff };
 
 	int lumpnum;              // lump number of sfx
 	unsigned int ms;          // [RH] length of sfx in milliseconds
@@ -54,9 +55,6 @@ struct sfxinfo_struct
 
 // the complete set of sound effects
 extern std::vector<sfxinfo_t> S_sfx;
-
-// [RH] Number of defined sounds
-extern int numsfx;
 
 // Initializes sound stuff, including volume
 // Sets channels, SFX and music volume,

--- a/common/s_sound.h
+++ b/common/s_sound.h
@@ -43,7 +43,7 @@ struct sfxinfo_struct
 	unsigned looping;           // Looping sample handle
 	void* data;
 
-	unsigned int link = NO_LINK;
+	int link = NO_LINK;
 	enum { NO_LINK = 0xffffffff };
 
 	int lumpnum;              // lump number of sfx
@@ -51,10 +51,14 @@ struct sfxinfo_struct
 	unsigned int next, index; // [RH] For hashing
 	unsigned int frequency;   // [RH] Preferred playback rate
 	unsigned int length;      // [RH] Length of the sound in bytes
+	bool israndom;            // [DE] Whether or not this is an alias for a set of random sounds
 };
 
 // the complete set of sound effects
 extern std::vector<sfxinfo_t> S_sfx;
+
+// map of every sound id for sounds that have randomized variants
+extern std::map<int, std::vector<int>> S_rnd;
 
 // Initializes sound stuff, including volume
 // Sets channels, SFX and music volume,
@@ -162,6 +166,7 @@ int S_FindSound(const char* logicalname);
 int S_FindSoundByLump(int lump);
 int S_AddSound(const char* logicalname, const char* lumpname); // Add sound by lumpname
 int S_AddSoundLump(char* logicalname, int lump);         // Add sound by lump index
+void S_AddRandomSound(int owner, std::vector<int>& list);
 void S_ClearSoundLumps();
 
 void UV_SoundAvoidPlayer(AActor* mo, byte channel, const char* name, byte attenuation);

--- a/common/s_sound.h
+++ b/common/s_sound.h
@@ -43,7 +43,7 @@ struct sfxinfo_struct
 	unsigned looping;           // Looping sample handle
 	void* data;
 
-	int link = NO_LINK;
+	int link;
 	enum { NO_LINK = 0xffffffff };
 
 	int lumpnum;              // lump number of sfx

--- a/server/src/s_sound.cpp
+++ b/server/src/s_sound.cpp
@@ -211,7 +211,7 @@ void S_StopMusic()
 // =============================== [RH]
 
 std::vector<sfxinfo_t> S_sfx; // [RH] This is no longer defined in sounds.c
-std::map<int, std::vector<int>> S_rnd;
+std::map<int, std::vector<int> > S_rnd;
 
 static struct AmbientSound {
 	unsigned	type;		// type of ambient sound

--- a/server/src/s_sound.cpp
+++ b/server/src/s_sound.cpp
@@ -211,6 +211,7 @@ void S_StopMusic()
 // =============================== [RH]
 
 std::vector<sfxinfo_t> S_sfx; // [RH] This is no longer defined in sounds.c
+std::map<int, std::vector<int>> S_rnd;
 
 static struct AmbientSound {
 	unsigned	type;		// type of ambient sound
@@ -455,12 +456,12 @@ void S_ParseSndInfo()
 					os.mustScan();
 					S_sfx[sfxfrom - 1].link = FindSoundTentative(os.getToken().c_str());
 				}
-				/*else if (os.compareTokenNoCase("random"))
+				else if (os.compareTokenNoCase("random"))
 				{
 					os.mustScan();
 
 
-				}*/
+				}
 				else
 				{
 					os.warning("Unknown SNDINFO command %s\n", os.getToken().c_str());

--- a/server/src/s_sound.cpp
+++ b/server/src/s_sound.cpp
@@ -46,7 +46,7 @@
 //
 // [RH] Print sound debug info. Called from D_Display()
 //
-void S_NoiseDebug (void)
+void S_NoiseDebug()
 {
 }
 
@@ -60,97 +60,97 @@ void S_NoiseDebug (void)
 // Sets channels, SFX and music volume,
 // allocates channel buffer, sets S_sfx lookup.
 //
-void S_Init (float sfxVolume, float musicVolume)
+void S_Init(float sfxVolume, float musicVolume)
 {
 	// [RH] Read in sound sequences
 	//NumSequences = 0;
 }
 
-void S_Start (void)
+void S_Start()
 {
 }
 
-void S_Stop (void)
+void S_Stop()
 {
 }
 
-void S_SoundID (int channel, int sound_id, float volume, int attenuation)
+void S_SoundID(int channel, int sound_id, float volume, int attenuation)
 {
 }
 
-void S_SoundID (AActor *ent, int channel, int sound_id, float volume, int attenuation)
+void S_SoundID(AActor *ent, int channel, int sound_id, float volume, int attenuation)
 {
 }
 
-void S_SoundID (fixed_t *pt, int channel, int sound_id, float volume, int attenuation)
+void S_SoundID(fixed_t *pt, int channel, int sound_id, float volume, int attenuation)
 {
 }
 
-void S_LoopedSoundID (AActor *ent, int channel, int sound_id, float volume, int attenuation)
+void S_LoopedSoundID(AActor *ent, int channel, int sound_id, float volume, int attenuation)
 {
 }
 
-void S_LoopedSoundID (fixed_t *pt, int channel, int sound_id, float volume, int attenuation)
+void S_LoopedSoundID(fixed_t *pt, int channel, int sound_id, float volume, int attenuation)
 {
 }
 
 // [Russell] - Hack to stop multiple plat stop sounds
-void S_PlatSound (fixed_t *pt, int channel, const char *name, float volume, int attenuation)
+void S_PlatSound(fixed_t *pt, int channel, const char *name, float volume, int attenuation)
 {
 }
 
-void S_Sound (int channel, const char *name, float volume, int attenuation)
+void S_Sound(int channel, const char *name, float volume, int attenuation)
 {
 }
 
-void S_Sound (AActor *ent, int channel, const char *name, float volume, int attenuation)
+void S_Sound(AActor *ent, int channel, const char *name, float volume, int attenuation)
 {
 }
 
-void S_Sound (fixed_t *pt, int channel, const char *name, float volume, int attenuation)
+void S_Sound(fixed_t *pt, int channel, const char *name, float volume, int attenuation)
 {
 }
 
-void S_LoopedSound (AActor *ent, int channel, const char *name, float volume, int attenuation)
+void S_LoopedSound(AActor *ent, int channel, const char *name, float volume, int attenuation)
 {
 }
 
-void S_LoopedSound (fixed_t *pt, int channel, const char *name, float volume, int attenuation)
+void S_LoopedSound(fixed_t *pt, int channel, const char *name, float volume, int attenuation)
 {
 }
 
-void S_Sound (fixed_t x, fixed_t y, int channel, const char *name, float volume, int attenuation)
+void S_Sound(fixed_t x, fixed_t y, int channel, const char *name, float volume, int attenuation)
 {
 }
 
-void S_StopSound (fixed_t *pt)
+void S_StopSound(fixed_t *pt)
 {
 }
 
-void S_StopSound (fixed_t *pt, int channel)
+void S_StopSound(fixed_t *pt, int channel)
 {
 }
 
-void S_StopSound (AActor *ent, int channel)
+void S_StopSound(AActor *ent, int channel)
 {
 }
 
-void S_StopAllChannels (void)
+void S_StopAllChannels()
 {
 }
 
 // Moves all the sounds from one thing to another. If the destination is
 // NULL, then the sound becomes a positioned sound.
-void S_RelinkSound (AActor *from, AActor *to)
+void S_RelinkSound(AActor *from, AActor *to)
 {
 }
 
-bool S_GetSoundPlayingInfo (fixed_t *pt, int sound_id)
+bool S_GetSoundPlayingInfo(fixed_t *pt, int sound_id)
 {
 	return false;
 }
 
-bool S_GetSoundPlayingInfo (AActor *ent, int sound_id)
+bool S_GetSoundPlayingInfo(AActor *ent, int sound_id)
 {
 	return S_GetSoundPlayingInfo (ent ? &ent->x : NULL, sound_id);
 }
@@ -158,18 +158,18 @@ bool S_GetSoundPlayingInfo (AActor *ent, int sound_id)
 //
 // Stop and resume music, during game PAUSE.
 //
-void S_PauseSound (void)
+void S_PauseSound()
 {
 }
 
-void S_ResumeSound (void)
+void S_ResumeSound()
 {
 }
 
 //
 // Updates music & sounds
 //
-void S_UpdateSounds (void *listener_p)
+void S_UpdateSounds(void *listener_p)
 {
 }
 
@@ -177,28 +177,28 @@ void S_UpdateMusic()
 {
 }
 
-void S_SetMusicVolume (float volume)
+void S_SetMusicVolume(float volume)
 {
 }
 
-void S_SetSfxVolume (float volume)
+void S_SetSfxVolume(float volume)
 {
 }
 
 //
 // Starts some music with the music id found in sounds.h.
 //
-void S_StartMusic (const char *m_id)
+void S_StartMusic(const char *m_id)
 {
 }
 
 // [RH] S_ChangeMusic() now accepts the name of the music lump.
 // It's up to the caller to figure out what that name is.
-void S_ChangeMusic (std::string musicname, int looping)
+void S_ChangeMusic(std::string musicname, int looping)
 {
 }
 
-void S_StopMusic (void)
+void S_StopMusic()
 {
 }
 
@@ -228,7 +228,7 @@ static struct AmbientSound {
 #define POSITIONAL	4
 #define SURROUND	16
 
-void S_HashSounds (void)
+void S_HashSounds()
 {
 	int i;
 	unsigned j;
@@ -246,7 +246,7 @@ void S_HashSounds (void)
 	}
 }
 
-int S_FindSound (const char *logicalname)
+int S_FindSound(const char *logicalname)
 {
 	if(!numsfx)
 		return -1;
@@ -259,7 +259,7 @@ int S_FindSound (const char *logicalname)
 	return i;
 }
 
-int S_FindSoundByLump (int lump)
+int S_FindSoundByLump(int lump)
 {
 	if (lump != -1) 
 	{
@@ -272,7 +272,7 @@ int S_FindSoundByLump (int lump)
 	return -1;
 }
 
-int S_AddSoundLump (char *logicalname, int lump)
+int S_AddSoundLump(char *logicalname, int lump)
 {
 	if (numsfx == maxsfx) {
 		maxsfx = maxsfx ? maxsfx*2 : 128;
@@ -295,7 +295,7 @@ void S_ClearSoundLumps()
 	maxsfx = 0;
 }
 
-int S_AddSound (char *logicalname, char *lumpname)
+int S_AddSound(char *logicalname, char *lumpname)
 {
 	int sfxid;
 
@@ -317,20 +317,21 @@ int S_AddSound (char *logicalname, char *lumpname)
 
 // S_ParseSndInfo
 // Parses all loaded SNDINFO lumps.
-void S_ParseSndInfo (void)
+void S_ParseSndInfo()
 {
-	char *sndinfo;
-	char *data;
+	char* data;
 
-	S_ClearSoundLumps ();
+	S_ClearSoundLumps();
 
 	int lump = -1;
-	while ((lump = W_FindLump ("SNDINFO", lump)) != -1)
+	while ((lump = W_FindLump("SNDINFO", lump)) != -1)
 	{
-		sndinfo = (char *)W_CacheLumpNum (lump, PU_CACHE);
+		char* sndinfo = static_cast<char*>(W_CacheLumpNum(lump, PU_CACHE));
 
-		while ( (data = COM_Parse (sndinfo)) ) {
-			if (com_token[0] == ';') {
+		while ((data = COM_Parse(sndinfo)))
+		{
+			if (com_token[0] == ';')
+			{
 				// Handle comments from Hexen MAPINFO lumps
 				while (*sndinfo && *sndinfo != ';')
 					sndinfo++;
@@ -339,111 +340,130 @@ void S_ParseSndInfo (void)
 				continue;
 			}
 			sndinfo = data;
-			if (com_token[0] == '$') {
+			if (com_token[0] == '$')
+			{
 				// com_token is a command
 
-				if (!stricmp (com_token + 1, "ambient")) {
-					// $ambient <num> <logical name> [point [atten]|surround] <type> [secs] <relative volume>
-					struct AmbientSound *ambient, dummy;
-					int index;
+				if (!stricmp(com_token + 1, "ambient"))
+				{
+					// $ambient <num> <logical name> [point [atten]|surround] <type>
+					// [secs] <relative volume>
+					AmbientSound *ambient, dummy;
 
-					sndinfo = COM_Parse (sndinfo);
-					index = atoi (com_token);
-					if (index < 0 || index > 255) {
-						Printf (PRINT_HIGH, "Bad ambient index (%d)\n", index);
+					sndinfo = COM_Parse(sndinfo);
+					int index = atoi(com_token);
+					if (index < 0 || index > 255)
+					{
+						Printf(PRINT_HIGH, "Bad ambient index (%d)\n", index);
 						ambient = &dummy;
-					} else {
+					}
+					else
+					{
 						ambient = Ambients + index;
 					}
-                    
-                    ambient->type = 0;
-                    ambient->periodmin = 0;
-                    ambient->periodmax = 0;
-                    ambient->volume = 0.0f;
 
-					sndinfo = COM_Parse (sndinfo);
-					strncpy (ambient->sound, com_token, MAX_SNDNAME);
+					ambient->type = 0;
+					ambient->periodmin = 0;
+					ambient->periodmax = 0;
+					ambient->volume = 0.0f;
+
+					sndinfo = COM_Parse(sndinfo);
+					strncpy(ambient->sound, com_token, MAX_SNDNAME);
 					ambient->sound[MAX_SNDNAME] = 0;
 					ambient->attenuation = 0.0f;
 
-					sndinfo = COM_Parse (sndinfo);
-					if (!stricmp (com_token, "point")) {
-						float attenuation;
-
+					sndinfo = COM_Parse(sndinfo);
+					if (!stricmp(com_token, "point"))
+					{
 						ambient->type = POSITIONAL;
-						sndinfo = COM_Parse (sndinfo);
-						attenuation = (float)atof (com_token);
+						sndinfo = COM_Parse(sndinfo);
+						float attenuation = (float)atof(com_token);
 						if (attenuation > 0)
 						{
 							ambient->attenuation = attenuation;
-							sndinfo = COM_Parse (sndinfo);
+							sndinfo = COM_Parse(sndinfo);
 						}
 						else
 						{
 							ambient->attenuation = 1;
 						}
-					} else if (!stricmp (com_token, "surround")) {
+					}
+					else if (!stricmp(com_token, "surround"))
+					{
 						ambient->type = SURROUND;
-						sndinfo = COM_Parse (sndinfo);
+						sndinfo = COM_Parse(sndinfo);
 						ambient->attenuation = -1;
 					}
 
-					if (!stricmp (com_token, "continuous")) {
+					if (!stricmp(com_token, "continuous"))
+					{
 						ambient->type |= CONTINUOUS;
-					} else if (!stricmp (com_token, "random")) {
+					}
+					else if (!stricmp(com_token, "random"))
+					{
 						ambient->type |= RANDOM;
-						sndinfo = COM_Parse (sndinfo);
-						ambient->periodmin = (int)(atof (com_token) * TICRATE);
-						sndinfo = COM_Parse (sndinfo);
-						ambient->periodmax = (int)(atof (com_token) * TICRATE);
-					} else if (!stricmp (com_token, "periodic")) {
+						sndinfo = COM_Parse(sndinfo);
+						ambient->periodmin = (int)(atof(com_token) * TICRATE);
+						sndinfo = COM_Parse(sndinfo);
+						ambient->periodmax = (int)(atof(com_token) * TICRATE);
+					}
+					else if (!stricmp(com_token, "periodic"))
+					{
 						ambient->type |= PERIODIC;
-						sndinfo = COM_Parse (sndinfo);
-						ambient->periodmin = (int)(atof (com_token) * TICRATE);
-					} else {
-						Printf (PRINT_HIGH, "Unknown ambient type (%s)\n", com_token);
+						sndinfo = COM_Parse(sndinfo);
+						ambient->periodmin = (int)(atof(com_token) * TICRATE);
+					}
+					else
+					{
+						Printf(PRINT_HIGH, "Unknown ambient type (%s)\n", com_token);
 					}
 
-					sndinfo = COM_Parse (sndinfo);
-					ambient->volume = (float)atof (com_token);
+					sndinfo = COM_Parse(sndinfo);
+					ambient->volume = (float)atof(com_token);
 					if (ambient->volume > 1)
 						ambient->volume = 1;
 					else if (ambient->volume < 0)
 						ambient->volume = 0;
-				} else if (!stricmp (com_token + 1, "map")) {
+				}
+				else if (!stricmp(com_token + 1, "map"))
+				{
 					// Hexen-style $MAP command
-					sndinfo = COM_Parse (sndinfo);
-					sprintf (com_token, "MAP%02d", atoi (com_token));
+					sndinfo = COM_Parse(sndinfo);
+					sprintf(com_token, "MAP%02d", atoi(com_token));
 					level_pwad_info_t& info = getLevelInfos().findByName(com_token);
-					sndinfo = COM_Parse (sndinfo);
+					sndinfo = COM_Parse(sndinfo);
 					if (info.mapname[0])
 					{
 						info.music = com_token; // denis - todo -string limit?
 					}
-				} else {
-					Printf (PRINT_HIGH, "Unknown SNDINFO command %s\n", com_token);
+				}
+				else
+				{
+					Printf(PRINT_HIGH, "Unknown SNDINFO command %s\n", com_token);
 					while (*sndinfo != '\n' && *sndinfo != '\0')
 						sndinfo++;
 				}
-			} else {
+			}
+			else
+			{
 				// com_token is a logical sound mapping
-				char name[MAX_SNDNAME+1];
+				char name[MAX_SNDNAME + 1];
 
-				strncpy (name, com_token, MAX_SNDNAME);
+				strncpy(name, com_token, MAX_SNDNAME);
 				name[MAX_SNDNAME] = 0;
-				sndinfo = COM_Parse (sndinfo);
-				S_AddSound (name, com_token);
+				sndinfo = COM_Parse(sndinfo);
+				S_AddSound(name, com_token);
 			}
 		}
 	}
-	S_HashSounds ();
+	S_HashSounds();
 }
 
-void A_Ambient (AActor *actor)
+void A_Ambient(AActor *actor)
 {
 }
 
-void S_ActivateAmbient (AActor *origin, int ambient)
+void S_ActivateAmbient(AActor *origin, int ambient)
 {
 }
 

--- a/server/src/s_sound.cpp
+++ b/server/src/s_sound.cpp
@@ -333,6 +333,7 @@ int S_AddSound(const char *logicalname, const char *lumpname)
 void S_AddRandomSound(int owner, std::vector<int>& list)
 {
 	S_rnd[owner] = list;
+	S_sfx[owner].link = owner;
 	S_sfx[owner].israndom = true;
 }
 

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -665,7 +665,7 @@ void SV_Sound (AActor *mo, byte channel, const char *name, byte attenuation)
 
 	sfx_id = S_FindSound (name);
 
-	if (sfx_id >= numsfx || sfx_id < 0)
+	if (sfx_id >= S_sfx.size() || sfx_id < 0)
 	{
 		Printf (PRINT_HIGH, "SV_StartSound: range error. Sfx_id = %d\n", sfx_id);
 		return;
@@ -694,7 +694,7 @@ void SV_Sound(player_t& pl, AActor* mo, const byte channel, const char* name,
 
 	sfx_id = S_FindSound (name);
 
-	if (sfx_id >= numsfx || sfx_id < 0)
+	if (sfx_id >= S_sfx.size() || sfx_id < 0)
 	{
 		Printf (PRINT_HIGH, "SV_StartSound: range error. Sfx_id = %d\n", sfx_id);
 		return;
@@ -728,7 +728,7 @@ void UV_SoundAvoidPlayer (AActor *mo, byte channel, const char *name, byte atten
 
 	sfx_id = S_FindSound (name);
 
-	if (sfx_id >= numsfx || sfx_id < 0)
+	if (sfx_id >= S_sfx.size() || sfx_id < 0)
 	{
 		Printf (PRINT_HIGH, "SV_StartSound: range error. Sfx_id = %d\n", sfx_id);
 		return;
@@ -758,7 +758,7 @@ void SV_SoundTeam (byte channel, const char* name, byte attenuation, int team)
 
 	sfx_id = S_FindSound( name );
 
-	if (sfx_id >= numsfx || sfx_id < 0)
+	if (sfx_id >= S_sfx.size() || sfx_id < 0)
 	{
 		Printf("SV_StartSound: range error. Sfx_id = %d\n", sfx_id );
 		return;
@@ -783,7 +783,7 @@ void SV_Sound (fixed_t x, fixed_t y, byte channel, const char *name, byte attenu
 
 	sfx_id = S_FindSound (name);
 
-	if (sfx_id >= numsfx || sfx_id < 0)
+	if (sfx_id >= S_sfx.size() || sfx_id < 0)
 	{
 		Printf (PRINT_HIGH, "SV_StartSound: range error. Sfx_id = %d\n", sfx_id);
 		return;

--- a/wad/lumps/sndinfo.lmp
+++ b/wad/lumps/sndinfo.lmp
@@ -593,3 +593,5 @@ vox/red/flag/drop		dvrfd
 vox/red/flag/manualreturn	dvrfm
 vox/red/flag/return		dvrfr
 
+$random menu/quit1 { player/male/death1 demon/pain grunt/pain misc/gibbed misc/teleport grunt/sight1 grunt/sight3 demon/melee }
+$random menu/quit2 { vile/active misc/p_pkup brain/cube misc/gibbed skeleton/swing knight/death baby/active demon/melee  }


### PR DESCRIPTION
Ported over a few ZDoom SNDINFO upgrades, namely $alias and $random. I also converted the menu quit to use it (but not the randomized enemy sounds for demo compatibility reasons) as a part of abstracting gameinfo so it can be serialized instead of hard coded.