### PR TITLE
[BUGFIX] Fix resurrected monsters not having height when using A_HealCorpse

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -263,7 +263,7 @@ BOOL P_CheckMissileRange (AActor *actor)
 	if (!actor->info->meleestate)
 		dist -= 128*FRACUNIT;	// no melee attack, so fire more
 
-	dist >>= FRACBITS;
+	dist >>= 16;
 
 	if (actor->flags3 & MF3_SHORTMRANGE)
 	{
@@ -276,6 +276,7 @@ BOOL P_CheckMissileRange (AActor *actor)
 	{
 		if (dist < 196)
 			return false;		// close for fist attack
+		dist >>= 1;
 	}
 
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -263,7 +263,7 @@ BOOL P_CheckMissileRange (AActor *actor)
 	if (!actor->info->meleestate)
 		dist -= 128*FRACUNIT;	// no melee attack, so fire more
 
-	dist >>= 16;
+	dist >>= FRACBITS;
 
 	if (actor->flags3 & MF3_SHORTMRANGE)
 	{
@@ -276,7 +276,6 @@ BOOL P_CheckMissileRange (AActor *actor)
 	{
 		if (dist < 196)
 			return false;		// close for fist attack
-		dist >>= 1;
 	}
 
 
@@ -2153,6 +2152,18 @@ bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 					}
 
 					P_SetMobjState(corpsehit, info->raisestate, true);
+
+					// [Nes] - Classic demo compatability: Ghost monster bug.
+					if ((co_novileghosts))
+					{
+						corpsehit->height =
+						    P_ThingInfoHeight(info);      // [RH] Use real mobj height
+						corpsehit->radius = info->radius; // [RH] Use real radius
+					}
+					else
+					{
+						corpsehit->height <<= 2;
+					}
 
 					corpsehit->flags = info->flags;
 					corpsehit->health = info->spawnhealth;


### PR DESCRIPTION
A leftover from DSDA, this will ensure that A_HealCorpse restores actor height depending on co_novileghosts, similar to how A_VileChase is done. Fixes #664.