### PR TITLE
[BUGFIX] Fix ghost monsters that occur with MBF21 use of A_HealChase

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2109,6 +2109,12 @@ void A_HealChase(AActor* actor)
 // 
 bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 {
+	// don't attempt to resurrect clientside
+	if (!serverside)
+	{
+		return false;
+	}
+
 	int xl, xh;
 	int yl, yh;
 	int bx, by;


### PR DESCRIPTION
A_HealChase was allowing MBF21 monsters to resurrect monsters clientside, which resulted in desynced "ghost" monsters that never attacked. This fixes that.