### PR TITLE
Make Odamex translate the Chex Quest smallfont (STCFN***).

### DIFF
--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -216,10 +216,14 @@ byte bosstable[256];
 
 static void R_BuildFontTranslation(int color_num, argb_t start_color, argb_t end_color)
 {
-	const palindex_t start_index = 0xB0;
-	const palindex_t end_index = 0xBF;
 	const palindex_t chexstart_index = 0x70;
 	const palindex_t chexend_index = 0x7F;
+	const palindex_t hacxstart_index = 0xC3;
+	const palindex_t hacxmid1_index = 0xCF;
+	const palindex_t hacxmid2_index = 0xF0;
+	const palindex_t hacxend_index = 0xF2;
+	const palindex_t start_index = 0xB0;
+	const palindex_t end_index = 0xBF;
 	const int index_range = end_index - start_index + 1;
 
 	palindex_t* dest = (palindex_t*)Ranges + color_num * 256;
@@ -229,6 +233,15 @@ static void R_BuildFontTranslation(int color_num, argb_t start_color, argb_t end
 		for (int index = 0; index < chexstart_index; index++)
 			dest[index] = index;
 		for (int index = chexend_index + 1; index < 256; index++)
+			dest[index] = index;
+	}
+	else if (gamemission == commercial_hacx)
+	{
+		for (int index = 0; index < hacxstart_index; index++)
+			dest[index] = index;
+		for (int index = hacxmid1_index + 1; index < hacxmid2_index; index++)
+			dest[index] = index;
+		for (int index = hacxend_index + 1; index < 256; index++)
 			dest[index] = index;
 	}
 	else
@@ -242,6 +255,7 @@ static void R_BuildFontTranslation(int color_num, argb_t start_color, argb_t end
 	int r_diff = end_color.getr() - start_color.getr();
 	int g_diff = end_color.getg() - start_color.getg();
 	int b_diff = end_color.getb() - start_color.getb();
+	int hacxtrack;
 
 	if (gamemode == retail_chex)
 	{
@@ -257,6 +271,28 @@ static void R_BuildFontTranslation(int color_num, argb_t start_color, argb_t end
 		}
 
 		dest[0x2C] = dest[0x2D] = dest[0x2F] = dest[chexend_index];
+	}
+	else if (gamemission == commercial_hacx)
+	{
+		for (palindex_t index = hacxstart_index; index <= hacxend_index; index++)
+		{
+			if (index > hacxmid1_index && index < hacxmid2_index)
+				index = hacxmid2_index;
+
+			if (index <= hacxmid1_index)
+				hacxtrack = hacxstart_index;
+			else
+				hacxtrack = hacxmid2_index - (hacxmid1_index - hacxstart_index + 1);
+			int i = index - hacxtrack;
+
+			int r = start_color.getr() + i * r_diff / index_range;
+			int g = start_color.getg() + i * g_diff / index_range;
+			int b = start_color.getb() + i * b_diff / index_range;
+
+			dest[index] = V_BestColor(V_GetDefaultPalette()->basecolors, r, g, b);
+		}
+
+		dest[0x2C] = dest[0x2D] = dest[0x2F] = dest[hacxend_index];
 	}
 	else
 	{

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -218,31 +218,61 @@ static void R_BuildFontTranslation(int color_num, argb_t start_color, argb_t end
 {
 	const palindex_t start_index = 0xB0;
 	const palindex_t end_index = 0xBF;
+	const palindex_t chexstart_index = 0x70;
+	const palindex_t chexend_index = 0x7F;
 	const int index_range = end_index - start_index + 1;
 
 	palindex_t* dest = (palindex_t*)Ranges + color_num * 256;
 
-	for (int index = 0; index < start_index; index++)
-		dest[index] = index;
-	for (int index = end_index + 1; index < 256; index++)
-		dest[index] = index;	
+	if (gamemode == retail_chex)
+	{
+		for (int index = 0; index < chexstart_index; index++)
+			dest[index] = index;
+		for (int index = chexend_index + 1; index < 256; index++)
+			dest[index] = index;
+	}
+	else
+	{
+		for (int index = 0; index < start_index; index++)
+			dest[index] = index;
+		for (int index = end_index + 1; index < 256; index++)
+			dest[index] = index;
+	}
 
 	int r_diff = end_color.getr() - start_color.getr();
 	int g_diff = end_color.getg() - start_color.getg();
 	int b_diff = end_color.getb() - start_color.getb();
 
-	for (palindex_t index = start_index; index <= end_index; index++)
+	if (gamemode == retail_chex)
 	{
-		int i = index - start_index;
+		for (palindex_t index = chexstart_index; index <= chexend_index; index++)
+		{
+			int i = index - chexstart_index;
 
-		int r = start_color.getr() + i * r_diff / index_range;
-		int g = start_color.getg() + i * g_diff / index_range;
-		int b = start_color.getb() + i * b_diff / index_range;
+			int r = start_color.getr() + i * r_diff / index_range;
+			int g = start_color.getg() + i * g_diff / index_range;
+			int b = start_color.getb() + i * b_diff / index_range;
 
-		dest[index] = V_BestColor(V_GetDefaultPalette()->basecolors, r, g, b);
+			dest[index] = V_BestColor(V_GetDefaultPalette()->basecolors, r, g, b);
+		}
+
+		dest[0x2C] = dest[0x2D] = dest[0x2F] = dest[chexend_index];
 	}
+	else
+	{
+		for (palindex_t index = start_index; index <= end_index; index++)
+		{
+			int i = index - start_index;
 
-	dest[0x2C] = dest[0x2D] = dest[0x2F] = dest[end_index];
+			int r = start_color.getr() + i * r_diff / index_range;
+			int g = start_color.getg() + i * g_diff / index_range;
+			int b = start_color.getb() + i * b_diff / index_range;
+
+			dest[index] = V_BestColor(V_GetDefaultPalette()->basecolors, r, g, b);
+		}
+
+		dest[0x2C] = dest[0x2D] = dest[0x2F] = dest[end_index];
+	}
 }
 
 /**


### PR DESCRIPTION
The way Odamex works with index palette entries for translating pixel colours causes hiccups sometimes. Specifically, with Chex Quest. All of the menu functions get lost in a sea of green, and while it's easy to suggest that 'Chex text should always be green', that works only in a Vanilla EXE vacuum. With ZDoom-style expanded menus, mono-colour text works a whole lot worse.

Included are two screenshots. The first shows the way it is now. Note that both the option and choice are the same colour. Worse, the distinct colours for the chosen message colours don't even show their true colours. It really is kind of a mess for Chex Quest. ZDoom/GZDoom/Zandronum outright disables Chex Quest 3's custom textcolo specifically for this reason.

This patch addresses this issue--at least for Chex Quest. HacX, another Odamex supported megawad, suffers the same issue. However, unlike Chex Quest's green colour, the blue colour used by HacX is split up across the palette. E.g., while there are still 16 primary colours like with DOOM and Chex Quest, HacX has them split across a palette range--because that's how DOOM's palette does it. It's possible a bigger expansion of the current system could address this, but that's adding code upon code. Wholesale changes may be in order to fix HacX.
![DOOM_translate](https://user-images.githubusercontent.com/63941237/209779228-c648da45-d386-4dde-a59a-5fa3b68d2818.png)
![Chex_translate](https://user-images.githubusercontent.com/63941237/209779227-7978853a-485a-462a-bb68-d08eeef4f9fe.png)
