### PR TITLE
[BUGFIX] Properly handle compat flags in MAPINFO

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1547,12 +1547,12 @@ struct MapInfoDataSetter<level_pwad_info_t>
 		       &ref.exitpic) // todo: add intermission script support
 		ENTRY2("interpic", &MIType_EatNext)
 		ENTRY2("translator", &MIType_EatNext)
-		ENTRY3("compat_shorttex", &MIType_CompatFlag, &ref.flags) // todo: not implemented - MIType_CompatFlag
-		ENTRY3("compat_limitpain", &MIType_CompatFlag, &ref.flags) // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_shorttex", &MIType_CompatFlag, &ref.flags) // todo: not implemented
+		ENTRY3("compat_limitpain", &MIType_CompatFlag, &ref.flags) // todo: not implemented
 		ENTRY4("compat_dropoff", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_DROPOFF)
-		ENTRY3("compat_trace", &MIType_CompatFlag, &ref.flags)    // todo: not implemented - MIType_CompatFlag
-		ENTRY3("compat_boomscroll", &MIType_CompatFlag, &ref.flags) // todo: not implemented - MIType_CompatFlag
-		ENTRY3("compat_sectorsounds", &MIType_CompatFlag, &ref.flags) // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_trace", &MIType_CompatFlag, &ref.flags) // todo: not implemented
+		ENTRY3("compat_boomscroll", &MIType_CompatFlag, &ref.flags) // todo: not implemented
+		ENTRY3("compat_sectorsounds", &MIType_CompatFlag, &ref.flags) // todo: not implemented
 		ENTRY4("compat_nopassover", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_NOPASSOVER)
 	}
 };

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1021,10 +1021,7 @@ void MIType_CompatFlag(OScanner& os, bool doEquals, void* data, unsigned int fla
 		else
 		{
 			os.unScan();
-			if (os.getTokenInt())
-				*static_cast<DWORD*>(data) |= flags;
-			else
-				*static_cast<DWORD*>(data) &= ~flags;
+		  *static_cast<DWORD*>(data) |= flags;
 		}
 	}
 	else
@@ -1550,12 +1547,12 @@ struct MapInfoDataSetter<level_pwad_info_t>
 		       &ref.exitpic) // todo: add intermission script support
 		ENTRY2("interpic", &MIType_EatNext)
 		ENTRY2("translator", &MIType_EatNext)
-		ENTRY3("compat_shorttex", &MIType_DoNothing, &ref.flags) // todo: not implemented - MIType_CompatFlag
-		ENTRY3("compat_limitpain", &MIType_DoNothing, &ref.flags) // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_shorttex", &MIType_CompatFlag, &ref.flags) // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_limitpain", &MIType_CompatFlag, &ref.flags) // todo: not implemented - MIType_CompatFlag
 		ENTRY4("compat_dropoff", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_DROPOFF)
-		ENTRY3("compat_trace", &MIType_DoNothing, &ref.flags)    // todo: not implemented - MIType_CompatFlag
-		ENTRY3("compat_boomscroll", &MIType_DoNothing, &ref.flags) // todo: not implemented - MIType_CompatFlag
-		ENTRY3("compat_sectorsounds", &MIType_DoNothing, &ref.flags) // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_trace", &MIType_CompatFlag, &ref.flags)    // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_boomscroll", &MIType_CompatFlag, &ref.flags) // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_sectorsounds", &MIType_CompatFlag, &ref.flags) // todo: not implemented - MIType_CompatFlag
 		ENTRY4("compat_nopassover", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_NOPASSOVER)
 	}
 };

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1550,12 +1550,12 @@ struct MapInfoDataSetter<level_pwad_info_t>
 		       &ref.exitpic) // todo: add intermission script support
 		ENTRY2("interpic", &MIType_EatNext)
 		ENTRY2("translator", &MIType_EatNext)
-		ENTRY3("compat_shorttex", &MIType_CompatFlag, &ref.flags) // todo: not implemented
-		ENTRY3("compat_limitpain", &MIType_CompatFlag, &ref.flags) // todo: not implemented
+		ENTRY3("compat_shorttex", &MIType_DoNothing, &ref.flags) // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_limitpain", &MIType_DoNothing, &ref.flags) // todo: not implemented - MIType_CompatFlag
 		ENTRY4("compat_dropoff", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_DROPOFF)
-		ENTRY3("compat_trace", &MIType_CompatFlag, &ref.flags) // todo: not implemented
-		ENTRY3("compat_boomscroll", &MIType_CompatFlag, &ref.flags) // todo: not implemented
-		ENTRY3("compat_sectorsounds", &MIType_CompatFlag, &ref.flags) // todo: not implemented
+		ENTRY3("compat_trace", &MIType_DoNothing, &ref.flags)    // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_boomscroll", &MIType_DoNothing, &ref.flags) // todo: not implemented - MIType_CompatFlag
+		ENTRY3("compat_sectorsounds", &MIType_DoNothing, &ref.flags) // todo: not implemented - MIType_CompatFlag
 		ENTRY4("compat_nopassover", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_NOPASSOVER)
 	}
 };

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1021,7 +1021,7 @@ void MIType_CompatFlag(OScanner& os, bool doEquals, void* data, unsigned int fla
 		else
 		{
 			os.unScan();
-		  *static_cast<DWORD*>(data) |= flags;
+			*static_cast<DWORD*>(data) |= flags;
 		}
 	}
 	else


### PR DESCRIPTION
In EPIC2.WAD, there's a ZMAPINFO with a property called "compat_trace." We don't implement this currently, but the stub for it failed because our MAPINFO parser tried to parse an int after it when not finding an equals sign, which is illegal according to [MAPINFO](https://zdoom.org/wiki/MAPINFO/Map_definition): 
```<Compat Option> = [value]: You can alter some compatibility options in MAPINFO as well. Specifying a compatibility option with no parameters turns it on, but the user can override the setting later. If [value] is 0, the option is forced off for the map, and a setting of 1 forces it on, regardless of the CVAR settings. This ensures that a map that requests a certain option to be on or off can be played correctly no matter what the user's settings are.```
This is fixed and treats compat properties by themselves as on, as it should be. Tested with compat_nopassover and compat_dropoff, the 2 compat flags we do support.