### PR TITLE
co_deadplayertarget: enemies keep chasing a dead player to avoid rare map bugs

### DIFF
--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -323,6 +323,9 @@ CVAR_RANGE(sv_countdown, "5",
 	CVAR(			co_blockmapfix, "0", "Fix the blockmap collision bug",
 					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 
+	CVAR(                   co_deadplayertarget, "0", "Enemies keep chasing a dead player",
+					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO)
+
 
 	// Boom-compatibility changes
 	//------------------------------

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -120,6 +120,10 @@ CVAR_RANGE(			sv_monstershealth, "1.0", "Amount to multiply monster health by",
 					CVARTYPE_FLOAT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH | CVAR_NOENABLEDISABLE,
 					0.0f, 100.0f)
 
+CVAR(                           sv_deadplayertarget, "0", "Enemies keep chasing a dead player",
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
+
+
 CVAR_RANGE(			sv_skill,"3", "Sets the skill level, values are:\n" \
 					"// 0 - No things mode\n" \
 					"// 1 - I'm Too Young To Die\n" \
@@ -322,9 +326,6 @@ CVAR_RANGE(sv_countdown, "5",
 
 	CVAR(			co_blockmapfix, "0", "Fix the blockmap collision bug",
 					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
-
-	CVAR(                   co_deadplayertarget, "0", "Enemies keep chasing a dead player",
-					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO)
 
 
 	// Boom-compatibility changes

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -50,7 +50,7 @@ EXTERN_CVAR (co_zdoomphys)
 EXTERN_CVAR (co_novileghosts)
 EXTERN_CVAR(co_zdoomsound)
 EXTERN_CVAR(co_removesoullimit)
-EXTERN_CVAR(co_deadplayertarget)
+EXTERN_CVAR(sv_deadplayertarget)
 
 enum dirtype_t
 {
@@ -954,9 +954,9 @@ void A_Chase (AActor *actor)
 	// [RH] If the target is dead (and not a goal), stop chasing it.
 	if (actor->target && actor->target != actor->goal && actor->target->health <= 0)
 	{
-		// with co_deadplayertarget enabled, keep chasing the corpse
+		// with sv_deadplayertarget enabled, keep chasing the corpse
 		// to avoid breaking some maps
-		if (co_deadplayertarget && actor->target->type == MT_PLAYER)
+		if (multiplayer && sv_deadplayertarget && actor->target->type == MT_PLAYER && players.size() > 0)
 		{
 			// test for sound like we would if we were in A_Look
 			// to let go of the corpse target asap in favor of a real player
@@ -997,7 +997,7 @@ void A_Chase (AActor *actor)
 		}
 	}
 
-	if (co_deadplayertarget && actor->target && actor->target->health <= 0) // let enemy move towards corpse
+	if (multiplayer && sv_deadplayertarget && actor->target && actor->target->health <= 0) // let enemy move towards corpse
 		goto nomissile;
 
 	// do not attack twice in a row

--- a/server/src/sv_mobj.cpp
+++ b/server/src/sv_mobj.cpp
@@ -42,7 +42,7 @@ void P_SetSpectatorFlags(player_t &player)
 {
 	player.spectator = true;
 
-	if (player.mo)
+	if (player.mo && player.health > 0) // if a dead player spectates, let the corpse collection logic pick it up
 	{
 		player.mo->oflags |= MFO_SPECTATOR;
 		player.mo->flags &= ~MF_SOLID;


### PR DESCRIPTION
I discovered a weird/broken behavior on Lunatic map05.

The map functions this way:

- you start in a secluded area, which is in the same sound propagation zone as *all* the monster closets of the map
- you have to shoot a switch to reach the next area, thus waking up *all* enemies
- you then teleport to the main arena. This sets free a voodoo doll on a conveyor belt which progressively releases monster closets to spawn the enemy waves in the main arena

The weird behavior was: enemy waves would randomly stop in the middle of the map.

I suspected something might be wrong with the voodoo dolls, but after checking the doll progression and all the closet states, it was fine.

Then I realized that the remaining monsters were actually idle in their closet, not awake. And since there are no conveyor belts in the closets, they just sit there. See the demo: http://doom.koholint.io/odamex-config/misc/odamex_lunatic_map05_bug.odd

 I wondered if there might be a sound propagation issue, so I experimented with `P_RecursiveSound` a bit, backporting boom code for testing purposes. This was a dead end, everything was fine.

It turns out the root cause is simpler: it was tied with player deaths.
When the player who fired at the switch initially, died, enemies dropped their target, which means those that didnt teleport in yet were stuck forever unless a respawning player happened to fire in the starting area (because the main arena is in a different sound propagation zone).

Different map design leading to different sound propagation zones, or a linedef to close the door in the initial area after teleporting would fix this specific map, but this seems like a general enough (if slightly odd) issue to fix it in the server itself instead of the map.

To fix it, I pick a new target among the players for awaken enemies when a player being targeted is either dead or spectates. This is a bit arbitrary, e.g. it puts more emphasis on the players at the start of the playerlist since it uses the first eligible one, and it also doesnt account for position at all which may lead to slightly odd behavior if the new target happens to be *far away* from the enemy whereas other players were right there.

I'm interested in hearing your thoughts about this one, it took a while to track down for me and the fix is a bit experimental.