### PR TITLE
[BUGFIX] Item Replay/Weapon Correction Fixes

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -253,7 +253,8 @@ static void CL_PlayerInfo(const odaproto::svc::PlayerInfo* msg)
 		p.pendingweapon = readyweapon;
 	}
 
-	if (pending == wp_nochange)
+	// Tic was replayed? Don't try and use the replays's autoswitch at the same tic as weapon correction.
+	if (ClientReplay::getInstance().wasReplayed() && pending == wp_nochange)
 	{
 		p.pendingweapon = wp_nochange;
 	}

--- a/client/src/cl_replay.cpp
+++ b/client/src/cl_replay.cpp
@@ -77,6 +77,17 @@ bool ClientReplay::enabled()
 }
 
 //
+// ClientReplay::replayedTic
+//
+// Denotes whether an item was replayed during the last tic.
+//
+
+bool ClientReplay::wasReplayed()
+{
+	return replayed;
+}
+
+//
 // ClientReplay::recordReplayItem
 //
 // Records a netid and gametic for an item that was picked up,
@@ -120,6 +131,11 @@ void ClientReplay::itemReplay()
 	    consoleplayer_id != displayplayer_id || consoleplayer().spectator)
 		return;
 
+	if (replayed)
+	{
+		replayed = false;
+	}
+
 	player_t& player = consoleplayer();
 
 	std::vector<std::pair<int, uint32_t> >::iterator it = itemReplayStack.begin();
@@ -148,6 +164,8 @@ void ClientReplay::itemReplay()
 		}
 
 		P_GiveSpecial(&player, mo);
+
+		replayed = true;
 
 		int ticDelta = (::gametic - it->first);
 

--- a/client/src/cl_replay.h
+++ b/client/src/cl_replay.h
@@ -42,10 +42,12 @@ public:
 	void recordReplayItem(const int tic, const uint32_t netId);
 	void removeReplayItem(const std::pair<int, uint32_t> replayItem);
 	void itemReplay();
+	bool wasReplayed();
 
 private:
   std::vector<std::pair<int, uint32_t> > itemReplayStack;			// Used to replay item pickups for items the clients can't find.
   static const uint32_t MAX_REPLAY_TIC_LENGTH = TICRATE * 3;	// Should be plenty of time.
+  bool replayed = false;
 	// <int, uint32_t> = <gametic, itemid>
 	ClientReplay() { }											// private contsructor (part of Singleton)
 	ClientReplay(const ClientReplay& rhs);	// private copy constructor

--- a/client/src/cl_replay.h
+++ b/client/src/cl_replay.h
@@ -48,6 +48,8 @@ private:
   std::vector<std::pair<int, uint32_t> > itemReplayStack;			// Used to replay item pickups for items the clients can't find.
   static const uint32_t MAX_REPLAY_TIC_LENGTH = TICRATE * 3;	// Should be plenty of time.
   bool replayed = false;
+  uint32_t replayDoneCounter = TICRATE * 7;
+  uint32_t firstReadyTic = 0;
 	// <int, uint32_t> = <gametic, itemid>
 	ClientReplay() { }											// private contsructor (part of Singleton)
 	ClientReplay(const ClientReplay& rhs);	// private copy constructor


### PR DESCRIPTION
I had previously tried to fix the edge case of an item replay and a weapon correction firing at the same time, causing the weapon to switch to itself after firing. But in doing this, I caused a desync in the scenario you advance a map in coop and keep your ready weapon out in the next map. This fixes that bug, and properly accounts for the edge case of an item replay occurring the same tic or before a weapon correction, triggered by firing immediately before your spawn weapon arrives, which seems quite common in such maps with large amounts of items such as SmartCTF2 MAP12.

Also included is a provision to only "play" the tics from the last ready state so the client matches up with what the server sees.