### PR TITLE
Get rid of "On" flag for status bar items

### DIFF
--- a/client/src/st_lib.cpp
+++ b/client/src/st_lib.cpp
@@ -79,15 +79,14 @@ void StatusBarWidget_Base::drawPatch(int x, int y, const patch_t* p)
 	}
 }
 
-void StatusBarWidgetNumber::init(int x_, int y_, lumpHandle_t* pl, int* num_, bool* on_,
-                       int maxdigits_)
+void StatusBarWidgetNumber::init(int x_, int y_, lumpHandle_t* pl, int* num_,
+                                 int maxdigits_)
 {
 	m_x = x_;
 	m_y = y_;
 	oldnum = 0;
 	maxdigits = maxdigits_;
 	num = num_;
-	on = on_;
 	p = pl;
 }
 
@@ -100,11 +99,11 @@ void StatusBarWidgetNumber::init(int x_, int y_, lumpHandle_t* pl, int* num_, bo
 void StatusBarWidgetNumber::update(bool force_refresh, bool cleararea)
 {
 	// [jsd]: prevent null references as hard as possible
-	if (num == NULL || on == NULL || p == NULL)
+	if (num == NULL || p == NULL)
 		return;
 
 	// only draw if the number is different or refresh is forced
-	if (!(force_refresh || oldnum != *num) || !*on)
+	if (!(force_refresh || oldnum != *num))
 		return;
 
 	int number = *num;
@@ -154,34 +153,33 @@ void StatusBarWidgetNumber::update(bool force_refresh, bool cleararea)
 		drawPatch(drawx - 8, m_y, W_ResolvePatchHandle(negminus));
 }
 
-void StatusBarWidgetPercent::init(int x, int y, lumpHandle_t* pl, int* num, bool* on,
-                        lumpHandle_t percent_patch)
+void StatusBarWidgetPercent::init(int x, int y, lumpHandle_t* pl, int* num,
+                                  lumpHandle_t percent_patch)
 {
-	StatusBarWidgetNumber::init(x, y, pl, num, on, 3);
+	StatusBarWidgetNumber::init(x, y, pl, num, 3);
 	m_percentLump = percent_patch;
 }
 
 void StatusBarWidgetPercent::update(bool force_refresh)
 {
-	if (force_refresh && *on)
+	if (force_refresh)
 		drawPatch(getX(), getY(), W_ResolvePatchHandle(m_percentLump));
 
 	StatusBarWidgetNumber::update(force_refresh);
 }
 
-void StatusBarWidgetMultiIcon::init(int x_, int y_, lumpHandle_t* il, int* inum_, bool* on_)
+void StatusBarWidgetMultiIcon::init(int x_, int y_, lumpHandle_t* il, int* inum_)
 {
 	m_x = x_;
 	m_y = y_;
 	oldinum = -1;
 	inum = inum_;
-	on = on_;
 	p = il;
 }
 
 void StatusBarWidgetMultiIcon::update(bool force_refresh)
 {
-	if (on && (force_refresh || oldinum != *inum) && (*inum != -1))
+	if ((force_refresh || oldinum != *inum) && (*inum != -1))
 	{
 		// clear the background area
 		if (oldinum != -1)

--- a/client/src/st_lib.h
+++ b/client/src/st_lib.h
@@ -74,15 +74,11 @@ class StatusBarWidgetNumber : StatusBarWidget_Base
 	// pointer to current value
 	int* num;
 
-	// pointer to bool stating
-	//	whether to update number
-	bool* on;
-
 	// list of patches for 0-9
 	lumpHandle_t* p;
 
 	// Number widget routines
-	void init(int x, int y, lumpHandle_t* pl, int* num, bool* on, int maxdigits);
+	void init(int x, int y, lumpHandle_t* pl, int* num, int maxdigits);
 
 	void update(bool refresh, bool cleararea = true);
 };
@@ -96,7 +92,7 @@ class StatusBarWidgetPercent : StatusBarWidgetNumber
 
   public:
 	// Percent widget routines
-	void init(int x, int y, lumpHandle_t* pl, int* num, bool* on, lumpHandle_t percent);
+	void init(int x, int y, lumpHandle_t* pl, int* num, lumpHandle_t percent);
 
 	void update(bool refresh);
 };
@@ -115,15 +111,11 @@ class StatusBarWidgetMultiIcon : StatusBarWidget_Base
 	// pointer to current icon
 	int* inum;
 
-	// pointer to bool stating
-	//	whether to update icon
-	bool* on;
-
 	// list of icons
 	lumpHandle_t* p;
 
 	// Multiple Icon widget routines
-	void init(int x, int y, lumpHandle_t* il, int* inum, bool* on);
+	void init(int x, int y, lumpHandle_t* il, int* inum);
 
 	void update(bool refresh);
 };

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -270,12 +270,6 @@ static bool st_oldchat;
 // whether chat window has the cursor on
 static bool st_cursoron;
 
-// !deathmatch && st_statusbaron
-static bool st_armson;
-
-// !deathmatch
-static bool st_fragson;
-
 // main bar left
 static lumpHandle_t sbar;
 
@@ -917,12 +911,6 @@ void ST_updateWidgets()
 	// refresh everything if this is him coming back to life
 	ST_updateFaceWidget();
 
-	// used by w_arms[] widgets
-	st_armson = st_statusbaron && G_IsCoopGame();
-
-	// used by w_frags widget
-	st_fragson = !G_IsCoopGame() && st_statusbaron;
-
 	//	[Toke - CTF]
 	if (sv_gametype == GM_CTF)
 		st_fragscount = GetTeamInfo(plyr->userinfo.team)->Points; // denis - todo - scoring for ctf
@@ -951,12 +939,6 @@ void ST_Ticker()
 
 void ST_drawWidgets(bool force_refresh)
 {
-	// used by w_arms[] widgets
-	st_armson = G_IsCoopGame() && st_statusbaron;
-
-	// used by w_frags widget
-	st_fragson = !G_IsCoopGame() && st_statusbaron;
-
 	w_ready.update(force_refresh);
 
 	for (int i = 0; i < 4; i++)
@@ -968,15 +950,25 @@ void ST_drawWidgets(bool force_refresh)
 	w_health.update(force_refresh);
 	w_armor.update(force_refresh);
 
-	for (int i = 0; i < 6; i++)
-		w_arms[i].update(force_refresh);
+	if (G_IsCoopGame())
+	{
+		for (int i = 0; i < 6; i++)
+		{
+			w_arms[i].update(force_refresh);
+		}
+	}
 
 	w_faces.update(force_refresh);
 
 	for (int i = 0; i < 3; i++)
+	{
 		w_keyboxes[i].update(force_refresh);
+	}
 
-	w_frags.update(force_refresh);
+	if (!G_IsCoopGame())
+	{
+		w_frags.update(force_refresh);
+	}
 
 	w_lives.update(true, G_IsLivesGame()); // Force refreshing to avoid tens
 	                                       // to be hidden by Doomguy's face
@@ -1260,64 +1252,51 @@ static void ST_unloadData()
 void ST_createWidgets()
 {
 	// ready weapon ammo
-	w_ready.init(ST_AMMOX, ST_AMMOY, tallnum, &st_current_ammo, &st_statusbaron,
-	             ST_AMMOWIDTH);
+	w_ready.init(ST_AMMOX, ST_AMMOY, tallnum, &st_current_ammo, ST_AMMOWIDTH);
 
 	// health percentage
-	w_health.init(ST_HEALTHX, ST_HEALTHY, tallnum, &st_health, &st_statusbaron,
-	              tallpercent);
+	w_health.init(ST_HEALTHX, ST_HEALTHY, tallnum, &st_health, tallpercent);
 
 	// weapons owned
 	for (int i = 0; i < 6; i++)
 	{
 		w_arms[i].init(ST_ARMSX + (i % 3) * ST_ARMSXSPACE,
-		               ST_ARMSY + (i / 3) * ST_ARMSYSPACE, arms[i], &st_weaponowned[i],
-		               &st_armson);
+		               ST_ARMSY + (i / 3) * ST_ARMSYSPACE, arms[i], &st_weaponowned[i]);
 	}
 
 	// frags sum
-	w_frags.init(ST_FRAGSX, ST_FRAGSY, tallnum, &st_fragscount, &st_fragson,
+	w_frags.init(ST_FRAGSX, ST_FRAGSY, tallnum, &st_fragscount,
 	             ST_FRAGSWIDTH);
 
 	// faces
-	w_faces.init(ST_FACESX, ST_FACESY, faces, &st_faceindex, &st_statusbaron);
+	w_faces.init(ST_FACESX, ST_FACESY, faces, &st_faceindex);
 
 	// armor percentage - should be colored later
-	w_armor.init(ST_ARMORX, ST_ARMORY, tallnum, &st_armor, &st_statusbaron, tallpercent);
+	w_armor.init(ST_ARMORX, ST_ARMORY, tallnum, &st_armor, tallpercent);
 
 	// keyboxes 0-2
-	w_keyboxes[0].init(ST_KEY0X, ST_KEY0Y, keys, &keyboxes[0], &st_statusbaron);
-	w_keyboxes[1].init(ST_KEY1X, ST_KEY1Y, keys, &keyboxes[1], &st_statusbaron);
-	w_keyboxes[2].init(ST_KEY2X, ST_KEY2Y, keys, &keyboxes[2], &st_statusbaron);
+	w_keyboxes[0].init(ST_KEY0X, ST_KEY0Y, keys, &keyboxes[0]);
+	w_keyboxes[1].init(ST_KEY1X, ST_KEY1Y, keys, &keyboxes[1]);
+	w_keyboxes[2].init(ST_KEY2X, ST_KEY2Y, keys, &keyboxes[2]);
 
 	// ammo count (all four kinds)
-	w_ammo[0].init(ST_AMMO0X, ST_AMMO0Y, shortnum, &st_ammo[0], &st_statusbaron,
-	               ST_AMMO0WIDTH);
-
-	w_ammo[1].init(ST_AMMO1X, ST_AMMO1Y, shortnum, &st_ammo[1], &st_statusbaron,
-	               ST_AMMO1WIDTH);
-
-	w_ammo[2].init(ST_AMMO2X, ST_AMMO2Y, shortnum, &st_ammo[2], &st_statusbaron,
-	               ST_AMMO2WIDTH);
-
-	w_ammo[3].init(ST_AMMO3X, ST_AMMO3Y, shortnum, &st_ammo[3], &st_statusbaron,
-	               ST_AMMO3WIDTH);
+	w_ammo[0].init(ST_AMMO0X, ST_AMMO0Y, shortnum, &st_ammo[0], ST_AMMO0WIDTH);
+	w_ammo[1].init(ST_AMMO1X, ST_AMMO1Y, shortnum, &st_ammo[1], ST_AMMO1WIDTH);
+	w_ammo[2].init(ST_AMMO2X, ST_AMMO2Y, shortnum, &st_ammo[2], ST_AMMO2WIDTH);
+	w_ammo[3].init(ST_AMMO3X, ST_AMMO3Y, shortnum, &st_ammo[3], ST_AMMO3WIDTH);
 
 	// max ammo count (all four kinds)
 	w_maxammo[0].init(ST_MAXAMMO0X, ST_MAXAMMO0Y, shortnum, &st_maxammo[0],
-	                  &st_statusbaron, ST_MAXAMMO0WIDTH);
-
+	                  ST_MAXAMMO0WIDTH);
 	w_maxammo[1].init(ST_MAXAMMO1X, ST_MAXAMMO1Y, shortnum, &st_maxammo[1],
-	                  &st_statusbaron, ST_MAXAMMO1WIDTH);
-
+	                  ST_MAXAMMO1WIDTH);
 	w_maxammo[2].init(ST_MAXAMMO2X, ST_MAXAMMO2Y, shortnum, &st_maxammo[2],
-	                  &st_statusbaron, ST_MAXAMMO2WIDTH);
-
+	                  ST_MAXAMMO2WIDTH);
 	w_maxammo[3].init(ST_MAXAMMO3X, ST_MAXAMMO3Y, shortnum, &st_maxammo[3],
-	                  &st_statusbaron, ST_MAXAMMO3WIDTH);
+	                  ST_MAXAMMO3WIDTH);
 
 	// Number of lives (not always rendered)
-	w_lives.init(ST_FX + 34, ST_FY + 25, shortnum, &st_lives, &st_statusbaron, 2);
+	w_lives.init(ST_FX + 34, ST_FY + 25, shortnum, &st_lives, 2);
 }
 
 void ST_Start()


### PR DESCRIPTION
While debugging #773 I rediscovered that status bar code points to a boolean "on" flag by reference.  This only serves to complicate and confuse things, so I removed the flag completely and now the decision of rendering the status bar is made at the update site.