### PR TITLE
More mapinfo fixes

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -789,7 +789,7 @@ void MIType_MapName(OScanner& os, bool newStyleMapInfo, void* data, unsigned int
 	{
 			// todo
 			if (newStyleMapInfo)
-			MustGetStringName(os, ",");
+				MustGetStringName(os, ",");
 
 			os.mustScan();
 	}
@@ -797,7 +797,7 @@ void MIType_MapName(OScanner& os, bool newStyleMapInfo, void* data, unsigned int
 	{
 			// todo
 			if (newStyleMapInfo)
-			MustGetStringName(os, ",");
+				MustGetStringName(os, ",");
 
 			os.mustScan();
 	}

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -2011,8 +2011,8 @@ void ParseMapInfoLump(int lump, const char* lumpname)
 
 			// Find the level.
 			level_pwad_info_t& info = (levels.findByName(map_name).exists())
-			                              ? levels.findByName(map_name)
-			                              : levels.create();
+				? levels.findByName(map_name)
+				: levels.create();
 
 			info = defaultinfo;
 			info.mapname = map_name;

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -785,31 +785,78 @@ void MIType_MapName(OScanner& os, bool newStyleMapInfo, void* data, unsigned int
 {
 	ParseMapInfoHelper<std::string>(os, newStyleMapInfo);
 
-	if (IsIdentifier(os))
+	if (os.compareTokenNoCase("EndPic"))
 	{
-		if (os.compareTokenNoCase("EndPic"))
-		{
 			// todo
 			if (newStyleMapInfo)
-				MustGetStringName(os, ",");
+			MustGetStringName(os, ",");
 
 			os.mustScan();
-		}
-		else if (os.compareTokenNoCase("EndSequence"))
-		{
-			// todo
-			if (newStyleMapInfo)
-				MustGetStringName(os, ",");
-
-			os.mustScan();
-		}
 	}
+	else if (os.compareTokenNoCase("EndSequence"))
+	{
+			// todo
+			if (newStyleMapInfo)
+			MustGetStringName(os, ",");
 
-	// If not identifier, check if it's a lumpname
-	os.unScan();
-	MustGet<OLumpName>(os);
-
-	if (os.compareTokenNoCase("endgame"))
+			os.mustScan();
+	}
+	else if (os.compareTokenNoCase("EndBunny"))
+	{
+		*static_cast<OLumpName*>(data) = "EndGame3";
+		return;
+	}
+	else if (os.compareTokenNoCase("EndGame1"))
+	{
+		*static_cast<OLumpName*>(data) = "EndGame1";
+		return;
+	}
+	else if (os.compareTokenNoCase("EndGame2"))
+	{
+		*static_cast<OLumpName*>(data) = "EndGame2";
+		return;
+	}
+	else if (os.compareTokenNoCase("EndGameW"))
+	{
+		// not supported (heretic)
+		return;
+	}
+	else if (os.compareTokenNoCase("EndGame4"))
+	{
+		*static_cast<OLumpName*>(data) = "EndGame4";
+		return;
+	}
+	else if (os.compareTokenNoCase("EndGameC"))
+	{
+		*static_cast<OLumpName*>(data) = "EndGameC";
+		return;
+	}
+	else if (os.compareTokenNoCase("EndGame3"))
+	{
+		*static_cast<OLumpName*>(data) = "EndGame3";
+		return;
+	}
+	else if (os.compareTokenNoCase("EndDemon"))
+	{
+		// not supported (heretic)
+		return;
+	}
+	else if (os.compareTokenNoCase("EndChess"))
+	{
+		// not supported (hexen)
+		return;
+	}
+	else if (os.compareTokenNoCase("EndGameS"))
+	{
+		// not supported (strife)
+		return;
+	}
+	else if (os.compareTokenNoCase("EndTitle"))
+	{
+		// not implemented
+		return;
+	}
+	else if (os.compareTokenNoCase("endgame"))
 	{
 		// endgame block
 		MustGetStringName(os, "{");
@@ -861,7 +908,7 @@ void MIType_MapName(OScanner& os, bool newStyleMapInfo, void* data, unsigned int
 			}
 		}
 	}
-	else
+	else // Must be map lump
 	{
 		char map_name[9];
 		strncpy(map_name, os.getToken().c_str(), 8);
@@ -870,11 +917,6 @@ void MIType_MapName(OScanner& os, bool newStyleMapInfo, void* data, unsigned int
 		{
 			const int map = std::atoi(map_name);
 			sprintf(map_name, "MAP%02d", map);
-		}
-		else if (os.compareTokenNoCase("EndBunny"))
-		{
-			*static_cast<OLumpName*>(data) = "EndGame3";
-			return;
 		}
 
 		*static_cast<OLumpName*>(data) = map_name;
@@ -976,7 +1018,7 @@ void MIType_Sky(OScanner& os, bool newStyleMapInfo, void* data, unsigned int fla
 	// Scroll speed
 	if (os.compareToken(","))
 	{
-		os.mustScanInt();
+		os.mustScanFloat();
 	}
 	if (IsRealNum(os.getToken().c_str()))
 	{


### PR DESCRIPTION
This patch fixes bug #810 by stubbing out every possible identifier for map functions like `next`, and handling a map if any of the known identifiers aren't found.

This also will allow a float for scrolling sky, which is allowed for MAPINFO, as well as integers.