### PR TITLE
PortMidi: Update volume after "reset all controllers" event

### DIFF
--- a/client/sdl/i_musicsystem_portmidi.cpp
+++ b/client/sdl/i_musicsystem_portmidi.cpp
@@ -140,6 +140,10 @@ void PortMidiMusicSystem::writeControl(int time, byte channel, byte control, byt
 {
 	PmMessage msg = Pm_Message(MIDI_EVENT_CONTROLLER | channel, control, value);
 	Pm_WriteShort(m_stream, time, msg);
+
+	// Reapply volume for devices that don't follow MIDI spec (e.g. MS GS Synth)
+	if (control == MIDI_CONTROLLER_RESET_ALL_CTRLS)
+		writeVolume(0, channel, m_channelVolume[channel]);
 }
 
 void PortMidiMusicSystem::writeChannel(int time, byte channel, byte status, byte param1, byte param2)
@@ -312,6 +316,11 @@ void PortMidiMusicSystem::restartSong()
 {
 	allNotesOff();
 	_ResetAllControllers();
+
+	// Reapply volume for devices that don't follow MIDI spec (e.g. MS GS Synth)
+	for (int i = 0; i < NUM_CHANNELS; i++)
+		writeVolume(0, i, m_channelVolume[i]);
+
 	MidiMusicSystem::restartSong();
 }
 


### PR DESCRIPTION
This is a workaround for a bug that appears when using PortMidi, Windows, and the default Windows MIDI synth (Microsoft GS Wavetable Synth). When the MS GS Synth receives a "reset all controllers" event it also resets the channel volume, deviating from MIDI spec. As a result, in certain cases the channel can be audible even if the music volume slider is set to zero. The workaround is to always update the volume after a "reset all controllers" event.

Test wad: [reset_all_ctrls_test.zip](https://github.com/odamex/odamex/files/11107650/reset_all_ctrls_test.zip)
