### PR TITLE
[BUGFIX] Share additional scroller information

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2511,7 +2511,7 @@ static void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 			break;
 		if (scrollType != DScroller::sc_side && affectee > ::numsectors)
 			break;
-		// remove null checks after 10.2 is released
+		// remove null checks after 11 is released
 		if (!control || control < 0)
 			control = -1;
 		if (!accel || accel < 0)

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2501,6 +2501,8 @@ static void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 		fixed_t dx = msg->scroller().scroll_x();
 		fixed_t dy = msg->scroller().scroll_y();
 		int affectee = msg->scroller().affectee();
+		int accel = msg->scroller().accel();
+		int control = msg->scroller().control();
 		if (::numsides <= 0 || ::numsectors <= 0)
 			break;
 		if (affectee < 0)
@@ -2509,8 +2511,12 @@ static void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 			break;
 		if (scrollType != DScroller::sc_side && affectee > ::numsectors)
 			break;
+		if (control <= 0)
+			control = -1;
+		if (accel < 0)
+			accel = 0;
 
-		new DScroller(scrollType, dx, dy, -1, affectee, 0);
+		new DScroller(scrollType, dx, dy, control, affectee, accel);
 		break;
 	}
 	case odaproto::svc::ThinkerUpdate::kFireFlicker: {

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2511,9 +2511,10 @@ static void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 			break;
 		if (scrollType != DScroller::sc_side && affectee > ::numsectors)
 			break;
-		if (control < 0)
+		// remove null checks after 10.2 is released
+		if (!control || control < 0)
 			control = -1;
-		if (accel < 0)
+		if (!accel || accel < 0)
 			accel = 0;
 
 		new DScroller(scrollType, dx, dy, control, affectee, accel);

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2511,7 +2511,7 @@ static void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 			break;
 		if (scrollType != DScroller::sc_side && affectee > ::numsectors)
 			break;
-		if (control <= 0)
+		if (control < 0)
 			control = -1;
 		if (accel < 0)
 			accel = 0;

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -224,6 +224,8 @@ public:
 	void SetRate (fixed_t dx, fixed_t dy) { m_dx = dx; m_dy = dy; }
 	bool IsType(EScrollType type) const { return type == m_Type; }
 	int GetAffectee() const { return m_Affectee; }
+	int GetAccel() const { return m_Accel; }
+	int GetControl() const { return m_Control; }
 
 	EScrollType GetType() const { return m_Type; }
 	fixed_t GetScrollX() const { return m_dx; }

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1398,6 +1398,8 @@ odaproto::svc::ThinkerUpdate SVC_ThinkerUpdate(DThinker* thinker)
 		smsg->set_scroll_x(scroller->GetScrollX());
 		smsg->set_scroll_y(scroller->GetScrollY());
 		smsg->set_affectee(scroller->GetAffectee());
+		smsg->set_control(scroller->GetControl());
+		smsg->set_accel(scroller->GetAccel());
 	}
 	else if (thinker->IsA(RUNTIME_CLASS(DFireFlicker)))
 	{

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -536,6 +536,8 @@ message ThinkerUpdate
 		sfixed32 scroll_x = 2;
 		sfixed32 scroll_y = 3;
 		int32 affectee = 4;
+		sint32 control = 5; // Default is -1.
+		uint32 accel = 6;
 	}
 
 	message FireFlicker


### PR DESCRIPTION
Because Odamex depends on the server to tell the client when scrolling begins, the client is completely dependent on the server's initial information for the scroller. Odamex currently omits some information so some scrollers will cause desyncs as their online behavior will not match their offline behavior. Take for instance, this SSG disappearing trick in Sunlust MAP07:

Here's what it looks like on Odamex 10.1:
https://youtu.be/GHlYsH6NZbE

And here's what it looks like for this patch (Odamex Stable):
https://youtu.be/xwikmdbOo2o

And how it looks in single-player (Odamex 11 Protobreak):
https://youtu.be/8vsCZMjoAsc

Also verified to not cause problems when playing on 10.1 servers. (The bug simply exists there but the scrollers work)