### PR TITLE
[BUGFIX] Fix "fast" scrollers

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2211,6 +2211,13 @@ static void CL_ResetMap(const odaproto::svc::ResetMap* msg)
 
 	P_DestroyButtonThinkers();
 
+	// Destroy scrollers
+	DScroller* scroller;
+	TThinkerIterator<DScroller> siterator;
+
+	while ((scroller = siterator.Next()))
+		scroller->Destroy();
+
 	// You don't get to keep cards.  This isn't communicated anywhere else.
 	if (sv_gametype == GM_COOP)
 		P_ClearPlayerCards(consoleplayer());

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2541,7 +2541,7 @@ static void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 		if (scrollType != DScroller::sc_side && affectee > ::numsectors)
 			break;
 		// remove null checks after 11 is released
-		if (!control || control < 0)
+		if (control < 0)
 			control = -1;
 		if (!accel || accel < 0)
 			accel = 0;


### PR DESCRIPTION
This is a simple fix to scrollers. Before, scrollers would spawn 2 scrollers on the map if the map underwent a soft map reset, such as when maps count down to play time (ala Survival). Demo shown as an example, on SUNLUST.WAD MAP01 as a demonstration.

Odamex 10.2 RC2 (Old build)
https://youtu.be/p1MBoMyTA-I

Odamex 10.2 Stable (This patch)
https://youtu.be/uAR-mWr9SiY