### PR TITLE
[BUGFIX] Fix nightmare skill respawn inconsistency with vanilla

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -968,7 +968,7 @@ void A_Chase (AActor *actor)
 	if (actor->flags & MF_JUSTATTACKED)
 	{
 		actor->flags &= ~MF_JUSTATTACKED;
-		if (G_GetCurrentSkill().respawn_counter && !sv_fastmonsters)
+		if (G_GetCurrentSkill().respawn_counter == 0 && !sv_fastmonsters)
 			P_NewChaseDir (actor);
 		return;
 	}


### PR DESCRIPTION
When I added the ability to change how long it takes for monsters to respawn in a skill definition, I accidentally set it so monsters can attack immediately after attacking only if it's NOT nightmare instead of it's ONLY nightmare. Mistake is fixed