### PR TITLE
Make mapinfo parser less strict, allow BTSX_E1A.WAD/BTSX_E1B.WAD to play

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -969,17 +969,12 @@ void MIType_Sky(OScanner& os, bool doEquals, void* data, unsigned int flags,
 
 	*static_cast<OLumpName*>(data) = os.getToken();
 
-	// Scroll speed
-	if (doEquals)
-	{
-		os.scan();
-		if (!os.compareToken(","))
-		{
-			os.unScan();
-			return;
-		}
-	}
 	os.scan();
+	// Scroll speed
+	if (os.compareToken(","))
+	{
+		os.mustScanInt();
+	}
 	if (IsRealNum(os.getToken().c_str()))
 	{
 		/*if (HexenHack)
@@ -1550,6 +1545,7 @@ struct MapInfoDataSetter<level_pwad_info_t>
 		ENTRY2("translator", &MIType_EatNext)
 		ENTRY3("compat_shorttex", &MIType_CompatFlag, &ref.flags) // todo: not implemented
 		ENTRY3("compat_limitpain", &MIType_CompatFlag, &ref.flags) // todo: not implemented
+		ENTRY3("compat_useblocking", &MIType_CompatFlag, &ref.flags) // special lines block use (not implemented, default odamex behavior)
 		ENTRY4("compat_dropoff", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_DROPOFF)
 		ENTRY3("compat_trace", &MIType_CompatFlag, &ref.flags) // todo: not implemented
 		ENTRY3("compat_boomscroll", &MIType_CompatFlag, &ref.flags) // todo: not implemented

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -2139,22 +2139,17 @@ void G_ParseMapInfo()
 	lump = W_GetNumForName(baseinfoname);
 	ParseMapInfoLump(lump, baseinfoname);
 
-	bool found_mapinfo = false;
-	lump = -1;
-	while ((lump = W_FindLump("UMAPINFO", lump)) != -1)
-	{
-		found_mapinfo = true;
-		ParseUMapInfoLump(lump, "UMAPINFO");
-	}
-
-	// If UMAPINFO exists, we don't parse a normal MAPINFO
-	if (found_mapinfo == true)
-		return;
-
+	// Parse MAPINFO then UMAPINFO, like dsda
 	lump = -1;
 	while ((lump = W_FindLump("MAPINFO", lump)) != -1)
 	{
 		ParseMapInfoLump(lump, "MAPINFO");
+	}
+
+	lump = -1;
+	while ((lump = W_FindLump("UMAPINFO", lump)) != -1)
+	{
+		ParseUMapInfoLump(lump, "UMAPINFO");
 	}
 
 	if (episodenum == 0)


### PR DESCRIPTION
Our mapinfo parser makes assumptions based on mapinfo version. For old mapinfo, our parser assumed equals was not allowed, which it is in other ports. This change may be rolled to all of our lower mapinfo MI functions, but it was most noticeable with the MIType_CompatFlag function. This function will now work if there's an equals or not. I changed doEquals to better describe what the intention of that boolean is -- a signal that this block came from a new style mapinfo that requires curly braces, while the old one is the old "hexen" style mapinfo that ZDoom extended before their new format.

I also changed MIType_Sky to read (but not implement) sky scrolling, again ignoring the mapinfo "version" and working if there's an equals or not.

With all these changes, BTSX E1 is now playable in Odamex.