### PR TITLE
[BUGFIX] Revert ticcmd changes

### DIFF
--- a/common/d_player.h
+++ b/common/d_player.h
@@ -134,7 +134,6 @@ public:
 
 	struct ticcmd_t cmd;	// the ticcmd currently being processed
 	std::queue<NetCommand> cmdqueue;	// all received ticcmds
-	int			missingticcmdcount;		// number of gametics without processing a ticcmd for this player
 
 	// [RH] who is this?
 	UserInfo	userinfo;

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -1321,7 +1321,6 @@ player_s::player_s() :
 	ping(0),
 	last_received(0),
 	tic(0),
-	missingticcmdcount(0),
 	snapshots(PlayerSnapshotManager()),
 	spying(0),
 	spectator(false),
@@ -1441,8 +1440,6 @@ player_s &player_s::operator =(const player_s &other)
 	last_received = other.last_received;
 
 	tic = other.tic;
-	missingticcmdcount = other.missingticcmdcount;
-
 	spying = other.spying;
 	spectator = other.spectator;
 //	deadspectator = other.deadspectator;

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3214,7 +3214,7 @@ int SV_CalculateNumTiccmds(player_t &player)
 		// Player is not moving
 		return 2;
 	}
-	if (player.cmdqueue.size() > 2 && gametic % (2*TICRATE) == player.id % (2*TICRATE))
+	if (player.cmdqueue.size() > 2 && gametic % 2*TICRATE == player.id % 2*TICRATE)
 	{
 		// Process an extra ticcmd once every 2 seconds to reduce the
 		// queue size. Use player id to stagger the timing to prevent everyone

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3204,38 +3204,34 @@ int SV_CalculateNumTiccmds(player_t &player)
 
 	static const size_t maximum_queue_size = TICRATE / 4;
 
-	if (!sv_ticbuffer || gamestate != GS_LEVEL || player.spectator || player.playerstate == PST_DEAD)
+	if (!sv_ticbuffer || player.spectator || player.playerstate == PST_DEAD)
 	{
 		// Process all queued ticcmds.
 		return maximum_queue_size;
 	}
-	if (player.missingticcmdcount > 0)
+	if (player.mo->momx == 0 && player.mo->momy == 0 && player.mo->momz == 0)
 	{
-		if (player.mo->momx == 0 && player.mo->momy == 0 && player.mo->momz == 0)
-		{
-			// Player is not moving
-			return 2;
-		}
-		if (player.cmdqueue.size() > 2 && gametic % (2*TICRATE) == player.id % (2*TICRATE))
-		{
-			// Process an extra ticcmd once every 2 seconds to reduce the
-			// queue size. Use player id to stagger the timing to prevent everyone
-			// from running an extra ticcmd at the same time.
-			return 2;
-		}
-		if (player.cmdqueue.size() > maximum_queue_size)
-		{
-			// The player experienced a large latency spike so try to catch up by
-			// processing more than one ticcmd at the expense of appearing perfectly
-			// smooth.
-			return 2;
-		}
+		// Player is not moving
+		return 2;
+	}
+	if (player.cmdqueue.size() > 2 && gametic % (2*TICRATE) == player.id % (2*TICRATE))
+	{
+		// Process an extra ticcmd once every 2 seconds to reduce the
+		// queue size. Use player id to stagger the timing to prevent everyone
+		// from running an extra ticcmd at the same time.
+		return 2;
+	}
+	if (player.cmdqueue.size() > maximum_queue_size)
+	{
+		// The player experienced a large latency spike so try to catch up by
+		// processing more than one ticcmd at the expense of appearing perfectly
+		//  smooth
+		return 2;
 	}
 
 	// always run at least 1 ticcmd if possible
 	return 1;
 }
-
 
 //
 // SV_ProcessPlayerCmd
@@ -3265,9 +3261,6 @@ void SV_ProcessPlayerCmd(player_t &player)
 	DPrintf("Cmd queue size for %s: %d\n",
 				player.userinfo.netname, player.cmdqueue.size());
 	#endif	// _TICCMD_QUEUE_DEBUG_
-
-	if (player.cmdqueue.empty())
-		player.missingticcmdcount++;
 
 	int num_cmds = SV_CalculateNumTiccmds(player);
 
@@ -3310,7 +3303,6 @@ void SV_ProcessPlayerCmd(player_t &player)
 		}
 
 		player.cmdqueue.pop();		// remove this tic from the queue after being processed
-		player.missingticcmdcount--;
 	}
 }
 


### PR DESCRIPTION
The ticcmd changes need to be reverted as they cause lag after a new game. We need to look at this issue closer at a later time.