### PR TITLE
In P_LookForPlayers, don't assume an actor has a subsector

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -677,7 +677,7 @@ void P_NewChaseDir (AActor *actor)
 bool P_LookForPlayers(AActor *actor, bool allaround)
 {
 	// [AM] Check subsectors first.
-	if (actor->subsector == nullptr)
+	if (actor->subsector == NULL)
 		return false;
 
 	sector_t* sector = actor->subsector->sector;

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -676,8 +676,11 @@ void P_NewChaseDir (AActor *actor)
 //
 bool P_LookForPlayers(AActor *actor, bool allaround)
 {
-	sector_t* sector = actor->subsector->sector;
+	// [AM] Check subsectors first.
+	if (actor->subsector == nullptr)
+		return false;
 
+	sector_t* sector = actor->subsector->sector;
 	if (!sector)
 		return false;
 


### PR DESCRIPTION
Almost all of the #767 dumps pointed to this line of code.

```c++
	sector_t* sector = actor->subsector->sector;
	if (!sector)
		return false;
```

If subsector is a null peter, a crash happens.

It does raise the question of why the actor isn't linked into any subsector, especially when the code suggests that it should be, but more safety checks aren't a bad thing.