### PR TITLE
[BUGFIX] Trigger ZDoom action specials on items that are picked up

### DIFF
--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -1299,6 +1299,16 @@ void P_TouchSpecialThing(AActor *special, AActor *toucher)
 	if (!serverside && (!cl_predictpickup || !P_SpecialIsWeapon(special)))
 		return;
 
+	// [Blair] Execute ZDoom thing specials on items that are picked up.
+	// (Then remove the special.)
+	if (map_format.getZDoom() && special->special)
+	{
+		LineSpecials[special->special](NULL, toucher, special->args[0], special->args[1],
+		                               special->args[2], special->args[3],
+		                               special->args[4]);
+		special->special = 0;
+	}
+
 	if (toucher->type == MT_AVATAR)
 	{
 		PlayersView pr = PlayerQuery().execute().players;

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -1301,7 +1301,7 @@ void P_TouchSpecialThing(AActor *special, AActor *toucher)
 
 	// [Blair] Execute ZDoom thing specials on items that are picked up.
 	// (Then remove the special.)
-	if (map_format.getZDoom() && special->special)
+	if (special->special)
 	{
 		LineSpecials[special->special](NULL, toucher, special->args[0], special->args[1],
 		                               special->args[2], special->args[3],


### PR DESCRIPTION
Fixes #638. Previously only action specials would play on killed monsters. Now, items that are consumed by a player will trigger an action special trigger (and then remove said trigger).