### PR TITLE
PortMidi: Send "reset all controllers" when a song loops

### DIFF
--- a/client/sdl/i_musicsystem.cpp
+++ b/client/sdl/i_musicsystem.cpp
@@ -280,7 +280,6 @@ void MidiMusicSystem::playEvent(int time, MidiEvent *event)
 	if (I_IsMidiMetaEvent(event))
 	{
 		MidiMetaEvent *metaevent = static_cast<MidiMetaEvent*>(event);
-		byte metatype = metaevent->getMetaType();
 
 		if (metaevent->getMetaType() == MIDI_META_SET_TEMPO)
 		{

--- a/client/sdl/i_musicsystem_portmidi.cpp
+++ b/client/sdl/i_musicsystem_portmidi.cpp
@@ -208,12 +208,19 @@ void PortMidiMusicSystem::allSoundOff()
 		writeControl(0, i, MIDI_CONTROLLER_ALL_SOUND_OFF, 0);
 }
 
-void PortMidiMusicSystem::_ResetControllers()
+void PortMidiMusicSystem::_ResetAllControllers()
 {
 	for (int i = 0; i < NUM_CHANNELS; i++)
 	{
-		// Reset commonly used controllers
 		writeControl(0, i, MIDI_CONTROLLER_RESET_ALL_CTRLS, 0);
+	}
+}
+
+void PortMidiMusicSystem::_ResetCommonControllers()
+{
+	for (int i = 0; i < NUM_CHANNELS; i++)
+	{
+		// Reset commonly used controllers not covered by "Reset All Controllers"
 		writeControl(0, i, MIDI_CONTROLLER_PAN, 64);
 		writeControl(0, i, MIDI_CONTROLLER_REVERB, 40);
 		writeControl(0, i, MIDI_CONTROLLER_CHORUS, 0);
@@ -251,7 +258,8 @@ void PortMidiMusicSystem::_ResetDevice(bool playing)
 	switch (midireset)
 	{
 		case MIDI_RESET_NONE:
-			_ResetControllers();
+			_ResetAllControllers();
+			_ResetCommonControllers();
 			break;
 
 		case MIDI_RESET_GM:
@@ -303,6 +311,7 @@ void PortMidiMusicSystem::pauseSong()
 void PortMidiMusicSystem::restartSong()
 {
 	allNotesOff();
+	_ResetAllControllers();
 	MidiMusicSystem::restartSong();
 }
 

--- a/client/sdl/i_musicsystem_portmidi.h
+++ b/client/sdl/i_musicsystem_portmidi.h
@@ -63,7 +63,8 @@ class PortMidiMusicSystem : public MidiMusicSystem
 	PmDeviceID m_outputDevice;
 	PmStream* m_stream;
 
-	void _ResetControllers();
+	void _ResetAllControllers();
+	void _ResetCommonControllers();
 	void _ResetPitchBendSensitivity();
 	void _ResetDevice(bool playing);
 	bool _IsSysExReset(const byte *data, size_t length);


### PR DESCRIPTION
Matches Vanilla Doom behavior and prevents hanging notes (NIN.WAD E1M8). Also removed an unused variable.