### PR TITLE
Add a lost soul limit cvar

### DIFF
--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -127,6 +127,7 @@ EXTERN_CVAR (cl_deathcam)
 EXTERN_CVAR (co_fineautoaim)
 EXTERN_CVAR (co_nosilentspawns)
 EXTERN_CVAR (co_boomphys)			// [ML] Roll-up of various compat options
+EXTERN_CVAR (co_removesoullimit)
 EXTERN_CVAR (co_blockmapfix)
 EXTERN_CVAR (co_globalsound)
 EXTERN_CVAR(hud_feedobits)
@@ -593,6 +594,7 @@ static menuitem_t CompatItems[] ={
 	{yellowtext, "Gameplay",							{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
 	{svdiscrete, "Finer-precision Autoaim",        {&co_fineautoaim},       {2.0}, {0.0}, {0.0}, {OnOff}},
 	{svdiscrete, "Fix hit detection at grid edges",{&co_blockmapfix},       {2.0}, {0.0}, {0.0}, {OnOff}},
+	{svdiscrete, "Remove pain elemental spawn limit",{&co_removesoullimit}, {2.0}, {0.0}, {0.0}, {OnOff}},
 	{redtext,   " ",								{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
 	{yellowtext, "Items and Decoration",				{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
 	{svdiscrete, "Fix invisible puffs under skies",{&co_fixweaponimpacts},  {2.0}, {0.0}, {0.0}, {OnOff}},

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -331,7 +331,7 @@ CVAR_RANGE(sv_countdown, "5",
 	CVAR(			co_novileghosts, "0", "Disables vanilla's ghost monster quirk that lets Arch-viles resurrect crushed monsters as unshootable ghosts",
 					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 	
-	CVAR(			co_removesoullimit, "0", "Allows pain elementals to still spawn lost souls if more than 21 are present",
+	CVAR(			co_removesoullimit, "0", "Allows pain elementals to still spawn lost souls if more than 20 are present",
 					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO)
 
 

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -330,6 +330,9 @@ CVAR_RANGE(sv_countdown, "5",
 
 	CVAR(			co_novileghosts, "0", "Disables vanilla's ghost monster quirk that lets Arch-viles resurrect crushed monsters as unshootable ghosts",
 					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
+	
+	CVAR(			co_removesoullimit, "0", "Allows pain elementals to still spawn lost souls if more than 21 are present",
+					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO)
 
 
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2477,9 +2477,12 @@ void A_PainShootSkull (AActor *actor, angle_t angle)
 
 	// if there are already 20 skulls on the level,
 	// don't spit another one
+	// co_removesoullimit removes the standard limit
 	if (count > 20 && !co_removesoullimit)
 		return;
-
+	// multiplayer retains a hard limit of 128
+	if (multiplayer && count > 128)
+		return;
 	// okay, there's room for another one
 	an = angle >> ANGLETOFINESHIFT;
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -49,6 +49,7 @@ EXTERN_CVAR (sv_fastmonsters)
 EXTERN_CVAR (co_zdoomphys)
 EXTERN_CVAR (co_novileghosts)
 EXTERN_CVAR(co_zdoomsound)
+EXTERN_CVAR(co_removesoullimit)
 
 enum dirtype_t
 {
@@ -2476,7 +2477,7 @@ void A_PainShootSkull (AActor *actor, angle_t angle)
 
 	// if there are already 20 skulls on the level,
 	// don't spit another one
-	if (count > 20)
+	if (count > 20 && !co_removesoullimit)
 		return;
 
 	// okay, there's room for another one


### PR DESCRIPTION
I know there is a desire to limit the number of cvars, but this keeps being an issue with pain elemental bosses in horde mode.

Addresses #707