### PR TITLE
Expand FPS cap options in menu

### DIFF
--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1122,7 +1122,11 @@ static value_t VidFPSCaps[] = {
 	{ 35.0,		"35fps" },
 	{ 60.0,		"60fps" },
 	{ 70.0,		"70fps" },
-	{ 120.0,	"120fps" },
+   	{ 105.0,	"105fps"},
+	{ 120.0,	"120fps" }, 
+	{ 140.0,	"140fps"},
+    	{ 144.0,	"144fps"},
+    	{ 240.0,	"240fps"},
 	{ 0.0,		"Unlimited" }
 };
 
@@ -1149,7 +1153,7 @@ static menuitem_t ModesItems[] = {
 #endif
 	{ discrete,	"Widescreen",			{&vid_widescreen},		{6.0}, {0.0},	{0.0}, {WidescreenMode} } ,
 	{ discrete,	"VSync",				{&vid_vsync},			{2.0}, {0.0},	{0.0}, {YesNo} },
-	{ discrete, "Framerate",			{&vid_maxfps},			{5.0}, {0.0},	{0.0}, {VidFPSCaps} },
+	{ discrete, "Framerate",			{&vid_maxfps},			{9.0}, {0.0},	{0.0}, {VidFPSCaps} },
 	{ discrete, "32-bit color",			{&vid_32bpp},			{2.0}, {0.0},	{0.0}, {YesNo} },
 	{ redtext,	"",						{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
 	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },


### PR DESCRIPTION
Add additional multiples of 35FPS (Doom base framerate) and common display refresh rates