### PR TITLE
Change g_coopthingfilter to g_thingfilter, and allow the value "3"

### DIFF
--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -245,12 +245,13 @@ CVAR(g_preroundreset, "0", "After preround is over, reset the map one last time.
 CVAR(g_postroundtime, "3", "Amount of time after a round before the next round/endgame",
      CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE)
 
-CVAR_RANGE(g_coopthingfilter, "0", "Removes cooperative things of the map. Values are:\n" \
-	"// 0 - All Coop things are retained (default).\n" \
+CVAR_RANGE(g_thingfilter, "0", "Removes some things from the map. Values are:\n" \
+	"// 0 - All things are retained (default).\n" \
 	"// 1 - Only Coop weapons are removed.\n" \
-        "// 2 - All Coop things are removed.",
+        "// 2 - All Coop things are removed.\n" \
+	"// 3 - All pickupable things are removed.",
            CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE | CVAR_LATCH,
-           0.0f, 2.0f)
+           0.0f, 3.0f)
 
 CVAR(g_resetinvonexit, "0",
      "Always reset players to their starting inventory on level exit", CVARTYPE_BOOL,

--- a/common/doomdata.h
+++ b/common/doomdata.h
@@ -269,7 +269,7 @@ typedef struct MapThing
 #define MTF_DEATHMATCH		0x0400	// Thing appears in deathmatch games
 
 // Custom MapThing Flags
-#define MTF_FILTER_COOPWPN  0x0800  // Weapon thing is filtered with g_coopthingfilter 1.
+#define MTF_FILTER_COOPWPN  0x0800  // Weapon thing is filtered with g_thingfilter 1.
 									// (Hate this method but it works...)
 
 

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -85,6 +85,7 @@ EXTERN_CVAR(co_fixweaponimpacts)
 EXTERN_CVAR(co_fineautoaim)
 EXTERN_CVAR(sv_allowshowspawns)
 EXTERN_CVAR(sv_teamsinplay)
+EXTERN_CVAR(g_thingfilter)
 
 mapthing2_t     itemrespawnque[ITEMQUESIZE];
 int             itemrespawntime[ITEMQUESIZE];
@@ -2745,6 +2746,16 @@ size_t P_GetMapThingPlayerNumber(mapthing2_t *mthing)
 			(mthing->type - 4001 + 4) % MAXPLAYERSTARTS;
 }
 
+int P_IsPickupableThing(short type)
+{
+	return (type == 82 // SSG
+			|| (type >= 2000 && type <= 2050) // weapons, ammo, health, armor, special items
+			|| type == 17 // cell pack
+			|| type == 83 // megasphere
+			|| type == 8 // backpack
+	       );
+}
+
 //
 // P_SpawnMapThing
 // The fields of the mapthing should
@@ -2885,6 +2896,9 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 		if (!(mthing->flags & MTF_COOPERATIVE))
 			return;
 	}
+
+	if (g_thingfilter == 3 && P_IsPickupableThing(mthing->type))
+		return;
 
 	// check for appropriate skill level
 	if (!(mthing->flags & G_GetCurrentSkill().spawn_filter))

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -70,7 +70,7 @@ int P_TranslateSectorSpecial(int special);
 extern dyncolormap_t NormalLight;
 extern AActor* shootthing;
 
-EXTERN_CVAR(g_coopthingfilter)
+EXTERN_CVAR(g_thingfilter)
 
 bool			g_ValidLevel = false;
 
@@ -629,9 +629,9 @@ void P_LoadThings (int lump)
 			#ifdef SERVER_APP
 			if (G_IsCoopGame())
 			{ 
-				if (g_coopthingfilter == 1)
+				if (g_thingfilter == 1)
 					mt2.flags |= MTF_FILTER_COOPWPN;
-				else if (g_coopthingfilter == 2)
+				else if (g_thingfilter == 2)
 					mt2.flags &= ~MTF_COOPERATIVE;
 			}
 			else


### PR DESCRIPTION
This is my proposition to address #893 

I generalized `g_coopthingfilter` and changed it to `g_thingfilter`.
Value "3" removes all pickupable things from the map, leaving teleporters, etc. intact

Context: I'm trying to set up a TLMS server with loadout (using `g_spawninv`) and no items on the floor