### PR TITLE
Always define INSTALL_PREFIX to fix paths for odalaunch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ include(GNUInstallDirs OPTIONAL)
 add_definitions(-DINSTALL_BINDIR="${CMAKE_INSTALL_BINDIR}")
 add_definitions(-DINSTALL_DATADIR="${CMAKE_INSTALL_DATADIR}")
 
+# Set up FHS installation path
+if(NOT APPLE AND NOT WIN32)
+  add_definitions(-DINSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
+endif()
+
 if(WIN32)
   set(USE_INTERNAL_LIBS 1)
 else()

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -128,11 +128,6 @@ if(APPLE)
     ${AUDIOUNIT_LIBRARY})
 endif()
 
-# Set up FHS installation path
-if(NOT APPLE AND NOT WIN32)
-  add_definitions(-DINSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
-endif()
-
 # Client target
 if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -37,11 +37,6 @@ if(WIN32 AND NOT MSVC)
   add_definitions(-DWINVER=0x0500)
 endif()
 
-# Set up FHS installation path
-if(NOT APPLE AND NOT WIN32)
-  add_definitions(-DINSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
-endif()
-
 add_executable(odasrv
   ${COMMON_SOURCES} ${SERVER_SOURCES} ${SERVER_WIN32_SOURCES})
 odamex_target_settings(odasrv)


### PR DESCRIPTION
Without INSTALL_PREFIX, it was falling back to the current directory and failing to launch the game.