### PR TITLE
[FEATURE] Display items collected/total countable items in the automap

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -64,6 +64,7 @@ EXTERN_CVAR(am_rotate)
 EXTERN_CVAR(am_overlay)
 EXTERN_CVAR(am_showsecrets)
 EXTERN_CVAR(am_showmonsters)
+EXTERN_CVAR(am_showitems)
 EXTERN_CVAR(am_showtime)
 EXTERN_CVAR(am_classicmapstring)
 EXTERN_CVAR(am_usecustomcolors)
@@ -1857,6 +1858,29 @@ void AM_Drawer()
 				{
 					x = 0;
 					y = OV_Y - (text_height * 2) + 1;
+				}
+
+				screen->DrawTextClean(CR_GREY, x, y, line);
+			}
+
+			if (am_showitems)
+			{
+				sprintf(line, TEXTCOLOR_RED "ITEMS:" TEXTCOLOR_NORMAL " %d / %d",
+				        level.found_items,
+				        level.total_items);
+
+				int x, y;
+				const int text_width = V_StringWidth(line) * CleanXfac;
+
+				if (AM_OverlayAutomapVisible())
+				{
+					x = surface_width - text_width;
+					y = OV_Y - (text_height * 5) + 1;
+				}
+				else
+				{
+					x = 0;
+					y = OV_Y - (text_height * 3) + 1;
 				}
 
 				screen->DrawTextClean(CR_GREY, x, y, line);

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -45,6 +45,9 @@ CVAR(					am_showsecrets, "1", "",
 CVAR(					am_showmonsters, "1", "",
 						CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
+CVAR(					am_showitems, "1", "",
+						CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 CVAR(					am_showtime, "1", "",
 						CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -888,6 +888,9 @@ static void CL_RemoveMobj(const odaproto::svc::RemoveMobj* msg)
 	if (mo && mo->player && mo->player->id == ::displayplayer_id)
 		::displayplayer_id = ::consoleplayer_id;
 
+	if (mo && mo->flags & MF_COUNTITEM)
+		level.found_items++;
+
 	P_ClearId(netid);
 }
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -730,6 +730,7 @@ void ResetCustomColors (void);
 EXTERN_CVAR (am_rotate)
 EXTERN_CVAR (am_overlay)
 EXTERN_CVAR (am_showmonsters)
+EXTERN_CVAR (am_showitems)
 EXTERN_CVAR (am_showsecrets)
 EXTERN_CVAR (am_showtime)
 EXTERN_CVAR (am_classicmapstring)
@@ -1021,7 +1022,8 @@ static menuitem_t AutomapItems[] = {
 	{ discrete, "Rotate automap",		{&am_rotate},		   	{2.0}, {0.0},	{0.0},  {OnOff} },
 	{ discrete, "Overlay automap",		{&am_overlay},			{4.0}, {0.0},	{0.0},  {Overlays} },
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-    { discrete, "Show monster count",	{&am_showmonsters},	   	{2.0}, {0.0},	{0.0},  {OnOff} },
+    { discrete, "Show item count",		{&am_showitems},		{2.0}, {0.0},	{0.0},  {OnOff} },
+    { discrete, "Show monster count",	{&am_showmonsters},		{2.0}, {0.0},	{0.0},	{OnOff} },
     { discrete, "Show secrets count",	{&am_showsecrets},	   	{2.0}, {0.0},	{0.0},  {OnOff} },
     { discrete, "Show map timer", 	    {&am_showtime}, 	   	{2.0}, {0.0},	{0.0},  {OnOff} },
     { discrete, "Map name style",       {&am_classicmapstring},	{2.0}, {0.0},	{0.0},  {ClassicMapStringTypes} },


### PR DESCRIPTION
A feature from the likes of DSDA doom and others, in order to assist players in 100% completion, we must display the total item count and the amount of collectable items the player(s) have collected so far. It includes a hook into the event for item removal to increase the found items, so it can keep players in sync in terms of item count when playing online.

Resolves #570