### PR TITLE
[BUGFIX] Fix last frag not being counted in WDLStats Deathmatch Modes

### DIFF
--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -2298,8 +2298,6 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 
 	if (target->health <= 0)
 	{
-		P_KillMobj(source, target, inflictor, false);
-
 		// WDL damage events.
 		// todo: handle voodoo dolls here
 		if (source == NULL && targethasflag)
@@ -2318,6 +2316,8 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 		{
 			M_LogActorWDLEvent(WDL_EVENT_KILL, source, target, 0, 0, mod, 0);
 		}
+
+		P_KillMobj(source, target, inflictor, false);
 
 		return;
 	}


### PR DESCRIPTION
This occurred because P_KillMobj would fire before recording the frag, which would call the end game functions and finalize the log. Now, WDL events will record the kill before the log is finalized.