### PR TITLE
Show better error when Odamex can't find IWAD

### DIFF
--- a/client/src/cl_download.cpp
+++ b/client/src/cl_download.cpp
@@ -129,70 +129,6 @@ bool CL_IsDownloading()
 }
 
 /**
- * @brief Print an error that occurrs from trying to download a commercial IWAD.
- * 
- * @param filename Filename of the wanted WAD.
- */
-static void CommercialIWADError(const OWantFile& filename)
-{
-	const fileIdentifier_t* info = W_GameInfo(filename.getWantedMD5());
-	if (!info)
-	{
-		Printf("This server requires a commercial IWAD that Odamex does not recognize.  "
-		       "This should not be possible, please report this message as a bug.\n");
-		return;
-	}
-
-	Printf("This server requires %s.\n", info->mIdName.c_str());
-
-	// Try to find an IWAD to compare it against.
-	OResFile* current = &*::wadfiles.begin();
-	if (current->getBasename() != filename.getBasename())
-	{
-		OWantFile wanted;
-		OWantFile::make(wanted, current->getBasename(), OFILE_WAD);
-		if (!M_ResolveWantedFile(*current, wanted))
-		{
-			Printf("Odamex cannot find the data file for this game.",
-			       info->mFilename.c_str());
-			current = NULL;
-		}
-	}
-
-	if (current != NULL)
-	{
-		const fileIdentifier_t* curInfo = W_GameInfo(current->getMD5());
-		if (curInfo)
-		{
-			// Found a file, but it's the wrong version.
-			Printf(
-			    "Odamex found a possible data file, but it's the wrong version - %s.\n",
-			    curInfo->mIdName.c_str());
-		}
-		else
-		{
-			// Found a file, but it's not recognized at all.
-			Printf(
-			    "Odamex found a possible data file, but Odamex does not recognize it.\n");
-		}
-
-#ifdef _WIN32
-		Printf("You can use a tool such as Omniscient "
-		       "<https://drinkybird.net/doom/omniscient> to patch your way to the "
-		       "correct version of the data file.");
-#else
-		Printf("You can use a tool such as xdelta3 <http://xdelta.org/> paried with IWAD "
-		       "patches located on Github <https://github.com/Doom-Utils/iwad-patches> "
-		       "to patch your way to the correct version of the data file.");
-#endif
-	}
-
-	Printf(
-	    "If you do not own this game, consider purchasing it on Steam or other digital "
-	    "storefront.\n");
-}
-
-/**
  * @brief Start a transfer.
  *
  * @param urls Website to download from, without the WAD at the end.
@@ -238,14 +174,12 @@ bool CL_StartDownload(const Websites& urls, const OWantFile& filename, unsigned 
 	if (W_IsFilenameCommercialIWAD(filename.getBasename()))
 	{
 		Printf(PRINT_WARNING, "Refusing to download commercial IWAD file.\n");
-		CommercialIWADError(filename);
 		return false;
 	}
 
 	if (W_IsFilehashCommercialIWAD(filename.getWantedMD5()))
 	{
 		Printf(PRINT_WARNING, "Refusing to download renamed commercial IWAD file.\n");
-		CommercialIWADError(filename);
 		return false;
 	}
 

--- a/client/src/cl_download.cpp
+++ b/client/src/cl_download.cpp
@@ -129,6 +129,70 @@ bool CL_IsDownloading()
 }
 
 /**
+ * @brief Print an error that occurrs from trying to download a commercial IWAD.
+ * 
+ * @param filename Filename of the wanted WAD.
+ */
+static void CommercialIWADError(const OWantFile& filename)
+{
+	const fileIdentifier_t* info = W_GameInfo(filename.getWantedMD5());
+	if (!info)
+	{
+		Printf("This server requires a commercial IWAD that Odamex does not recognize.  "
+		       "This should not be possible, please report this message as a bug.\n");
+		return;
+	}
+
+	Printf("This server requires %s.\n", info->mIdName.c_str());
+
+	// Try to find an IWAD to compare it against.
+	OResFile* current = &*::wadfiles.begin();
+	if (current->getBasename() != filename.getBasename())
+	{
+		OWantFile wanted;
+		OWantFile::make(wanted, current->getBasename(), OFILE_WAD);
+		if (!M_ResolveWantedFile(*current, wanted))
+		{
+			Printf("Odamex cannot find the data file for this game.",
+			       info->mFilename.c_str());
+			current = NULL;
+		}
+	}
+
+	if (current != NULL)
+	{
+		const fileIdentifier_t* curInfo = W_GameInfo(current->getMD5());
+		if (curInfo)
+		{
+			// Found a file, but it's the wrong version.
+			Printf(
+			    "Odamex found a possible data file, but it's the wrong version - %s.\n",
+			    curInfo->mIdName.c_str());
+		}
+		else
+		{
+			// Found a file, but it's not recognized at all.
+			Printf(
+			    "Odamex found a possible data file, but Odamex does not recognize it.\n");
+		}
+
+#ifdef _WIN32
+		Printf("You can use a tool such as Omniscient "
+		       "<https://drinkybird.net/doom/omniscient> to patch your way to the "
+		       "correct version of the data file.");
+#else
+		Printf("You can use a tool such as xdelta3 <http://xdelta.org/> paried with IWAD "
+		       "patches located on Github <https://github.com/Doom-Utils/iwad-patches> "
+		       "to patch your way to the correct version of the data file.");
+#endif
+	}
+
+	Printf(
+	    "If you do not own this game, consider purchasing it on Steam or other digital "
+	    "storefront.\n");
+}
+
+/**
  * @brief Start a transfer.
  *
  * @param urls Website to download from, without the WAD at the end.
@@ -174,12 +238,14 @@ bool CL_StartDownload(const Websites& urls, const OWantFile& filename, unsigned 
 	if (W_IsFilenameCommercialIWAD(filename.getBasename()))
 	{
 		Printf(PRINT_WARNING, "Refusing to download commercial IWAD file.\n");
+		CommercialIWADError(filename);
 		return false;
 	}
 
 	if (W_IsFilehashCommercialIWAD(filename.getWantedMD5()))
 	{
 		Printf(PRINT_WARNING, "Refusing to download renamed commercial IWAD file.\n");
+		CommercialIWADError(filename);
 		return false;
 	}
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1717,6 +1717,14 @@ bool CL_PrepareConnect()
 	}
 	else if (!ok && !missingfiles.empty() || cl_forcedownload)
 	{
+		if (::missingCommercialIWAD)
+		{
+			Printf(PRINT_WARNING,
+			       "Server requires commercial IWAD that was don't have.\n");
+			CL_QuitNetGame(NQ_ABORT);
+			return false;
+		}
+
 		OWantFile missing_file;
 		if (missingfiles.empty())				// cl_forcedownload
 		{

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1720,7 +1720,7 @@ bool CL_PrepareConnect()
 		if (::missingCommercialIWAD)
 		{
 			Printf(PRINT_WARNING,
-			       "Server requires commercial IWAD that was don't have.\n");
+			       "Server requires commercial IWAD that was not found.\n");
 			CL_QuitNetGame(NQ_ABORT);
 			return false;
 		}

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -803,7 +803,7 @@ static void CL_LoadMap(const odaproto::svc::LoadMap* msg)
 	{
 		if (::missingCommercialIWAD)
 		{
-			Printf(PRINT_WARNING, "Server requires commercial IWAD that was don't have.\n");
+			Printf(PRINT_WARNING, "Server requires commercial IWAD that was not found.\n");
 			CL_QuitNetGame(NQ_DISCONNECT);
 			return;
 		}

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -801,6 +801,13 @@ static void CL_LoadMap(const odaproto::svc::LoadMap* msg)
 
 	if (!missingfiles.empty())
 	{
+		if (::missingCommercialIWAD)
+		{
+			Printf(PRINT_WARNING, "Server requires commercial IWAD that was don't have.\n");
+			CL_QuitNetGame(NQ_DISCONNECT);
+			return;
+		}
+
 		OWantFile missing_file = missingfiles.front();
 		CL_QuitAndTryDownload(missing_file);
 		return;

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -273,7 +273,7 @@ void D_Display()
 			return;
 
 		case GS_LEVEL:
-			if (!gametic)
+		    if (!gametic || !g_ValidLevel)
 				break;
 
 			V_DoPaletteEffects();
@@ -711,6 +711,9 @@ void STACK_ARGS D_Shutdown()
 
 	// reset the Zone memory manager
 	Z_Close();
+
+	// [AM] Level is now invalid due to torching zone memory.
+	g_ValidLevel = false;
 
 	// [AM] All of our dyncolormaps are freed, tidy up so we
 	//      don't follow wild pointers.

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -70,6 +70,7 @@
 OResFiles wadfiles;
 OResFiles patchfiles;
 OWantFiles missingfiles;
+bool missingCommercialIWAD = false;
 
 bool lastWadRebootSuccess = true;
 extern bool step_mode;
@@ -550,6 +551,85 @@ static void LoadResolvedFiles(const OResFiles& newwadfiles,
 	D_LoadResolvedPatches();
 }
 
+/**
+ * @brief Print a warning that occurrs when the user has an IWAD that's a
+ *        different version than the one we want.
+ * 
+ * @param wanted The IWAD that we wanted.
+ * @return True if we emitted an commercial IWAD warning.
+ */
+static bool CommercialIWADWarning(const OWantFile& wanted)
+{
+	const OMD5Hash& hash = wanted.getWantedMD5();
+	if (hash.empty())
+	{
+		// No MD5 means there is no error we can reasonably display.
+		return false;
+	}
+
+	const fileIdentifier_t* info = W_GameInfo(wanted.getWantedMD5());
+	if (!info)
+	{
+		// No GameInfo means that we're not dealing with a WAD we recognize.
+		return false;
+	}
+
+	if (!info->mIsCommercial)
+	{
+		// Not commercial means that we should treat the IWAD like any other
+		// WAD, with no special callout.
+		return false;
+	}
+
+	Printf("Odamex attempted to load\n> %s.\n\n", info->mIdName.c_str());
+
+	// Try to find an IWAD file with a matching name in the user's directories.
+	OWantFile sameNameWant;
+	OWantFile::make(sameNameWant, wanted.getBasename(), OFILE_WAD);
+	OResFile sameNameRes;
+	const bool resolved = M_ResolveWantedFile(sameNameRes, sameNameWant);
+	if (!resolved)
+	{
+		Printf(
+		    "Odamex could not find the data file for this game in any of the locations "
+		    "it searches for WAD files.  If you know you have %s on your hard drive, you "
+		    "can add that path to the 'waddirs' cvar so Odamex can find it.\n\n",
+		    wanted.getBasename().c_str());
+	}
+	else
+	{
+		const fileIdentifier_t* curInfo = W_GameInfo(sameNameRes.getMD5());
+		if (curInfo)
+		{
+			// Found a file, but it's the wrong version.
+			Printf("Odamex found a possible data file, but it's the wrong version.\n> "
+			       "%s\n> %s\n\n",
+			       curInfo->mIdName.c_str(), sameNameRes.getFullpath().c_str());
+		}
+		else
+		{
+			// Found a file, but it's not recognized at all.
+			Printf("Odamex found a possible data file, but Odamex does not recognize "
+			       "it.\n> %s\n\n",
+			       sameNameRes.getFullpath().c_str());
+		}
+
+#ifdef _WIN32
+		Printf("You can use a tool such as Omniscient "
+		       "<https://drinkybird.net/doom/omniscient> to patch your way to the "
+		       "correct version of the data file.\n");
+#else
+		Printf("You can use a tool such as xdelta3 <http://xdelta.org/> paried with IWAD "
+		       "patches located on Github <https://github.com/Doom-Utils/iwad-patches> "
+		       "to patch your way to the correct version of the data file.\n");
+#endif
+	}
+
+	Printf("If you do not own this game, consider purchasing it on Steam, GOG, or other "
+	       "digital storefront.\n\n");
+	return true;
+}
+
 //
 // D_LoadResourceFiles
 //
@@ -564,6 +644,7 @@ void D_LoadResourceFiles(const OWantFiles& newwadfiles, const OWantFiles& newpat
 	OResFile next_iwad;
 
 	::missingfiles.clear();
+	::missingCommercialIWAD = false;
 
 	// Resolve wanted wads.
 	OResFiles resolved_wads;
@@ -574,6 +655,13 @@ void D_LoadResourceFiles(const OWantFiles& newwadfiles, const OWantFiles& newpat
 		OResFile file;
 		if (!M_ResolveWantedFile(file, *it))
 		{
+			// Give more useful information when trying to load an IWAD.
+			const bool isCommercial = CommercialIWADWarning(*it);
+			if (isCommercial && !::missingCommercialIWAD)
+			{
+				::missingCommercialIWAD = true;
+			}
+
 			::missingfiles.push_back(*it);
 			Printf(PRINT_WARNING, "Could not resolve resource file \"%s\".",
 			       it->getWantedPath().c_str());

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -72,6 +72,8 @@ extern AActor* shootthing;
 
 EXTERN_CVAR(g_coopthingfilter)
 
+bool			g_ValidLevel = false;
+
 //
 // MAP related Lookup tables.
 // Store VERTEXES, LINEDEFS, SIDEDEFS, etc.
@@ -1821,6 +1823,7 @@ void P_SetupLevel (const char *lumpname, int position)
 
 	DThinker::DestroyAllThinkers ();
 	Z_FreeTags (PU_LEVEL, PU_LEVELMAX);
+	g_ValidLevel = false;		// [AM] False until the level is loaded.
 	NormalLight.next = NULL;	// [RH] Z_FreeTags frees all the custom colormaps
 
 	// [AM] Every new level starts with fresh netids.
@@ -1944,6 +1947,9 @@ void P_SetupLevel (const char *lumpname, int position)
 	if (precache)
 		R_PrecacheLevel ();
 #endif
+
+	// [AM] Level is now safely loaded.
+	g_ValidLevel = true;
 }
 
 //

--- a/common/r_state.h
+++ b/common/r_state.h
@@ -62,6 +62,8 @@ extern int				numspritelumps;
 //
 // Lookup tables for map data.
 //
+extern bool				g_ValidLevel;
+
 extern int				numsprites;
 extern spritedef_t* 	sprites;
 

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -224,6 +224,33 @@ static const identData_t identdata[] = {
         200,                                // weight
     },
     {
+        UDOOM_PREFIX " Classic Unity v1.3", // mIdName
+        "DOOM.WAD",                         // mFilename
+        "75C3B7BF",                         // mCRC32Sum
+        "8517C4E8F0EEF90B82852667D345EB86", // mMd5Sum
+        UDOOM_PREFIX " v1.9",               // mGroupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        245,                                // weight
+    },
+    {
+        UDOOM_PREFIX " Classic Unity v1.1", // mIdName
+        "DOOM.WAD",                         // mFilename
+        "346A4BFD",                         // mCRC32Sum
+        "21B200688D0FA7C1B6F63703D2BDD455", // mMd5Sum
+        UDOOM_PREFIX " v1.9",               // mGroupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        245,                                // weight
+    },
+    {
+        UDOOM_PREFIX " Classic Unity v1.0", // mIdName
+        "DOOM.WAD",                         // mFilename
+        "46359DFB",                         // mCRC32Sum
+        "232A79F7121B22D7401905EE0EE1E487", // mMd5Sum
+        UDOOM_PREFIX " v1.9",               // mGroupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        245,                                // weight
+    },
+    {
         UDOOM_PREFIX " BFG Edition",        // mIdName
         "DOOMBFG.WAD",                      // mFilename
         "5EFA677E",                         // mCRC32Sum

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -77,6 +77,24 @@ static const identData_t identdata[] = {
         100,                                // weight
     },
     {
+        DOOM2_PREFIX " Classic Unity v1.1", // idName
+        "DOOM2.WAD",                        // filename
+        "22c291c8",                         // crc32Sum
+        "7895d10c281305c45a7e5f01b3f7b1d8", // md5Sum
+        DOOM2_PREFIX " v1.9",               // groupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        145,                                // weight
+    },
+    {
+        DOOM2_PREFIX " Classic Unity v1.0", // idName
+        "DOOM2.WAD",                        // filename
+        "897339a7",                         // crc32Sum
+        "e7395bd5e838d58627bd028871efbc14", // md5Sum
+        DOOM2_PREFIX " v1.9",               // groupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        145,                                // weight
+    },
+    {
         DOOM2_PREFIX " BFG Edition",        // idName
         "DOOM2BFG.WAD",                     // filename
         "927A778A",                         // crc32Sum
@@ -1043,6 +1061,14 @@ void W_SetupFileIdentifiers()
 const fileIdentifier_t* W_GameInfo(const OCRC32Sum& crc32)
 {
 	return ::identtab.lookupByCRC32Sum(crc32);
+}
+
+/**
+ * @brief Return the gameinfo associated with the given MD5.
+ */
+const fileIdentifier_t* W_GameInfo(const OMD5Hash& md5)
+{
+	return ::identtab.lookupByMd5Sum(md5);
 }
 
 //

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -77,10 +77,19 @@ static const identData_t identdata[] = {
         100,                                // weight
     },
     {
+        DOOM2_PREFIX " Classic Unity v1.3", // idName
+        "DOOM2.WAD",                        // filename
+        "F1D1AD55",                         // crc32Sum
+        "8AB6D0527A29EFDC1EF200E5687B5CAE", // md5Sum
+        DOOM2_PREFIX " v1.9",               // groupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        145,                                // weight
+    },
+    {
         DOOM2_PREFIX " Classic Unity v1.1", // idName
         "DOOM2.WAD",                        // filename
-        "22c291c8",                         // crc32Sum
-        "7895d10c281305c45a7e5f01b3f7b1d8", // md5Sum
+        "22C291C8",                         // crc32Sum
+        "7895D10C281305C45A7E5F01B3F7B1D8", // md5Sum
         DOOM2_PREFIX " v1.9",               // groupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
         145,                                // weight
@@ -88,8 +97,8 @@ static const identData_t identdata[] = {
     {
         DOOM2_PREFIX " Classic Unity v1.0", // idName
         "DOOM2.WAD",                        // filename
-        "897339a7",                         // crc32Sum
-        "e7395bd5e838d58627bd028871efbc14", // md5Sum
+        "897339A7",                         // crc32Sum
+        "E7395BD5E838D58627BD028871EFBC14", // md5Sum
         DOOM2_PREFIX " v1.9",               // groupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
         145,                                // weight

--- a/common/w_ident.h
+++ b/common/w_ident.h
@@ -43,6 +43,7 @@ struct fileIdentifier_t
 
 void W_SetupFileIdentifiers();
 const fileIdentifier_t* W_GameInfo(const OCRC32Sum& crc32);
+const fileIdentifier_t* W_GameInfo(const OMD5Hash& md5);
 void W_ConfigureGameInfo(const OResFile& iwad);
 bool W_IsKnownIWAD(const OWantFile& file);
 bool W_IsIWAD(const OResFile& file);

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -37,6 +37,7 @@
 extern OResFiles wadfiles;
 extern OResFiles patchfiles;
 extern OWantFiles missingfiles;
+extern bool missingCommercialIWAD;
 
 //
 // TYPES

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -211,6 +211,9 @@ void STACK_ARGS D_Shutdown()
 
 	// reset the Zone memory manager
 	Z_Close();
+
+	// [AM] Level is now invalid due to torching zone memory.
+	g_ValidLevel = false;
 	
 	// [AM] All of our dyncolormaps are freed, tidy up so we
 	//      don't follow wild pointers.


### PR DESCRIPTION
This PR gives a more in-depth reason when a user doesn't have the correct version of a commercial IWAD.  It also cuts off any attempt to even start the download process in the first place.

Additionally, I came across two other issues that I fixed:
- During testing, I found that the Unity versions of the various Doom games were not a part of the IWAD database.  This has been addressed.
- If the game was in `GS_LEVEL` state when the level data had been unloaded, Odamex would still attempt to render the level.  This specifically came up in the context of disconnecting after the server switched to an IWAD the client doesn't have, but I can't imagine this is the only circumstance when it happened.

Addresses #759.