### PR TITLE
Add to PLAYER SETUP the ability to switch between custom and preset colors. [FEATURE] #322

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -386,6 +386,12 @@ CVAR_FUNC_DECL(		cl_name, "Player", "",
 CVAR(				cl_color, "40 cf 00", "",
 					CVARTYPE_STRING, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE)
 
+CVAR(				cl_customcolor, "40 cf 00", "",// Acts 19 quiz
+					CVARTYPE_STRING, CVAR_CLIENTARCHIVE)
+
+CVAR(				cl_colorpreset, "custom", "",// Acts 19 quiz
+					CVARTYPE_STRING, CVAR_CLIENTARCHIVE)
+
 CVAR(				cl_gender, "male", "",
 					CVARTYPE_STRING, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE)
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -386,10 +386,10 @@ CVAR_FUNC_DECL(		cl_name, "Player", "",
 CVAR(				cl_color, "40 cf 00", "",
 					CVARTYPE_STRING, CVAR_USERINFO | CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE)
 
-CVAR(				cl_customcolor, "40 cf 00", "",// Acts 19 quiz
+CVAR(				cl_customcolor, "40 cf 00", "",
 					CVARTYPE_STRING, CVAR_CLIENTARCHIVE)
 
-CVAR(				cl_colorpreset, "custom", "",// Acts 19 quiz
+CVAR(				cl_colorpreset, "custom", "",
 					CVARTYPE_STRING, CVAR_CLIENTARCHIVE)
 
 CVAR(				cl_gender, "male", "",

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -118,7 +118,7 @@ team_t D_TeamByName (const char *team)
 	return TEAM_NONE;
 }
 
-colorpreset_t D_ColorPreset (const char *colorpreset)// Acts 19 quiz
+colorpreset_t D_ColorPreset (const char *colorpreset)
 {
 	if (!stricmp(colorpreset, "blue"))
 		return COLOR_BLUE;

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -118,6 +118,22 @@ team_t D_TeamByName (const char *team)
 	return TEAM_NONE;
 }
 
+colorpreset_t D_ColorPreset (const char *colorpreset)// Acts 19 quiz
+{
+	if (!stricmp(colorpreset, "blue"))
+		return COLOR_BLUE;
+	else if (!stricmp(colorpreset, "gray"))
+		return COLOR_GRAY;
+	else if (!stricmp(colorpreset, "green"))
+		return COLOR_GREEN;
+	else if (!stricmp(colorpreset, "brown"))
+		return COLOR_BROWN;
+	else if (!stricmp(colorpreset, "red"))
+		return COLOR_RED;
+	else
+		return COLOR_CUSTOM;
+}
+
 
 static cvar_t *weaponpref_cvar_map[NUMWEAPONS] = {
 	&cl_weaponpref_fst, &cl_weaponpref_pis, &cl_weaponpref_sg, &cl_weaponpref_cg,

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -122,14 +122,24 @@ colorpreset_t D_ColorPreset (const char *colorpreset)// Acts 19 quiz
 {
 	if (!stricmp(colorpreset, "blue"))
 		return COLOR_BLUE;
-	else if (!stricmp(colorpreset, "gray"))
-		return COLOR_GRAY;
+	else if (!stricmp(colorpreset, "indigo"))
+		return COLOR_INDIGO;
 	else if (!stricmp(colorpreset, "green"))
 		return COLOR_GREEN;
 	else if (!stricmp(colorpreset, "brown"))
 		return COLOR_BROWN;
 	else if (!stricmp(colorpreset, "red"))
 		return COLOR_RED;
+	else if (!stricmp(colorpreset, "gold"))
+		return COLOR_GOLD;
+	else if (!stricmp(colorpreset, "jungle green"))
+		return COLOR_JUNGLEGREEN;
+	else if (!stricmp(colorpreset, "purple"))
+		return COLOR_PURPLE;
+	else if (!stricmp(colorpreset, "white"))
+		return COLOR_WHITE;
+	else if (!stricmp(colorpreset, "black"))
+		return COLOR_BLACK;
 	else
 		return COLOR_CUSTOM;
 }

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -178,8 +178,8 @@ static void M_EditPlayerName (int choice);
 static void M_PlayerNameChanged (int choice);
 static void M_ChangeGender (int choice);
 static void M_ChangeAutoAim (int choice);
-static void M_ChangeColorPreset (int choice);// Acts 19 quiz
-static void SendNewColor (int red, int green, int blue);// Acts 19 quiz
+static void M_ChangeColorPreset (int choice);
+static void SendNewColor (int red, int green, int blue);
 static void M_SlidePlayerRed (int choice);
 static void M_SlidePlayerGreen (int choice);
 static void M_SlidePlayerBlue (int choice);
@@ -339,7 +339,7 @@ enum psetup_t
 	playerteam,
 	playersex,
 	playeraim,
-	playercolorpreset,// Acts 19 quiz
+	playercolorpreset,
 	playerred,
 	playergreen,
 	playerblue,
@@ -352,7 +352,7 @@ oldmenuitem_t PlayerSetupMenu[] =
 	{ 2,"", M_ChangeTeam, 'T' },
 	{ 2,"", M_ChangeGender, 'E' },
 	{ 2,"", M_ChangeAutoAim, 'A' },
-    { 2,"", M_ChangeColorPreset, 'C' },// Acts 19 quiz
+    { 2,"", M_ChangeColorPreset, 'C' },
 	{ 2,"", M_SlidePlayerRed, 'R' },
 	{ 2,"", M_SlidePlayerGreen, 'G' },
 	{ 2,"", M_SlidePlayerBlue, 'B' }
@@ -1272,7 +1272,8 @@ void M_QuitDOOM(int choice)
 void M_DrawSlider(int x, int y, float leftval, float rightval, float cur, float step);
 
 static const char *genders[3] = { "male", "female", "cyborg" };
-static const char *colorpresets[11] = { "custom", "blue", "indigo", "green", "brown", "red", "gold", "jungle green", "purple", "white", "black" };// Acts 19 quiz the order must match d_netinf.h
+// Acts 19 quiz the order must match d_netinf.h
+static const char *colorpresets[11] = { "custom", "blue", "indigo", "green", "brown", "red", "gold", "jungle green", "purple", "white", "black" };
 static state_t *PlayerState;
 static int PlayerTics;
 argb_t CL_GetPlayerColor(player_t*);
@@ -1280,8 +1281,8 @@ argb_t CL_GetPlayerColor(player_t*);
 
 EXTERN_CVAR (cl_name)
 EXTERN_CVAR (cl_team)
-EXTERN_CVAR (cl_colorpreset)// Acts 19 quiz
-EXTERN_CVAR (cl_customcolor)// Acts 19 quiz
+EXTERN_CVAR (cl_colorpreset)
+EXTERN_CVAR (cl_customcolor)
 EXTERN_CVAR (cl_color)
 EXTERN_CVAR (cl_gender)
 EXTERN_CVAR (cl_autoaim)
@@ -1364,7 +1365,7 @@ static void M_PlayerSetupDrawer()
 	const int x2 = (I_GetSurfaceWidth() / 2) + (160 * CleanXfac);
 	const int y2 = (I_GetSurfaceHeight() / 2) + (100 * CleanYfac);
 
-	int colorpreset = D_ColorPreset(cl_colorpreset.cstring());// Acts 19 quiz
+	int colorpreset = D_ColorPreset(cl_colorpreset.cstring());
 
 	// Background effect
 	OdamexEffect(x1,y1,x2,y2);
@@ -1538,7 +1539,6 @@ static void M_PlayerSetupDrawer()
 			aim <= 3 ? "Very High" : "Always");
 	}
 
-	// Acts 19 quiz
 	// Draw color setting
 	{
 		const int x = V_StringWidth ("Color") + 8 + PSetupDef.x;
@@ -1632,7 +1632,7 @@ static void M_ChangeAutoAim (int choice)
 	cl_autoaim.Set (aim);
 }
 
-static void M_ChangeColorPreset (int choice)// Acts 19 quiz
+static void M_ChangeColorPreset (int choice)
 {
 	int colorpreset = D_ColorPreset(cl_colorpreset.cstring());
 	argb_t customcolor = V_GetColorFromString(cl_customcolor);
@@ -1706,15 +1706,15 @@ static void M_PlayerTeamChanged (int choice)
 
 static void SendNewColor(int red, int green, int blue)
 {
-	char colorcommand[24];
-	char customcolorcommand[30];// Acts 19 quiz
-	int colorpreset = D_ColorPreset(cl_colorpreset.cstring());// Acts 19 quiz
+	std::string colorcommand;
+	std::string customcolorcommand;
+	int colorpreset = D_ColorPreset(cl_colorpreset.cstring());
 
-	sprintf(colorcommand, "cl_color \"%02x %02x %02x\"", red, green, blue);
+	StrFormat(colorcommand, "cl_color \"%02x %02x %02x\"", red, green, blue);
 	AddCommandString(colorcommand);
-	if (colorpreset == COLOR_CUSTOM)// Acts 19 quiz
+	if (colorpreset == COLOR_CUSTOM)
 	{
-		sprintf(customcolorcommand, "cl_customcolor \"%02x %02x %02x\"", red, green, blue);
+		StrFormat(customcolorcommand, "cl_customcolor \"%02x %02x %02x\"", red, green, blue);
 		AddCommandString(customcolorcommand);
 	}
 

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1272,7 +1272,7 @@ void M_QuitDOOM(int choice)
 void M_DrawSlider(int x, int y, float leftval, float rightval, float cur, float step);
 
 static const char *genders[3] = { "male", "female", "cyborg" };
-static const char *colorpresets[6] = { "custom", "blue", "gray", "green", "brown", "red" };// Acts 19 quiz the order must match d_netinf.h
+static const char *colorpresets[11] = { "custom", "blue", "indigo", "green", "brown", "red", "gold", "jungle green", "purple", "white", "black" };// Acts 19 quiz the order must match d_netinf.h
 static state_t *PlayerState;
 static int PlayerTics;
 argb_t CL_GetPlayerColor(player_t*);
@@ -1638,16 +1638,16 @@ static void M_ChangeColorPreset (int choice)// Acts 19 quiz
 	argb_t customcolor = V_GetColorFromString(cl_customcolor);
 
 	if (!choice)
-		colorpreset = (colorpreset == 0) ? 5 : colorpreset - 1;
+		colorpreset = (colorpreset == 0) ? 10 : colorpreset - 1;
 	else
-		colorpreset = (colorpreset == 5) ? 0 : colorpreset + 1;
+		colorpreset = (colorpreset == 10) ? 0 : colorpreset + 1;
 
 	cl_colorpreset = colorpresets[colorpreset];
 
 	if (colorpreset == COLOR_BLUE)
 		// the Corn Chex jump suit; it should be brighter, but that introduces gray pixels on 8-bit
 		SendNewColor(57, 57, 255);
-	else if (colorpreset == COLOR_GRAY)
+	else if (colorpreset == COLOR_INDIGO)
 		// the Wheat Chex jump suit; a little darker than the blue
 		SendNewColor(134, 134, 134);
 	else if (colorpreset == COLOR_GREEN)
@@ -1659,6 +1659,16 @@ static void M_ChangeColorPreset (int choice)// Acts 19 quiz
 	else if (colorpreset == COLOR_RED)
 		// the blue luminosity matched to the Vanilla red hue without looking bad on 8-bit
 		SendNewColor(250, 62, 62);
+	else if (colorpreset == COLOR_GOLD)
+		SendNewColor(255, 206, 43);
+	else if (colorpreset == COLOR_JUNGLEGREEN)
+		SendNewColor(32, 104, 0);
+	else if (colorpreset == COLOR_PURPLE)
+		SendNewColor(255, 10, 255);
+	else if (colorpreset == COLOR_WHITE)
+		SendNewColor(255, 255, 255);
+	else if (colorpreset == COLOR_BLACK)
+		SendNewColor(0, 0, 0);
 	else
 		SendNewColor(customcolor.getr(), customcolor.getg(), customcolor.getb());
 }

--- a/common/d_netinf.h
+++ b/common/d_netinf.h
@@ -40,10 +40,15 @@ enum colorpreset_t	// Acts 19 quiz the order must match m_menu.cpp.
 {
 	COLOR_CUSTOM,
 	COLOR_BLUE,
-	COLOR_GRAY,
+	COLOR_INDIGO,
 	COLOR_GREEN,
 	COLOR_BROWN,
 	COLOR_RED,
+	COLOR_GOLD,
+	COLOR_JUNGLEGREEN,
+	COLOR_PURPLE,
+	COLOR_WHITE,
+	COLOR_BLACK,
 
 	NUMCOLOR
 };

--- a/common/d_netinf.h
+++ b/common/d_netinf.h
@@ -36,6 +36,18 @@ enum gender_t
 	NUMGENDER
 };
 
+enum colorpreset_t	// Acts 19 quiz the order must match m_menu.cpp.
+{
+	COLOR_CUSTOM,
+	COLOR_BLUE,
+	COLOR_GRAY,
+	COLOR_GREEN,
+	COLOR_BROWN,
+	COLOR_RED,
+
+	NUMCOLOR
+};
+
 enum weaponswitch_t
 {
 	WPSW_NEVER,


### PR DESCRIPTION
In response to [FEATURE] request #322, here is the PLAYER SETUP menu rigged up with the ability to switch between current CUSTOM COLOR, as well as five select presets. This commit introduces changes to four files and two new CVARS, cl_customcolor and cl_colorpreset. cl_colorpresets is unchanged. cl_colorpreset keeps track of where players have that option set, and cl_customcolor saves the slider positions for RED, GREEN and BLUE when a preset color is chosen.

If this is setup correctly, these two new CVARs are stored locally only. The server in netplay should never see them since only cl_color itself is relevant.

I'm open to changes to some of the color presets given there's some wiggle room to try to matchup Odamex's RGB values to Vanilla DOOM's indexed palette.

Included is a short video.

https://user-images.githubusercontent.com/63941237/209765647-33f84af1-fed8-4449-abec-6fe8cd4fe1c0.mp4