### PR TITLE
Add default sky for mapinfo and umapinfo

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -558,7 +558,7 @@ void ParseUMapInfoLump(int lump, const char* lumpname)
 
 		// for maps above 32, if no sky is defined, it will show texture 0 (aastinky)
 		// so instead, lets just try to give it the first defined sky in the level set.
-		if (levels.size() > 0 && info.skypic == "")
+		if (levels.size() > 0)
 		{
 			level_pwad_info_t& def = levels.at(0);
 			info.skypic = def.skypic;

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1978,6 +1978,15 @@ void ParseMapInfoLump(int lump, const char* lumpname)
 			if (!levelExists)
 				info = defaultinfo;
 
+			// for maps above 32, if no sky is defined, it will show texture 0 (aastinky)
+			// so instead, lets just try to give it the first defined sky in the level set.
+
+			if (levels.size() > 0)
+			{
+				level_pwad_info_t& def = levels.at(0);
+				info.skypic = def.skypic;
+			}
+
 			info.mapname = map_name;
 
 			// Map name.

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1967,12 +1967,17 @@ void ParseMapInfoLump(int lump, const char* lumpname)
 				    LEVEL_NOINTERMISSION | LEVEL_EVENLIGHTING | LEVEL_SNDSEQTOTALCTRL;
 			}
 
-			// Find the level.
-			level_pwad_info_t& info = (levels.findByName(map_name).exists())
-			                              ? levels.findByName(map_name)
-			                              : levels.create();
+			// Build upon already defined levels, that way we don't miss any defaults 
+			bool levelExists = levels.findByName(map_name).exists();
 
-			info = defaultinfo;
+			// Find the level.
+			level_pwad_info_t& info = levelExists ? 
+																			levels.findByName(map_name):
+																			levels.create();
+
+			if (!levelExists)
+				info = defaultinfo;
+
 			info.mapname = map_name;
 
 			// Map name.

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -556,6 +556,14 @@ void ParseUMapInfoLump(int lump, const char* lumpname)
 		                              ? levels.findByName(mapname)
 		                              : levels.create();
 
+		// for maps above 32, if no sky is defined, it will show texture 0 (aastinky)
+		// so instead, lets just try to give it the first defined sky in the level set.
+		if (levels.size() > 0 && info.skypic == "")
+		{
+			level_pwad_info_t& def = levels.at(0);
+			info.skypic = def.skypic;
+		}
+
 		info.mapname = mapname;
 
 		MapNameToLevelNum(info);
@@ -1980,8 +1988,7 @@ void ParseMapInfoLump(int lump, const char* lumpname)
 
 			// for maps above 32, if no sky is defined, it will show texture 0 (aastinky)
 			// so instead, lets just try to give it the first defined sky in the level set.
-
-			if (levels.size() > 0)
+			if (levels.size() > 0 && defaultinfo.skypic == "")
 			{
 				level_pwad_info_t& def = levels.at(0);
 				info.skypic = def.skypic;


### PR DESCRIPTION
Due to our patchwork support of MAPINFO combined with loose MAPINFO interpretations from other ports and lumps, it's in our best interest to match other ports and provide sensible defaults for maps where needed. This mainly affects us for skies.

The wad "PUSS23 Mappin Round the Doommas Tree.wad" has a defaultmap defined, but uses the actual graphic RSKY1 in for the sky instead of the texture that Odamex and DSDA expects, however, DSDA doesn't parse the `defaultmap` token, and provides a default sky for maps without a defined one. This allows DSDA to show a sky on every map, despite the WAD going above 32 maps.

In current Odamex `stable`, the wad shows AASHITTY as the sky for every map in the WAD. This patch provides sensible defaults for the sky, defaulting to the first sky defined in the IWAD (usually replaced via pwad patch) if one is not defined.