### PR TITLE
[BUGFIX] Return if unrecognized sound effect is encountered

### DIFF
--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -261,15 +261,16 @@ static Uint8 *perform_sdlmix_conv(Uint8 *data, Uint32 size, Uint32 *newsize)
     return ret_data;
 }
 
-static void getsfx (struct sfxinfo_struct *sfx)
+static void getsfx(sfxinfo_struct *sfx)
 {
-    Uint32 samplerate;
-	Uint32 length ,expanded_length;
-	Uint8 *data;
 	Uint32 new_size = 0;
 	Mix_Chunk *chunk;
 
-    data = (Uint8 *)W_CacheLumpNum(sfx->lumpnum, PU_STATIC);
+	if (sfx->lumpnum == -1)
+		return;
+
+    Uint8* data = (Uint8*)W_CacheLumpNum(sfx->lumpnum, PU_STATIC);
+
     // [Russell] - ICKY QUICKY HACKY SPACKY *I HATE THIS SOUND MANAGEMENT SYSTEM!*
     // get the lump size, shouldn't this be filled in elsewhere?
     sfx->length = W_LumpLength(sfx->lumpnum);
@@ -299,14 +300,14 @@ static void getsfx (struct sfxinfo_struct *sfx)
         return;
     }
 
-	samplerate = (data[3] << 8) | data[2];
-    length = (data[5] << 8) | data[4];
+	const Uint32 samplerate = (data[3] << 8) | data[2];
+    Uint32 length = (data[5] << 8) | data[4];
 
     // [Russell] - Ignore doom's sound format length info
     // if the lump is longer than the value, fixes exec.wad's ssg
     length = (sfx->length - 8 > length) ? sfx->length - 8 : length;
 
-    expanded_length = (uint32_t) ((((uint64_t) length) * mixer_freq) / samplerate);
+    Uint32 expanded_length = (uint32_t)((((uint64_t)length) * mixer_freq) / samplerate);
 
     // Double up twice: 8 -> 16 bit and mono -> stereo
 

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -121,7 +121,7 @@ CVAR_FUNC_IMPL (snd_channels)
 
 
 // whether songs are mus_paused
-static BOOL mus_paused;
+static bool mus_paused;
 
 // music currently being played
 static struct mus_playing_t
@@ -264,7 +264,7 @@ void S_Init(float sfxVolume, float musicVolume)
 	I_SetChannels(numChannels);
 
 	// no sounds are playing, and they are not mus_paused
-	mus_paused = 0;
+	mus_paused = false;
 }
 
 /**
@@ -302,7 +302,7 @@ void S_Start()
 		S_StopChannel(i);
 
 	// start new music for the level
-	mus_paused = 0;
+	mus_paused = false;
 
 	// [RH] This is a lot simpler now.
 	S_ChangeMusic (std::string(level.music.c_str(), 8), true);
@@ -795,7 +795,10 @@ static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, in
 		sfx_id = S_FindSound(name);
 
 	if (sfx_id == -1)
-		DPrintf ("Unknown sound %s\n", name);
+	{
+		DPrintf("Unknown sound %s\n", name);
+		return;
+	}
 
 	if (ent && ent != (AActor *)(~0))
 		S_StartSound(&ent->x, x, y, channel, sfx_id, volume, attenuation, looping);

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -755,7 +755,9 @@ static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, in
 	if (!consoleplayer().mo && channel != CHAN_INTERFACE)
 		return;
 
-	if (name == NULL || strlen(name) == 0 ||
+	const std::string soundname = name ? name : "";
+
+	if (soundname.empty() ||
 			(ent && ent != (AActor *)(~0) && ent->subsector && ent->subsector->sector &&
 			ent->subsector->sector->MoreFlags & SECF_SILENT))
 	{
@@ -764,7 +766,7 @@ static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, in
 
 	int sfx_id = -1;
 
-	if (*name == '*')
+	if (soundname[0] == '*')
 	{
 		// Sexed sound
 		char nametemp[128];
@@ -777,26 +779,26 @@ static void S_StartNamedSound(AActor *ent, fixed_t *pt, fixed_t x, fixed_t y, in
 		sfx_id = -1;
 		if (ent && ent != (AActor *)(~0) && (player = ent->player))
 		{
-			sprintf(nametemp, templat, "base", name + 1);
+			sprintf(nametemp, templat, "base", soundname.substr(1).c_str());
 			sfx_id = S_FindSound(nametemp);
 			if (sfx_id == -1)
 			{
-				sprintf(nametemp, templat, genders[player->userinfo.gender], name + 1);
+				sprintf(nametemp, templat, genders[player->userinfo.gender], soundname.substr(1).c_str());
 				sfx_id = S_FindSound(nametemp);
 			}
 		}
 		if (sfx_id == -1)
 		{
-			sprintf(nametemp, templat, "male", name + 1);
+			sprintf(nametemp, templat, "male", soundname.substr(1).c_str());
 			sfx_id = S_FindSound(nametemp);
 		}
 	}
 	else
-		sfx_id = S_FindSound(name);
+		sfx_id = S_FindSound(soundname.c_str());
 
 	if (sfx_id == -1)
 	{
-		DPrintf("Unknown sound %s\n", name);
+		DPrintf("Unknown sound %s\n", soundname.c_str());
 		return;
 	}
 


### PR DESCRIPTION
Returns if the sound effect that is attempted to be played doesn't exist rather than attempting to play it and crashing