### PR TITLE
[BUGFIX] Clear specials on the client as well as the server

### DIFF
--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1942,9 +1942,12 @@ void P_CrossSpecialLine(line_t*	line, int side, AActor* thing, bool bossaction)
 		result = map_format.cross_special_line(line, side, thing, bossaction);
 	}
 
-	if (serverside && result.lineexecuted)
+	if (result.lineexecuted)
 	{
-		SV_OnActivatedLine(line, thing, side, LineCross, bossaction);
+		if (serverside)
+		{
+			SV_OnActivatedLine(line, thing, side, LineCross, bossaction);
+		}
 
 		bool repeat;
 


### PR DESCRIPTION
Due to the logic, the client would fail to clear special lines for single-activation items and cause a desync, mainly for teleport lines where the client tries to handle it.

Fixes #685 