### PR TITLE
Add visible values for sliders

### DIFF
--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1258,7 +1258,7 @@ void M_QuitDOOM(int choice)
 //		Player Setup Menu code
 // -----------------------------------------------------
 
-void M_DrawSlider (int x, int y, float min, float max, float cur);
+void M_DrawSlider(int x, int y, float leftval, float rightval, float cur, float step);
 
 static const char *genders[3] = { "male", "female", "cyborg" };
 static state_t *PlayerState;
@@ -1502,9 +1502,9 @@ static void M_PlayerSetupDrawer()
 		const int x = V_StringWidth("Green") + 8 + PSetupDef.x;
 		const argb_t playercolor = V_GetColorFromString(cl_color);
 
-		M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*2, 0.0f, 255.0f, playercolor.getr());
-		M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*3, 0.0f, 255.0f, playercolor.getg());
-		M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*4, 0.0f, 255.0f, playercolor.getb());
+		M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*2, 0.0f, 255.0f, playercolor.getr(), 0.0f);
+		M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*3, 0.0f, 255.0f, playercolor.getg(), 0.0f);
+		M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*4, 0.0f, 255.0f, playercolor.getb(), 0.0f);
 	}
 
 	// Draw team setting

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1444,7 +1444,7 @@ bool M_StartOptionsMenu (void)
 	return true;
 }
 
-void M_DrawSlider (int x, int y, float leftval, float rightval, float cur)
+void M_DrawSlider (int x, int y, float leftval, float rightval, float cur, float step)
 {
 	if (leftval < rightval)
 		cur = clamp(cur, leftval, rightval);
@@ -1459,6 +1459,17 @@ void M_DrawSlider (int x, int y, float leftval, float rightval, float cur)
 	screen->DrawPatchClean (W_CachePatch ("RSLIDE"), x + 88, y);
 
 	screen->DrawPatchClean (W_CachePatch ("CSLIDE"), x + 5 + (int)(dist * 78.0), y);
+
+	std::string buf;
+	if (step == 0.0f)
+		return;
+	else if (step >= 1.0f)
+		StrFormat(buf, "%.0f", cur);
+	else if (step >= 0.1f)
+		StrFormat(buf, "%.1f", cur);
+	else
+		StrFormat(buf, "%.2f", cur);
+	screen->DrawTextCleanMove(CR_GREY, x + 96, y, buf.c_str());
 }
 
 void M_DrawColoredSlider(int x, int y, float leftval, float rightval, float cur, argb_t color)
@@ -1629,7 +1640,7 @@ void M_OptDrawer (void)
 				break;
 
 			case slider:
-				M_DrawSlider (CurrentMenu->indent + 8, y, item->b.leftval, item->c.rightval, item->a.cvar->value());
+				M_DrawSlider (CurrentMenu->indent + 8, y, item->b.leftval, item->c.rightval, item->a.cvar->value(), item->d.step);
 				break;
 
 			case redslider:

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1469,7 +1469,7 @@ void M_DrawSlider (int x, int y, float leftval, float rightval, float cur, float
 		StrFormat(buf, "%.1f", cur);
 	else
 		StrFormat(buf, "%.2f", cur);
-	screen->DrawTextCleanMove(CR_GREY, x + 96, y, buf.c_str());
+	screen->DrawTextCleanMove(CR_GREEN, x + 96, y, buf.c_str());
 }
 
 void M_DrawColoredSlider(int x, int y, float leftval, float rightval, float cur, argb_t color)


### PR DESCRIPTION
This commit adds visible numbers for slider controls.

Not all of them, RGB kind of speaks for themselves.

![odamex_HL9pMA8gO1](https://user-images.githubusercontent.com/23563/174441407-048ce7bc-7e07-4640-a3ba-2ccb168e7cd3.png)

