### PR TITLE
[BUGFIX] Fix Horde Monsters getting crunched at full health from doors

### DIFF
--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -78,9 +78,6 @@ static AActor::AActorPtr SpawnMonster(hordeSpawn_t& spawn, const hordeRecipe_t& 
 	{
 		if (P_TestMobjLocation(mo))
 		{
-			// Don't respawn
-			mo->flags |= MF_DROPPED;
-
 			if (recipe.isBoss)
 			{
 				// Heavy is the head that wears the crown.


### PR DESCRIPTION
This was an interesting and funny bug. It was caused by monsters in horde being flagged with MF_DROPPED. PIT_ChangeSector looks for this item flag in order to check if it can crunch items. Doors crunching horde boxes is because it has MF_DROPPED (removing that would interfere with P_TouchSpecial I believe, and other items are crunched by doors, so it's okay in my mind) but doors crunching full HP monsters is not good.

I've fixed that by removing MF_DROPPED and I ensured the monsters won't respawn by other means, which was the entire reason they were flagged with MF_DROPPED.

Resolves #715.