### PR TITLE
PortMidi: Ignore SysEx messages and use GM mode by default

### DIFF
--- a/client/sdl/i_musicsystem_portmidi.cpp
+++ b/client/sdl/i_musicsystem_portmidi.cpp
@@ -65,24 +65,8 @@ PortMidiMusicSystem::PortMidiMusicSystem()
 		return;
 	}
 
-	std::string prefdevicename(snd_musicdevice.cstring());
-
-#ifdef _WIN32
-	// Bypass the MIDI mapper and start with the first non-virtual device
-	const char mmname[] = "Microsoft MIDI Mapper";
-	for (int i = 0; i < Pm_CountDevices(); i++)
-	{
-		info = Pm_GetDeviceInfo(i);
-		if (!info || !info->output || _strnicmp(mmname, info->name, sizeof(mmname)) == 0)
-			continue;
-
-		m_outputDevice = i;
-		break;
-	}
-#else
-	// Start with the default device
 	m_outputDevice = Pm_GetDefaultOutputDeviceID();
-#endif
+	std::string prefdevicename(snd_musicdevice.cstring());
 
 	// List PortMidi devices
 	for (int i = 0; i < Pm_CountDevices(); i++)
@@ -115,14 +99,6 @@ PortMidiMusicSystem::PortMidiMusicSystem()
 
 	if (!m_stream)
 		return;
-
-	info = Pm_GetDeviceInfo(m_outputDevice);
-
-#ifdef _WIN32
-	// Is this device Microsoft GS Wavetable Synth?
-	const char msname[] = "Microsoft GS Wavetable";
-	m_isMsGsSynth = (_strnicmp(msname, info->name, sizeof(msname) - 1) == 0);
-#endif
 
 	// Initialize tracked channel volumes
 	for (int i = 0; i < NUM_CHANNELS; i++)
@@ -177,19 +153,11 @@ void PortMidiMusicSystem::writeSysEx(int time, const byte *data, size_t length)
 	if (length > PM_DEFAULT_SYSEX_BUFFER_SIZE - 1)
 		return;
 
-	bool isSysExReset = _IsSysExReset(data, length);
-
-#ifdef _WIN32
-	// Ignore SysEx reset from MIDI file for Microsoft GS Wavetable Synth
-	if (isSysExReset && m_isMsGsSynth)
-		return;
-#endif
-
 	// Copy data to buffer due to PortMidi not using a const pointer
 	memcpy(&sysex_buffer[1], data, length);
 	Pm_WriteSysEx(m_stream, time, sysex_buffer);
 
-	if (isSysExReset)
+	if (_IsSysExReset(data, length))
 	{
 		// SysEx reset also resets volume. Take the default channel volumes
 		// and scale them by the user's volume slider

--- a/client/sdl/i_musicsystem_portmidi.cpp
+++ b/client/sdl/i_musicsystem_portmidi.cpp
@@ -36,6 +36,7 @@
 EXTERN_CVAR(snd_musicdevice)
 EXTERN_CVAR(snd_midireset)
 EXTERN_CVAR(snd_mididelay)
+EXTERN_CVAR(snd_midisysex)
 
 // ============================================================================
 // Partially based on an implementation from prboom-plus by Nicholai Main (Natt).
@@ -149,6 +150,9 @@ void PortMidiMusicSystem::writeChannel(int time, byte channel, byte status, byte
 
 void PortMidiMusicSystem::writeSysEx(int time, const byte *data, size_t length)
 {
+	if (!snd_midisysex)
+		return;
+
 	// Ignore messages that are too long
 	if (length > PM_DEFAULT_SYSEX_BUFFER_SIZE - 1)
 		return;

--- a/client/sdl/i_musicsystem_portmidi.cpp
+++ b/client/sdl/i_musicsystem_portmidi.cpp
@@ -272,6 +272,10 @@ void PortMidiMusicSystem::_ResetDevice(bool playing)
 	if (midireset == MIDI_RESET_GS)
 		_EnableFallback();
 
+	// Reset tracked channel volumes
+	for (int i = 0; i < NUM_CHANNELS; i++)
+		m_channelVolume[i] = DEFAULT_VOLUME;
+
 	// Reset to default volume on shutdown if no SysEx reset selected
 	if (!playing && midireset == MIDI_RESET_NONE)
 	{

--- a/client/sdl/i_musicsystem_portmidi.h
+++ b/client/sdl/i_musicsystem_portmidi.h
@@ -60,6 +60,10 @@ class PortMidiMusicSystem : public MidiMusicSystem
 	float m_volumeScale;
 	bool m_isInitialized;
 
+#ifdef _WIN32
+	bool m_isMsGsSynth;
+#endif
+
 	PmDeviceID m_outputDevice;
 	PmStream* m_stream;
 

--- a/client/sdl/i_musicsystem_portmidi.h
+++ b/client/sdl/i_musicsystem_portmidi.h
@@ -60,10 +60,6 @@ class PortMidiMusicSystem : public MidiMusicSystem
 	float m_volumeScale;
 	bool m_isInitialized;
 
-#ifdef _WIN32
-	bool m_isMsGsSynth;
-#endif
-
 	PmDeviceID m_outputDevice;
 	PmStream* m_stream;
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -648,13 +648,16 @@ static char *C_GetDefaultMusicSystem()
 	return str;
 }
 
+CVAR(			snd_midisysex, "0", "Read SysEx from MIDI files (0: Disable, 1: Enable)",
+				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 CVAR(			snd_midifallback, "1", "MIDI instrument fallback (0: Disable, 1: Enable)",
 				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
 CVAR_RANGE(		snd_mididelay, "0", "MIDI delay after reset (0 to 2000 milliseconds)",
 				CVARTYPE_INT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2000.0f)
 
-CVAR_RANGE(		snd_midireset, "2", "MIDI reset type (0: None, 1: GM, 2: GS, 3: XG)",
+CVAR_RANGE(		snd_midireset, "1", "MIDI reset type (0: None, 1: GM, 2: GS, 3: XG)",
 				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 3.0f)
 
 CVAR_FUNC_DECL(	snd_musicsystem, C_GetDefaultMusicSystem(), "Music subsystem preference",


### PR DESCRIPTION
~~This is a small patch to ensure that instrument fallback isn't auto-disabled when the user's MIDI device is the default Windows synth (Microsoft GS Wavetable Synth).~~ Edit: See post below.

An easy test for this is DBP37_AUGZEN.wad at the title screen or MAP22.