### PR TITLE
[BUGFIX] Fix numpad usage with and without Numlock

### DIFF
--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -803,7 +803,8 @@ static int I_GetEventRepeaterKey(const event_t* ev)
 	int button = ev->data1;
 	if (button == OKEY_CAPSLOCK || button == OKEY_SCRLCK ||
 		button == OKEY_LSHIFT || button == OKEY_LCTRL || button == OKEY_LALT ||
-		button == OKEY_RSHIFT || button == OKEY_RCTRL || button == OKEY_RALT)
+		button == OKEY_RSHIFT || button == OKEY_RCTRL || button == OKEY_RALT ||
+		button == OKEY_NUMLOCK)
 		return 0;
 	else if (button >= OKEY_HAT1 && button <= OKEY_HAT8)
 		return button;

--- a/client/sdl/i_input_sdl12.cpp
+++ b/client/sdl/i_input_sdl12.cpp
@@ -279,6 +279,8 @@ void ISDL12KeyboardInputDevice::gatherEvents()
 					ev.data2 = ev.data3 = '\r';
 				else if ((sdl_ev.key.keysym.unicode & 0xFF80) == 0)
 					ev.data2 = ev.data3 = sdl_ev.key.keysym.unicode;
+
+				ev.mod = sdl_ev.key.keysym.mod;
 				
 				if (ev.data1)
 					mEvents.push(ev);

--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -282,7 +282,7 @@ void ISDL20KeyboardInputDevice::gatherEvents()
 		if (sdl_ev.type == SDL_KEYDOWN || sdl_ev.type == SDL_KEYUP)
 		{
 			const int sym = sdl_ev.key.keysym.sym;
-			const int mod = sdl_ev.key.keysym.mod;
+			int mod = sdl_ev.key.keysym.mod;
 
 			event_t ev;
 			ev.type = (sdl_ev.type == SDL_KEYDOWN) ? ev_keydown : ev_keyup;
@@ -322,6 +322,9 @@ void ISDL20KeyboardInputDevice::gatherEvents()
 				SDL_PushEvent(&sdl_quit_ev);
 				continue;
 			}
+
+			// Add the mod in
+			ev.mod = mod;
 
 			// Normal game keyboard event - insert it into our internal queue
 			if (ev.data1)

--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -282,7 +282,7 @@ void ISDL20KeyboardInputDevice::gatherEvents()
 		if (sdl_ev.type == SDL_KEYDOWN || sdl_ev.type == SDL_KEYUP)
 		{
 			const int sym = sdl_ev.key.keysym.sym;
-			int mod = sdl_ev.key.keysym.mod;
+			const int mod = sdl_ev.key.keysym.mod;
 
 			event_t ev;
 			ev.type = (sdl_ev.type == SDL_KEYDOWN) ? ev_keydown : ev_keyup;

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -81,8 +81,9 @@ constate_e	ConsoleState = c_up;
 
 extern byte *ConChars;
 
-BOOL		KeysShifted;
-BOOL		KeysCtrl;
+bool		KeysShifted;
+bool		KeysCtrl;
+bool		NumLockEnabled;
 
 static bool midprinting;
 
@@ -1882,32 +1883,9 @@ static bool C_HandleKey(const event_t* ev)
 
 	switch (ch)
 	{
-	case OKEY_HOME:
-		CmdLine.moveCursorHome();
-		return true;
-	case OKEY_END:
-		CmdLine.moveCursorEnd();
-		return true;		
 	case OKEY_BACKSPACE:
 		CmdLine.backspace();
 		TabCycleClear();
-		return true;
-	case OKEY_DEL:
-		CmdLine.deleteCharacter();
-		TabCycleClear();
-		return true;
-	case OKEY_LALT:
-	case OKEY_RALT:
-		// Do nothing
-		return true;
-	case OKEY_LCTRL:
-	case OKEY_RCTRL:
-		KeysCtrl = true;
-		return true;
-	case OKEY_LSHIFT:
-	case OKEY_RSHIFT:
-		// SHIFT was pressed
-		KeysShifted = true;
 		return true;
 	case OKEY_MOUSE3:
 		// Paste from clipboard - add each character to command line
@@ -1917,9 +1895,30 @@ static bool C_HandleKey(const event_t* ev)
 		return true;
 	}
 
+	// Add modifiers for these keys
+	KeysCtrl = (ev->mod & OMOD_CTRL);
+	KeysShifted = (ev->mod & OMOD_SHIFT);
+	NumLockEnabled = (ev->mod & OMOD_NUM);
+
 // General keys used by all systems
 	{
-		if (Key_IsPageUpKey(ch))
+		if (Key_IsHomeKey(ch, NumLockEnabled))
+		{
+			CmdLine.moveCursorHome();
+			return true;
+		}
+		else if (Key_IsEndKey(ch, NumLockEnabled))
+		{
+			CmdLine.moveCursorEnd();
+			return true;
+		}
+		else if (Key_IsDelKey(ch, NumLockEnabled))
+		{
+			CmdLine.deleteCharacter();
+			TabCycleClear();
+			return true;
+		}
+		else if (Key_IsPageUpKey(ch, NumLockEnabled))
 		{
 			if ((int)(ConRows) > (int)(ConBottom / 8))
 			{
@@ -1932,7 +1931,7 @@ static bool C_HandleKey(const event_t* ev)
 			}
 			return true;
 		}
-		else if (Key_IsPageDownKey(ch))
+		else if (Key_IsPageDownKey(ch, NumLockEnabled))
 		{
 			if (KeysShifted)
 				// Move to bottom of console buffer
@@ -1942,7 +1941,7 @@ static bool C_HandleKey(const event_t* ev)
 				ScrollState = SCROLLDN;
 			return true;
 		}
-		else if (Key_IsLeftKey(ch))
+		else if (Key_IsLeftKey(ch, NumLockEnabled))
 		{
 			if (KeysCtrl)
 				CmdLine.moveCursorLeftWord();
@@ -1950,7 +1949,7 @@ static bool C_HandleKey(const event_t* ev)
 				CmdLine.moveCursorLeft();
 			return true;
 		}
-		else if (Key_IsRightKey(ch))
+		else if (Key_IsRightKey(ch, NumLockEnabled))
 		{
 			if (KeysCtrl)
 				CmdLine.moveCursorRightWord();
@@ -1958,7 +1957,7 @@ static bool C_HandleKey(const event_t* ev)
 				CmdLine.moveCursorRight();
 			return true;
 		}
-		else if (Key_IsUpKey(ch))
+		else if (Key_IsUpKey(ch, NumLockEnabled))
 		{
 			// Move to previous entry in the command history
 			History.movePositionUp();
@@ -1968,7 +1967,7 @@ static bool C_HandleKey(const event_t* ev)
 			TabCycleClear();
 			return true;
 		}
-		else if (Key_IsDownKey(ch))
+		else if (Key_IsDownKey(ch, NumLockEnabled))
 		{
 			// Move to next entry in the command history
 			History.movePositionDown();
@@ -2049,26 +2048,13 @@ BOOL C_Responder(event_t *ev)
 	if (ev->type == ev_keyup)
 	{
 		// General Keys used by all systems
-		if (Key_IsPageUpKey(ev->data1) || Key_IsPageDownKey(ev->data1))
+		if (Key_IsPageUpKey(ev->data1, NumLockEnabled) || Key_IsPageDownKey(ev->data1, NumLockEnabled))
 		{
 			ScrollState = SCROLLNO;
 		}
 		else
 		{
-			// Keyboard keys only
-			switch (ev->data1)
-			{
-			case OKEY_LCTRL:
-			case OKEY_RCTRL:
-				KeysCtrl = false;
-				break;
-			case OKEY_LSHIFT:
-			case OKEY_RSHIFT:
-				KeysShifted = false;
-				break;
-			default:
 				return false;
-			}
 		}
 	}
 	else if (ev->type == ev_keydown)

--- a/client/src/cl_responderkeys.cpp
+++ b/client/src/cl_responderkeys.cpp
@@ -32,7 +32,7 @@
 //
 // Key_IsUpKey
 //
-bool Key_IsUpKey(int key)
+bool Key_IsUpKey(int key, bool numlock)
 {
     switch (platform)
     {
@@ -42,13 +42,13 @@ bool Key_IsUpKey(int key)
         break;
     }
 
-    return (key == OKEY_HAT1 || key == OKEY_UPARROW || key == OKEYP_8 || key == OKEY_JOY12);
+    return (key == OKEY_HAT1 || key == OKEY_UPARROW || (key == OKEYP_8 && !numlock) || key == OKEY_JOY12);
 }
 
 //
 // Key_IsDownKey
 //
-bool Key_IsDownKey(int key)
+bool Key_IsDownKey(int key, bool numlock)
 {
     switch (platform)
     {
@@ -58,16 +58,16 @@ bool Key_IsDownKey(int key)
         break;
     }
 
-    return (key == OKEY_HAT3 || key == OKEY_DOWNARROW || key == OKEYP_2 || key == OKEY_JOY13);
+    return (key == OKEY_HAT3 || key == OKEY_DOWNARROW || (key == OKEYP_2 && !numlock) || key == OKEY_JOY13);
 }
 
 //
 // Key_IsLeftKey
 //
-bool Key_IsLeftKey(int key)
+bool Key_IsLeftKey(int key, bool numlock)
 {
     // Default Keyboard press
-    bool keyboard = (key == OKEY_LEFTARROW || key == OKEYP_4);
+    bool keyboard = (key == OKEY_LEFTARROW || (key == OKEYP_4 && !numlock));
 
     switch (platform)
     {
@@ -83,10 +83,10 @@ bool Key_IsLeftKey(int key)
 //
 // Key_IsRightKey
 //
-bool Key_IsRightKey(int key)
+bool Key_IsRightKey(int key, bool numlock)
 {
     // Default Keyboard press
-    bool keyboard = (key == OKEY_RIGHTARROW || key == OKEYP_6);
+    bool keyboard = (key == OKEY_RIGHTARROW || (key == OKEYP_6 && !numlock));
 
     switch (platform)
     {
@@ -101,9 +101,9 @@ bool Key_IsRightKey(int key)
     return (key == OKEY_HAT2 || keyboard || key == OKEY_JOY15);
 }
 
-bool Key_IsPageUpKey(int key)
+bool Key_IsPageUpKey(int key, bool numlock)
 {
-    bool keyboard = (key == OKEY_PGUP);
+    bool keyboard = (key == OKEY_PGUP || (key == OKEYP_9 && !numlock));
 
     switch (platform)
     {
@@ -118,9 +118,9 @@ bool Key_IsPageUpKey(int key)
     return (keyboard || key == OKEY_JOY10);
 }
 
-bool Key_IsPageDownKey(int key)
+bool Key_IsPageDownKey(int key, bool numlock)
 {
-    bool keyboard = (key == OKEY_PGDN);
+    bool keyboard = (key == OKEY_PGDN || (key == OKEYP_3 && !numlock));
 
     switch (platform)
     {
@@ -133,6 +133,26 @@ bool Key_IsPageDownKey(int key)
     }
 
     return (keyboard || key == OKEY_JOY11);
+}
+
+bool Key_IsHomeKey(int key, bool numlock)
+{
+	return (key == OKEY_HOME || (key == OKEYP_7 && !numlock));
+}
+
+bool Key_IsEndKey(int key, bool numlock)
+{
+	return (key == OKEY_END || (key == OKEYP_1 && !numlock));
+}
+
+bool Key_IsInsKey(int key, bool numlock)
+{
+	return (key == OKEY_INS || (key == OKEYP_0 && !numlock));
+}
+
+bool Key_IsDelKey(int key, bool numlock)
+{
+	return (key == OKEY_DEL || (key == OKEYP_PERIOD && !numlock));
 }
 
 //

--- a/client/src/cl_responderkeys.h
+++ b/client/src/cl_responderkeys.h
@@ -24,13 +24,17 @@
 #pragma once
 
         // Movement Keys
-bool Key_IsUpKey(int key);
-bool Key_IsDownKey(int key);
-bool Key_IsLeftKey(int key);
-bool Key_IsRightKey(int key);
+bool Key_IsUpKey(int key, bool numlock);
+bool Key_IsDownKey(int key, bool numlock);
+bool Key_IsLeftKey(int key, bool numlock);
+bool Key_IsRightKey(int key, bool numlock);
 
-bool Key_IsPageUpKey(int key);
-bool Key_IsPageDownKey(int key);
+bool Key_IsPageUpKey(int key, bool numlock);
+bool Key_IsPageDownKey(int key, bool numlock);
+bool Key_IsHomeKey(int key, bool numlock);
+bool Key_IsEndKey(int key, bool numlock);
+bool Key_IsInsKey(int key, bool numlock);
+bool Key_IsDelKey(int key, bool numlock);
 
 bool Key_IsAcceptKey(int key);
 bool Key_IsCancelKey(int key);

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1754,9 +1754,9 @@ int M_StringHeight(char* string)
 //
 bool M_Responder (event_t* ev)
 {
-	int ch, ch2;
+	int ch, ch2, mod;
 
-	ch = ch2 = -1;
+	ch = ch2 = mod = -1;
 
 	// eat mouse events
 	if(menuactive)
@@ -1785,6 +1785,7 @@ bool M_Responder (event_t* ev)
 	{
 		ch = ev->data1; 		// scancode
 		ch2 = ev->data3;		// ASCII
+		mod = ev->mod;			// key mods
 	}
 
 	if (ch == -1 || HU_ChatMode() != CHAT_INACTIVE)
@@ -1797,8 +1798,10 @@ bool M_Responder (event_t* ev)
 		return true;
 	}
 
+	bool numlock = mod & OKEY_NUMLOCK;
+
 	// Handle Repeat
-	if (Key_IsLeftKey(ch) || Key_IsRightKey(ch))
+	if (Key_IsLeftKey(ch, numlock) || Key_IsRightKey(ch, numlock))
 	{
 		if (repeatKey == ch)
 			repeatCount++;
@@ -1905,7 +1908,7 @@ bool M_Responder (event_t* ev)
 
 	// Keys usable within menu
 	{
-		if (Key_IsDownKey(ch))
+		if (Key_IsDownKey(ch, numlock))
 		{
 			do {
 				if (itemOn + 1 > currentMenu->numitems - 1)
@@ -1916,7 +1919,7 @@ bool M_Responder (event_t* ev)
 			} while (currentMenu->menuitems[itemOn].status == -1);
 			return true;
 		}
-		else if (Key_IsUpKey(ch))
+		else if (Key_IsUpKey(ch, numlock))
 		{
 			do {
 				if (!itemOn)
@@ -1927,7 +1930,7 @@ bool M_Responder (event_t* ev)
 			} while (currentMenu->menuitems[itemOn].status == -1);
 			return true;
 		}
-		else if (Key_IsLeftKey(ch))
+		else if (Key_IsLeftKey(ch, numlock))
 		{
 			if (currentMenu->menuitems[itemOn].routine &&
 				currentMenu->menuitems[itemOn].status == 2)
@@ -1937,7 +1940,7 @@ bool M_Responder (event_t* ev)
 			}
 			return true;
 		}
-		else if (Key_IsRightKey(ch))
+		else if (Key_IsRightKey(ch, numlock))
 		{
 			if (currentMenu->menuitems[itemOn].routine &&
 				currentMenu->menuitems[itemOn].status == 2)

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1776,7 +1776,7 @@ void M_OptResponder (event_t *ev)
 
 	item = CurrentMenu->items + CurrentItem;
 
-	bool numlock = mod & OKEY_NUMLOCK;
+	bool numlock = mod & OMOD_NUM;
 
 	// Waiting on a key press for control binding
 	if (WaitingForKey)

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1771,9 +1771,12 @@ void M_OptResponder (event_t *ev)
 {
 	menuitem_t *item;
 	int ch = ev->data1;
+	int mod = ev->mod;
 	const char *cmd = Bindings.GetBind(ch).c_str();
 
 	item = CurrentMenu->items + CurrentItem;
+
+	bool numlock = mod & OKEY_NUMLOCK;
 
 	// Waiting on a key press for control binding
 	if (WaitingForKey)
@@ -1843,7 +1846,7 @@ void M_OptResponder (event_t *ev)
 	}
 
 	if (item->type == bitflag && flagsvar &&
-	    (Key_IsLeftKey(ch) || Key_IsRightKey(ch) || Key_IsAcceptKey(ch))
+	    (Key_IsLeftKey(ch, numlock) || Key_IsRightKey(ch, numlock) || Key_IsAcceptKey(ch))
 		&& !demoplayback)
 	{
 			int newflags = *item->e.flagint ^ item->a.flagmask;
@@ -1866,7 +1869,7 @@ void M_OptResponder (event_t *ev)
 
 	// Handle Keys
 	{
-		if (Key_IsDownKey(ch))
+		if (Key_IsDownKey(ch, numlock))
 		{
 			int modecol;
 
@@ -1904,7 +1907,7 @@ void M_OptResponder (event_t *ev)
 
 			S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
 		}
-		else if (Key_IsUpKey(ch))
+		else if (Key_IsUpKey(ch, numlock))
 		{
 			int modecol;
 
@@ -1944,7 +1947,7 @@ void M_OptResponder (event_t *ev)
 
 			S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
 		}
-		else if (Key_IsPageUpKey(ch))
+		else if (Key_IsPageUpKey(ch, numlock))
 		{
 			if (CanScrollUp)
 			{
@@ -1965,7 +1968,7 @@ void M_OptResponder (event_t *ev)
 				S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
 			}
 		}
-		else if (Key_IsPageDownKey(ch)) 
+		else if (Key_IsPageDownKey(ch, numlock)) 
 		{
 			if (CanScrollDown)
 			{
@@ -1987,7 +1990,7 @@ void M_OptResponder (event_t *ev)
 				S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
 			}
 		}
-		else if (Key_IsLeftKey(ch))
+		else if (Key_IsLeftKey(ch, numlock))
 		{
 		switch (item->type)
 		{
@@ -2115,7 +2118,7 @@ void M_OptResponder (event_t *ev)
 			break;
 		}
 		}
-		else if (Key_IsRightKey(ch))
+		else if (Key_IsRightKey(ch, numlock))
 		{
 		switch (item->type)
 		{

--- a/common/d_event.h
+++ b/common/d_event.h
@@ -39,8 +39,8 @@ typedef enum
 // Event structure.
 struct event_t
 {
-	event_t(evtype_t t = ev_keydown, int d1 = 0, int d2 = 0, int d3 = 0) :
-		type(t), data1(d1), data2(d2), data3(d3)
+	event_t(evtype_t t = ev_keydown, int d1 = 0, int d2 = 0, int d3 = 0, int mod = 0) :
+		type(t), data1(d1), data2(d2), data3(d3), mod(mod)
 	{ }
 
 	event_t(const event_t& other)
@@ -52,6 +52,7 @@ struct event_t
 	{
 		type = other.type;
 		data1 = other.data1; data2 = other.data2; data3 = other.data3;
+		mod = other.mod;
 		return *this;
 	}
 
@@ -59,6 +60,7 @@ struct event_t
 	int 		data1;			// keys / mouse/joystick buttons
 	int 		data2;			// mouse/joystick x move
 	int 		data3;			// mouse/joystick y move
+	int			mod;				// input mods
 };
 
  

--- a/common/doomkeys.h
+++ b/common/doomkeys.h
@@ -95,6 +95,27 @@
 #define OKEYP_PERIOD         0x40000063
 #define OKEYP_PLUS           0x40000057
 
+// These are keymods that indicate what modifiers are engaged
+// when the key events are made.
+// These also link up to SDL2.0
+#define OMOD_NONE						0x0000
+#define OMOD_LSHIFT					0x0001
+#define	OMOD_RSHIFT					0x0002
+#define OMOD_LCTRL					0x0040
+#define OMOD_RCTRL					0x0080
+#define OMOD_LALT						0x0100
+#define OMOD_RALT						0x0200
+#define OMOD_LGUI						0x0400
+#define OMOD_RGUI						0x0800
+#define OMOD_NUM						0x1000
+#define OMOD_CAPS						0x2000
+#define OMOD_MODE						0x4000
+#define OMOD_SCROLL					0x8000
+#define OMOD_CTRL						(OMOD_LCTRL		| OMOD_RCTRL)
+#define OMOD_SHIFT					(OMOD_LSHIFT	| OMOD_RSHIFT)
+#define OMOD_ALT						(OMOD_LALT		| OMOD_RALT)
+#define OMOD_GUI						(OMOD_LGUI		| OMOD_RGUI)
+#define OMOD_RESERVED				OMOD_SCROLL /* This is for source-level compatibility with SDL 2.0.0. */
 
 // These are custom to Odamex and not SDL 2.0 keycodes
 // Mouse and joystick button presses are mapped to their own keycodes.


### PR DESCRIPTION
This was achieved by using SDL's mod system for determining what key combinations were used with keys, and use that to determine their final function. Previously, Odamex would handle this functionality, which worked well for keys you have to keep pressing for the mod to work, but does not with mods like capslock, scrolllock and numlock.

To keep everything consistent, I've converted the Shift and Ctrl functionality for console to this mod method, and converted the options menu to be able to use numpad as well.

Fixes #799 and #380. I also added functionality for chat macros -- they can now be performed on numpad keys if numlock is on.

These changes are only performed on the console, chat macros and the options menu. The rest of the key code is intact.