### PR TITLE
Fix CentOS7 CI pipeline build

### DIFF
--- a/ci/centos.Dockerfile
+++ b/ci/centos.Dockerfile
@@ -4,6 +4,9 @@ WORKDIR odamex
 
 COPY . .
 
+sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 # Packages
 RUN set -x && \
     yum -y install epel-release gcc-c++ alsa-lib-devel libcurl-devel && \

--- a/ci/centos.Dockerfile
+++ b/ci/centos.Dockerfile
@@ -4,8 +4,8 @@ WORKDIR odamex
 
 COPY . .
 
-sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 # Packages
 RUN set -x && \


### PR DESCRIPTION
CentOS7 went out of life on June 30th, 2024. Helpfully, this is when they shut down their epel mirror as well and moved it to a legacy mirror. This PR fixes the URL for the docker image after its installed so it can find the prereqs required to build on CentOS7.