### PR TITLE
Fix WADs with spaces in their filename not compatible with callvote map

### DIFF
--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -297,7 +297,17 @@ void G_ChangeMap(size_t index) {
 		return;
 	}
 
-	G_LoadWadString(JoinStrings(maplist_entry.wads, " "), maplist_entry.map);
+	std::string wadstr;
+	for (size_t i = 0; i < maplist_entry.wads.size(); i++)
+	{
+		if (i != 0)
+		{
+			wadstr += " ";
+		}
+		wadstr += C_QuoteString(maplist_entry.wads.at(i));
+	}
+
+	G_LoadWadString(wadstr, maplist_entry.map);
 
 	// Set the new map as the current map
 	Maplist::instance().set_index(index);


### PR DESCRIPTION
Because `callvote map` is handled differently than other map advancement functions, the C_QuoteString function was missing for changing map based on maplist index, such as `callvote map` or `callvote randmap`, but not `callvote nextmap`, since that advances to the next map, and handles the WADs properly, which is why `callvote nextmap` is not affected. This caused `callvote map` to give the following error message when trying to callvote to a wad with spaces:

![image](https://github.com/odamex/odamex/assets/2531014/18b51fd7-04cd-4f8f-8eac-92cdeb8dd9fa)
