### PR TITLE
[FEATURE] Add ALT+DEL and CTRL+Backspace to delete words to the right and left of the cursor in console, respectively.

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -360,7 +360,7 @@ void ConsoleCommandLine::moveCursorLeftWord()
 
 	const char* str = text.c_str();
 
-	if (str[cursor_position - 1] == ' ')
+	if (cursor_position > 0 && isspace(str[cursor_position - 1]))
 	{
 		spaceWord = true;
 	}
@@ -369,18 +369,18 @@ void ConsoleCommandLine::moveCursorLeftWord()
 	{
 		if (spaceWord)
 		{
-			if (str[cursor_position - 1] != ' ')
+			if (!isspace(str[cursor_position - 1]))
 			{
 				break;
 			}
 		}
 		else
 		{
-			if (firstSpacesCleared && str[cursor_position] == ' ')
+			if (firstSpacesCleared && isspace(str[cursor_position]))
 			{
 				break;
 			}
-			else if (str[cursor_position] != ' ' && !firstSpacesCleared)
+			else if (!isspace(str[cursor_position]) && !firstSpacesCleared)
 			{
 				firstSpacesCleared = true;
 			}
@@ -458,7 +458,7 @@ void ConsoleCommandLine::deleteLeftWord()
 	const char* str = text.c_str();
 
 	// Delete trailing spaces instead of the word
-	if (str[cursor_position - 1] == ' ')
+	if (cursor_position > 0 && isspace(str[cursor_position - 1]))
 	{
 		spaceWord = true;
 	}
@@ -467,18 +467,18 @@ void ConsoleCommandLine::deleteLeftWord()
 	{
 		if (spaceWord)
 		{
-			if (str[cursor_position - 1] != ' ')
+			if (!isspace(str[cursor_position - 1]))
 			{
 				break;
 			}
 		}
 		else
 		{
-			if (firstSpacesCleared && str[cursor_position] == ' ')
+			if (firstSpacesCleared && isspace(str[cursor_position]))
 			{
 				break;
 			}
-			else if (str[cursor_position] != ' ' && !firstSpacesCleared)
+			else if (!isspace(str[cursor_position]) && !firstSpacesCleared)
 			{
 				firstSpacesCleared = true;
 			}
@@ -499,7 +499,7 @@ void ConsoleCommandLine::deleteRightWord()
 
 	const char* str = text.c_str();
 
-	if (str[cursor_position] == ' ')
+	if (cursor_position > 0 && isspace(str[cursor_position]))
 	{
 		spaceWord = true;
 	}

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -499,7 +499,9 @@ void ConsoleCommandLine::deleteRightWord()
 
 	const char* str = text.c_str();
 
-	if (cursor_position > 0 && isspace(str[cursor_position]))
+	if (cursor_position > 0 &&
+			cursor_position < text.length() &&
+			isspace(str[cursor_position]))
 	{
 		spaceWord = true;
 	}

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -361,15 +361,13 @@ void ConsoleCommandLine::moveCursorLeftWord()
 	bool spaceWord = false;
 	
 	if (cursor_position > 0 && isspace(str[cursor_position]))
-			firstSpacesCleared = true;
+		firstSpacesCleared = true;
 
 	if (cursor_position > 0)
 		cursor_position--;
 
 	if (cursor_position > 0 && firstSpacesCleared)
-	{
 		spaceWord = true;
-	}
 
 	while (cursor_position > 0)
 	{

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -355,12 +355,39 @@ void ConsoleCommandLine::moveCursorRight()
 
 void ConsoleCommandLine::moveCursorLeftWord()
 {
-	if (cursor_position > 0)
-		cursor_position--;
+	bool firstSpacesCleared = false;
+	bool spaceWord = false;
 
 	const char* str = text.c_str();
-	while (cursor_position > 0 && str[cursor_position - 1] != ' ')
+
+	if (str[cursor_position - 1] == ' ')
+	{
+		spaceWord = true;
+	}
+
+	while (cursor_position > 0)
+	{
+		if (spaceWord)
+		{
+			if (str[cursor_position - 1] != ' ')
+			{
+				break;
+			}
+		}
+		else
+		{
+			if (firstSpacesCleared && str[cursor_position] == ' ')
+			{
+				break;
+			}
+			else if (str[cursor_position] != ' ' && !firstSpacesCleared)
+			{
+				firstSpacesCleared = true;
+			}
+		}
+
 		cursor_position--;
+	}
 
 	doScrolling();
 }

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -357,8 +357,11 @@ void ConsoleCommandLine::moveCursorLeftWord()
 {
 	const char* str = text.c_str();
 
-	bool firstSpacesCleared = isspace(str[cursor_position]);
+	bool firstSpacesCleared = false;
 	bool spaceWord = false;
+	
+	if (cursor_position > 0 && isspace(str[cursor_position]))
+			firstSpacesCleared = true;
 
 	if (cursor_position > 0)
 		cursor_position--;

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -468,14 +468,33 @@ void ConsoleCommandLine::deleteLeftWord()
 
 void ConsoleCommandLine::deleteRightWord()
 {
+	bool spaceWord = false;
+
+	const char* str = text.c_str();
+
+	if (str[cursor_position] == ' ')
+	{
+		spaceWord = true;
+	}
+
 	size_t word = 0;
-	// find first non-space character after the next space(s)
-	word = text.find_first_not_of(' ', text.find_first_of(' ', cursor_position));
+	size_t wordLength = 0;
+	
+	if (spaceWord)
+	{
+		word = text.find_first_not_of(' ', cursor_position);
+	}
+	else
+	{
+		word = text.find_first_not_of(' ', text.find_first_of(' ', cursor_position));
+	}
 
 	if (word == std::string::npos)
-		word = text.length();
+			wordLength = text.length();
+		else
+			wordLength = word - cursor_position;
 
-	text.erase(cursor_position, word);
+	text.erase(cursor_position, wordLength);
 
 	doScrolling();
 }

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -355,12 +355,15 @@ void ConsoleCommandLine::moveCursorRight()
 
 void ConsoleCommandLine::moveCursorLeftWord()
 {
-	bool firstSpacesCleared = false;
-	bool spaceWord = false;
-
 	const char* str = text.c_str();
 
-	if (cursor_position > 0 && isspace(str[cursor_position - 1]))
+	bool firstSpacesCleared = isspace(str[cursor_position]);
+	bool spaceWord = false;
+
+	if (cursor_position > 0)
+		cursor_position--;
+
+	if (cursor_position > 0 && firstSpacesCleared)
 	{
 		spaceWord = true;
 	}
@@ -376,11 +379,11 @@ void ConsoleCommandLine::moveCursorLeftWord()
 		}
 		else
 		{
-			if (firstSpacesCleared && isspace(str[cursor_position]))
+			if (firstSpacesCleared && isspace(str[cursor_position - 1]))
 			{
 				break;
 			}
-			else if (!isspace(str[cursor_position]) && !firstSpacesCleared)
+			else if (!isspace(str[cursor_position - 1]) && !firstSpacesCleared)
 			{
 				firstSpacesCleared = true;
 			}


### PR DESCRIPTION
This feature resolves issue #321, and includes more shortcuts to manipulate text in the console. Alt+Del will delete the word to the immediate right of the cursor, while Ctrl+Backspace will delete the word on the left of the cursor. Ctrl+Backspace has logic to delete an extended whitespace or the word, but not both. Also included is a fix to ConsoleCommandLine::moveCursorLeftWord(). It now treats a body of whitespace as a word that can be skipped, rather than moved one cursor length at a time.

With these changes, a user who is privy to shortcut usage can manipulate text in the console as fast as any other text input in the operating system.

This also contains code for PR #802 and should be merged after that one is.