### PR TITLE
Fix Static Init Damage

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1271,7 +1271,18 @@ void P_PlayerInCompatibleSector(player_t* player)
 	sector_t* sector = player->mo->subsector->sector;
 	if (sector->special == 0 && sector->damageamount > 0) // Odamex Static Init Damage
 	{
-		P_ApplySectorDamage(player, sector->damageamount, 0);
+		if (sector->damageamount < 20)
+		{
+			P_ApplySectorDamageNoRandom(player, sector->damageamount, MOD_UNKNOWN);
+		}
+		else if (sector->damageamount < 50)
+		{
+			P_ApplySectorDamage(player, sector->damageamount, 5, MOD_UNKNOWN);
+		}
+		else
+		{
+			P_ApplySectorDamageNoWait(player, sector->damageamount, MOD_UNKNOWN);
+		}
 	}
 	// jff add if to handle old vs generalized types
 	else if (sector->special < 32) // regular sector specials

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2159,6 +2159,18 @@ bool P_PushSpecialLine(AActor* thing, line_t* line, int side)
     return true;
 }
 
+void P_ApplySectorDamageNoWait(player_t* player, int damage, int mod)
+{
+	P_DamageMobj(player->mo, NULL, NULL, damage, mod);
+}
+
+void P_ApplySectorDamageNoRandom(player_t* player, int damage, int mod)
+{
+	if (!player->powers[pw_ironfeet])
+		if (!(level.time & 0x1f))
+			P_DamageMobj(player->mo, NULL, NULL, damage, mod);
+}
+
 void P_ApplySectorDamage(player_t* player, int damage, int leak, int mod)
 {
 	if (!player->powers[pw_ironfeet] || (leak && P_Random(player->mo)<leak))

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -113,6 +113,8 @@ bool P_MovingCeilingCompleted(sector_t *sector);
 bool P_MovingFloorCompleted(sector_t *sector);
 bool P_HandleSpecialRepeat(line_t* line);
 void P_ApplySectorDamage(player_t* player, int damage, int leak, int mod = 0);
+void P_ApplySectorDamageNoRandom(player_t* player, int damage, int mod = 0);
+void P_ApplySectorDamageNoWait(player_t* player, int damage, int mod = 0);
 void P_ApplySectorDamageEndLevel(player_t* player);
 void P_CollectSecretCommon(sector_t* sector, player_t* player);
 int P_FindSectorFromTagOrLine(int tag, const line_t* line, int start);

--- a/common/p_zdoomhexspec.cpp
+++ b/common/p_zdoomhexspec.cpp
@@ -270,6 +270,22 @@ void P_PlayerInZDoomSector(player_t* player)
 		}
 	}
 
+	if (sector->special == 0 && sector->damageamount > 0) // ZDoom Static Init Damage
+	{
+		if (sector->damageamount < 20)
+		{
+			P_ApplySectorDamageNoRandom(player, sector->damageamount, MOD_UNKNOWN);
+		}
+		else if (sector->damageamount < 50)
+		{
+			P_ApplySectorDamage(player, sector->damageamount, 5, MOD_UNKNOWN);
+		}
+		else
+		{
+			P_ApplySectorDamageNoWait(player, sector->damageamount, MOD_UNKNOWN);
+		}
+	}
+
 	switch (sector->special)
 	{
 	case dScroll_EastLavaDamage:

--- a/common/p_zdoomhexspec.cpp
+++ b/common/p_zdoomhexspec.cpp
@@ -247,41 +247,40 @@ void P_PlayerInZDoomSector(player_t* player)
 				player->hazardcount += sector->damageamount;
 				player->hazardinterval = sector->damageinterval;
 			}
-			else
+
+			if (sector->special == 0) // ZDoom Static Init Damage
 			{
-				if (level.time % sector->damageinterval == 0)
+				if (sector->damageamount < 20)
 				{
-					P_DamageMobj(player->mo, NULL, NULL, sector->damageamount);
-
-					if (sector->flags & SECF_ENDLEVEL && player->health <= 10)
-					{
-						if (serverside && sv_allowexit)
-						{
-							G_ExitLevel(0, 1);
-						}
-					}
-
-					if (sector->flags & SECF_DMGTERRAINFX)
-					{
-						// MAP_FORMAT_TODO: damage special effects
-					}
+					P_ApplySectorDamageNoRandom(player, sector->damageamount,
+					 MOD_UNKNOWN);
+				}
+				else if (sector->damageamount < 50)
+				{
+					P_ApplySectorDamage(player, sector->damageamount, 5, MOD_UNKNOWN);
+				}
+				else
+				{
+					P_ApplySectorDamageNoWait(player, sector->damageamount,
+					 MOD_UNKNOWN);
 				}
 			}
-		}
+			else if (level.time % sector->damageinterval == 0)
+			{
+				P_DamageMobj(player->mo, NULL, NULL, sector->damageamount);
+			}
 
-		if (sector->special == 0) // ZDoom Static Init Damage
-		{
-			if (sector->damageamount < 20)
+			if (sector->flags & SECF_ENDLEVEL && player->health <= 10)
 			{
-				P_ApplySectorDamageNoRandom(player, sector->damageamount, MOD_UNKNOWN);
+				if (serverside && sv_allowexit)
+				{
+					G_ExitLevel(0, 1);
+				}
 			}
-			else if (sector->damageamount < 50)
+
+			if (sector->flags & SECF_DMGTERRAINFX)
 			{
-				P_ApplySectorDamage(player, sector->damageamount, 5, MOD_UNKNOWN);
-			}
-			else
-			{
-				P_ApplySectorDamageNoWait(player, sector->damageamount, MOD_UNKNOWN);
+				// MAP_FORMAT_TODO: damage special effects
 			}
 		}
 	}

--- a/common/p_zdoomhexspec.cpp
+++ b/common/p_zdoomhexspec.cpp
@@ -268,21 +268,21 @@ void P_PlayerInZDoomSector(player_t* player)
 				}
 			}
 		}
-	}
 
-	if (sector->special == 0 && sector->damageamount > 0) // ZDoom Static Init Damage
-	{
-		if (sector->damageamount < 20)
+		if (sector->special == 0) // ZDoom Static Init Damage
 		{
-			P_ApplySectorDamageNoRandom(player, sector->damageamount, MOD_UNKNOWN);
-		}
-		else if (sector->damageamount < 50)
-		{
-			P_ApplySectorDamage(player, sector->damageamount, 5, MOD_UNKNOWN);
-		}
-		else
-		{
-			P_ApplySectorDamageNoWait(player, sector->damageamount, MOD_UNKNOWN);
+			if (sector->damageamount < 20)
+			{
+				P_ApplySectorDamageNoRandom(player, sector->damageamount, MOD_UNKNOWN);
+			}
+			else if (sector->damageamount < 50)
+			{
+				P_ApplySectorDamage(player, sector->damageamount, 5, MOD_UNKNOWN);
+			}
+			else
+			{
+				P_ApplySectorDamageNoWait(player, sector->damageamount, MOD_UNKNOWN);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #536, this was a bug in how fast damage over 50 would be applied. Static init damage over 50 should be applied per tic instead of gametic & 31.