### PR TITLE
Make feed fadeout time adjustable

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -556,6 +556,8 @@ CVAR(hud_demobar, "1", "Shows the netdemo bar and timer on the HUD.", CVARTYPE_B
      CVAR_CLIENTARCHIVE)
 CVAR(hud_demoprotos, "0", "Debug protocol messages while demo is paused.", CVARTYPE_BOOL,
      CVAR_CLIENTARCHIVE)
+CVAR_RANGE(hud_feedtime, "3.0", "How long entries show in the event feed, in seconds.",
+           CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 1.0, 10.0)
 CVAR(hud_feedobits, "1", "Show obituaries in the event feed.", CVARTYPE_BOOL,
      CVAR_CLIENTARCHIVE)
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -127,6 +127,7 @@ EXTERN_CVAR (co_boomphys)			// [ML] Roll-up of various compat options
 EXTERN_CVAR (co_blockmapfix)
 EXTERN_CVAR (co_globalsound)
 EXTERN_CVAR(hud_feedobits)
+EXTERN_CVAR(hud_feedtime)
 
 // [Toke - Menu] New Menu Stuff.
 void MouseSetup (void);
@@ -878,7 +879,8 @@ static menuitem_t HUDItems[] = {
     // clang-format on
     {discrete, "Timer Type", {&hud_timer}, {3.0}, {0.0}, {0.0}, {TimerStyles}},
     {discrete, "Speedometer", {&hud_speedometer}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {discrete, "Killfeed", {&hud_feedobits}, {2.0}, {0.0}, {0.0}, {OnOff}},
+    {slider, "Feed Timeout", {&hud_feedtime}, {1.0}, {10.0}, {0.25}, {NULL}},
+    {discrete, "Feed Obits", {&hud_feedobits}, {2.0}, {0.0}, {0.0}, {OnOff}},
     {discrete, "Netdemo infos", {&hud_demobar}, {2.0}, {0.0}, {0.0}, {OnOff}},
     {redtext, " ", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -880,7 +880,7 @@ static menuitem_t HUDItems[] = {
     {discrete, "Timer Type", {&hud_timer}, {3.0}, {0.0}, {0.0}, {TimerStyles}},
     {discrete, "Speedometer", {&hud_speedometer}, {2.0}, {0.0}, {0.0}, {OnOff}},
     {slider, "Feed Timeout", {&hud_feedtime}, {1.0}, {10.0}, {0.25}, {NULL}},
-    {discrete, "Feed Obits", {&hud_feedobits}, {2.0}, {0.0}, {0.0}, {OnOff}},
+    {discrete, "Show Kills in Feed", {&hud_feedobits}, {2.0}, {0.0}, {0.0}, {OnOff}},
     {discrete, "Netdemo infos", {&hud_demobar}, {2.0}, {0.0}, {0.0}, {OnOff}},
     {redtext, " ", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
 

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -121,6 +121,7 @@ EXTERN_CVAR(sv_teamsinplay)
 EXTERN_CVAR(g_lives)
 EXTERN_CVAR(sv_scorelimit);
 EXTERN_CVAR(sv_warmup)
+EXTERN_CVAR(hud_feedtime)
 EXTERN_CVAR(hud_feedobits)
 EXTERN_CVAR(g_horde_waves)
 EXTERN_CVAR(g_roundlimit)
@@ -952,6 +953,9 @@ void DrawToasts()
 	if (!hud_feedobits)
 		return;
 
+	const int fadeDoneTics = (hud_feedtime * float(TICRATE));
+	const int fadeOutTics = fadeDoneTics - TICRATE;
+
 	V_SetFont("DIGFONT");
 	const int TOAST_HEIGHT = V_LineHeight() + 2;
 
@@ -961,13 +965,13 @@ void DrawToasts()
 	const float oldtrans = ::hud_transparency;
 	for (drawToasts_t::const_iterator it = g_Toasts.begin(); it != g_Toasts.end(); ++it)
 	{
-		// Only render the message if it's less than 2 seconds in.
+		// Fade the toast out.
 		int tics = ::gametic - it->tic;
-		if (tics < TICRATE * 2)
+		if (tics < fadeOutTics)
 		{
 			::hud_transparency.ForceSet(1.0);
 		}
-		else if (tics < TICRATE * 3)
+		else if (tics < fadeDoneTics)
 		{
 			tics %= TICRATE;
 			float trans = static_cast<float>(TICRATE - tics) / TICRATE;
@@ -1008,13 +1012,15 @@ void DrawToasts()
 
 void ToastTicker()
 {
+	const int fadeDoneTics = (hud_feedtime * float(TICRATE));
+
 	// Remove stale toasts in a loop.
 	drawToasts_t::iterator it = g_Toasts.begin();
 	while (it != g_Toasts.end())
 	{
 		int tics = ::gametic - it->tic;
 
-		if (tics >= TICRATE * 3)
+		if (tics >= fadeDoneTics)
 		{
 			it = g_Toasts.erase(it);
 		}


### PR DESCRIPTION
This adds a new `hud_feedtime` cvar and menu item that adjust the amount of time that the killfeed obituaries stay onscreen.

This PR addresses #674 .