### PR TITLE
[BUGFIX] Fix +RIP projectiles

### DIFF
--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -1244,19 +1244,14 @@ static int PatchThing(int thingy)
 						info->flags3 |= MF3_E4M8BOSS;
 					}
 
+					if (tempval & BIT(17)) // MBF21 RIP is 1 << 17
+					{
+						info->flags2 |= MF2_RIP;
+					}
+
 					if (tempval & MF3_FULLVOLSOUNDS)
 					{
 						info->flags3 |= MF3_FULLVOLSOUNDS;
-					}
-
-					if (tempval & MF2_NODMGTHRUST)
-					{
-						info->flags2 |= MF2_NODMGTHRUST;
-					}
-
-					if (tempval & MF2_RIP)
-					{
-						info->flags2 |= MF2_RIP;
 					}
 
 					value[3] |= atoi(strval);


### PR DESCRIPTION
This was caused by the MBF21 dehacked function checking for incorrect specified bits when it came to RIP. This patch fixes this. Should fix #850 