### PR TITLE
Escape URIs so CURL can properly find WADs with spaces

### DIFF
--- a/client/src/cl_download.cpp
+++ b/client/src/cl_download.cpp
@@ -277,11 +277,15 @@ static void TickCheck()
 			::dlstate.checkfilename = StdStringToLower(::dlstate.checkfilename);
 		}
 
-		// Now we have the full URL.
-		fullurl += ::dlstate.checkfilename;
-
 		// Create the check transfer.
 		::dlstate.check = new OTransferCheck(CheckDone, CheckError);
+
+		std::string safeFileName =
+		    ::dlstate.check->escapeFileName(::dlstate.checkfilename.c_str());
+
+		// Now we have the full URL.
+		fullurl += safeFileName;
+
 		::dlstate.check->setURL(fullurl.c_str());
 		if (!::dlstate.check->start())
 		{

--- a/client/src/otransfer.cpp
+++ b/client/src/otransfer.cpp
@@ -154,6 +154,17 @@ void OTransferCheck::setURL(const std::string& src)
 }
 
 /**
+ * @brief Escapes a filename and encodes it to be a legal URI
+ *
+ * @param filename Complete filename
+ */
+std::string OTransferCheck::escapeFileName(const std::string& filename)
+{
+	// Let's escape the filename so we have a legal url to try
+	return curl_easy_escape(m_curl, filename.c_str(), filename.length());
+}
+
+/**
  * @brief Start the checking transfer.
  *
  * @return True if the transfer started properly.

--- a/client/src/otransfer.h
+++ b/client/src/otransfer.h
@@ -80,6 +80,7 @@ class OTransferCheck
 	}
 
 	void setURL(const std::string& src);
+	std::string escapeFileName(const std::string& src);
 	bool start();
 	void stop();
 	bool tick();


### PR DESCRIPTION
[RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) lists the need to percent-encode reserved characters in URIs. These encompass many different characters but the most common use case is spaces. CURL requires a percent-encoded URI to properly function, which makes WADs with spaces not able to be searched, or the wrong WAD downloaded (the first word of the wad filename with no file extension, if exists, will be downloaded).

This uses `curl_easy_escape` to percent-encode the filename so the behavior is correct. This has been tested on WADs with spaces and WADs without spaces, and WADs with underscores.