### PR TITLE
[FEATURE] Integrate Match Duel HUD changes

### DIFF
--- a/ci/upload-b2.py
+++ b/ci/upload-b2.py
@@ -29,10 +29,16 @@ B2_KEY_ID = os.getenv("B2_KEY_ID")
 GITHUB_EVENT_NAME = os.getenv("GITHUB_EVENT_NAME")
 GITHUB_SHA = os.getenv("GITHUB_SHA")
 GITHUB_REF = os.getenv("GITHUB_REF")
+GITHUB_REPOSITORY_OWNER = os.getenv("GITHUB_REPOSITORY_OWNER")
 
 # Skip for pull requests
 if GITHUB_EVENT_NAME == "pull_request":
     print(f"==> Skipping upload for \"{GITHUB_EVENT_NAME}\".")
+    sys.exit(0)
+
+# Skip if on a fork
+if GITHUB_REPOSITORY_OWNER != "odamex":
+    print(f"==> Skipping upload because repo owner is \"{GITHUB_REPOSITORY_OWNER}\" and not \"odamex\".")
     sys.exit(0)
 
 # Load up JSON so we can grab a message

--- a/client/src/hu_elements.cpp
+++ b/client/src/hu_elements.cpp
@@ -416,7 +416,7 @@ std::string PersonalSpread()
 	{
 		// Seek the highest number of rounds or frags.
 		PlayerQuery pq = PlayerQuery().filterSortMax();
-		if (g_rounds)
+		if (g_rounds && !G_IsMatchDuelGame())
 			pq.sortWins();
 		else
 			pq.sortFrags();
@@ -435,9 +435,13 @@ std::string PersonalSpread()
 		}
 
 		// The interesting thing changes based on rounds.
-		int top_number = g_rounds ? max_players.players.at(0)->roundwins
-		                          : max_players.players.at(0)->fragcount;
-		int plyr_number = g_rounds ? plyr.roundwins : plyr.fragcount;
+
+		int top_number = g_rounds && !G_IsMatchDuelGame()
+		                     ? max_players.players.at(0)->roundwins
+		                     : max_players.players.at(0)->fragcount;
+
+		int plyr_number =
+		    g_rounds && !G_IsMatchDuelGame() ? plyr.roundwins : plyr.fragcount;
 
 		if (max_players.players.size() > 1 && top_number == plyr_number)
 		{
@@ -449,15 +453,16 @@ std::string PersonalSpread()
 		{
 			// Do a second query without a filter.
 			PlayerQuery pq = PlayerQuery().filterSortNotMax();
-			if (g_rounds)
+			if (g_rounds && !G_IsMatchDuelGame())
 				pq.sortWins();
 			else
 				pq.sortFrags();
 			PlayerResults other_players = pq.execute();
 
 			// The interesting thing changes based on rounds.
-			int next_number = g_rounds ? other_players.players.at(0)->roundwins
-			                           : other_players.players.at(0)->fragcount;
+			int next_number = g_rounds && !G_IsMatchDuelGame()
+			                      ? other_players.players.at(0)->roundwins
+			                      : other_players.players.at(0)->fragcount;
 
 			// Player is on top.
 			int diff = plyr_number - next_number;
@@ -580,7 +585,7 @@ std::string PersonalScore()
 	}
 	else if (G_IsFFAGame())
 	{
-		if (G_IsRoundsGame())
+		if (G_IsRoundsGame() && !G_IsMatchDuelGame())
 		{
 			if (g_winlimit)
 			{
@@ -604,6 +609,30 @@ std::string PersonalScore()
 				StrFormat(str, TEXTCOLOR_GREY "%d", plyr.fragcount);
 			}
 		}
+	}
+
+	return str;
+}
+
+/**
+ * @brief Return a string that contains the current player's round placement
+ * expressed in a short, colorized string.
+ *
+ * @return Colorized string to render to the HUD.
+ */
+std::string PersonalMatchDuelPlacement()
+{
+	std::string str;
+	const player_t& plyr = displayplayer();
+
+	if (g_winlimit)
+	{
+		StrFormat(str, TEXTCOLOR_GREY "%d/%d W", plyr.roundwins,
+				    g_winlimit.asInt());
+	}
+	else
+	{
+		StrFormat(str, TEXTCOLOR_GREY "%d W", plyr.roundwins);
 	}
 
 	return str;

--- a/client/src/hu_elements.h
+++ b/client/src/hu_elements.h
@@ -31,6 +31,7 @@ std::string IntermissionTimer();
 std::string Timer();
 std::string PersonalSpread();
 std::string PersonalScore();
+std::string PersonalMatchDuelPlacement();
 std::string NetdemoElapsed(void);
 std::string NetdemoMaps(void);
 std::string ClientsSplit(void);

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -912,11 +912,34 @@ void OdamexHUD() {
 	// number on the other side of the screen.
 	if (::hud_bigfont)
 		V_SetFont("BIGFONT");
+	
+	// Special 3 line formatting for match duel
+	int spreadheight, scoreheight, placeheight;
 
-	hud::DrawText(4, 24 + V_LineHeight() + 1, ::hud_scale, hud::X_RIGHT, hud::Y_BOTTOM,
-	              hud::X_RIGHT, hud::Y_BOTTOM, hud::PersonalSpread().c_str(), CR_GREY);
-	hud::DrawText(4, 24, ::hud_scale, hud::X_RIGHT, hud::Y_BOTTOM, hud::X_RIGHT,
+	if (G_IsMatchDuelGame())
+	{
+		spreadheight = 24 + (V_LineHeight() * 2) + 2;
+		scoreheight = 24 + V_LineHeight() + 1;
+		placeheight = 24;
+	}
+	else
+	{
+		spreadheight = 24 + V_LineHeight() + 1;
+		scoreheight = 24;
+		placeheight = 0; // No place height drawn if not match duel
+	}
+
+	hud::DrawText(4, spreadheight, ::hud_scale, hud::X_RIGHT, hud::Y_BOTTOM, hud::X_RIGHT,
+	              hud::Y_BOTTOM, hud::PersonalSpread().c_str(), CR_GREY);
+	hud::DrawText(4, scoreheight, ::hud_scale, hud::X_RIGHT, hud::Y_BOTTOM, hud::X_RIGHT,
 	              hud::Y_BOTTOM, hud::PersonalScore().c_str(), CR_GREY);
+
+	if (G_IsMatchDuelGame())
+	{
+		hud::DrawText(4, placeheight, ::hud_scale, hud::X_RIGHT, hud::Y_BOTTOM,
+		              hud::X_RIGHT, hud::Y_BOTTOM,
+		              hud::PersonalMatchDuelPlacement().c_str(), CR_GREY);
+	}
 
 	if (::hud_bigfont)
 		V_SetFont("SMALLFONT");

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -126,6 +126,7 @@ EXTERN_CVAR(hud_feedobits)
 EXTERN_CVAR(g_horde_waves)
 EXTERN_CVAR(g_roundlimit)
 EXTERN_CVAR(hud_hordeinfo_debug)
+EXTERN_CVAR(g_preroundreset)
 
 void ST_unloadNew()
 {
@@ -1276,8 +1277,16 @@ void LevelStateHUD()
 	}
 	case LevelState::PREROUND_COUNTDOWN: {
 		StrFormat(lines.title, "Round " TEXTCOLOR_YELLOW " %d", ::levelstate.getRound());
-		StrFormat(lines.subtitle[0], "Weapons unlocked in " TEXTCOLOR_GREEN "%d",
-		          ::levelstate.getCountdown());
+		if (g_preroundreset)
+		{
+			StrFormat(lines.subtitle[0], "Round begins in " TEXTCOLOR_GREEN "%d",
+			          ::levelstate.getCountdown());
+		}
+		else
+		{
+			StrFormat(lines.subtitle[0], "Weapons unlocked in " TEXTCOLOR_GREEN "%d",
+			          ::levelstate.getCountdown());
+		}
 		break;
 	}
 	case LevelState::INGAME: {

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -239,6 +239,9 @@ CVAR(g_winnerstays, "0", "After a match winners stay in the game, losers get spe
 CVAR(g_preroundtime, "5", "Amount of time before a round where you can't shoot",
      CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE)
 
+CVAR(g_preroundreset, "0", "After preround is over, reset the map one last time.",
+     CVARTYPE_INT, CVAR_SERVERARCHIVE)
+
 CVAR(g_postroundtime, "3", "Amount of time after a round before the next round/endgame",
      CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE)
 

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -315,6 +315,14 @@ bool G_IsFFAGame()
 }
 
 /**
+ * @brief Check if the gametype is Match Duel, a new take on classic Doom duel.
+ */
+bool G_IsMatchDuelGame()
+{
+	return sv_gametype == GM_DM && sv_maxplayers == 2 && g_rounds;
+}
+
+/**
  * @brief Check if the gametype is made for Duels.
  */
 bool G_IsDuelGame()

--- a/common/g_gametype.h
+++ b/common/g_gametype.h
@@ -56,6 +56,7 @@ bool G_IsDefendingTeam(team_t team);
 bool G_IsHordeMode();
 bool G_IsCoopGame();
 bool G_IsFFAGame();
+bool G_IsMatchDuelGame();
 bool G_IsDuelGame();
 bool G_IsTeamGame();
 bool G_IsRoundsGame();

--- a/common/info.cpp
+++ b/common/info.cpp
@@ -7559,7 +7559,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 		100,            // mass
 		0,              // damage
 		NULL,           // activesound
-		0,              // flags
+		MF_NOGRAVITY,   // flags
 		0,              // flags2
 		S_NULL,         // raisestate
 		0x10000,

--- a/common/p_horde.cpp
+++ b/common/p_horde.cpp
@@ -50,6 +50,7 @@ EXTERN_CVAR(g_horde_spawnempty_min)
 EXTERN_CVAR(g_horde_spawnempty_max)
 EXTERN_CVAR(g_horde_spawnfull_min)
 EXTERN_CVAR(g_horde_spawnfull_max)
+EXTERN_CVAR(sv_nomonsters)
 
 void A_PainDie(AActor* actor);
 
@@ -625,6 +626,9 @@ void HordeState::tick()
 		switch (m_state)
 		{
 		case HS_PRESSURE: {
+			if (sv_nomonsters)
+				break;
+
 			// Pick a recipe for some monsters.
 			hordeRecipe_t recipe;
 			const bool ok = P_HordeSpawnRecipe(recipe, define, false);
@@ -654,6 +658,9 @@ void HordeState::tick()
 		case HS_RELAX:
 			break;
 		case HS_WANTBOSS: {
+			if (sv_nomonsters)
+				break;
+
 			// Do we already have bosses spawned?
 			if (m_bossRecipe.isValid() && m_bosses.size() >= m_bossRecipe.count)
 				break;


### PR DESCRIPTION
Addresses a small portion of #676. This expanded match duel hud has frag count/frag spread instead of round count/round spread, but also includes amounts of rounds won, and the win limit if applicable.

![image](https://user-images.githubusercontent.com/2531014/180596321-3a32d2da-fc1a-471d-9ebb-3de101b6f6bd.png)

In a mode that's not match duel, the spread and score reverts to the old behavior, and round placement isn't shown.

![image](https://user-images.githubusercontent.com/2531014/180596328-6e61f7da-bc2d-44ae-b82f-757727164daf.png)

(This was merged with `stable` before merging `scoreboard-rework`, apologies for that.)