### PR TITLE
[BUGFIX] Don't target spectators in MBF21 tracer functions.

### DIFF
--- a/common/p_maputl.cpp
+++ b/common/p_maputl.cpp
@@ -1231,6 +1231,13 @@ static AActor* RoughBlockCheck(AActor* mo, int index, angle_t fov)
 			continue;
 		}
 
+		// [Blair] Don't target spectators
+		if (mo->target->player && mo->target->player->spectator)
+		{
+			link = link->snext;
+			continue;
+		}
+
 		// [Blair] Don't target teammates
 		if (mo->target->player && link->player &&
 			P_AreTeammates((player_t&)mo->target->player, (player_t&)link->player))

--- a/common/p_maputl.cpp
+++ b/common/p_maputl.cpp
@@ -1232,7 +1232,7 @@ static AActor* RoughBlockCheck(AActor* mo, int index, angle_t fov)
 		}
 
 		// [Blair] Don't target spectators
-		if (mo->target->player && mo->target->player->spectator)
+		if (link->player && link->player->spectator)
 		{
 			link = link->snext;
 			continue;


### PR DESCRIPTION
Does as the title suggests. Fixes #883 