### PR TITLE
Fix wad downloads when filename uses mixed case

### DIFF
--- a/common/m_resfile.cpp
+++ b/common/m_resfile.cpp
@@ -71,7 +71,7 @@ bool OResFile::make(OResFile& out, const std::string& file)
 
 	out.m_fullpath = fullpath;
 	out.m_md5 = hash;
-	out.m_basename = StdStringToUpper(basename);
+	out.m_basename = basename;
 	return true;
 }
 
@@ -111,7 +111,7 @@ bool OResFile::makeWithHash(OResFile& out, const std::string& file, const OMD5Ha
 
 	out.m_fullpath = fullpath;
 	out.m_md5 = hash;
-	out.m_basename = StdStringToUpper(basename);
+	out.m_basename = basename;
 	return true;
 }
 
@@ -136,8 +136,8 @@ bool OWantFile::make(OWantFile& out, const std::string& file, const ofile_t type
 
 	out.m_wantedpath = file;
 	out.m_wantedtype = type;
-	out.m_basename = StdStringToUpper(basename);
-	out.m_extension = std::string(".") + StdStringToUpper(extension);
+	out.m_basename = basename;
+	out.m_extension = std::string(".") + extension;
 	return true;
 }
 
@@ -165,8 +165,8 @@ bool OWantFile::makeWithHash(OWantFile& out, const std::string& file, const ofil
 	out.m_wantedpath = file;
 	out.m_wantedtype = type;
 	out.m_wantedMD5 = hash;
-	out.m_basename = StdStringToUpper(basename);
-	out.m_extension = StdStringToUpper(extension);
+	out.m_basename = basename;
+	out.m_extension = extension;
 	return true;
 }
 
@@ -290,7 +290,7 @@ bool M_ResolveWantedFile(OResFile& out, const OWantFile& wanted)
 	M_ExtractFileBase(path, basename);
 	if (M_ExtractFileExtension(path, strext))
 	{
-		exts.push_back("." + StdStringToUpper(strext));
+		exts.push_back("." + strext);
 	}
 	else
 	{

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -129,12 +129,8 @@ bool Maplist::insert(const size_t &position, maplist_entry_t &maplist_entry) {
 		}
 	}
 
-	// capitalize the map name and WAD file names
+	// capitalize the map names
 	maplist_entry.map = StdStringToUpper(maplist_entry.map);
-
-	for (std::vector<std::string>::iterator it = maplist_entry.wads.begin();
-		it != maplist_entry.wads.end(); ++it)
-		*it = StdStringToUpper(*it);
 
 	// Puts the map into its proper place
 	this->maplist.insert(this->maplist.begin() + position, maplist_entry);


### PR DESCRIPTION
Fixes #843

This makes it so filenames advertised to the client use exactly the same case as the files present on the server.

I've tested a linux server with linux and windows clients, and it seems to work fine.
Tested via maplist progression, `callvote map`, `rcon wad`, with upper, lower, and mixed case filenames.
Everything downloaded correctly through the server advertised in `sv_downloadsites`.
Also tested locally in the client via the `wad` command.

nginx access log serving `Lunatic.wad` for reference:
`[03/Oct/2023:16:32:53 +0000] "GET /wads/Lunatic.wad HTTP/1.1" 200 18160632 "-" "Odamex/10.4.0"`

I think this works fine, but I'd appreciate someone more experimented with the codebase making sure that the changes in common/m_resfile.cpp don't have weird side effects.