### PR TITLE
Fix a minor typo in `g_horde.cpp`

### DIFF
--- a/common/g_horde.cpp
+++ b/common/g_horde.cpp
@@ -518,7 +518,7 @@ const hordeDefine_t& G_HordeDefine(size_t id)
 	if (id >= ::WAVE_DEFINES.size())
 	{
 		Printf(PRINT_WARNING,
-		       "Tried to access horde wave %llu but only have %llu hode defines!\n", id,
+		       "Tried to access horde wave %llu but only have %llu horde defines!\n", id,
 		       ::WAVE_DEFINES.size());
 		return EMPTY_WAVE_DEFINE;
 	}


### PR DESCRIPTION
This is a very small change. It just changes "hode" to "horde" in a warning.