### PR TITLE
Ticcmd queue fixes

### DIFF
--- a/common/d_player.h
+++ b/common/d_player.h
@@ -134,6 +134,7 @@ public:
 
 	struct ticcmd_t cmd;	// the ticcmd currently being processed
 	std::queue<NetCommand> cmdqueue;	// all received ticcmds
+	int			missingticcmdcount;		// number of gametics without processing a ticcmd for this player
 
 	// [RH] who is this?
 	UserInfo	userinfo;

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -1321,6 +1321,7 @@ player_s::player_s() :
 	ping(0),
 	last_received(0),
 	tic(0),
+	missingticcmdcount(0),
 	snapshots(PlayerSnapshotManager()),
 	spying(0),
 	spectator(false),
@@ -1440,6 +1441,8 @@ player_s &player_s::operator =(const player_s &other)
 	last_received = other.last_received;
 
 	tic = other.tic;
+	missingticcmdcount = other.missingticcmdcount;
+
 	spying = other.spying;
 	spectator = other.spectator;
 //	deadspectator = other.deadspectator;

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3214,7 +3214,7 @@ int SV_CalculateNumTiccmds(player_t &player)
 		// Player is not moving
 		return 2;
 	}
-	if (player.cmdqueue.size() > 2 && gametic % 2*TICRATE == player.id % 2*TICRATE)
+	if (player.cmdqueue.size() > 2 && gametic % (2*TICRATE) == player.id % (2*TICRATE))
 	{
 		// Process an extra ticcmd once every 2 seconds to reduce the
 		// queue size. Use player id to stagger the timing to prevent everyone


### PR DESCRIPTION
Mitigate exploits related to clients sending multiple ticcmds within a single gametic. Only process multiple ticcmds from a client if expected ticcmds have been delayed, rather than blindly accepting and processing ticcmds when the buffer is full.

Additionally, fixes a bug in the logic around processing an extra ticcmd from a client. Missing parenthesis around 2*TICRATE cause an extra ticcmd to be processed every other gametic, rather than the intended behavior of once every two seconds.