### PR TITLE
[BUGFIX] Workaround Pumpfaking Monsters

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -999,7 +999,8 @@ void A_Chase (AActor *actor)
 		if (actor->info->attacksound)
 			S_Sound (actor, CHAN_WEAPON, actor->info->attacksound, 1, ATTN_NORM);
 
-		P_SetMobjState (actor, actor->info->meleestate, true);
+		if (serverside)
+			P_SetMobjState (actor, actor->info->meleestate, true);
 		return;
 	}
 
@@ -1014,7 +1015,8 @@ void A_Chase (AActor *actor)
 		if (!P_CheckMissileRange (actor))
 			goto nomissile;
 
-		P_SetMobjState (actor, actor->info->missilestate, true);
+		if (serverside)
+			P_SetMobjState (actor, actor->info->missilestate, true);
 		actor->flags |= MF_JUSTATTACKED;
 		return;
 	}

--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -78,6 +78,9 @@ static AActor::AActorPtr SpawnMonster(hordeSpawn_t& spawn, const hordeRecipe_t& 
 	{
 		if (P_TestMobjLocation(mo))
 		{
+			// Don't respawn
+			mo->flags |= MF_DROPPED;
+
 			if (recipe.isBoss)
 			{
 				// Heavy is the head that wears the crown.

--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -78,9 +78,6 @@ static AActor::AActorPtr SpawnMonster(hordeSpawn_t& spawn, const hordeRecipe_t& 
 	{
 		if (P_TestMobjLocation(mo))
 		{
-			// Don't respawn
-			mo->flags |= MF_DROPPED;
-
 			if (recipe.isBoss)
 			{
 				// Heavy is the head that wears the crown.


### PR DESCRIPTION
After a deep dive of the pump-faking monsters, I figured a cheap and easy win is to simply force the client to only honor missilestate/meleestate changes from the server. This does not scale well with a ton of ping, so its a simple workaround and not really a permanent fix, but the results speak for themselves for clients with average ping. Attached to this ticket are horde gameplay videos of this client against 10.1 Release servers.

https://youtu.be/lpsrdJ_iXro
https://www.youtube.com/watch?v=IikPTb7UwoQ
https://youtu.be/nTwIUA1AU94

Partially solves #538 