### PR TITLE
[BUGFIX] Fix Boom Format Line 192

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -2836,7 +2836,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		case 192:
 			// Lights to brightest neighbor sector
 			// 192 SR  EV_LightTurnOn(0)
-			EV_LightTurnOn(line->id, 0);
+			EV_LightTurnOn(line->id, -1);
 			reuse = true;
 			trigger = true;
 			


### PR DESCRIPTION
EV_LightTurnOn only checks brightness of nearby sectors if the value passed in for bright is less than 0. 0 was being passed in, no searching would be done, and then the brightness would be set to 0.

Addresses #786