### PR TITLE
Restore doublesky and sky2

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -545,10 +545,19 @@ void G_DoLoadLevel (int position)
 	// [ML] 5/11/06 - remove sky2 remenants
 	// [SL] 2012-03-19 - Add sky2 back
 	sky1texture = R_TextureNumForName (level.skypic.c_str());
+	sky1scrolldelta = level.sky1ScrollDelta;
+	sky1columnoffset = 0;
+	sky2columnoffset = 0;
 	if (!level.skypic2.empty())
-		sky2texture = R_TextureNumForName (level.skypic2.c_str());
+	{
+		sky2texture = R_TextureNumForName(level.skypic2.c_str());
+		sky2scrolldelta = level.sky2ScrollDelta;
+	}
 	else
+	{
 		sky2texture = 0;
+		sky2scrolldelta = 0;
+	}
 
 	// [RH] Set up details about sky rendering
 	R_InitSkyMap ();

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -220,13 +220,13 @@ void R_RenderSkyRange(visplane_t* pl)
 	{
 		// use sky1
 		skytex = sky1texture;
-		front_offset = sky1columnoffset >> 16;
+		front_offset = sky1columnoffset >> 6;
 	}
 	else if (pl->picnum == int(PL_SKYFLAT))
 	{
 		// use sky2
 		skytex = sky2texture;
-		front_offset = sky2columnoffset >> 16;
+		front_offset = sky2columnoffset >> 6;
 	}
 	else
 	{

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -199,18 +199,6 @@ inline void SkyColumnBlaster()
 	R_BlastSkyColumn(colfunc);
 }
 
-inline bool R_PostDataIsTransparent(byte* data, int length)
-{
-		for (int i = 0; i < length; i++)
-		{
-				if (data[i] == 0)
-				{
-						return true;
-				}
-		}
-	    return false;
-}
-
 //
 // R_RenderSkyRange
 //
@@ -218,6 +206,7 @@ inline bool R_PostDataIsTransparent(byte* data, int length)
 // in the normal convention for patches, but uses color 0 as a transparent
 // color.
 // [ML] 5/11/06 - Removed sky2
+// [BC] 7/5/24 - Brought back for real this time
 //
 void R_RenderSkyRange(visplane_t* pl)
 {

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -220,13 +220,13 @@ void R_RenderSkyRange(visplane_t* pl)
 	{
 		// use sky1
 		skytex = sky1texture;
-		front_offset = sky1columnoffset >> 6;
+		front_offset = sky1columnoffset >> 8;
 	}
 	else if (pl->picnum == int(PL_SKYFLAT))
 	{
 		// use sky2
 		skytex = sky2texture;
-		front_offset = sky2columnoffset >> 6;
+		front_offset = sky2columnoffset >> 8;
 	}
 	else
 	{

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -309,38 +309,37 @@ void R_RenderSkyRange(visplane_t* pl)
 		else
 		{
 			// create composite of both skies
-			byte composite[MAXWIDTH]; // column replacement
-			byte* skypost;
-			byte* skypost2;
-			byte* dest;
-			int count;
+			tallpost_t composite[MAXWIDTH]; // column replacement
+			tallpost_t* skypost;
+			tallpost_t* skypost2;
+			tallpost_t* dest;
 			int top;
 			int bottom;
 
 			top = dcol.texturefrac >> FRACBITS;
 			bottom = (dcol.texturemid + (dcol.yh - centery) * dcol.iscale) >> FRACBITS;
-			count = bottom - top + 1;
 
-			skypost = R_GetTextureColumnData(frontskytex, colnum);
-			colnum = ((((viewangle + xtoviewangle[x])^skyflip)>>sky2shift) + back_offset)>>16;
-			skypost2 = R_GetTextureColumnData(backskytex, colnum);
-			dest = composite + 4;
+			skypost  = R_GetTextureColumn(frontskytex, colnum);
+			colnum = ((((viewangle + xtoviewangle[x]) ^ skyflip) >> sky2shift) + back_offset) >> FRACBITS;
+			skypost2 = R_GetTextureColumn(backskytex, colnum);
+			dest = composite + top;
 
-			do
+			while (!skypost->end())
 			{
-				if (*skypost)
+				if (*skypost->data())
 				{
-					*dest++ = *skypost++;
-					skypost2++;
+					*dest++ = *skypost;
 				}
 				else
 				{
-					*dest++ = *skypost2++;
-					skypost++;
+					*dest++ = *skypost2;
 				}
-			} while (--count);
 
-			skyposts[x] = (tallpost_t*)(byte*)composite;
+				skypost = skypost->next();
+				skypost2 = skypost2->next();
+			}
+
+			skyposts[x] = composite;
 		}
 	}
 

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -220,13 +220,13 @@ void R_RenderSkyRange(visplane_t* pl)
 	{
 		// use sky1
 		skytex = sky1texture;
-		front_offset = sky1columnoffset >> 8;
+		front_offset = sky1columnoffset;
 	}
 	else if (pl->picnum == int(PL_SKYFLAT))
 	{
 		// use sky2
 		skytex = sky2texture;
-		front_offset = sky2columnoffset >> 8;
+		front_offset = sky2columnoffset;
 	}
 	else
 	{

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -56,8 +56,8 @@ fixed_t		skyheight;
 fixed_t		skyiscale;
 
 int			sky1shift,		sky2shift;
-fixed_t		sky1pos=0,		sky1speed=0;
-fixed_t		sky2pos=0,		sky2speed=0;
+fixed_t sky1scrolldelta, sky2scrolldelta;
+fixed_t sky1columnoffset, sky2columnoffset;
 
 // The xtoviewangleangle[] table maps a screen pixel
 // to the lowest viewangle that maps back to x ranges
@@ -220,11 +220,13 @@ void R_RenderSkyRange(visplane_t* pl)
 	{
 		// use sky1
 		skytex = sky1texture;
+		front_offset = sky1columnoffset >> 16;
 	}
 	else if (pl->picnum == int(PL_SKYFLAT))
 	{
 		// use sky2
 		skytex = sky2texture;
+		front_offset = sky2columnoffset >> 16;
 	}
 	else
 	{

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -56,8 +56,8 @@ fixed_t		skyheight;
 fixed_t		skyiscale;
 
 int			sky1shift,		sky2shift;
-fixed_t		sky1scrolldelta,		sky2scrolldelta;
-fixed_t		sky1columnoffset,		sky2columnoffset;
+fixed_t		sky1scrolldelta,	sky2scrolldelta;
+fixed_t		sky1columnoffset,	sky2columnoffset;
 
 // The xtoviewangleangle[] table maps a screen pixel
 // to the lowest viewangle that maps back to x ranges

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -73,6 +73,7 @@ char SKYFLATNAME[8] = "F_SKY1";
 
 
 static tallpost_t* skyposts[MAXWIDTH];
+static byte compositeskybuffer[MAXWIDTH][512]; // holds doublesky composite sky to blit to the screen
 
 
 //
@@ -307,9 +308,6 @@ void R_RenderSkyRange(visplane_t* pl)
 		dcol.colormap = shaderef_t(&pal->maps, 0);
 	}
 
-	// buffer for the sky
-	// doing it this way to keep it on the stack
-
 	// determine which texture posts will be used for each screen
 	// column in this range.
 	for (int x = pl->minx; x <= pl->maxx; x++)
@@ -329,7 +327,7 @@ void R_RenderSkyRange(visplane_t* pl)
 			int count = MIN<int> (512, MIN (textureheight[backskytex], textureheight[frontskytex]) >> FRACBITS);
 			int destpostlen = 0;
 
-			byte* composite = new byte[512]; // column data replacement
+			BYTE* composite = compositeskybuffer[x];
 			tallpost_t* destpost = (tallpost_t*)composite;
 
 			tallpost_t* orig = destpost; // need a pointer to the og element to return!
@@ -339,7 +337,7 @@ void R_RenderSkyRange(visplane_t* pl)
 			// in a lot of cases there's gaps in length and topdelta because of transparency
 			// its up to us to find these gaps and put in sky2 when needed
 
-			// the finished tallpost should be the same length as count, and 0 topdelta.
+			// the finished tallpost should be the same length as count, and 0 topdelta, with a endpost after.
 			
 			destpost->topdelta = 0;
 

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -56,8 +56,8 @@ fixed_t		skyheight;
 fixed_t		skyiscale;
 
 int			sky1shift,		sky2shift;
-fixed_t sky1scrolldelta, sky2scrolldelta;
-fixed_t sky1columnoffset, sky2columnoffset;
+fixed_t		sky1scrolldelta,		sky2scrolldelta;
+fixed_t		sky1columnoffset,		sky2columnoffset;
 
 // The xtoviewangleangle[] table maps a screen pixel
 // to the lowest viewangle that maps back to x ranges

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -885,6 +885,8 @@ void G_InitLevelLocals()
 	{
 		::level.skypic2 =::level.skypic.c_str();
 	}
+	::level.sky1ScrollDelta = info.sky1ScrollDelta;
+	::level.sky2ScrollDelta = info.sky2ScrollDelta;
 
 	if (::level.flags & LEVEL_JUMP_YES)
 	{

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -173,6 +173,9 @@ struct level_pwad_info_t
 	std::string		intertextsecret;
 	OLumpName		interbackdrop;
 	OLumpName		intermusic;
+
+	fixed_t sky1ScrollDelta;
+	fixed_t sky2ScrollDelta;
 	
 	std::vector<bossaction_t> bossactions;
 	
@@ -181,7 +184,8 @@ struct level_pwad_info_t
 	      partime(0), skypic(""), music(""), flags(0), cluster(0), snapshot(NULL),
 	      defered(NULL), fadetable("COLORMAP"), skypic2(""), gravity(0.0f),
 	      aircontrol(0.0f), exitpic(""), enterpic(""), endpic(""), intertext(""),
-	      intertextsecret(""), interbackdrop(""), intermusic(""), bossactions()
+	      intertextsecret(""), interbackdrop(""), intermusic(""), 
+			  sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions()
 	{
 		ArrayInit(fadeto_color, 0);
 		ArrayInit(level_fingerprint, 0);
@@ -197,7 +201,7 @@ struct level_pwad_info_t
 		  snapshot(other.snapshot), defered(other.defered), fadetable("COLORMAP"),
 		  skypic2(""), gravity(0.0f), aircontrol(0.0f), exitpic(""), enterpic(""),
 		  endpic(""), intertext(""), intertextsecret(""), interbackdrop(""), intermusic(""),
-		  bossactions()
+		  sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions()
 	{
 		ArrayInit(fadeto_color, 0);
 		ArrayInit(outsidefog_color, 0);
@@ -237,6 +241,8 @@ struct level_pwad_info_t
 		intertextsecret = other.intertextsecret;
 		interbackdrop = other.interbackdrop;
 		intermusic = other.intermusic;
+		sky1ScrollDelta = other.sky1ScrollDelta;
+		sky2ScrollDelta = other.sky2ScrollDelta;
 		bossactions.clear();
 		std::copy(other.bossactions.begin(), other.bossactions.end(),
 		          bossactions.begin());
@@ -281,6 +287,9 @@ struct level_locals_t
 	OLumpName		music;
 	OLumpName		skypic;
 	OLumpName		skypic2;
+
+	fixed_t sky1ScrollDelta;
+	fixed_t sky2ScrollDelta;
 
 	int				total_secrets;
 	int				found_secrets;

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -174,8 +174,8 @@ struct level_pwad_info_t
 	OLumpName		interbackdrop;
 	OLumpName		intermusic;
 
-	fixed_t sky1ScrollDelta;
-	fixed_t sky2ScrollDelta;
+	fixed_t			sky1ScrollDelta;
+	fixed_t			sky2ScrollDelta;
 	
 	std::vector<bossaction_t> bossactions;
 	
@@ -185,7 +185,7 @@ struct level_pwad_info_t
 	      defered(NULL), fadetable("COLORMAP"), skypic2(""), gravity(0.0f),
 	      aircontrol(0.0f), exitpic(""), enterpic(""), endpic(""), intertext(""),
 	      intertextsecret(""), interbackdrop(""), intermusic(""), 
-			  sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions()
+	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions()
 	{
 		ArrayInit(fadeto_color, 0);
 		ArrayInit(level_fingerprint, 0);
@@ -288,8 +288,8 @@ struct level_locals_t
 	OLumpName		skypic;
 	OLumpName		skypic2;
 
-	fixed_t sky1ScrollDelta;
-	fixed_t sky2ScrollDelta;
+	fixed_t			sky1ScrollDelta;
+	fixed_t			sky2ScrollDelta;
 
 	int				total_secrets;
 	int				found_secrets;

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -970,24 +970,35 @@ void MIType_Sky(OScanner& os, bool newStyleMapInfo, void* data, unsigned int fla
 {
 	ParseMapInfoHelper<OLumpName>(os, newStyleMapInfo);
 
-	*static_cast<OLumpName*>(data) = os.getToken();
+	level_pwad_info_t& info = *static_cast<level_pwad_info_t*>(data);
+
+	std::string pic = os.getToken();
+
+	if (flags == 1)
+	{
+		info.skypic = pic;
+	}
+	else
+	{
+		info.skypic2 = pic;
+	}
 
 	os.scan();
 	// Scroll speed
 	if (os.compareToken(","))
 	{
-		os.mustScanInt();
+		os.mustScanFloat();
 	}
 	if (IsRealNum(os.getToken().c_str()))
 	{
-		/*if (HexenHack)
+		if (flags == 1)
 		{
-		    *((fixed_t *)(info + handler->data2)) = sc_Number << 8;
+			info.sky1ScrollDelta = FLOAT2FIXED(os.getTokenFloat()) << 8;
 		}
-		 else
+		else
 		{
-		    *((fixed_t *)(info + handler->data2)) = (fixed_t)(sc_Float * 65536.0f);
-		}*/
+			info.sky2ScrollDelta = FLOAT2FIXED(os.getTokenFloat()) << 8;
+		}
 	}
 	else
 	{
@@ -1486,8 +1497,8 @@ struct MapInfoDataSetter<level_pwad_info_t>
 		ENTRY3("secretnext", &MIType_MapName, &ref.secretmap)
 		ENTRY3("secret", &MIType_MapName, &ref.secretmap)
 		ENTRY3("cluster", &MIType_Cluster, &ref.cluster)
-		ENTRY3("sky1", &MIType_Sky, &ref.skypic)
-		ENTRY3("sky2", &MIType_Sky, &ref.skypic2)
+		ENTRY4("sky1", &MIType_Sky, &ref, 1)
+		ENTRY4("sky2", &MIType_Sky, &ref, 2)
 		ENTRY3("fade", &MIType_Color, &ref.fadeto_color)
 		ENTRY3("outsidefog", &MIType_Color, &ref.outsidefog_color)
 		ENTRY3("titlepatch", &MIType_LumpName, &ref.pname)

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -993,11 +993,11 @@ void MIType_Sky(OScanner& os, bool newStyleMapInfo, void* data, unsigned int fla
 	{
 		if (flags == 1)
 		{
-			info.sky1ScrollDelta = FLOAT2FIXED(os.getTokenFloat()) << 8;
+			info.sky1ScrollDelta = FLOAT2FIXED(os.getTokenFloat());
 		}
 		else
 		{
-			info.sky2ScrollDelta = FLOAT2FIXED(os.getTokenFloat()) << 8;
+			info.sky2ScrollDelta = FLOAT2FIXED(os.getTokenFloat());
 		}
 	}
 	else

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2260,7 +2260,9 @@ void P_UpdateSpecials (void)
 		}
 	}
 
-	// [ML] 5/11/06 - Remove sky scrolling ability
+	// Update sky column offsets
+	sky1columnoffset += sky1scrolldelta;
+	sky1columnoffset += sky2scrolldelta;
 }
 
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2261,8 +2261,8 @@ void P_UpdateSpecials (void)
 	}
 
 	// Update sky column offsets
-	sky1columnoffset = (sky1columnoffset + level.sky1ScrollDelta) & 0xffffff;
-	sky2columnoffset = (sky2columnoffset + level.sky2ScrollDelta) & 0xffffff;
+	sky1columnoffset += level.sky1ScrollDelta & 0xffffff;
+	sky2columnoffset += level.sky2ScrollDelta & 0xffffff;
 }
 
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2262,7 +2262,7 @@ void P_UpdateSpecials (void)
 
 	// Update sky column offsets
 	sky1columnoffset += sky1scrolldelta;
-	sky1columnoffset += sky2scrolldelta;
+	sky2columnoffset += sky2scrolldelta;
 }
 
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2261,8 +2261,8 @@ void P_UpdateSpecials (void)
 	}
 
 	// Update sky column offsets
-	sky1columnoffset += sky1scrolldelta;
-	sky2columnoffset += sky2scrolldelta;
+	sky1columnoffset = (sky1columnoffset + level.sky1ScrollDelta) & 0xffffff;
+	sky2columnoffset = (sky2columnoffset + level.sky2ScrollDelta) & 0xffffff;
 }
 
 

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -31,10 +31,10 @@ extern int		sky1shift;				//		[ML] 5/11/06 - remove sky2 remenants
 
 extern int 		sky1texture;				//		""
 extern int 		sky2texture;				//		""
-extern fixed_t sky1scrolldelta;
-extern fixed_t sky2scrolldelta;
+extern fixed_t	sky1scrolldelta;
+extern fixed_t	sky2scrolldelta;
 extern fixed_t	sky1columnoffset;
-extern fixed_t  sky2columnoffset;
+extern fixed_t	sky2columnoffset;
 extern fixed_t	skytexturemid;
 extern int		skystretch;
 extern fixed_t	skyiscale;

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -31,7 +31,10 @@ extern int		sky1shift;				//		[ML] 5/11/06 - remove sky2 remenants
 
 extern int 		sky1texture;				//		""
 extern int 		sky2texture;				//		""
-extern fixed_t	skypos;					//		""
+extern fixed_t sky1scrolldelta;
+extern fixed_t sky2scrolldelta;
+extern fixed_t	sky1columnoffset;
+extern fixed_t  sky2columnoffset;
 extern fixed_t	skytexturemid;
 extern int		skystretch;
 extern fixed_t	skyiscale;

--- a/server/src/r_sky.cpp
+++ b/server/src/r_sky.cpp
@@ -33,8 +33,8 @@
 int 		skyflatnum;
 int 		sky1texture, sky2texture;
 
-fixed_t sky1scrolldelta, sky2scrolldelta;
-fixed_t sky1columnoffset, sky2columnoffset;
+fixed_t		sky1scrolldelta,	sky2scrolldelta;
+fixed_t		sky1columnoffset,	sky2columnoffset;
 
 char SKYFLATNAME[8] = "F_SKY1";
 

--- a/server/src/r_sky.cpp
+++ b/server/src/r_sky.cpp
@@ -33,7 +33,8 @@
 int 		skyflatnum;
 int 		sky1texture, sky2texture;
 
-fixed_t		sky1pos=0,		sky1speed=0;
+fixed_t sky1scrolldelta, sky2scrolldelta;
+fixed_t sky1columnoffset, sky2columnoffset;
 
 char SKYFLATNAME[8] = "F_SKY1";
 


### PR DESCRIPTION
(Depends on changes from #971)

This patch restores doublesky and sky2 functionality. Using the test wad in #920 (thanks Afterglow!) I was able to recreate this functionality while working with our `tallpost_t` paradigm of detecting transparency and removing it to compress the column. Every time the sky visplane function is called, which can sometimes return thousands of columns at once, we needed to be able to walk the first sky texture and replace the pixel with the 2nd texture if the 1st wasn't in a valid range of topdelta + length compared to current pixel. We also check that data for '\0' (transparency in non-converted patches) and replace the pixel with sky2 data if present to work with both forms of "transparency."

Before:
![344521955-271a9644-b0dc-45b7-b921-ecfb25b51ec1](https://github.com/odamex/odamex/assets/2531014/b48e70ec-991c-48d5-b45d-ef79254eb3a2)

After:
https://github.com/odamex/odamex/assets/2531014/4e6a0180-4d7e-42a9-91d1-eac42ff42ae9

And here's a test wad I used to test sky2:

[sky2test.zip](https://github.com/user-attachments/files/16112577/sky2test.zip)
