### PR TITLE
[BUGFIX] Show K/D instead of Wins on scoreboard for DM

### DIFF
--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -895,7 +895,7 @@ static void scoreCols(scoreCol_e* columns)
 				columns[2] = SCOL_FRAGS;
 			}
 		}
-		else if (G_IsRoundsGame)
+		else if (G_IsRoundsGame())
 		{
 			columns[0] = SCOL_FRAGS;
 			columns[1] = SCOL_DEATHS;


### PR DESCRIPTION
After the recent scoreboard changes, I went ahead and fixed a simple check for a round game that was causing wins instead of K/D to be displayed in normal deathmatch modes.