### PR TITLE
[BUGFIX] Send line specials activated via ACS through the proper logic path

### DIFF
--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -1825,10 +1825,9 @@ void DLevelScript::SetLineSpecial(int lineid, int special, int arg1, int arg2, i
 void DLevelScript::ActivateLineSpecial(byte special, line_t* line, AActor* activator,
                                        int arg0, int arg1, int arg2, int arg3, int arg4)
 {
-	LineSpecials[special](line, activator, arg0, arg1, arg2, arg3, arg4);
-
 	if (serverside)
 	{
+		LineSpecials[special](line, activator, arg0, arg1, arg2, arg3, arg4);
 		SERVER_ONLY(SV_SendExecuteLineSpecial(special, line, activator, arg0, arg1, arg2,
 		                                      arg3, arg4));
 	}


### PR DESCRIPTION
This was a bug discovered during Hordamex testing. Map36 has a bug where scrollers created via an Enter script would run at light speed because it was being applied twice. Map45 has an issue with a perpetual lift created via infinite looping ENTER script. The lift will shoot above where it's supposed to because it runs both clientside and serverside.

This fix ensures ENTER scripts happen on the server first, and then are propagated to clients via SV_ExecuteLineSpecial to ensure things run at the proper time, and don't run twice. LS_ACS_Execute already ensures it only runs on servers (and is only executed on line executions), but no check existed for OPEN/ENTER scripts.