### PR TITLE
[BUGFIX]Fix A_PlaySound

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -3058,11 +3058,7 @@ void A_PlaySound(AActor* mo)
 		sndmap = 0;
 	}
 
-	if (!clientside)
-		SV_Sound(mo, CHAN_BODY, SoundMap[sndmap],
-		         (mo->state->misc2 ? ATTN_NONE : ATTN_NORM));
-	else
-		S_Sound(mo, CHAN_BODY, SoundMap[sndmap], 1,
+	S_Sound(mo, CHAN_BODY, SoundMap[sndmap], 1,
 		        (mo->state->misc2 ? ATTN_NONE : ATTN_NORM));
 }
 


### PR DESCRIPTION
Previous to this fix, A_PlaySound would play locally and online, which resulted in the activator hearing the same thing twice. Ambient sounds also play twice online, as seen in AD_MORTEM.WAD MAP02. This will fix this behavior.