### PR TITLE
[FEATURE] Add options tab to boot GUI

### DIFF
--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -112,6 +112,9 @@ class BootWindow : public Fl_Window
 	Fl_Hold_Browser* m_IWADBrowser;
 	Fl_Check_Browser* m_PWADSelectBrowser;
 	Fl_Hold_Browser* m_PWADOrderBrowser;
+	Fl_Check_Button* m_nomonstersCheckButton;
+	Fl_Check_Button* m_fastCheckButton;
+	Fl_Check_Button* m_respawnCheckButton;
 	StringTokens m_WADDirs;
 	Fl_Hold_Browser* m_WADDirList;
 
@@ -165,6 +168,24 @@ class BootWindow : public Fl_Window
 				} // Fl_Button* doWADRemove
 				m_tabPWADs->end();
 			} // Fl_Group* tabPWADs
+			{
+				Fl_Group* tabGameOptions = 
+					new Fl_Group(0, 25, 425, 175, "Game Options");
+				{
+					m_nomonstersCheckButton = new Fl_Check_Button(10, 50, 20, 20, " No Monsters");
+					m_nomonstersCheckButton->down_box(FL_DOWN_BOX);
+				}
+				{
+					m_fastCheckButton = new Fl_Check_Button(10, 100, 20, 20, " Fast Monsters");
+					m_fastCheckButton->down_box(FL_DOWN_BOX);
+				}
+				{
+					m_respawnCheckButton = new Fl_Check_Button(10, 150, 20, 20, " Respawn Monsters");
+					m_respawnCheckButton->down_box(FL_DOWN_BOX);
+				}
+				tabGameOptions->end();
+
+			} // Fl_Group* tabGameOptions
 			{
 				Fl_Group* tabWADDirs =
 				    new Fl_Group(0, 25, 425, 175, "Resource Locations");

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -293,6 +293,7 @@ class BootWindow : public Fl_Window
 		}
 
 		boot->selectedWADs();
+		boot->setOptions();
 		Fl::delete_widget(boot);
 	}
 
@@ -516,6 +517,13 @@ class BootWindow : public Fl_Window
 		{
 			g_SelectedWADs.pwads.push_back((*it)->path);
 		}
+	}
+
+	void setOptions()
+	{
+		g_SelectedWADs.fast = m_fastCheckButton->value();
+		g_SelectedWADs.nomonsters = m_nomonstersCheckButton->value();
+		g_SelectedWADs.respawn = m_respawnCheckButton->value();
 	}
 
 	/**

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -59,10 +59,10 @@ typedef std::vector<scannedPWAD_t*> scannedPWADPtrs_t;
 // display strings for options tab and their corresponding command line arguments
 const std::vector<std::pair<std::string, std::string>> OPTIONS_LIST =
 {
-	{"No Monsters", "-nomonsters"},
-	{"Fast Monsters", "-fast"},
-	{"Respawn Monsters", "-respawn"},
-	{"Pistol Start", "-pistolstart"}
+	std::make_pair("No Monsters", "-nomonsters"),
+	std::make_pair("Fast Monsters", "-fast"),
+	std::make_pair("Respawn Monsters", "-respawn"),
+	std::make_pair("Pistol Start", "-pistolstart")
 };
 
 /**

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -174,7 +174,7 @@ class BootWindow : public Fl_Window
 				{
 					Fl_Box* o = new Fl_Box(
 					    10, 35, 405, 20,
-					    "Set options idk.");
+					    "Set gameplay options to modify your experience.");
 					o->align(Fl_Align(132 | FL_ALIGN_INSIDE));
 				} // Fl_Box* o
 				{

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -116,7 +116,7 @@ class BootWindow : public Fl_Window
 	StringTokens m_WADDirs;
 	Fl_Hold_Browser* m_WADDirList;
 	// display strings for options tab and their corresponding command line arguments
-	std::vector<std::pair<std::string, std::string>> OPTIONS_LIST;
+	std::vector<std::pair<std::string, std::string> > OPTIONS_LIST;
 
   public:
 	BootWindow(int X, int Y, int W, int H, const char* L)

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -112,9 +112,7 @@ class BootWindow : public Fl_Window
 	Fl_Hold_Browser* m_IWADBrowser;
 	Fl_Check_Browser* m_PWADSelectBrowser;
 	Fl_Hold_Browser* m_PWADOrderBrowser;
-	Fl_Check_Button* m_nomonstersCheckButton;
-	Fl_Check_Button* m_fastCheckButton;
-	Fl_Check_Button* m_respawnCheckButton;
+	Fl_Check_Browser* m_gameOptionsBrowser;
 	StringTokens m_WADDirs;
 	Fl_Hold_Browser* m_WADDirList;
 
@@ -172,16 +170,16 @@ class BootWindow : public Fl_Window
 				Fl_Group* tabGameOptions = 
 					new Fl_Group(0, 25, 425, 175, "Game Options");
 				{
-					m_nomonstersCheckButton = new Fl_Check_Button(10, 50, 20, 20, " No Monsters");
-					m_nomonstersCheckButton->down_box(FL_DOWN_BOX);
-				}
+					Fl_Box* o = new Fl_Box(
+					    10, 35, 405, 20,
+					    "Set options idk.");
+					o->align(Fl_Align(132 | FL_ALIGN_INSIDE));
+				} // Fl_Box* o
 				{
-					m_fastCheckButton = new Fl_Check_Button(10, 100, 20, 20, " Fast Monsters");
-					m_fastCheckButton->down_box(FL_DOWN_BOX);
-				}
-				{
-					m_respawnCheckButton = new Fl_Check_Button(10, 150, 20, 20, " Respawn Monsters");
-					m_respawnCheckButton->down_box(FL_DOWN_BOX);
+					m_gameOptionsBrowser = new Fl_Check_Browser(10, 65, 405, 125);
+					m_gameOptionsBrowser->add("No Monsters");
+					m_gameOptionsBrowser->add("Fast Monsters");
+					m_gameOptionsBrowser->add("Respawn Monsters");
 				}
 				tabGameOptions->end();
 
@@ -521,9 +519,9 @@ class BootWindow : public Fl_Window
 
 	void setOptions()
 	{
-		g_SelectedWADs.fast = m_fastCheckButton->value();
-		g_SelectedWADs.nomonsters = m_nomonstersCheckButton->value();
-		g_SelectedWADs.respawn = m_respawnCheckButton->value();
+		for (int i = 1; i <= m_gameOptionsBrowser->nitems(); i++) {
+			g_SelectedWADs.options.push_back(m_gameOptionsBrowser->checked(i));
+		}
 	}
 
 	/**

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -133,6 +133,7 @@ class BootWindow : public Fl_Window
 				} // Fl_Box* logo
 				{
 					m_IWADBrowser = new Fl_Hold_Browser(135, 35, 280, 155);
+					m_IWADBrowser->callback(BootWindow::doPlayCB, static_cast<void*>(this));
 				} // Fl_Browser* m_IWADBrowser
 				m_tabIWAD->end();
 			} // Fl_Group* tabIWAD

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -188,7 +188,7 @@ class BootWindow : public Fl_Window
 				} // Fl_Box* o
 				{
 					m_gameOptionsBrowser = new Fl_Check_Browser(10, 65, 405, 125);
-					for (auto it = OPTIONS_LIST.begin();
+					for (std::vector<std::pair<std::string, std::string>>::const_iterator it = OPTIONS_LIST.begin();
 		    	 		 it != OPTIONS_LIST.end(); ++it)
 					{
 						m_gameOptionsBrowser->add((*it).first.c_str());

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -122,10 +122,10 @@ class BootWindow : public Fl_Window
 	BootWindow(int X, int Y, int W, int H, const char* L)
 	    : Fl_Window(X, Y, W, H, L), m_IWADs()
 	{
-		OPTIONS_LIST.emplace_back("No Monsters", "-nomonsters");
-		OPTIONS_LIST.emplace_back("Fast Monsters", "-fast");
-		OPTIONS_LIST.emplace_back("Respawn Monsters", "-respawn");
-		OPTIONS_LIST.emplace_back("Pistol Start", "-pistolstart");
+		OPTIONS_LIST.push_back(std::make_pair("No Monsters", "-nomonsters"));
+		OPTIONS_LIST.push_back(std::make_pair("Fast Monsters", "-fast"));
+		OPTIONS_LIST.push_back(std::make_pair("Respawn Monsters", "-respawn"));
+		OPTIONS_LIST.push_back(std::make_pair("Pistol Start", "-pistolstart"));
 		{
 			Fl_Tabs* tabs = new Fl_Tabs(0, 0, 425, 200);
 			{

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -56,6 +56,15 @@ typedef std::vector<scannedIWAD_t> scannedIWADs_t;
 typedef std::vector<scannedPWAD_t> scannedPWADs_t;
 typedef std::vector<scannedPWAD_t*> scannedPWADPtrs_t;
 
+// display strings for options tab and their corresponding command line arguments
+const std::vector<std::pair<std::string, std::string>> OPTIONS_LIST =
+{
+	{"No Monsters", "-nomonsters"},
+	{"Fast Monsters", "-fast"},
+	{"Respawn Monsters", "-respawn"},
+	{"Pistol Start", "-pistolstart"}
+};
+
 /**
  * @brief Find the PWAD pointer in the scanned WAD array.
  */
@@ -98,7 +107,7 @@ static void EraseSelected(scannedPWADPtrs_t& mut, scannedPWAD_t* pwad)
 const scannedIWAD_t* g_SelectedIWAD;
 scannedWADs_t g_SelectedWADs;
 
-const int WINDOW_WIDTH = 320;
+const int WINDOW_WIDTH = 425;
 const int WINDOW_HEIGHT = 240;
 
 class BootWindow : public Fl_Window
@@ -179,10 +188,11 @@ class BootWindow : public Fl_Window
 				} // Fl_Box* o
 				{
 					m_gameOptionsBrowser = new Fl_Check_Browser(10, 65, 405, 125);
-					m_gameOptionsBrowser->add("No Monsters");
-					m_gameOptionsBrowser->add("Fast Monsters");
-					m_gameOptionsBrowser->add("Respawn Monsters");
-					m_gameOptionsBrowser->add("Pistol Start");
+					for (auto it = OPTIONS_LIST.begin();
+		    	 		 it != OPTIONS_LIST.end(); ++it)
+					{
+						m_gameOptionsBrowser->add((*it).first.c_str());
+					}
 				}
 				tabGameOptions->end();
 
@@ -523,7 +533,8 @@ class BootWindow : public Fl_Window
 	void setOptions()
 	{
 		for (int i = 1; i <= m_gameOptionsBrowser->nitems(); i++) {
-			g_SelectedWADs.options.push_back(m_gameOptionsBrowser->checked(i));
+			if (m_gameOptionsBrowser->checked(i))
+				g_SelectedWADs.options.push_back(OPTIONS_LIST[i - 1].second);
 		}
 	}
 
@@ -557,7 +568,7 @@ class BootWindow : public Fl_Window
  */
 static BootWindow* MakeBootWindow()
 {
-	return new BootWindow(0, 0, 425, 240, "Odamex " DOTVERSIONSTR);
+	return new BootWindow(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT, "Odamex " DOTVERSIONSTR);
 }
 
 /**

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -56,15 +56,6 @@ typedef std::vector<scannedIWAD_t> scannedIWADs_t;
 typedef std::vector<scannedPWAD_t> scannedPWADs_t;
 typedef std::vector<scannedPWAD_t*> scannedPWADPtrs_t;
 
-// display strings for options tab and their corresponding command line arguments
-const std::vector<std::pair<std::string, std::string>> OPTIONS_LIST =
-{
-	std::make_pair("No Monsters", "-nomonsters"),
-	std::make_pair("Fast Monsters", "-fast"),
-	std::make_pair("Respawn Monsters", "-respawn"),
-	std::make_pair("Pistol Start", "-pistolstart")
-};
-
 /**
  * @brief Find the PWAD pointer in the scanned WAD array.
  */
@@ -124,11 +115,17 @@ class BootWindow : public Fl_Window
 	Fl_Check_Browser* m_gameOptionsBrowser;
 	StringTokens m_WADDirs;
 	Fl_Hold_Browser* m_WADDirList;
+	// display strings for options tab and their corresponding command line arguments
+	std::vector<std::pair<std::string, std::string>> OPTIONS_LIST;
 
   public:
 	BootWindow(int X, int Y, int W, int H, const char* L)
 	    : Fl_Window(X, Y, W, H, L), m_IWADs()
 	{
+		OPTIONS_LIST.emplace_back("No Monsters", "-nomonsters");
+		OPTIONS_LIST.emplace_back("Fast Monsters", "-fast");
+		OPTIONS_LIST.emplace_back("Respawn Monsters", "-respawn");
+		OPTIONS_LIST.emplace_back("Pistol Start", "-pistolstart");
 		{
 			Fl_Tabs* tabs = new Fl_Tabs(0, 0, 425, 200);
 			{
@@ -188,7 +185,7 @@ class BootWindow : public Fl_Window
 				} // Fl_Box* o
 				{
 					m_gameOptionsBrowser = new Fl_Check_Browser(10, 65, 405, 125);
-					for (std::vector<std::pair<std::string, std::string>>::const_iterator it = OPTIONS_LIST.begin();
+					for (std::vector<std::pair<std::string, std::string> >::const_iterator it = OPTIONS_LIST.begin();
 		    	 		 it != OPTIONS_LIST.end(); ++it)
 					{
 						m_gameOptionsBrowser->add((*it).first.c_str());

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -134,6 +134,7 @@ class BootWindow : public Fl_Window
 				{
 					m_IWADBrowser = new Fl_Hold_Browser(135, 35, 280, 155);
 					m_IWADBrowser->callback(BootWindow::doPlayCB, static_cast<void*>(this));
+					m_IWADBrowser->when(FL_WHEN_ENTER_KEY);
 				} // Fl_Browser* m_IWADBrowser
 				m_tabIWAD->end();
 			} // Fl_Group* tabIWAD

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -180,6 +180,7 @@ class BootWindow : public Fl_Window
 					m_gameOptionsBrowser->add("No Monsters");
 					m_gameOptionsBrowser->add("Fast Monsters");
 					m_gameOptionsBrowser->add("Respawn Monsters");
+					m_gameOptionsBrowser->add("Pistol Start");
 				}
 				tabGameOptions->end();
 

--- a/client/gui/gui_boot.h
+++ b/client/gui/gui_boot.h
@@ -27,6 +27,9 @@ struct scannedWADs_t
 {
     std::string iwad;
     StringTokens pwads;
+    bool nomonsters;
+    bool respawn;
+    bool fast;
 };
 
 scannedWADs_t GUI_BootWindow();

--- a/client/gui/gui_boot.h
+++ b/client/gui/gui_boot.h
@@ -29,7 +29,7 @@ struct scannedWADs_t
 {
     std::string iwad;
     StringTokens pwads;
-    std::vector<bool> options;
+    StringTokens options;
 };
 
 scannedWADs_t GUI_BootWindow();

--- a/client/gui/gui_boot.h
+++ b/client/gui/gui_boot.h
@@ -22,14 +22,13 @@
 //-----------------------------------------------------------------------------
 
 #pragma once
+#include <array>
 
 struct scannedWADs_t
 {
     std::string iwad;
     StringTokens pwads;
-    bool nomonsters;
-    bool respawn;
-    bool fast;
+    std::vector<bool> options;
 };
 
 scannedWADs_t GUI_BootWindow();

--- a/client/gui/gui_boot.h
+++ b/client/gui/gui_boot.h
@@ -22,7 +22,8 @@
 //-----------------------------------------------------------------------------
 
 #pragma once
-#include <array>
+
+#include "m_argv.h"
 
 struct scannedWADs_t
 {

--- a/client/gui/gui_boot.h
+++ b/client/gui/gui_boot.h
@@ -23,8 +23,6 @@
 
 #pragma once
 
-#include "m_argv.h"
-
 struct scannedWADs_t
 {
     std::string iwad;

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -801,6 +801,12 @@ void D_DoomMain()
 			scannedWADs_t wads = GUI_BootWindow();
 			iwad = wads.iwad;
 			pwads = wads.pwads;
+			// Nomonsters
+			sv_nomonsters = wads.nomonsters;
+			// Respawn
+			sv_monstersrespawn = wads.respawn;
+			// Fast
+			sv_fastmonsters = wads.fast;
 		}
 	}
 
@@ -860,13 +866,13 @@ void D_DoomMain()
 		vid_ticker.SetDefault("1");
  
 	// Nomonsters
-	sv_nomonsters = Args.CheckParm("-nomonsters");
+	//sv_nomonsters = Args.CheckParm("-nomonsters");
 
 	// Respawn
-	sv_monstersrespawn = Args.CheckParm("-respawn");
+	//sv_monstersrespawn = Args.CheckParm("-respawn");
 
 	// Fast
-	sv_fastmonsters = Args.CheckParm("-fast");
+	//sv_fastmonsters = Args.CheckParm("-fast");
 
 	// Pistol start
 	g_resetinvonexit = Args.CheckParm("-pistolstart");

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -802,21 +802,11 @@ void D_DoomMain()
 			iwad = wads.iwad;
 			pwads = wads.pwads;
 
-			// Nomonsters
-			if(wads.options[0])
-				Args.AppendArg("-nomonsters");
-
-			// Fast
-			if(wads.options[1])
-				Args.AppendArg("-fast");
-
-			// Respawn
-			if(wads.options[2])
-				Args.AppendArg("-respawn");
-
-			//Pistol start
-			if(wads.options[3])
-				Args.AppendArg("-pistolstart");
+			for (StringTokens::iterator it = wads.options.begin();
+		    	 it != wads.options.end(); ++it)
+			{
+				Args.AppendArg((*it).c_str());
+			}
 		}
 	}
 

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -801,12 +801,22 @@ void D_DoomMain()
 			scannedWADs_t wads = GUI_BootWindow();
 			iwad = wads.iwad;
 			pwads = wads.pwads;
+
 			// Nomonsters
-			sv_nomonsters = wads.options[0];
+			if(wads.options[0])
+				Args.AppendArg("-nomonsters");
+
 			// Fast
-			sv_fastmonsters = wads.options[1];
+			if(wads.options[1])
+				Args.AppendArg("-fast");
+
 			// Respawn
-			sv_monstersrespawn = wads.options[2];
+			if(wads.options[2])
+				Args.AppendArg("-respawn");
+
+			//Pistol start
+			if(wads.options[3])
+				Args.AppendArg("-pistolstart");
 		}
 	}
 
@@ -864,15 +874,15 @@ void D_DoomMain()
 	// set the default value for vid_ticker based on the presence of -devparm
 	if (devparm)
 		vid_ticker.SetDefault("1");
- 
+
 	// Nomonsters
-	//sv_nomonsters = Args.CheckParm("-nomonsters");
+	sv_nomonsters = Args.CheckParm("-nomonsters");
 
 	// Respawn
-	//sv_monstersrespawn = Args.CheckParm("-respawn");
+	sv_monstersrespawn = Args.CheckParm("-respawn");
 
 	// Fast
-	//sv_fastmonsters = Args.CheckParm("-fast");
+	sv_fastmonsters = Args.CheckParm("-fast");
 
 	// Pistol start
 	g_resetinvonexit = Args.CheckParm("-pistolstart");

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -802,11 +802,11 @@ void D_DoomMain()
 			iwad = wads.iwad;
 			pwads = wads.pwads;
 			// Nomonsters
-			sv_nomonsters = wads.nomonsters;
-			// Respawn
-			sv_monstersrespawn = wads.respawn;
+			sv_nomonsters = wads.options[0];
 			// Fast
-			sv_fastmonsters = wads.fast;
+			sv_fastmonsters = wads.options[1];
+			// Respawn
+			sv_monstersrespawn = wads.options[2];
 		}
 	}
 


### PR DESCRIPTION
I often find myself wishing I had the no monsters option when loading a wad from the GUI. This adds a new tab with checkboxes for options such as that. This also adds the ability to double click an IWAD in the Game Select list to start the game, same as clicking the Play button.

![image](https://github.com/odamex/odamex/assets/84749759/d73945cd-24fa-4fe6-a70b-34e7d0c50e0e)
