### PR TITLE
Integrate chex.exe green damage tint for chex.wad.

### DIFF
--- a/client/src/v_palette.cpp
+++ b/client/src/v_palette.cpp
@@ -1168,6 +1168,20 @@ void V_DoPaletteEffects()
 		V_AddBlend(blend, R_GetSectorBlend());
 		V_AddBlend(blend, plyr->blend_color);
 
+		float greendamagecolor;
+		float reddamagecolor;
+
+		if (gamemode == retail_chex)
+		{
+			reddamagecolor = 0.0f;
+			greendamagecolor = 255.0f / 255.0f;
+		}
+		else
+		{
+			reddamagecolor = 255.0f / 255.0f;
+			greendamagecolor = 0.0f;
+		}
+
 		// red tint for pain / berzerk power
 		if (plyr->damagecount || plyr->powers[pw_strength])
 		{
@@ -1184,8 +1198,8 @@ void V_DoPaletteEffects()
 				red_amount = MIN(red_amount, 56.0f);
 				float alpha = (red_amount + 8.0f) / 72.0f;
 
-				static const float red = 255.0f / 255.0f;
-				static const float green = 0.0f;
+				static const float red = reddamagecolor;
+				static const float green = greendamagecolor;
 				static const float blue = 0.0f;
 				V_AddBlend(blend, fargb_t(alpha, red, green, blue));
 			}


### PR DESCRIPTION
The aim of this PR is to fix the issue where chex.wad lacks the green damage tint for 'getting slimed' (and Berserk) as opposed to 'getting bloodied'.

There is currently no way for modders to change what the colour of the damage tint is, which is (ironically) a step backwards from Vanilla DOOM where modders could edit PLAYPAL for this purpose. Of course, there's a good reason for this: the necessity of Odamex ignoring those palette indexes in order to create smooth 32-bit colour palette changes. ZDoom has found a way past this to restore the Vanilla functionality, but see below.

This is at the least a Vanilla-ish fix for the current bug.

**Alternatives considered:**

It would be great to have a system customizable by modders to let them dictate on a per-WAD basis what the damage tint is so as to avoid engine hacks like this (used in chex.exe, Chocolate Doom, etc.). The problem is ZDoom does this with a DECORATE actor property, "player.damagescreencolor". So what would an Odamex equivalent look like? A MBF21 property? MBF21 deals more in actor states and things, and it's something that all supporting source ports would have to agree upon. That seems outside of the scope of what MBF21, DEHEXTRA, etc. are aiming for. It could also be some other customizable Odamex lump, but... eh.