### PR TITLE
[FEATURE] Add cl_centerbobonfire

### DIFF
--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -749,6 +749,7 @@ EXTERN_CVAR (r_loadicon)
 EXTERN_CVAR (r_showendoom)
 EXTERN_CVAR (r_painintensity)
 EXTERN_CVAR (cl_movebob)
+EXTERN_CVAR (cl_centerbobonfire)
 EXTERN_CVAR (cl_showspawns)
 EXTERN_CVAR (hud_show_scoreboard_ondeath)
 EXTERN_CVAR (hud_demobar)
@@ -801,6 +802,7 @@ static menuitem_t VideoItems[] = {
 	{ slider,	"Movement bobbing",			{&cl_movebob},			{0.0}, {1.0},	{0.1},	{NULL} },
 	{ slider,   "Weapon Visibility",        {&r_drawplayersprites}, {0.0}, {1.0},   {0.1},  {NULL} },
 	{ discrete,	"Visible Spawn Points",		{&cl_showspawns},		{2.0}, {0.0},	{0.0},	{OnOff} },
+	{ discrete, "Center weapon when firing",{&cl_centerbobonfire},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ redtext,	" ",					    {NULL},				    {0.0}, {0.0},	{0.0},  {NULL} },
 	{ discrete, "Force Team Color",			{&r_forceteamcolor},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ redslider,   "Team Color Red",        {&r_teamcolor},  {0.0}, {0.0},   {0.0},  {NULL} },

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -371,6 +371,10 @@ CVAR(				cl_predictpickup, "1", "Predict weapon pickups",
 CVAR_RANGE(			cl_movebob, "1.0", "Adjust weapon and movement bobbing",
 					CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 1.0f)
 
+CVAR(				cl_centerbobonfire, "0",
+					"Centers the weapon bobbing when firing a weapon",
+					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 CVAR_RANGE_FUNC_DECL(sv_gravity, "800", "Gravity of the environment",
 					CVARTYPE_WORD, CVAR_ARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE,
 					0.0f, 32768.0f)

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -56,6 +56,7 @@ EXTERN_CVAR(sv_infiniteammo)
 EXTERN_CVAR(sv_freelook)
 EXTERN_CVAR(sv_allowpwo)
 EXTERN_CVAR(co_fineautoaim)
+EXTERN_CVAR(cl_centerbobonfire)
 
 const char *weaponnames[] =
 {
@@ -132,6 +133,11 @@ fixed_t P_CalculateWeaponBobX(player_t* player, float scale_amount)
 		return center_sx + scale_amount * FixedMul(player->bob, finecosine[angle_index]);
 	}
 
+	if (weaponstate == atkstate && cl_centerbobonfire)
+	{
+		return FRACUNIT;
+	}
+
 	// scale the weapon's distance away from center
 	return center_sx + scale_amount * (psp->sx - center_sx);
 }
@@ -161,6 +167,11 @@ fixed_t P_CalculateWeaponBobY(player_t* player, float scale_amount)
 	{
 		unsigned int angle_index = ((128 * level.time) & FINEMASK) & (FINEANGLES / 2 - 1);
 		return center_sy + scale_amount * FixedMul(player->bob, finesine[angle_index]);
+	}
+
+	if (weaponstate == atkstate && cl_centerbobonfire)
+	{
+		return psp->sy;
 	}
 
 	// scale the weapon's distance away from center


### PR DESCRIPTION
This is a simple feature addition that centers the weapon sprite when firing a weapon, to emulate ZDoom 2.x behavior. Helpful for crosshair-less players used to modern ZDoom ports for purposes of aiming.

cl_centerbobonfire off:
https://youtu.be/9Kk-LCMLfyI

cl_centerbobonfire on:
https://youtu.be/hLcQs-Qkg_c

Resolves #731 