### PR TITLE
Send flags with "Server Full" message

### DIFF
--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1765,8 +1765,13 @@ void SV_ConnectClient()
 		Printf("%s disconnected (server full).\n", NET_AdrToString (net_from));
 
 		static buf_t smallbuf(1024);
-		MSG_WriteLong(&smallbuf, 0);
-		MSG_WriteSVC(&smallbuf, SVC_Disconnect("Server is full\n"));
+		if (smallbuf.size() == 0)
+		{
+			MSG_WriteLong(&smallbuf, 0); // First packet.
+			MSG_WriteByte(&smallbuf, 0); // No flags.
+			MSG_WriteSVC(&smallbuf, SVC_Disconnect("Server is full\n"));
+		}
+
 		NET_SendPacket(smallbuf, net_from);
 		return;
 	}


### PR DESCRIPTION
The previous "Server Full" message had not been updated to send flags with the rest of the header.

Fixes #765.