### PR TITLE
Add message line and mid message timeouts to menu

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -163,16 +163,18 @@ public:
 //
 // ============================================================================
 
-ConsoleLine::ConsoleLine() :
-	color_code("\034-"), wrapped(false), print_level(PRINT_HIGH),	// TEXTCOLOR_ESCAPE
-	timeout(gametic + con_notifytime.asInt() * TICRATE)
-{ }
+ConsoleLine::ConsoleLine()
+    : color_code("\034-"), wrapped(false), print_level(PRINT_HIGH),
+      timeout(gametic + int(con_notifytime * TICRATE))
+{
+}
 
 ConsoleLine::ConsoleLine(const std::string& _text, const std::string& _color_code,
-			int _print_level) :
-	text(_text), color_code(_color_code), wrapped(false), print_level(_print_level),
-	timeout(gametic + con_notifytime.asInt() * TICRATE)
-{ }
+                         int _print_level)
+    : text(_text), color_code(_color_code), wrapped(false), print_level(_print_level),
+      timeout(gametic + int(con_notifytime * TICRATE))
+{
+}
 
 
 //
@@ -2124,8 +2126,7 @@ void C_MidPrint(const char *msg, player_t *p, int msgtime)
 {
 	unsigned int i;
 
-	if (!msgtime)
-		msgtime = con_midtime.asInt();
+	const float fmsgtime = msgtime ? float(msgtime) : con_midtime;
 
 	if (MidMsg)
 		V_FreeBrokenLines(MidMsg);
@@ -2151,7 +2152,7 @@ void C_MidPrint(const char *msg, player_t *p, int msgtime)
 
 		if ( (MidMsg = V_BreakLines(I_GetSurfaceWidth() / V_TextScaleXAmount(), (byte *)newmsg)) )
 		{
-			MidTicker = (int)(msgtime * TICRATE) + gametic;
+			MidTicker = (int)(fmsgtime * TICRATE) + gametic;
 
 			for (i = 0; MidMsg[i].width != -1; i++)
 				;
@@ -2208,8 +2209,7 @@ void C_GMidPrint(const char* msg, int color, int msgtime)
 {
 	unsigned int i;
 
-	if (!msgtime)
-		msgtime = con_midtime.asInt();
+	const float fmsgtime = msgtime ? float(msgtime) : con_midtime;
 
 	if (GameMsg)
 		V_FreeBrokenLines(GameMsg);
@@ -2230,7 +2230,7 @@ void C_GMidPrint(const char* msg, int color, int msgtime)
 
 		if ((GameMsg = V_BreakLines(I_GetSurfaceWidth() / V_TextScaleXAmount(), (byte *)newmsg)) )
 		{
-			GameTicker = (int)(msgtime * TICRATE) + gametic;
+			GameTicker = (int)(fmsgtime * TICRATE) + gametic;
 
 			for (i = 0;GameMsg[i].width != -1;i++)
 				;

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -175,11 +175,13 @@ CVAR(					am_ovteleportcolor, "ff a3 00", "",
 CVAR(				print_stdout, "0", "Print console text to stdout",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
-CVAR_RANGE(			con_notifytime, "3", "Number of seconds to display messages to top of the HUD",
-					CVARTYPE_INT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 10.0f)
+CVAR_RANGE(con_notifytime, "3.0",
+           "Number of seconds to display messages to top of the HUD", CVARTYPE_FLOAT,
+           CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 1.0f, 10.0f)
 
-CVAR_RANGE(			con_midtime, "3", "Number of seconds to display messages in the middle of the screen",
-					CVARTYPE_INT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 10.0f)
+CVAR_RANGE(con_midtime, "3.0",
+           "Number of seconds to display messages in the middle of the screen",
+           CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 1.0f, 10.0f)
 
 CVAR_RANGE(			con_scrlock, "1", "",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -81,6 +81,9 @@ extern short			skullAnimCounter;
 
 extern NetDemo netdemo;
 
+EXTERN_CVAR(con_notifytime)
+EXTERN_CVAR(con_midtime)
+
 EXTERN_CVAR (i_skipbootwin)
 EXTERN_CVAR (cl_run)
 EXTERN_CVAR (invertmouse)
@@ -971,6 +974,8 @@ static menuitem_t MessagesItems[] = {
 #if 0
 	{ discrete, "Language", 			 {&language},		   	{4.0}, {0.0},   {0.0}, {Languages} },
 #endif
+	{ slider,	"Message Timeout",		 {&con_notifytime},		{1.0}, {10.0},	{0.25}, {NULL} },
+	{ slider,	"Center Message Timeout",{&con_midtime},		{1.0}, {10.0},	{0.25}, {NULL} },
 	{ slider,	"Scale message text",    {&hud_scaletext},		{1.0}, {4.0}, 	{1.0}, {NULL} },
 	{ discrete,	"Colorize messages",	{&con_coloredmessages},	{2.0}, {0.0},   {0.0},	{OnOff} },
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },


### PR DESCRIPTION
We actually technically had support for this in-tree, but now it's surfaced in the menus as well (under messages).  The cvars have also been changed to floats, to allow non-integer second wait times.

Addresses #558.