### PR TITLE
[FEATURE] Implement r_softinvulneffect

### DIFF
--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -97,6 +97,7 @@ EXTERN_CVAR (r_forceteamcolor)
 EXTERN_CVAR (r_teamcolor)
 EXTERN_CVAR (r_forceenemycolor)
 EXTERN_CVAR (r_enemycolor)
+EXTERN_CVAR (r_softinvulneffect)
 EXTERN_CVAR (cl_mouselook)
 EXTERN_CVAR (in_autosr50)
 EXTERN_CVAR (gammalevel)
@@ -816,6 +817,7 @@ static menuitem_t VideoItems[] = {
 	{ discrete, "See killer on Death",			{&cl_deathcam},   {2.0}, {0.0}, {0.0}, {OnOff}},
 	{ discrete, "Stretch short skies",	    {&r_stretchsky},	   	{3.0}, {0.0},	{0.0},  {OnOffAuto} },
 	{ discrete, "Invuln changes skies",		{&r_skypalette},		{2.0}, {0.0},	{0.0},	{OnOff} },
+	{ discrete, "Use softer invuln effect", {&r_softinvulneffect},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Screen wipe style",	    {&r_wipetype},			{4.0}, {0.0},	{0.0},  {Wipes} },
 	{ discrete, "Multiplayer Intermissions",{&wi_oldintermission},	{2.0}, {0.0},	{0.0},  {DoomOrOdamex} },
 	{ discrete, "Show loading disk icon",	{&r_loadicon},			{2.0}, {0.0},	{0.0},	{OnOff} },

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -779,11 +779,14 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 		vis->mobjflags = MF_SHADOW;
 	}
 
-	if (camera->player && (camera->player->powers[pw_invulnerability] > 4 * 32 ||
-	                       camera->player->powers[pw_invulnerability] & 8))
+	if (r_softinvulneffect)
 	{
-		// draw invuln palette on vissprite only
-		vis->colormap = basecolormap.with(INVERSECOLORMAP);
+		if (camera->player && (camera->player->powers[pw_invulnerability] > 4 * 32 ||
+		                       camera->player->powers[pw_invulnerability] & 8))
+		{
+			// draw invuln palette on vissprite only
+			vis->colormap = basecolormap.with(INVERSECOLORMAP);
+		}
 	}
 
 	// Don't display the weapon sprite if using spectating without spynext

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -65,6 +65,7 @@ int*			spritelights;
 #define SPRITE_NEEDS_INFO	MAXINT
 
 EXTERN_CVAR (r_drawplayersprites)
+EXTERN_CVAR (r_softinvulneffect)
 EXTERN_CVAR (r_particles)
 
 //
@@ -776,6 +777,13 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 	{
 		// shadow draw
 		vis->mobjflags = MF_SHADOW;
+	}
+
+	if (camera->player && (camera->player->powers[pw_invulnerability] > 4 * 32 ||
+	                       camera->player->powers[pw_invulnerability] & 8))
+	{
+		// draw invuln palette on vissprite only
+		vis->colormap = basecolormap.with(INVERSECOLORMAP);
 	}
 
 	// Don't display the weapon sprite if using spectating without spynext

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -785,7 +785,9 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 		                       camera->player->powers[pw_invulnerability] & 8))
 		{
 			// draw invuln palette on vissprite only
-			vis->colormap = basecolormap.with(INVERSECOLORMAP);
+			// and don't include sector colored lighting because it creates strange colors.
+			const palette_t* pal = V_GetDefaultPalette();
+			vis->colormap = shaderef_t(&pal->maps, INVERSECOLORMAP);
 		}
 	}
 

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -383,6 +383,10 @@ CVAR_RANGE_FUNC_DECL(sv_splashfactor, "1.0", "Rocket explosion thrust effect?",
 CVAR(               cl_waddownloaddir, "", "Set custom WAD download directory",
 					CVARTYPE_STRING, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE)
 
+CVAR				(r_softinvulneffect, "1",
+					"Change invuln to enable light googles and invert the pallete on the weapon sprite only.",
+					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 // Misc stuff
 // ----------
 

--- a/common/doomdef.h
+++ b/common/doomdef.h
@@ -341,6 +341,9 @@ struct lineresult_s
 	bool lineexecuted;
 };
 
+// Index of the special effects (INVUL inverse) map.
+#define INVERSECOLORMAP 32
+
 // The current state of the game: whether we are
 // playing, gazing at the intermission screen,
 // the game final animation, or a demo.

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -43,9 +43,6 @@
 
 #include "p_mapformat.h"
 
-// Index of the special effects (INVUL inverse) map.
-#define INVERSECOLORMAP 		32
-
 //
 // Movement.
 //
@@ -62,6 +59,7 @@ EXTERN_CVAR (sv_forcerespawn)
 EXTERN_CVAR (sv_forcerespawntime)
 EXTERN_CVAR (sv_spawndelaytime)
 EXTERN_CVAR (g_lives)
+EXTERN_CVAR (r_softinvulneffect)
 
 extern bool predicting, step_mode;
 
@@ -1040,7 +1038,10 @@ void P_PlayerThink (player_t *player)
 	{
 		if (displayplayer().powers[pw_invulnerability] > 4*32
 			|| (displayplayer().powers[pw_invulnerability]&8) )
-			displayplayer().fixedcolormap = INVERSECOLORMAP;
+			if (r_softinvulneffect)
+				displayplayer().fixedcolormap = 1;
+			else
+				displayplayer().fixedcolormap = INVERSECOLORMAP;
 		else
 			displayplayer().fixedcolormap = 0;
 	}


### PR DESCRIPTION
The invuln that is experienced in Horde is eye-watering at best, and a photosensitive epilepsy hazard at worst. I've went ahead and implemented a mockup by @rakohus that changes the effect to such:

- Only the weapon sprite has the invuln effect drawn.
- The light googles effect is also drawn in order to provide the added "shadow" invuln benefit of sussing out fuzzy monsters.
- Colored sectors don't affect the weapon sprite when using this and the player is invuln, as the color translation doesn't work well with inversion and colored sector lighting.

Here's a video of the new effect:
https://www.youtube.com/watch?v=L8km6GVQts4

If implemented, this will resolve #703 in spirit, since we generate colormaps off palettes, and cannot use the COLORMAP lump.

Test wad here: [invuln-color-test.zip](https://github.com/odamex/odamex/files/9186134/invuln-color-test.zip)
