### PR TITLE
[BUGFIX] Fix horde bosses not triggering special lines

### DIFF
--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -78,6 +78,9 @@ static AActor::AActorPtr SpawnMonster(hordeSpawn_t& spawn, const hordeRecipe_t& 
 	{
 		if (P_TestMobjLocation(mo))
 		{
+			// Don't respawn
+			mo->flags |= MF_DROPPED;
+
 			if (recipe.isBoss)
 			{
 				// Heavy is the head that wears the crown.

--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -88,9 +88,7 @@ static AActor::AActorPtr SpawnMonster(hordeSpawn_t& spawn, const hordeRecipe_t& 
 				mo->oflags = MFO_INFIGHTINVUL | MFO_UNFLINCHING | MFO_ARMOR | MFO_QUICK |
 				             MFO_NORAISE | MFO_BOSSPOOL | MFO_FULLBRIGHT;
 
-				mo->flags2 = MF2_BOSS;
-
-				mo->flags3 = MF3_FULLVOLSOUNDS | MF3_DMGIGNORED;
+				mo->flags3 = MF3_FULLVOLSOUNDS | MF3_DMGIGNORED | MF3_NORADIUSDMG;
 			}
 			SV_SpawnMobj(mo);
 

--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -78,9 +78,6 @@ static AActor::AActorPtr SpawnMonster(hordeSpawn_t& spawn, const hordeRecipe_t& 
 	{
 		if (P_TestMobjLocation(mo))
 		{
-			// Don't respawn
-			mo->flags |= MF_DROPPED;
-
 			if (recipe.isBoss)
 			{
 				// Heavy is the head that wears the crown.


### PR DESCRIPTION
The reason horde bosses weren't triggering special lines was because it had MF2_BOSS as an actor flag, which is designed for use for Arachnatrons and Mancubuses in MAP07 to activate special lines on death. MF2_BOSS would force spechits to be bossaction spec hits, which limits what linedef specials the actor can execute, mainly map exits.

Fixes #699 