### PR TITLE
[BUGFIX] Fix "Dark Lift" ZDCTFMP MAP08 Phenomenon

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1674,7 +1674,7 @@ static void CL_Switch(const odaproto::svc::Switch* msg)
 {
 	int l = msg->linenum();
 	byte switchactive = msg->switch_active();
-	byte special = msg->special();
+	unsigned int special = msg->special();
 	unsigned int state = msg->state(); // DActiveButton::EWhere
 	short texture = msg->button_texture();
 	unsigned int time = msg->timer();


### PR DESCRIPTION
This was caused by the client clamping specials to `byte`, thereby changing their intended special completely. This was generally okay in all maps both ZDoom and Boom, except for Generalized specials, which extend far beyond the range of `byte` and thus had unintended consequences. This is a clientside-only change, the server does the correct thing already.

https://cdn.discordapp.com/attachments/236518337671200768/959427197335121920/unknown.png

_Goodbye spooky lift, 2022-2022._