### PR TITLE
[BUGFIX] Restore floor damage text obituaries

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1279,14 +1279,14 @@ void P_PlayerInCompatibleSector(player_t* player)
 		switch (sector->special)
 		{
 		case 5:
-			P_ApplySectorDamage(player, 10, 0);
+			P_ApplySectorDamage(player, 10, 0, MOD_SLIME);
 			break;
 		case 7:
-			P_ApplySectorDamage(player, 5, 0);
+			P_ApplySectorDamage(player, 5, 0, MOD_SLIME);
 			break;
 		case 16:
 		case 4:
-			P_ApplySectorDamage(player, 20, 5);
+			P_ApplySectorDamage(player, 20, 5, MOD_SLIME);
 			break;
 		case 9:
 			P_CollectSecretVanilla(sector, player);

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2159,11 +2159,11 @@ bool P_PushSpecialLine(AActor* thing, line_t* line, int side)
     return true;
 }
 
-void P_ApplySectorDamage(player_t* player, int damage, int leak)
+void P_ApplySectorDamage(player_t* player, int damage, int leak, int mod)
 {
 	if (!player->powers[pw_ironfeet] || (leak && P_Random(player->mo)<leak))
 		if (!(level.time & 0x1f))
-			P_DamageMobj(player->mo, NULL, NULL, damage);
+			P_DamageMobj(player->mo, NULL, NULL, damage, mod);
 }
 
 void P_ApplySectorDamageEndLevel(player_t* player)

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -112,7 +112,7 @@ void P_RemoveMovingFloor(sector_t *sector);
 bool P_MovingCeilingCompleted(sector_t *sector);
 bool P_MovingFloorCompleted(sector_t *sector);
 bool P_HandleSpecialRepeat(line_t* line);
-void P_ApplySectorDamage(player_t* player, int damage, int leak);
+void P_ApplySectorDamage(player_t* player, int damage, int leak, int mod = 0);
 void P_ApplySectorDamageEndLevel(player_t* player);
 void P_CollectSecretCommon(sector_t* sector, player_t* player);
 int P_FindSectorFromTagOrLine(int tag, const line_t* line, int start);


### PR DESCRIPTION
Addresses #812 

Death by damaging sectors now displays "%o mutated." instead of "%o died."
This matches the behavior of other ZDoom based ports.