### PR TITLE
[BUGFIX] Fix up more vanilla demos

### DIFF
--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -961,7 +961,7 @@ BOOL EV_DoFloor (DFloor::EFloor floortype, line_t *line, int tag,
 
 manual_floor:
 		// ALREADY MOVING?	IF SO, KEEP GOING...
-		if (sec->floordata)
+		if (sec->floordata || (demoplayback && sec->ceilingdata))
 		{
 			if (co_boomphys && manual)
 				return false;

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3060,7 +3060,7 @@ void P_RadiusAttack(AActor *spot, AActor *source, int damage, int distance,
 	bombmod = mod;
 
 	// [Blair] Prevent crash from barrels hit by crushers
-	if (bombsource == NULL && bombspot != NULL)
+	if (!demoplayback && bombsource == NULL && bombspot != NULL)
 	{
 		bombsource = bombspot;
 	}
@@ -3170,7 +3170,7 @@ BOOL PIT_ChangeSector (AActor *thing)
 
 	nofit = true;
 
-	if (crushchange > NO_CRUSH && !(level.time&3) )
+	if (crushchange > 0 && !(level.time&3) )
 	{
 		P_DamageMobj(thing, NULL, NULL, crushchange, MOD_CRUSH);
 


### PR DESCRIPTION
3 things were causing vanilla demos to fail in OdaTests:

1. Null bombspot crash prevention was interfering with vanilla compatibility (when barrels would hit other barrels and hit a monster, eg TNT.WAD DEMO2).
2. Monsters in a trap that has 0 height until the trap is sprung will squirt blood like a stuck pig. This will cycle P_Random 4 times a tic, which would shred any sort of vanilla demo when that happens.
3. Floor thinkers were being created for vanilla demos when ceiling thinkers existed, causing desyncs in icarus.wad demo2 and av.wad demo2. This caused linedef 40 to only move the ceiling on the first run of a w1 line, and only when it stops moving will it allow a w1/wr line to move the floor.

This, combined with the bossaction fix, brings our compatible demo level in Odatests from 70 demos to 77 demos, and all the IWAD demos are working once again.