### PR TITLE
Implement Chex Quet par times into _CHEXNFO (Chex Quest MAPINFO).

### DIFF
--- a/wad/lumps/_chexnfo.lmp
+++ b/wad/lumps/_chexnfo.lmp
@@ -21,7 +21,7 @@ map E1M1 lookup "CHUSTR_E1M1"
 	secretnext = "E1M9"
 	sky1 = "SKY1"
 	cluster = 1
-	par = 30
+	par = 120
 	music = "$MUSIC_E1M1"
 }
 
@@ -33,7 +33,7 @@ map E1M2 lookup "CHUSTR_E1M2"
 	secretnext = "E1M9"
 	sky1 = "SKY1"
 	cluster = 1
-	par = 75
+	par = 360
 	music = "$MUSIC_E1M2"
 }
 
@@ -45,7 +45,7 @@ map E1M3 lookup "CHUSTR_E1M3"
 	secretnext = "E1M9"
 	sky1 = "SKY1"
 	cluster = 1
-	par = 120
+	par = 480
 	music = "$MUSIC_E1M3"
 }
 
@@ -57,7 +57,7 @@ map E1M4 lookup "CHUSTR_E1M4"
 	secretnext = "E1M9"
 	sky1 = "SKY1"
 	cluster = 1
-	par = 90
+	par = 200
 	music = "$MUSIC_E1M4"
 }
 
@@ -69,7 +69,7 @@ map E1M5 lookup "CHUSTR_E1M5"
 	secretnext = "E1M9"
 	sky1 = "SKY1"
 	cluster = 1
-	par = 165
+	par = 360
 	music = "$MUSIC_E1M5"
 	nointermission
 }


### PR DESCRIPTION
Currently, _CHEXNFO (odamex.wad's internal MAPINFO definitions used for Chex Quest 1) has par times duplicated from Ultimate DOOM. This change corrects them to CHEX.EXE's internal par times. Included is [the little-known par time](https://github.com/chocolate-doom/chocolate-doom/issues/1355) of E1M5: Caverns of Bazoik from CHEX.EXE.

For references, here are CHEX.EXE's par times:

<table>
	<tr>
		<th>Map</th>
		<th>Time</th>
		<th>Seconds</th>
		<th>HEX</th>
	</tr>
	<tr>
		<td>E1M1</td>
		<td>2:00</td>
		<td>120</td>
		<td>78.00</td>
	</tr>
	<tr>
		<td>E1M2</td>
		<td>6:00</td>
		<td>360</td>
		<td>68.01</td>
	</tr>
	<tr>
		<td>E1M3</td>
		<td>8:00</td>
		<td>480</td>
		<td>E0.01</td>
	</tr>
	<tr>
		<td>E1M4</td>
		<td>3:20</td>
		<td>200</td>
		<td>C8.00</td>
	</tr>
	<tr>
		<td>E1M5</td>
		<td>6:00</td>
		<td>360</td>
		<td>68.01</td>
	</tr>
</table>