### PR TITLE
Update M_PlayerNameChanged to keep track of PSetupDepth and not immediately exit the menu.

### DIFF
--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -114,6 +114,7 @@ bool				drawSkull;			// [RH] don't always draw skull
 
 // hack for PlayerSetup
 int					PSetupDepth;
+int					PSetupArchive;
 
 // graphic name of skulls
 char				skullName[2][9] = {"M_SKULL1", "M_SKULL2"};
@@ -1691,10 +1692,14 @@ static void M_EditPlayerName (int choice)
 
 static void M_PlayerNameChanged (int choice)
 {
-	char command[SAVESTRINGSIZE+8+2];
+	std::string command;
 
-	sprintf (command, "cl_name \"%s\"", savegamestrings[0]);
+	StrFormat(command, "cl_name \"%s\"", savegamestrings[0]);
 	AddCommandString (command);
+
+	PSetupArchive = PSetupDepth;
+	AddCommandString ("menu_player");
+	PSetupDepth = PSetupArchive;
 }
 /*
 static void M_PlayerTeamChanged (int choice)

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1697,9 +1697,12 @@ static void M_PlayerNameChanged (int choice)
 	StrFormat(command, "cl_name \"%s\"", savegamestrings[0]);
 	AddCommandString (command);
 
-	PSetupArchive = PSetupDepth;
-	AddCommandString ("menu_player");
-	PSetupDepth = PSetupArchive;
+	if (currentMenu == &PSetupDef)
+	{
+		PSetupArchive = PSetupDepth;
+		AddCommandString("menu_player");
+		PSetupDepth = PSetupArchive;
+	}
 }
 /*
 static void M_PlayerTeamChanged (int choice)


### PR DESCRIPTION
The current fix (https://github.com/odamex/odamex/pull/816) for keeping track of the menu stack depth in Player Setup has an oversight. Any submitted changes to player names immediately exits the menu. I can't find a probable cause for this.

This hot fix adds another integer to keep track of what the current menu stack depth is, then immediately issues a "menu_player" command after a successful name change. One side effect is that the fire background behind the player sprite refreshes. However, it does do the job of staying in the Player Setup menu after name changes while keeping track of what the menu stack depth should have been.

Another minor change is with regards to the policy on sprintf. I accordingly changed the name change command over to std::string.