### PR TITLE
Don't include d.WAD in the PWAD select tab

### DIFF
--- a/common/m_resfile.cpp
+++ b/common/m_resfile.cpp
@@ -397,7 +397,14 @@ std::vector<scannedPWAD_t> M_ScanPWADs()
 				continue;
 
 			OWantFile file;
-			OWantFile::make(file, filename, OFILE_WAD);
+			if (iequals(filename, "d.WAD"))
+			{
+				OMD5Hash hash = W_MD5(dir + PATHSEP + filename);
+				OWantFile::makeWithHash(file, filename, OFILE_WAD, hash);
+			} else
+			{
+				OWantFile::make(file, filename, OFILE_WAD);
+			}
 			if (W_IsKnownIWAD(file))
 				continue;
 

--- a/common/m_resfile.cpp
+++ b/common/m_resfile.cpp
@@ -401,7 +401,8 @@ std::vector<scannedPWAD_t> M_ScanPWADs()
 			{
 				OMD5Hash hash = W_MD5(dir + PATHSEP + filename);
 				OWantFile::makeWithHash(file, filename, OFILE_WAD, hash);
-			} else
+			}
+			else
 			{
 				OWantFile::make(file, filename, OFILE_WAD);
 			}


### PR DESCRIPTION
Installations of The Ultimate Doom from Steam include a file called d.WAD in the same directory as doom.wad. It is an exact copy of doom.wad, but because of the different filename, it currently gets considered a PWAD and is added to the PWAD select. This is likely to confuse users who are uncertain of what this file is or where it is, and when loaded it is difficult to realize at first what is happening. This change checks the MD5 hash of a file ONLY if it has the name "d.WAD" and does not include it if it matches a known IWAD hash.