### PR TITLE
[BUGFIX] Fix #662 (Sector Flags Not Serializing on Save Game)

### DIFF
--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -804,6 +804,10 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 		{
 			sec->floorpic = line->frontsector->floorpic;
 			sec->special = line->frontsector->special;
+			sec->flags = line->frontsector->flags;
+			sec->damageinterval = line->frontsector->damageinterval;
+			sec->leakrate = line->frontsector->leakrate;
+			sec->damageamount = line->frontsector->damageamount;
 		}
 		break;
 
@@ -816,6 +820,9 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 		// --> should not affect compatibility <--
 		m_NewSpecial = sec->special;
 		m_NewFlags = sec->flags;
+		m_NewDmgInterval = sec->damageinterval;
+		m_NewLeakRate = sec->leakrate;
+		m_NewDamageRate = sec->damageamount;
 
 		//jff 5/23/98 use model subroutine to unify fixes and handling
 		sec = P_FindModelFloorSector (m_FloorDestHeight,sec);
@@ -824,6 +831,9 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 			m_Texture = sec->floorpic;
 			m_NewSpecial = sec->special;
 			m_NewFlags = sec->flags;
+			m_NewDmgInterval = sec->damageinterval;
+			m_NewLeakRate = sec->leakrate;
+			m_NewDamageRate = sec->damageamount;
 		}
 		break;
 
@@ -863,11 +873,17 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 				case 1:
 					m_NewSpecial = 0;
 					m_NewFlags = 0;
+					m_NewDmgInterval = 0;
+					m_NewLeakRate = 0;
+					m_NewDamageRate = 0;
 					m_Type = DFloor::genFloorChg0;
 					break;
 				case 2:
 					m_NewSpecial = found->special;
 					m_NewFlags = found->flags;
+					m_NewDmgInterval = found->damageinterval;
+					m_NewLeakRate = found->leakrate;
+					m_NewDamageRate = found->damageamount;
 					m_Type = DFloor::genFloorChgT;
 					break;
 				case 3:
@@ -890,6 +906,9 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 				case 2:
 				    m_NewSpecial = line->frontsector->special;
 				    m_NewFlags = line->frontsector->flags;
+				    m_NewDmgInterval = line->frontsector->damageinterval;
+				    m_NewLeakRate = line->frontsector->leakrate;
+				    m_NewDamageRate = line->frontsector->damageamount;
 					m_Type = DFloor::genFloorChgT;
 					break;
 				case 3:

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -815,6 +815,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 		// in case no surrounding sector is at floordestheight
 		// --> should not affect compatibility <--
 		m_NewSpecial = sec->special;
+		m_NewFlags = sec->flags;
 
 		//jff 5/23/98 use model subroutine to unify fixes and handling
 		sec = P_FindModelFloorSector (m_FloorDestHeight,sec);
@@ -822,6 +823,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 		{
 			m_Texture = sec->floorpic;
 			m_NewSpecial = sec->special;
+			m_NewFlags = sec->flags;
 		}
 		break;
 
@@ -860,10 +862,12 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 				{
 				case 1:
 					m_NewSpecial = 0;
+					m_NewFlags = 0;
 					m_Type = DFloor::genFloorChg0;
 					break;
 				case 2:
 					m_NewSpecial = found->special;
+					m_NewFlags = found->flags;
 					m_Type = DFloor::genFloorChgT;
 					break;
 				case 3:
@@ -880,10 +884,12 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 			switch (change & 3) {
 				case 1:
 					m_NewSpecial = 0;
+				    m_NewFlags = 0;
 					m_Type = DFloor::genFloorChg0;
 					break;
 				case 2:
-					m_NewSpecial = sec->special;
+				    m_NewSpecial = line->frontsector->special;
+				    m_NewFlags = line->frontsector->flags;
 					m_Type = DFloor::genFloorChgT;
 					break;
 				case 3:

--- a/common/p_saveg.cpp
+++ b/common/p_saveg.cpp
@@ -90,6 +90,7 @@ void P_SerializeWorld (FArchive &arc)
 				<< sec->ceilingpic
 				<< sec->lightlevel
 				<< sec->special
+				<< sec->flags
 				<< sec->tag
 				<< sec->secretsector
 				<< sec->soundtraversed
@@ -181,6 +182,7 @@ void P_SerializeWorld (FArchive &arc)
 				>> sec->ceilingpic
 				>> sec->lightlevel
 				>> sec->special
+				>> sec->flags
 				>> sec->tag
 				>> sec->secretsector
 				>> sec->soundtraversed


### PR DESCRIPTION
This will fix the phenomenon of players dying, or secrets getting revealed twice on certain sectors (seem to be secret sectors) when saving/loading. The same function is called on level complete, so its likely this is called in certain situations that aren't game saving/loading. Fixes #662.