### PR TITLE
master: include time.h on all platforms

### DIFF
--- a/master/main.cpp
+++ b/master/main.cpp
@@ -38,16 +38,15 @@
 #include <string.h>
 
 #include <stdint.h>
+#include <time.h>
 
 #ifdef UNIX
 #include <netinet/in.h>
 #include <unistd.h>
-#include <sys/time.h>
 #endif
 
 #ifdef _WIN32
 #include <winsock.h>
-#include <time.h>
 #define usleep(n) Sleep(n/1000)
 #endif
 


### PR DESCRIPTION
`time()` is only declared i `time.h`, I don't know what `sys/time.h` was intended for, but it compiles without it on Fedora 38