### PR TITLE
[BUGFIX] Fix client scrolling desyncs

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1689,6 +1689,10 @@ void P_SpawnCompatibleSectorSpecial(sector_t* sector)
 
 void P_SpawnCompatibleScroller(line_t* l, int i)
 {
+	// [Blair] don't run scrolling on clients to prevent desyncs
+	if (IgnoreSpecial)
+		return;
+
 	fixed_t dx = l->dx >> SCROLL_SHIFT; // direction and speed of scrolling
 	fixed_t dy = l->dy >> SCROLL_SHIFT;
 	int control = -1, accel = 0; // no control sector or acceleration


### PR DESCRIPTION
In Odamex, scrollers are designed to be initiated by the server ONLY, and any client scrollers that start independent of the server will desync as there is no mechanism to reconcile improper scroller/actor position from the client/server. This seems to manifest itself by the scrollers "adding" the scroll value between client and server on the client.

This introduced a bug when MapFormat was introduced, as Boom scrollers were initiated on clients as well as servers. ZDoom scrollers still had the correct behavior.

This fixes #683.