### PR TITLE
Set odamast C++ standard to 98

### DIFF
--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB MASTER_SOURCES *.cpp *.h)
 # Master target
 add_executable(odamast ${MASTER_SOURCES})
 odamex_target_settings(odamast)
+set_property(TARGET odamast PROPERTY CXX_STANDARD 98)
 
 if(WIN32)
   target_link_libraries(odamast wsock32)


### PR DESCRIPTION
Otherwise the use of `byte` is ambiguous with newer compilers, resulting in a build error.

```
odamex-src-10.0.0/master/main.cpp: In function ‘void addServerInfo(netadr_t)’:
odamex-src-10.0.0/master/main.cpp:201:17: error: reference to ‘byte’ is ambiguous
  201 |                 byte playercount = net_message.ReadByte();
      |                 ^~~~
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/include/g++-v11/bits/stl_algobase.h:61,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/include/g++-v11/bits/char_traits.h:39,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/include/g++-v11/string:40,
                 from odamex-src-10.0.0/master/main.cpp:32:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/include/g++-v11/bits/cpp_type_traits.h:404:30: note: candidates are: ‘enum class std::byte’
  404 |   enum class byte : unsigned char;
      |                              ^~~~
In file included from odamex-src-10.0.0/master/main.cpp:54:
odamex-src-10.0.0/master/i_net.h:34:23: note:                 ‘typedef unsigned char byte’
   34 | typedef unsigned char byte;
      |                       ^~~~
```