### PR TITLE
[BUGFIX] Display levelnames specified in UMAPINFO on intermission screens

### DIFF
--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -535,7 +535,7 @@ void WI_drawEL()
 	// [RH] Changed to adjust by height of entering patch instead of title
 	y += (5 * ent->height()) / 4;
 
-	if (lnames1)
+	if (!lnames[1].empty())
 	{
 		// draw level
 		screen->DrawPatchClean(lnames1, (320 - lnames1->width()) / 2, y);

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -295,6 +295,7 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 	{
 		os.mustScan();
 		mape->level_name = os.getToken();
+		mape->pname.clear();
 	}
 	else if (!stricmp(pname.c_str(), "next"))
 	{


### PR DESCRIPTION
This fixes two related bugs. Level names specified in UMAPINFO were not being used in intermissions, instead using the Doom 2 names. Additionally, level names specified in MAPINFO were not being shown on the ENTERING intermission screens, just leaving a blank space. Both of these are addressed.