### PR TITLE
[BUGFIX] Fix Horde monster effect add/removal

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -682,6 +682,10 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 		mo->flags |= MF_CORPSE | MF_DROPOFF;
 		mo->height >>= 2;
 		mo->flags &= ~MF_SOLID;
+		if (mo->oflags & hordeBossModMask)
+		{
+			mo->effects = 0; // Remove sparkles from boss corpses
+		}
 
 		if (mo->player)
 			mo->player->playerstate = PST_DEAD;

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -553,7 +553,8 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 
 	// Light up the projectile if it came from a horde boss
 	// This is a hack because oflags are a hack.
-	if (mo->flags & MF_MISSILE && mo->target && mo->target->oflags)
+	if (mo->flags & MF_MISSILE && mo->target && mo->target->oflags &&
+	    (mo->target->oflags & hordeBossModMask))
 	{
 		mo->oflags |= MFO_FULLBRIGHT;
 		mo->effects = FX_YELLOWFOUNTAIN;

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2616,7 +2616,7 @@ void A_Fall (AActor *actor)
 	// Remove any sort of boss effect on kill
 	// OFlags hack because of client issues
 	// Only remove the sparkling fountain, keep the transition
-	if (actor->type != MT_PLAYER && actor->oflags)
+	if (actor->type != MT_PLAYER && (actor->oflags & hordeBossModMask))
 	{
 		actor->effects = 0;
 	}

--- a/common/p_mobj.h
+++ b/common/p_mobj.h
@@ -123,6 +123,10 @@ inline static fixed_t DegToSlope(fixed_t a)
 
 extern NetIDHandler ServerNetID;
 
+// All oflag mods that are sent to horde bosses.
+const uint32_t hordeBossModMask = MFO_INFIGHTINVUL | MFO_UNFLINCHING | MFO_ARMOR |
+                                  MFO_QUICK | MFO_NORAISE | MFO_FULLBRIGHT;
+
 void P_ClearAllNetIds();
 AActor* P_FindThingById(uint32_t id);
 void P_SetThingId(AActor* mo, uint32_t newnetid);

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -366,12 +366,10 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(AActor* mo)
 	}
 
 	// odamex flags - only monster flags for now
-	const uint32_t modMask = MFO_INFIGHTINVUL | MFO_UNFLINCHING | MFO_ARMOR | MFO_QUICK |
-	                         MFO_NORAISE | MFO_FULLBRIGHT;
-	if (mo->oflags & modMask)
+	if (mo->oflags & hordeBossModMask)
 	{
 		spawnFlags |= SVC_SM_OFLAGS;
-		cur->set_oflags(mo->oflags & modMask);
+		cur->set_oflags(mo->oflags & hordeBossModMask);
 	}
 
 	// animating corpses


### PR DESCRIPTION
Since the gear calculation for torque applies MFO_FALLING on monsters, monsters who were recognized as falling would throw out projectiles that appeared to be from a horde boss. This fixes that behavior by making the oflags hack less hacky.

Another fix was to remove the fountain effect on horde boss corpses on connect.