### PR TITLE
[BUGFIX] Fix obits for MBF21 Projectiles

### DIFF
--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -680,8 +680,16 @@ static BOOL PIT_CheckThing (AActor *thing)
 						mod = MOD_BFG_BOOM;
 						break;
 					// [AM] Monster fireballs get a special MOD.
+				  // Unless they're from players
 					default:
-					    mod = MOD_FIREBALL;
+							if ((tmthing->target && tmthing->target->player) || !tmthing->target)
+							{
+						        mod = MOD_UNKNOWN;
+							}
+							else
+							{
+						        mod = MOD_FIREBALL;
+							}
 						break;
 				}
 				P_DamageMobj (thing, tmthing, tmthing->target, damage, mod);

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -651,7 +651,7 @@ static BOOL PIT_CheckThing (AActor *thing)
 			if (tmthing->info->ripsound)
 				S_Sound(tmthing, CHAN_VOICE, tmthing->info->ripsound, 1, ATTN_NORM);
 
-			P_DamageMobj(thing, tmthing, tmthing->target, damage);
+			P_DamageMobj(thing, tmthing, tmthing->target, damage, MOD_UNKNOWN);
 			if (thing->flags2 & MF2_PUSHABLE && !(tmthing->flags2 & MF2_CANNOTPUSH))
 			{ // Push thing
 				thing->momx += tmthing->momx >> 2;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2630,9 +2630,9 @@ void P_ExplodeMissile (AActor* mo)
 		case MT_BFG:
 			mod = MOD_BFG_BOOM;
 			break;
-		// [AM] Monster fireballs get a special MOD.
+		// Blair: Unknown player projectiles get an unknown mod
 		default:
-			mod = MOD_FIREBALL;
+			mod = MOD_UNKNOWN;
 			break;
 		}
 


### PR DESCRIPTION
Previously, I fixed obits for MBF21 monsters and most instances of player weapons. However, I did not fix player projectiles. This fixes that.