### PR TITLE
Relax SDL2 minor version checking

### DIFF
--- a/ci/macos-buildgen.sh
+++ b/ci/macos-buildgen.sh
@@ -8,9 +8,7 @@ IFS=$'\n\t'
 set -x
 
 # Install packages
-# Ensure to install sdl 2.0.22, as Homebrew latest is 2.24.0
-curl https://raw.githubusercontent.com/Homebrew/homebrew-core/3a9d188a695a38244c42e68117aff412ae0884eb/Formula/sdl2.rb > $(find $(brew --repository) -name sdl2.rb) && brew install sdl2
-brew install sdl2_mixer wxmac
+brew install sdl2 sdl2_mixer wxmac
 
 # Generate build
 mkdir -p build && cd build

--- a/client/sdl/i_sdl.h
+++ b/client/sdl/i_sdl.h
@@ -25,7 +25,7 @@
 
 #include <SDL.h>
 
-#if (SDL_MAJOR_VERSION == 2 && SDL_MINOR_VERSION == 0)
+#if (SDL_MAJOR_VERSION == 2)
 	#define SDL20
 #elif (SDL_MAJOR_VERSION == 1 && SDL_MINOR_VERSION == 2)
 	#define SDL12

--- a/libraries/textscreen/txt_sdl.h
+++ b/libraries/textscreen/txt_sdl.h
@@ -23,7 +23,7 @@
 
 #include "SDL.h"
 
-#if (SDL_MAJOR_VERSION == 2 && SDL_MINOR_VERSION == 0)
+#if (SDL_MAJOR_VERSION == 2)
 	#define SDL20
 #elif (SDL_MAJOR_VERSION == 1 && SDL_MINOR_VERSION == 2)
 	#define SDL12


### PR DESCRIPTION
With the change in the sdl2 version numbering scheme, minor version changes no longer imply an break in backwards compatibility. This relaxes the sdl version check, and reverts the changes to the macOS workflow now that they aren't need.