### PR TITLE
Implement sv_curpwad to allow scripting based on wad names

### DIFF
--- a/server/src/sv_cvarlist.cpp
+++ b/server/src/sv_cvarlist.cpp
@@ -89,6 +89,9 @@ CVAR(			sv_endmapscript, "",  "Script to run at end of each map (e.g. to choose 
 CVAR(			sv_startmapscript, "", "Script to run at start of each map (e.g. to override cvars)",
 				CVARTYPE_STRING, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE)
 
+CVAR(			sv_curpwad, "", "Set to the first pwad filename passed to the wad command (for scripting)",
+				CVARTYPE_STRING, CVAR_NOSET | CVAR_NOENABLEDISABLE)
+
 CVAR(			sv_curmap, "", "Set to the last played map",
 				CVARTYPE_STRING, CVAR_NOSET | CVAR_NOENABLEDISABLE)
 

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -68,6 +68,7 @@ extern int nextupdate;
 
 EXTERN_CVAR (sv_endmapscript)
 EXTERN_CVAR (sv_startmapscript)
+EXTERN_CVAR (sv_curpwad)
 EXTERN_CVAR (sv_curmap)
 EXTERN_CVAR (sv_nextmap)
 EXTERN_CVAR (sv_loopepisode)
@@ -345,7 +346,19 @@ void G_DoNewGame()
 
 	sv_curmap.ForceSet(d_mapname.c_str());
 
-	G_InitNew(d_mapname);
+	if (::wadfiles.size() < 3) // odamex.wad, iwad, pwad(s)
+	{
+		sv_curpwad.ForceSet("");
+	}
+	else
+	{
+		OResFiles::const_iterator it = ::wadfiles.begin();
+		std::advance(it, 2);
+		sv_curpwad.ForceSet(it->getBasename().c_str());
+	}
+
+	G_InitNew (d_mapname);
+
 	gameaction = ga_nothing;
 
 	// run script at the start of each map

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -368,6 +368,9 @@ void G_DoNewGame()
 	if (strlen(sv_startmapscript.cstring()))
 		AddCommandString(sv_startmapscript.cstring());
 
+	G_InitNew (d_mapname);
+	gameaction = ga_nothing;
+
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{
 		if (!(it->ingame()))

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -357,10 +357,6 @@ void G_DoNewGame()
 		sv_curpwad.ForceSet(it->getBasename().c_str());
 	}
 
-	G_InitNew (d_mapname);
-
-	gameaction = ga_nothing;
-
 	// run script at the start of each map
 	// [ML] 8/22/2010: There are examples in the wiki that outright don't work
 	// when onlcvars (addcommandstring's second param) is true.  Is there a


### PR DESCRIPTION
This is meant to simplify coop server administration to allow customizing compatibility cvars, g_thingfilter (to remove too generous coop things in some wads), or sv_doubleammo (e.g. to compensate for a wad not designed for coop play) differently for each wad featured on the server.

Example use in a `sv_startmapscript` file :
```
alias "boomphys" "set co_allowdropoff 1; set co_boomphys 1; set co_novileghosts 1; set co_removesoullimit 1"
if sv_curpwad eq EVITERNITY.WAD boomphys
if sv_curpwad eq OVERBOARD.WAD boomphys
// etc.
```