### PR TITLE
Fix MAPINFO token compat_invisibility from causing an error

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1555,6 +1555,7 @@ struct MapInfoDataSetter<level_pwad_info_t>
 		ENTRY3("compat_boomscroll", &MIType_CompatFlag, &ref.flags) // todo: not implemented
 		ENTRY3("compat_sectorsounds", &MIType_CompatFlag, &ref.flags) // todo: not implemented
 		ENTRY4("compat_nopassover", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_NOPASSOVER)
+		ENTRY3("compat_invisibility", &MIType_CompatFlag, &ref.flags) // todo: not implemented
 	}
 };
 


### PR DESCRIPTION
As said in the title. Does not implement said token.