### PR TITLE
[BUGFIX] Fix latched cvar strings in console to show pending value instead of broken text

### DIFF
--- a/common/c_cvars.cpp
+++ b/common/c_cvars.cpp
@@ -612,12 +612,12 @@ static std::string C_GetLatchedValueString(const cvar_t* var)
 		return C_GetValueString(var);
 
 	if (var->flags() & CVAR_NOENABLEDISABLE)
-		return '"' + var->latched() + '"';
+		return '"' + std::string(var->latched()) + '"';
 
 	if (atof(var->latched()) == 0.0f)
 		return "disabled";
 	else
-		return "enabled";	
+		return "enabled";
 }
 
 BEGIN_COMMAND (set)

--- a/common/c_cvars.cpp
+++ b/common/c_cvars.cpp
@@ -612,7 +612,11 @@ static std::string C_GetLatchedValueString(const cvar_t* var)
 		return C_GetValueString(var);
 
 	if (var->flags() & CVAR_NOENABLEDISABLE)
-		return '"' + std::string(var->latched()) + '"';
+	{
+		std::string str = "";
+		StrFormat(str, "\"%s\"", var->latched());
+		return str;
+	}
 
 	if (atof(var->latched()) == 0.0f)
 		return "disabled";


### PR DESCRIPTION
Due to how strings were expressed for latched cvar pending change retrieval, they'd create broken strings every time. I fixed this behavior by making the pending change a string from the beginning.

Old behavior:
![image](https://user-images.githubusercontent.com/2531014/201387707-c5b01c27-fdd3-48d9-ade8-01be4711e6b5.png)

New behavior: 
![image](https://user-images.githubusercontent.com/2531014/201387748-44e673f0-c881-433f-9883-487412c312c6.png)

Fixes #798 