### PR TITLE
Hack to make the PlayerSetup hack keep track of the menu stack.

### DIFF
--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -112,7 +112,7 @@ short				whichSkull; 		// which skull to draw
 bool				drawSkull;			// [RH] don't always draw skull
 
 // hack for PlayerSetup
-bool				F4menu;
+int					PSetupDepth;
 
 // graphic name of skulls
 char				skullName[2][9] = {"M_SKULL1", "M_SKULL2"};
@@ -510,7 +510,7 @@ BEGIN_COMMAND (menu_main)
     S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
 	M_StartControlPanel ();
 	M_SetupNextMenu (&MainDef);
-	F4menu = false;
+	PSetupDepth = 2;
 }
 END_COMMAND (menu_main)
 
@@ -549,7 +549,7 @@ BEGIN_COMMAND (menu_options)
     S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
     M_StartControlPanel ();
 	M_Options(0);
-	F4menu = true;
+	PSetupDepth = 1;
 }
 END_COMMAND (menu_options)
 
@@ -594,6 +594,7 @@ BEGIN_COMMAND (menu_player)
     S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
 	M_StartControlPanel ();
 	M_PlayerSetup(0);
+	PSetupDepth = 0;
 }
 END_COMMAND (menu_player)
 
@@ -2146,20 +2147,16 @@ void M_PopMenuStack (void)
 		S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
 	} else {
 		M_ClearMenus ();
-		if (currentMenu == &PSetupDef)			// hack for PlayerSetup
+		if (currentMenu == &PSetupDef && PSetupDepth > 0)			// hack for PlayerSetup
 		{
 			S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
 			M_StartControlPanel();
-			if (!F4menu)
-			{
+			if (PSetupDepth == 2)
 				M_SetupNextMenu(&MainDef);
-			}
 			M_Options(0);
 		}
 		else
-		{
 			S_Sound (CHAN_INTERFACE, "switches/exitbutn", 1, ATTN_NONE);
-		}
 	}
 }
 

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -111,6 +111,9 @@ short				skullAnimCounter;	// skull animation counter
 short				whichSkull; 		// which skull to draw
 bool				drawSkull;			// [RH] don't always draw skull
 
+// hack for PlayerSetup
+bool				F4menu;
+
 // graphic name of skulls
 char				skullName[2][9] = {"M_SKULL1", "M_SKULL2"};
 
@@ -507,6 +510,7 @@ BEGIN_COMMAND (menu_main)
     S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
 	M_StartControlPanel ();
 	M_SetupNextMenu (&MainDef);
+	F4menu = false;
 }
 END_COMMAND (menu_main)
 
@@ -545,6 +549,7 @@ BEGIN_COMMAND (menu_options)
     S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
     M_StartControlPanel ();
 	M_Options(0);
+	F4menu = true;
 }
 END_COMMAND (menu_options)
 
@@ -2141,7 +2146,20 @@ void M_PopMenuStack (void)
 		S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
 	} else {
 		M_ClearMenus ();
-		S_Sound (CHAN_INTERFACE, "switches/exitbutn", 1, ATTN_NONE);
+		if (currentMenu == &PSetupDef)			// hack for PlayerSetup
+		{
+			S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
+			M_StartControlPanel();
+			if (!F4menu)
+			{
+				M_SetupNextMenu(&MainDef);
+			}
+			M_Options(0);
+		}
+		else
+		{
+			S_Sound (CHAN_INTERFACE, "switches/exitbutn", 1, ATTN_NONE);
+		}
 	}
 }
 


### PR DESCRIPTION
The following is a pull request to address the issue where the "hacked" way of getting PlayerSetup to work with Odamex's menu doesn't keep track of the menu stack. Specifically, this is to address the bug where upon entering "PLAYER SETUP", exiting the menu immediately goes directly back to the game, not the previous OPTIONS menu.

This introduces a check for whether or not PSetupDef is active, and a boolean to catch differing situations from reaching PLAYER SETUP from Escape or from F4.