### PR TITLE
[BUGFIX] Fix MacOS build workflow

### DIFF
--- a/ci/macos-buildgen.sh
+++ b/ci/macos-buildgen.sh
@@ -8,7 +8,9 @@ IFS=$'\n\t'
 set -x
 
 # Install packages
-brew install sdl2 sdl2_mixer wxmac
+# Ensure to install sdl 2.0.22, as Homebrew latest is 2.24.0
+curl https://raw.githubusercontent.com/Homebrew/homebrew-core/3a9d188a695a38244c42e68117aff412ae0884eb/Formula/sdl2.rb > $(find $(brew --repository) -name sdl2.rb) && brew install sdl2
+brew install sdl2_mixer wxmac
 
 # Generate build
 mkdir -p build && cd build


### PR DESCRIPTION
When testing builds on my local fork, I noticed macOS builds failing. This is because Homebrew has updated SDL to 2.24.0, which causes compiling issues with Odamex currently (https://formulae.brew.sh/api/formula/sdl2.json).

This is fixed by using a (hacky) way to ensure 2.0.22 is used for Odamex builds.