### PR TITLE
[BUGFIX] Propagate Line Special Clearing

### DIFF
--- a/common/doomdef.h
+++ b/common/doomdef.h
@@ -335,12 +335,6 @@ enum GameMission_t
 // Texture scrollers operate at a rate of x/64 units per tic.
 #define SCROLL_UNIT 64
 
-struct lineresult_s
-{
-	bool switchchanged;
-	bool lineexecuted;
-};
-
 // Index of the special effects (INVUL inverse) map.
 #define INVERSECOLORMAP 32
 

--- a/common/p_boomfspec.h
+++ b/common/p_boomfspec.h
@@ -28,16 +28,16 @@
 void G_SecretExitLevel(int position, int drawscores);
 void P_DamageMobj(AActor* target, AActor* inflictor, AActor* source, int damage, int mod,
                   int flags);
-lineresult_s P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
+bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
                                           bool bossaction);
 const unsigned int P_TranslateCompatibleLineFlags(const unsigned int flags, const bool reserved);
 void P_ApplyGeneralizedSectorDamage(player_t* player, int bits);
 void P_CollectSecretBoom(sector_t* sector, player_t* player);
 void P_PlayerInCompatibleSector(player_t* player);
 bool P_ActorInCompatibleSector(AActor* actor);
-lineresult_s P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
+bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
                                         bool bossaction);
-lineresult_s P_ShootCompatibleSpecialLine(AActor* thing, line_t* line);
+bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line);
 BOOL EV_DoGenDoor(line_t* line);
 BOOL EV_DoGenFloor(line_t* line);
 BOOL EV_DoGenCeiling(line_t* line);

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -145,7 +145,7 @@ void MapFormat::spawn_extra(int i)
 		P_SpawnCompatibleExtra(i);
 }
 
-lineresult_s MapFormat::cross_special_line(line_t* line, int side, AActor* thing,
+bool MapFormat::cross_special_line(line_t* line, int side, AActor* thing,
                                            bool bossaction)
 {
 	if (map_format.zdoom)

--- a/common/p_mapformat.h
+++ b/common/p_mapformat.h
@@ -43,7 +43,7 @@ class MapFormat
 	void spawn_friction(line_t*);
 	void spawn_pusher(line_t*);
 	void spawn_extra(int);
-	lineresult_s cross_special_line(line_t*, int, AActor*, bool);
+	bool cross_special_line(line_t*, int, AActor*, bool);
 	void post_process_sidedef_special(side_t*, mapsidedef_t*, sector_t*, int);
 	void post_process_linedef_special(line_t* line);
 
@@ -79,9 +79,9 @@ void P_SpawnZDoomExtra(int i);
 void P_RecordCompatibleLineSpecial(line_t* ld, maplinedef_t* mld);
 void P_RecordZDoomLineSpecial(line_t* ld, maplinedef_t* mld);
 
-lineresult_s P_CrossZDoomSpecialLine(line_t* line, int side, AActor* thing,
+bool P_CrossZDoomSpecialLine(line_t* line, int side, AActor* thing,
                                      bool bossaction);
-lineresult_s P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
+bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
                                           bool bossaction);
 
 void P_PostProcessZDoomSidedefSpecial(side_t* sd, mapsidedef_t* msd, sector_t* sec,

--- a/common/p_zdoomhexspec.cpp
+++ b/common/p_zdoomhexspec.cpp
@@ -34,13 +34,9 @@ EXTERN_CVAR(sv_allowexit)
 EXTERN_CVAR(sv_fragexitswitch)
 EXTERN_CVAR(sv_forcewater)
 
-lineresult_s P_CrossZDoomSpecialLine(line_t* line, int side, AActor* thing,
+bool P_CrossZDoomSpecialLine(line_t* line, int side, AActor* thing,
                                      bool bossaction)
 {
-	lineresult_s result;
-	result.lineexecuted = false;
-	result.switchchanged = false;
-
 	// Do not teleport on the wrong side
 	if (side)
 	{
@@ -52,7 +48,7 @@ lineresult_s P_CrossZDoomSpecialLine(line_t* line, int side, AActor* thing,
 		case Teleport_EndGame:
 		case Teleport_NoStop:
 		case Teleport_Line:
-			return result;
+			return false;
 			break;
 		default:
 			break;
@@ -76,19 +72,14 @@ lineresult_s P_CrossZDoomSpecialLine(line_t* line, int side, AActor* thing,
 	{ // [RH] Just a little hack for BOOM compatibility
 		return P_ActivateZDoomLine(line, thing, side, ML_SPAC_MCROSS);
 	}
-	return result;
+	return false;
 }
 
-lineresult_s P_ActivateZDoomLine(line_t* line, AActor* mo, int side,
+bool P_ActivateZDoomLine(line_t* line, AActor* mo, int side,
                                  unsigned int activationType)
 {
 	bool repeat;
 	bool buttonSuccess;
-
-	lineresult_s result;
-
-	result.lineexecuted = false;
-	result.switchchanged = false;
 
 	// Err...
 	// Use the back sides of VERY SPECIAL lines...
@@ -102,22 +93,19 @@ lineresult_s P_ActivateZDoomLine(line_t* line, AActor* mo, int side,
 			break;
 
 		default:
-			return result;
+			return false;
 		}
 	}
 
 	if (!P_TestActivateZDoomLine(line, mo, side, activationType) ||
 	    !P_CanActivateSpecials(mo, line))
 	{
-		return result;
+		return false;
 	}
 
 	buttonSuccess = P_ExecuteZDoomLineSpecial(line->special, line->args, line, side, mo);
 
-	result.switchchanged = buttonSuccess;
-	result.lineexecuted = buttonSuccess;
-
-	return result;
+	return buttonSuccess;
 }
 
 const LineActivationType P_LineActivationTypeForSPACFlag(const unsigned int activationType)

--- a/common/p_zdoomhexspec.h
+++ b/common/p_zdoomhexspec.h
@@ -46,9 +46,9 @@ void P_AddSectorSecret(sector_t* sector);
 void P_SpawnLightFlash(sector_t* sector);
 void P_SpawnStrobeFlash(sector_t* sector, int utics, int ltics, bool inSync);
 void P_SpawnFireFlicker(sector_t* sector);
-lineresult_s P_CrossZDoomSpecialLine(line_t* line, int side, AActor* thing,
+bool P_CrossZDoomSpecialLine(line_t* line, int side, AActor* thing,
                                      bool bossaction);
-lineresult_s P_ActivateZDoomLine(line_t* line, AActor* mo, int side,
+bool P_ActivateZDoomLine(line_t* line, AActor* mo, int side,
                                  unsigned int activationType);
 void P_CollectSecretZDoom(sector_t* sector, player_t* player);
 bool P_TestActivateZDoomLine(line_t* line, AActor* mo, int side,


### PR DESCRIPTION
In Odamex, specials are cleared by the server and sent to clients primarily thru the `P_UpdateButtons(client_t*)` (on connect) and `SVC_Switch(line_t&, uint32_t, uint32_t)` (on demand) functions. This acts upon the `wastoggled` property of `line_t` to see if a linedef was triggered. The nomenclature is confusing, because you'd think only switches would be applicable here, but here it, in fact, updates all linedefs, and only applies switch logic to it if the texture is a switch.

This fixes the DOOM II MAP20 blue switch offline and online (line special wasn't cleared on the D1 immediately before the switch). This was fixed offline by removing logic for changed switches, as that logic isn't necessary as downstream logic will only apply switch logic to actual switch textures.

This also fixes DOOM II MAP27 online, when lowering the cyberdemon and spider mastermind, a 2nd player could come in and also lower the cyberdemon and spider mastermind to the floor, a map bug. This fixes that. Also fixed, are the cleared line specials sent to the client upon connect. Before, one time switches and such could be activated a 2nd time by a client if they were to reconnect. This is fixed.