### PR TITLE
Preround reset

### DIFF
--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -126,6 +126,7 @@ EXTERN_CVAR(hud_feedobits)
 EXTERN_CVAR(g_horde_waves)
 EXTERN_CVAR(g_roundlimit)
 EXTERN_CVAR(hud_hordeinfo_debug)
+EXTERN_CVAR(g_preroundreset)
 
 void ST_unloadNew()
 {
@@ -1276,8 +1277,16 @@ void LevelStateHUD()
 	}
 	case LevelState::PREROUND_COUNTDOWN: {
 		StrFormat(lines.title, "Round " TEXTCOLOR_YELLOW " %d", ::levelstate.getRound());
-		StrFormat(lines.subtitle[0], "Weapons unlocked in " TEXTCOLOR_GREEN "%d",
-		          ::levelstate.getCountdown());
+		if (g_preroundreset)
+		{
+			StrFormat(lines.subtitle[0], "Round begins in " TEXTCOLOR_GREEN "%d",
+			          ::levelstate.getCountdown());
+		}
+		else
+		{
+			StrFormat(lines.subtitle[0], "Weapons unlocked in " TEXTCOLOR_GREEN "%d",
+			          ::levelstate.getCountdown());
+		}
 		break;
 	}
 	case LevelState::INGAME: {

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -239,6 +239,9 @@ CVAR(g_winnerstays, "0", "After a match winners stay in the game, losers get spe
 CVAR(g_preroundtime, "5", "Amount of time before a round where you can't shoot",
      CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE)
 
+CVAR(g_preroundreset, "0", "After preround is over, reset the map one last time.",
+     CVARTYPE_INT, CVAR_SERVERARCHIVE)
+
 CVAR(g_postroundtime, "3", "Amount of time after a round before the next round/endgame",
      CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE)
 


### PR DESCRIPTION
Add an option to reset the round one last time after the pre-round countdown is done but before the game starts in earnest.