### PR TITLE
[BUGFIX] Clear secrets on clients when discovered by players other than the consoleplayer.

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1941,7 +1941,12 @@ static void CL_SecretEvent(const odaproto::svc::SecretEvent* msg)
 		return;
 
 	sector_t* sector = &::sectors[sectornum];
-	sector->special = special;
+	sector->flags &= ~SECF_SECRET;
+	sector->secretsector = false;
+
+	if (!map_format.getZDoom())
+		if (sector->special < 32)
+			sector->special = 0;
 
 	// Don't show other secrets if requested
 	if (!::hud_revealsecrets || ::hud_revealsecrets > 2)


### PR DESCRIPTION
Does what it says on the tin. MapFormat changed the secret format to closely resemble Boom, but these changes weren't carried over when parsed by a client from a message by the server. This fixes that.