### PR TITLE
[BUGFIX] Fix random bad lighting glow that would sometimes happen on soft map reset

### DIFF
--- a/common/p_lnspec.h
+++ b/common/p_lnspec.h
@@ -532,6 +532,8 @@ BOOL EV_CompatibleTeleport(int tag, line_t* line, int side, AActor* thing, int f
 bool P_LineSpecialMovesSector(short special);
 bool P_CanActivateSpecials(AActor* mo, line_t* line);
 bool P_ActorInSpecialSector(AActor* actor);
+void P_DestroyScrollerThinkers();
+void P_DestroyLightThinkers();
 
 int P_FindLineFromLineTag(const line_t* line, int start);
 int P_IsUnderDamage(const AActor* actor);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -97,6 +97,8 @@ line_t* 		lines;
 int 			numsides;
 side_t* 		sides;
 
+int*			originalLightLevels; // Needed for map resets
+
 // [RH] Set true if the map contains a BEHAVIOR lump
 bool			HasBehavior = false;
 
@@ -306,6 +308,8 @@ void P_LoadSectors (int lump)
 
 	numsectors = W_LumpLength (lump) / sizeof(mapsector_t);
 
+	originalLightLevels = new int[numsectors];
+
 	// denis - properly construct sectors so that smart pointers they contain don't get screwed
 	sectors = new sector_t[numsectors];
 	memset(sectors, 0, sizeof(sector_t)*numsectors);
@@ -326,6 +330,7 @@ void P_LoadSectors (int lump)
 		ss->floorpic = (short)R_FlatNumForName(ms->floorpic);
 		ss->ceilingpic = (short)R_FlatNumForName(ms->ceilingpic);
 		ss->lightlevel = LESHORT(ms->lightlevel);
+		originalLightLevels[i] = LESHORT(ms->lightlevel);
 		ss->special = LESHORT(ms->special);
 		ss->secretsector = !!(ss->special&SECRET_MASK);
 		ss->tag = LESHORT(ms->tag);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -97,7 +97,7 @@ line_t* 		lines;
 int 			numsides;
 side_t* 		sides;
 
-int*			originalLightLevels; // Needed for map resets
+std::vector<int>originalLightLevels; // Needed for map resets
 
 // [RH] Set true if the map contains a BEHAVIOR lump
 bool			HasBehavior = false;
@@ -305,10 +305,9 @@ void P_LoadSectors (int lump)
 
 	// denis - properly destroy sectors so that smart pointers they contain don't get screwed
 	delete[] sectors;
+	originalLightLevels.clear();
 
 	numsectors = W_LumpLength (lump) / sizeof(mapsector_t);
-
-	originalLightLevels = new int[numsectors];
 
 	// denis - properly construct sectors so that smart pointers they contain don't get screwed
 	sectors = new sector_t[numsectors];
@@ -330,7 +329,7 @@ void P_LoadSectors (int lump)
 		ss->floorpic = (short)R_FlatNumForName(ms->floorpic);
 		ss->ceilingpic = (short)R_FlatNumForName(ms->ceilingpic);
 		ss->lightlevel = LESHORT(ms->lightlevel);
-		originalLightLevels[i] = LESHORT(ms->lightlevel);
+		originalLightLevels.push_back(LESHORT(ms->lightlevel));
 		ss->special = LESHORT(ms->special);
 		ss->secretsector = !!(ss->special&SECRET_MASK);
 		ss->tag = LESHORT(ms->tag);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -97,7 +97,7 @@ line_t* 		lines;
 int 			numsides;
 side_t* 		sides;
 
-std::vector<int>originalLightLevels; // Needed for map resets
+std::vector<int>	originalLightLevels; // Needed for map resets
 
 // [RH] Set true if the map contains a BEHAVIOR lump
 bool			HasBehavior = false;

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2342,6 +2342,68 @@ void P_ClearNonGeneralizedSectorSpecial(sector_t* sector)
 	sector->special &= map_format.getGeneralizedMask();
 }
 
+void P_DestroyScrollerThinkers()
+{
+	// Destroy scrollers
+	DScroller* scroller;
+	TThinkerIterator<DScroller> siterator;
+
+	while ((scroller = siterator.Next()))
+		scroller->Destroy();
+}
+
+void P_DestroyLightThinkers()
+{
+	// Destroy fireflicker
+	DFireFlicker* fireflicker;
+	TThinkerIterator<DFireFlicker> ffliterator;
+
+	while ((fireflicker = ffliterator.Next()))
+		fireflicker->Destroy();
+
+	// Destroy flicker
+	DFlicker* flicker;
+	TThinkerIterator<DFlicker> fliterator;
+
+	while ((flicker = fliterator.Next()))
+		flicker->Destroy();
+
+	// Destroy lightflash
+	DLightFlash* flash;
+	TThinkerIterator<DLightFlash> flashiterator;
+
+	while ((flash = flashiterator.Next()))
+		flash->Destroy();
+
+	// Destroy strobe
+	DStrobe* strobe;
+	TThinkerIterator<DStrobe> strobeiterator;
+
+	while ((strobe = strobeiterator.Next()))
+		strobe->Destroy();
+
+	// Destroy glow
+	DGlow* glow;
+	TThinkerIterator<DGlow> glowiterator;
+
+	while ((glow = glowiterator.Next()))
+		glow->Destroy();
+
+	// Destroy glow2
+	DGlow2* glow2;
+	TThinkerIterator<DGlow2> glow2iterator;
+
+	while ((glow2 = glow2iterator.Next()))
+		glow2->Destroy();
+
+	// Destroy phased
+	DPhased* phased;
+	TThinkerIterator<DPhased> phasediterator;
+
+	while ((phased = phasediterator.Next()))
+		phased->Destroy();
+}
+
 void P_SpawnPhasedLight(sector_t* sector, int base, int index)
 {
 	int i, b;

--- a/common/r_state.h
+++ b/common/r_state.h
@@ -86,6 +86,8 @@ extern line_t*			lines;
 extern int				numsides;
 extern side_t*			sides;
 
+extern int*				originalLightLevels;
+
 inline FArchive &operator<< (FArchive &arc, sector_t *sec)
 {
 	if (sec)

--- a/common/r_state.h
+++ b/common/r_state.h
@@ -86,7 +86,7 @@ extern line_t*			lines;
 extern int				numsides;
 extern side_t*			sides;
 
-extern int*				originalLightLevels;
+extern std::vector<int> originalLightLevels;
 
 inline FArchive &operator<< (FArchive &arc, sector_t *sec)
 {

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1443,12 +1443,12 @@ odaproto::svc::ThinkerUpdate SVC_ThinkerUpdate(DThinker* thinker)
 	else if (thinker->IsA(RUNTIME_CLASS(DGlow2)))
 	{
 		DGlow2* glow2 = static_cast<DGlow2*>(thinker);
-		odaproto::svc::ThinkerUpdate_Glow2* gmsg = msg.mutable_glow2();
-		gmsg->set_sector(glow2->GetSector() - sectors);
-		gmsg->set_start(glow2->GetStart());
-		gmsg->set_end(glow2->GetEnd());
-		gmsg->set_max_tics(glow2->GetMaxTics());
-		gmsg->set_one_shot(glow2->GetOneShot());
+		odaproto::svc::ThinkerUpdate_Glow2* g2msg = msg.mutable_glow2();
+		g2msg->set_sector(glow2->GetSector() - sectors);
+		g2msg->set_start(glow2->GetStart());
+		g2msg->set_end(glow2->GetEnd());
+		g2msg->set_max_tics(glow2->GetMaxTics());
+		g2msg->set_one_shot(glow2->GetOneShot());
 	}
 	else if (thinker->IsA(RUNTIME_CLASS(DPhased)))
 	{


### PR DESCRIPTION
I was afraid I would have to do this when I did the scroller fix, as lighting glow is transmitted the same way and has the same issues.

The reason why lighting glow would sometimes mess up (Odahorde map01 is a good example) online, was on map reset -- The map would 1.) not clear the previous thinkers, which wasn't a big deal for glow things as it just uses a sector as input, but the big deal was 2.) original light levels are not restored, even if the Glow thinker is destroyed, so when the thinker is created, it takes the minimum light level of an already in-progress glow, which can only be lower than the original light level.

This problem becomes very evident on SUNLUST MAP01, which has glow lights prominently on the first spawn. After a few failed attempts, the lights eventually stop glowing.

This is fixed by 1.) destroying light thinkers on map reset and 2.) restoring the original light level of every sector on map reset.

Also, I've re-added the null check for scroller control sectors. This has the side effect of not allowing sector 0 as a control sector, but I figure the alternative is that 10.2 clients simply won't scroll when playing on 10.1 servers, so the devil you know...