### PR TITLE
[FEATURE] Show horde boss projectiles as having the same effect as horde bosses

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -553,8 +553,9 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 
 	// Light up the projectile if it came from a horde boss
 	// This is a hack because oflags are a hack.
-	if (mo->target && mo->target->oflags)
+	if (mo->flags & MF_MISSILE && mo->target && mo->target->oflags)
 	{
+		mo->oflags |= MFO_FULLBRIGHT;
 		mo->effects = FX_YELLOWFOUNTAIN;
 		mo->translation = translationref_t(&::bosstable[0]);
 	}

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -551,6 +551,14 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 		mo->target = AActor::AActorPtr();
 	}
 
+	// Light up the projectile if it came from a horde boss
+	// This is a hack because oflags are a hack.
+	if (mo->target && mo->target->oflags)
+	{
+		mo->effects = FX_YELLOWFOUNTAIN;
+		mo->translation = translationref_t(&::bosstable[0]);
+	}
+
 	AActor* tracer = NULL;
 	if (bflags & baseline_t::TRACER)
 		tracer = P_FindThingById(msg->current().tracerid());

--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -78,6 +78,9 @@ static AActor::AActorPtr SpawnMonster(hordeSpawn_t& spawn, const hordeRecipe_t& 
 	{
 		if (P_TestMobjLocation(mo))
 		{
+			// Don't respawn
+			mo->flags |= MF_DROPPED;
+
 			if (recipe.isBoss)
 			{
 				// Heavy is the head that wears the crown.

--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -78,9 +78,6 @@ static AActor::AActorPtr SpawnMonster(hordeSpawn_t& spawn, const hordeRecipe_t& 
 	{
 		if (P_TestMobjLocation(mo))
 		{
-			// Don't respawn
-			mo->flags |= MF_DROPPED;
-
 			if (recipe.isBoss)
 			{
 				// Heavy is the head that wears the crown.

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2325,6 +2325,13 @@ AActor* P_SpawnMissile (AActor *source, AActor *dest, mobjtype_t type)
     th->target = source->ptr();	// where it came from
     an = P_PointToAngle (source->x, source->y, dest_x, dest_y);
 
+	// Horde boss? Make their projectiles look bossy
+	if (source->oflags & MFO_BOSSPOOL)
+	{
+		th->effects = FX_YELLOWFOUNTAIN;
+		th->translation = translationref_t(&bosstable[0]);
+	}
+
     // fuzzy player
     if (dest_flags & MF_SHADOW)
 		an += P_RandomDiff()<<20;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2328,6 +2328,7 @@ AActor* P_SpawnMissile (AActor *source, AActor *dest, mobjtype_t type)
 	// Horde boss? Make their projectiles look bossy
 	if (source->oflags & MFO_BOSSPOOL)
 	{
+		th->oflags |= MFO_FULLBRIGHT;
 		th->effects = FX_YELLOWFOUNTAIN;
 		th->translation = translationref_t(&bosstable[0]);
 	}


### PR DESCRIPTION
This is a simple change that applies the horde boss effect (yellow fountain with yellow transition table) to fired horde projectiles. Video below:

https://youtu.be/ikGJOLdlMFc

Resolves #697 