### PR TITLE
[FEATURE] Widescreen asset support

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -131,6 +131,11 @@ endif()
 # Client target
 if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
 
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    message(STATUS "GNU Detected, forcing GCC to link math.h")
+    target_compile_options(odamex PRIVATE -lm)
+  endif()
+
   if (NOT GCONSOLE)
     # Textscreen
     set(TEXTSCREEN_LIBRARY "textscreen")
@@ -179,10 +184,6 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     endif()
   else()
     message(STATUS "Default SIMD flags not used on user request")
-  endif()
-
-  if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(odamex PRIVATE -lm)
   endif()
 
   if(MSVC)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -181,7 +181,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     message(STATUS "Default SIMD flags not used on user request")
   endif()
 
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(odamex PRIVATE -lm)
   endif()
 

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -181,6 +181,10 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     message(STATUS "Default SIMD flags not used on user request")
   endif()
 
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(odamex PRIVATE -lm)
+  endif()
+
   if(MSVC)
     # We supply our own manifest, don't use the default one.
     set_target_properties(odamex PROPERTIES LINK_FLAGS "/MANIFEST:NO")

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -131,11 +131,6 @@ endif()
 # Client target
 if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
 
-  if (CMAKE_COMPILER_IS_GNUCXX)
-    message(STATUS "GNU Detected, forcing GCC to link math.h")
-    target_compile_options(odamex PRIVATE -lm)
-  endif()
-
   if (NOT GCONSOLE)
     # Textscreen
     set(TEXTSCREEN_LIBRARY "textscreen")
@@ -184,6 +179,11 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     endif()
   else()
     message(STATUS "Default SIMD flags not used on user request")
+  endif()
+
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    message(STATUS "GNU Detected, forcing GCC to link math.h")
+    target_compile_options(odamex PRIVATE -lm)
   endif()
 
   if(MSVC)

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -317,9 +317,9 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 //
 // Blits a surface into this surface, automatically scaling the source image
 // to fit the destination dimensions. However, instead of scaling the image to fit
-// the destination, it scales the image and then crops it to the screen if it's
-// off the side of the surface in any direction.
-// 
+// the surface dimensions, it scales the image to destination dimensions and then
+// crops it to the screen if it's off the side of the surface in any direction.
+//
 void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, int srcy,
 			int srcw, int srch, int destx, int desty, int destw, int desth)
 {

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -257,13 +257,217 @@ static void BlitLoop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 	}
 }
 
+template <typename SOURCE_PIXEL_T, typename DEST_PIXEL_T>
+static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
+					int destpitchpixels, int srcpitchpixels,
+					int destw, int desth,
+					int off_top, int off_bottom, int off_left, int off_right,
+					fixed_t xstep, fixed_t ystep, const argb_t* palette)
+{
+	fixed_t yfrac = 0;
+
+	int pixelcur = 0;
+	for (int y = 0; y < desth; y++)
+	{
+		// Find if we're off the top or bottom of page
+		if (y + off_top >= 0 && y + off_bottom <= desth)
+		{
+			if (sizeof(DEST_PIXEL_T) == sizeof(SOURCE_PIXEL_T) && xstep == FRACUNIT)
+			{
+				for (int x = 0; x < destw; x++)
+				{
+					// Find if we're off the left or right of page
+					if (x - off_left >= 0 && x + off_right <= destw)
+					{
+						dest[pixelcur] = source[x];
+						pixelcur++;
+					}
+				}
+				pixelcur = 0;
+			}
+			else
+			{
+				fixed_t xfrac = 0;
+				for (int x = 0; x < destw; x++)
+				{
+					// Find if we're off the left or right of page
+					if (x - off_left >= 0 && x + off_right <= destw)
+					{
+						dest[pixelcur] = ConvertPixel<SOURCE_PIXEL_T, DEST_PIXEL_T>(source[xfrac >> FRACBITS], palette);
+						pixelcur++;
+					}
+
+					xfrac += xstep;
+				}
+				pixelcur = 0;
+			}
+		}
+
+		dest += destpitchpixels;
+		yfrac += ystep;
+
+		source += srcpitchpixels * (yfrac >> FRACBITS);
+		yfrac &= (FRACUNIT - 1);
+	}
+}
+
+
+//
+// IWindowSurface::blitcrop
+//
+// Blits a surface into this surface, automatically scaling the source image
+// to fit the destination dimensions. However, instead of scaling the image to fit
+// the destination, it scales the image and then crops it to the screen if it's
+// off the side of the surface in any direction.
+// 
+void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, int srcy,
+			int srcw, int srch, int destx, int desty, int destw, int desth)
+{
+	int off_left = 0;
+	int off_right = 0;
+	int off_top = 0;
+	int off_bottom = 0;
+
+	int bufferx = 0;
+	int buffery = 0;
+
+	// clamp to source surface edges
+	if (srcx < 0)
+	{
+		srcw += srcx;
+		srcx = 0;
+	}
+
+	if (srcy < 0)
+	{
+		srch += srcy;
+		srcy = 0;
+	}
+
+	if (srcx + srcw > source_surface->getWidth())
+		srcw = source_surface->getWidth() - srcx;
+	if (srcy + srch > source_surface->getHeight())
+		srch = source_surface->getHeight() - srcy;
+
+	if (srcw == 0 || srch == 0)
+		return;
+
+	// clamp buffer to source edges, but keep destx and desty
+	// for clipping purposes
+
+	if (destx < 0)
+	{
+		off_left -= destx;
+		bufferx = 0;
+	}
+	else
+	{
+		bufferx = destx;
+	}
+
+	if (desty < 0)
+	{
+		off_top -= desty;
+		buffery = 0;
+	}
+	else
+	{
+		buffery = desty;
+	}
+
+	if (destx + destw > getWidth())
+	{
+		off_right = destw + destx - getWidth();
+	}
+	if (desty + desth > getHeight())
+	{
+		off_bottom = destw + desty - getHeight();
+	}
+
+	if (destw == 0 || desth == 0)
+		return;
+
+	// Our starting position is off the screen
+	// And we will never recover from this
+	// Someone messed their x/y or desth/w calc up!
+	// We're done here!
+
+	// Too far right to draw anything
+	if (destx > getWidth())
+		return;
+
+	// Too far down to draw anything
+	if (desty > getHeight())
+		return;
+
+	// Box at the top will never be drawn
+	if (desty + desth < 0)
+		return;
+
+	// Box at the left will never be drawn
+	if (destx + destw < 0)
+		return;
+
+	fixed_t xstep = FixedDiv(srcw << FRACBITS, destw << FRACBITS);
+	fixed_t ystep = FixedDiv(srch << FRACBITS, desth << FRACBITS);
+
+	int srcbits = source_surface->getBitsPerPixel();
+	int destbits = getBitsPerPixel();
+	int srcpitchpixels = source_surface->getPitchInPixels();
+	int destpitchpixels = getPitchInPixels();
+
+	const argb_t* palette = source_surface->getPalette();
+
+	if (srcbits == 8 && destbits == 8)
+	{
+		const palindex_t* source =
+		    (palindex_t*)source_surface->getBuffer() + srcy * srcpitchpixels + srcx;
+		palindex_t* dest = (palindex_t*)getBuffer() + buffery * destpitchpixels + bufferx;
+
+		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
+			destw, desth, 
+			off_top, off_bottom, off_left, off_right,
+			xstep, ystep, palette);
+	}
+	else if (srcbits == 8 && destbits == 32)
+	{
+		if (palette == NULL)
+			return;
+
+		const palindex_t* source =
+		    (palindex_t*)source_surface->getBuffer() + srcy * srcpitchpixels + srcx;
+		argb_t* dest = (argb_t*)getBuffer() + buffery * destpitchpixels + bufferx;
+
+		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
+				destw, desth,
+				off_top, off_bottom, off_left, off_right,
+				xstep, ystep, palette);
+	}
+	else if (srcbits == 32 && destbits == 8)
+	{
+		// we can't quickly convert from 32bpp source to 8bpp dest so don't bother
+		return;
+	}
+	else if (srcbits == 32 && destbits == 32)
+	{
+		const argb_t* source =
+		    (argb_t*)source_surface->getBuffer() + srcy * srcpitchpixels + srcx;
+		argb_t* dest = (argb_t*)getBuffer() + buffery * destpitchpixels + bufferx;
+
+		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
+			destw, desth,
+			off_top, off_bottom, off_left, off_right,
+			xstep, ystep, palette);
+	}
+}
+
 
 //
 // IWindowSurface::blit
 //
 // Blits a surface into this surface, automatically scaling the source image
 // to fit the destination dimensions.
-//
+// 
 void IWindowSurface::blit(const IWindowSurface* source_surface, int srcx, int srcy, int srcw, int srch,
 			int destx, int desty, int destw, int desth)
 {

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -264,7 +264,7 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 					int destpitchpixels, int srcpitchpixels,
 					int destw, int desth,
 					int off_top, int off_bottom, int off_left, int off_right,
-					fixed_t xstep, fixed_t ystep, const argb_t* palette)
+					fixed_t xstep, fixed_t ystep, const argb_t* palette, bool transparency)
 {
 	fixed_t yfrac = 0;
 
@@ -281,7 +281,8 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 					// Find if we're off the left or right of page
 					if (x - off_left >= 0 && x < destw - off_right)
 					{
-						dest[pixelcur] = source[x];
+						if (!transparency || (transparency && source[x] != '\0'))
+							dest[pixelcur] = source[x];
 						pixelcur++;
 					}
 				}
@@ -295,7 +296,8 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 					// Find if we're off the left or right of page
 					if (x - off_left >= 0 && x < destw - off_right)
 					{
-						dest[pixelcur] = ConvertPixel<SOURCE_PIXEL_T, DEST_PIXEL_T>(source[xfrac >> FRACBITS], palette);
+						if (!transparency || (transparency && source[xfrac >> FRACBITS] != '\0'))
+							dest[pixelcur] = ConvertPixel<SOURCE_PIXEL_T, DEST_PIXEL_T>(source[xfrac >> FRACBITS], palette);
 						pixelcur++;
 					}
 
@@ -323,7 +325,7 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 // crops it to the screen if it's off the side of the surface in any direction.
 //
 void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, int srcy,
-			int srcw, int srch, int destx, int desty, int destw, int desth)
+			int srcw, int srch, int destx, int desty, int destw, int desth, bool transparency)
 {
 	int off_left = 0;
 	int off_right = 0;
@@ -429,7 +431,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
 			destw, desth, 
 			off_top, off_bottom, off_left, off_right,
-			xstep, ystep, palette);
+			xstep, ystep, palette, transparency);
 	}
 	else if (srcbits == 8 && destbits == 32)
 	{
@@ -443,7 +445,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
 				destw, desth,
 				off_top, off_bottom, off_left, off_right,
-				xstep, ystep, palette);
+				xstep, ystep, palette, transparency);
 	}
 	else if (srcbits == 32 && destbits == 8)
 	{
@@ -459,7 +461,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
 			destw, desth,
 			off_top, off_bottom, off_left, off_right,
-			xstep, ystep, palette);
+			xstep, ystep, palette, transparency);
 	}
 }
 

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -1434,4 +1434,10 @@ const PixelFormat* I_Get32bppPixelFormat()
 	return &format;
 }
 
+int I_GetAspectCorrectWidth(int surface_height, int asset_height, int asset_width)
+{
+	float aspect_scale_ratio = (float)surface_height / (float)asset_height;
+	return aspect_scale_ratio * asset_width;
+}
+
 VERSION_CONTROL (i_video_cpp, "$Id$")

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -272,14 +272,14 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 	for (int y = 0; y < desth; y++)
 	{
 		// Find if we're off the top or bottom of page
-		if (y - off_top >= 0 && y <= desth - off_bottom)
+		if (y - off_top >= 0 && y < desth - off_bottom)
 		{
 			if (sizeof(DEST_PIXEL_T) == sizeof(SOURCE_PIXEL_T) && xstep == FRACUNIT)
 			{
 				for (int x = 0; x < destw; x++)
 				{
 					// Find if we're off the left or right of page
-					if (x - off_left >= 0 && x <= destw - off_right)
+					if (x - off_left >= 0 && x < destw - off_right)
 					{
 						dest[pixelcur] = source[x];
 						pixelcur++;
@@ -293,7 +293,7 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 				for (int x = 0; x < destw; x++)
 				{
 					// Find if we're off the left or right of page
-					if (x - off_left >= 0 && x <= destw - off_right)
+					if (x - off_left >= 0 && x < destw - off_right)
 					{
 						dest[pixelcur] = ConvertPixel<SOURCE_PIXEL_T, DEST_PIXEL_T>(source[xfrac >> FRACBITS], palette);
 						pixelcur++;

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -270,7 +270,7 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 	for (int y = 0; y < desth; y++)
 	{
 		// Find if we're off the top or bottom of page
-		if (y + off_top >= 0 && y + off_bottom <= desth)
+		if (y - off_top >= 0 && y + off_bottom <= desth)
 		{
 			if (sizeof(DEST_PIXEL_T) == sizeof(SOURCE_PIXEL_T) && xstep == FRACUNIT)
 			{

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -264,7 +264,7 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 					int destpitchpixels, int srcpitchpixels,
 					int destw, int desth,
 					int off_top, int off_bottom, int off_left, int off_right,
-					fixed_t xstep, fixed_t ystep, const argb_t* palette, bool transparency)
+					fixed_t xstep, fixed_t ystep, const argb_t* palette)
 {
 	fixed_t yfrac = 0;
 
@@ -281,8 +281,7 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 					// Find if we're off the left or right of page
 					if (x - off_left >= 0 && x < destw - off_right)
 					{
-						if (!transparency || (transparency && source[x] != '\0'))
-							dest[pixelcur] = source[x];
+						dest[pixelcur] = source[x];
 						pixelcur++;
 					}
 				}
@@ -296,8 +295,7 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 					// Find if we're off the left or right of page
 					if (x - off_left >= 0 && x < destw - off_right)
 					{
-						if (!transparency || (transparency && source[xfrac >> FRACBITS] != '\0'))
-							dest[pixelcur] = ConvertPixel<SOURCE_PIXEL_T, DEST_PIXEL_T>(source[xfrac >> FRACBITS], palette);
+						dest[pixelcur] = ConvertPixel<SOURCE_PIXEL_T, DEST_PIXEL_T>(source[xfrac >> FRACBITS], palette);
 						pixelcur++;
 					}
 
@@ -325,7 +323,7 @@ static void BlitLoopCrop(DEST_PIXEL_T* dest, const SOURCE_PIXEL_T* source,
 // crops it to the screen if it's off the side of the surface in any direction.
 //
 void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, int srcy,
-			int srcw, int srch, int destx, int desty, int destw, int desth, bool transparency)
+			int srcw, int srch, int destx, int desty, int destw, int desth)
 {
 	int off_left = 0;
 	int off_right = 0;
@@ -431,7 +429,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
 			destw, desth, 
 			off_top, off_bottom, off_left, off_right,
-			xstep, ystep, palette, transparency);
+			xstep, ystep, palette);
 	}
 	else if (srcbits == 8 && destbits == 32)
 	{
@@ -445,7 +443,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
 				destw, desth,
 				off_top, off_bottom, off_left, off_right,
-				xstep, ystep, palette, transparency);
+				xstep, ystep, palette);
 	}
 	else if (srcbits == 32 && destbits == 8)
 	{
@@ -461,7 +459,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
 			destw, desth,
 			off_top, off_bottom, off_left, off_right,
-			xstep, ystep, palette, transparency);
+			xstep, ystep, palette);
 	}
 }
 

--- a/client/sdl/i_video.h
+++ b/client/sdl/i_video.h
@@ -360,7 +360,7 @@ public:
 			int destx, int desty, int destw, int desth);
 
 	void blitcrop(const IWindowSurface* source, int srcx, int srcy, int srcw, int srch,
-			int destx, int desty, int destw, int desth);
+			int destx, int desty, int destw, int desth, bool transparency);
 
 	void clear();
 

--- a/client/sdl/i_video.h
+++ b/client/sdl/i_video.h
@@ -99,6 +99,8 @@ const PixelFormat* I_Get32bppPixelFormat();
 
 void I_DrawLoadingIcon();
 
+int I_GetAspectCorrectWidth(int surface_height, int asset_height, int asset_width);
+
 
 // ****************************************************************************
 

--- a/client/sdl/i_video.h
+++ b/client/sdl/i_video.h
@@ -362,7 +362,7 @@ public:
 			int destx, int desty, int destw, int desth);
 
 	void blitcrop(const IWindowSurface* source, int srcx, int srcy, int srcw, int srch,
-			int destx, int desty, int destw, int desth, bool transparency);
+			int destx, int desty, int destw, int desth);
 
 	void clear();
 

--- a/client/sdl/i_video.h
+++ b/client/sdl/i_video.h
@@ -359,6 +359,9 @@ public:
 	void blit(const IWindowSurface* source, int srcx, int srcy, int srcw, int srch,
 			int destx, int desty, int destw, int desth);
 
+	void blitcrop(const IWindowSurface* source, int srcx, int srcy, int srcw, int srch,
+			int destx, int desty, int destw, int desth);
+
 	void clear();
 
 	inline void lock()

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -542,12 +542,10 @@ void D_DoAdvanceDemo (void)
     // [Russell] - Still need this toilet humor for now unfortunately
 	if (pagename)
 	{
-		const lumpHandle_t handle = W_CachePatchHandle(pagename);
-
-		page_width = W_ResolvePatchHandle(handle)->width();
-		page_height = W_ResolvePatchHandle(handle)->height();
-
 		const patch_t* patch = W_CachePatch(pagename);
+
+		page_width = patch->width();
+		page_height = patch->height();
 
 		I_FreeSurface(page_surface);
 

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -413,25 +413,26 @@ void D_PageDrawer()
 		}
 		else if (surface_width * 3 >= surface_height * 4)
 		{
-			if (page_width > 320)
-			{
-				float aspect_scale_ratio = surface_height / page_height;
-				int newPageWidth = aspect_scale_ratio * page_width;
-				destw = newPageWidth, desth = surface_height;
-			}
-			else
-			{
-				destw = surface_height * 4 / 3, desth = surface_height;
-			}
+			destw = surface_height * 4 / 3, desth = surface_height;
 		}
 		else
 		{
 			destw = surface_width, desth = surface_width * 3 / 4;
 		}
 
+		// Using widescreen assets? It may go off screen.
+		// Preserve the aspect ratio and make the box big
+		// Maybe too big? (it will be cropped if so)
+		if (page_width > 320)
+		{
+			float aspect_scale_ratio = (float)desth / (float)page_height;
+			int newPageWidth = aspect_scale_ratio * page_width;
+			destw = newPageWidth;
+		}
+
 		page_surface->lock();
 
-		primary_surface->blit(page_surface, 0, 0, page_surface->getWidth(), page_surface->getHeight(),
+		primary_surface->blitcrop(page_surface, 0, 0, page_surface->getWidth(), page_surface->getHeight(),
 				(surface_width - destw) / 2, (surface_height - desth) / 2, destw, desth);
 
 		page_surface->unlock();

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -40,7 +40,7 @@
 #include <dirent.h>
 #endif
 
-#include <math.h>
+#include <cmath>
 
 
 #include "m_alloc.h"

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -433,7 +433,7 @@ void D_PageDrawer()
 		page_surface->lock();
 
 		primary_surface->blitcrop(page_surface, 0, 0, page_surface->getWidth(), page_surface->getHeight(),
-				(surface_width - destw) / 2, (surface_height - desth) / 2, destw, desth);
+				(surface_width - destw) / 2, (surface_height - desth) / 2, destw, desth, false);
 
 		page_surface->unlock();
 	}

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -407,18 +407,26 @@ void D_PageDrawer()
 	{
 		int destw, desth;
 
-		if (I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight()))
+		if (I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight())) // Always fill/stretch pages on protected resolutions
 		{
 			destw = surface_width, desth = surface_height;
 		}
-		else if ((surface_height * (4 / 3) == surface_width) ||
-			(page_height <= 200 && page_width <= 320))
+		else if (surface_width * 3 >= surface_height * 4)
 		{
-			destw = surface_height * 4 / 3, desth = surface_height;
+			if (page_width > 320)
+			{
+				float aspect_scale_ratio = surface_height / page_height;
+				int newPageWidth = aspect_scale_ratio * page_width;
+				destw = newPageWidth;
+			}
+			else
+			{
+				destw = surface_height * 4 / 3, desth = surface_height;
+			}
 		}
 		else
 		{
-				destw = surface_width, desth = surface_width * 3 / 4;
+			destw = surface_width, desth = surface_width * 3 / 4;
 		}
 
 		page_surface->lock();

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -425,9 +425,7 @@ void D_PageDrawer()
 		// Maybe too big? (it will be cropped if so)
 		if (page_width > 320)
 		{
-			float aspect_scale_ratio = (float)desth / (float)page_height;
-			int newPageWidth = aspect_scale_ratio * page_width;
-			destw = newPageWidth;
+			destw = I_GetAspectCorrectWidth(desth, page_height, page_width);
 		}
 
 		page_surface->lock();

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -417,7 +417,7 @@ void D_PageDrawer()
 			{
 				float aspect_scale_ratio = surface_height / page_height;
 				int newPageWidth = aspect_scale_ratio * page_width;
-				destw = newPageWidth;
+				destw = newPageWidth, desth = surface_height;
 			}
 			else
 			{

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -431,7 +431,7 @@ void D_PageDrawer()
 		page_surface->lock();
 
 		primary_surface->blitcrop(page_surface, 0, 0, page_surface->getWidth(), page_surface->getHeight(),
-				(surface_width - destw) / 2, (surface_height - desth) / 2, destw, desth, false);
+				(surface_width - destw) / 2, (surface_height - desth) / 2, destw, desth);
 
 		page_surface->unlock();
 	}

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -44,6 +44,17 @@
 
 static IWindowSurface* cast_surface = NULL;
 
+// Draw finale flats/textures on a
+// (320 < patch_width)x(200 < patch_height)
+// canvas and scale them.
+// Also used for endpics
+static IWindowSurface* finale_surface = NULL;
+
+// Draw the bunny scroll on 2 surfaces
+// and clip them against the screen
+static IWindowSurface* bunny1_surface = NULL;
+static IWindowSurface* bunny2_surface = NULL; 
+
 // Stage of animation:
 //	0 = text, 1 = art screen, 2 = character cast
 unsigned int	finalestage;
@@ -232,6 +243,9 @@ void F_StartFinale(finale_options_t& options)
 void STACK_ARGS F_ShutdownFinale()
 {
 	I_FreeSurface(cast_surface);
+	I_FreeSurface(finale_surface);
+	I_FreeSurface(bunny1_surface);
+	I_FreeSurface(bunny2_surface);
 }
 
 
@@ -659,220 +673,74 @@ void F_CastDrawer()
 
 
 //
-// F_DrawPatchCol
-//
-
-// Palettized version 8bpp
-
-void F_DrawPatchColP(int x, const patch_t *patch, int col)
-{
-	IWindowSurface* surface = I_GetPrimarySurface();
-	const int surface_width = surface->getWidth(), surface_height = surface->getHeight();
-
-	// [RH] figure out how many times to repeat this column
-	// (for screens wider than 320 pixels)
-	const float mul = static_cast<float>(surface_width) / 320.0f;
-	const float fx = static_cast<float>(x);
-	const int repeat = static_cast<int>(floor(mul * (fx + 1)) - floor(mul * fx));
-	if (repeat == 0)
-		return;
-
-	// [RH] Remap virtual-x to real-x
-	x = static_cast<int>(floor(mul * x));
-
-	// [RH] Figure out per-row fixed-point step
-	const unsigned int step = (200<<16) / surface_height;
-	const unsigned int invstep = (surface_height<<16) / 200;
-
-	const tallpost_t *post = (tallpost_t *)((byte *)patch + LELONG(patch->columnofs[col]));
-	
-	byte* desttop = surface->getBuffer() + x;
-	const int pitch = surface->getPitchInPixels();
-
-	// step through the posts in a column
-	while (!post->end())
-	{
-		const byte* source = post->data();
-		byte* dest = desttop + ((post->topdelta * invstep)>>16) * pitch;
-		unsigned int count = (post->length * invstep) >> 16;
-		int c = 0;
-		palindex_t p;
-
-		switch (repeat)
-		{
-			case 1:
-				do
-				{
-					*dest = source[c>>16];
-					dest += pitch;
-					c += step;
-				} while (--count);
-				break;
-			case 2:
-				do
-				{
-					p = source[c>>16];
-					dest[0] = p;
-					dest[1] = p;
-					dest += pitch;
-					c += step;
-				} while (--count);
-				break;
-			case 3:
-				do
-				{
-					p = source[c>>16];
-					dest[0] = p;
-					dest[1] = p;
-					dest[2] = p;
-					dest += pitch;
-					c += step;
-				} while (--count);
-				break;
-			case 4:
-				do
-				{
-					p = source[c>>16];
-					dest[0] = p;
-					dest[1] = p;
-					dest[2] = p;
-					dest[3] = p;
-					dest += pitch;
-					c += step;
-				} while (--count);
-				break;
-			default:
-				{
-					do
-					{
-						p = source[c>>16];
-						for (int count2 = repeat; count2; count2--)
-						{
-							dest[count2] = p;
-						}
-						dest += pitch;
-						c += step;
-					} while (--count);
-				}
-				break;
-		}
-
-		post = post->next();
-	}
-}
-
-// Direct version 32bpp:
-
-void F_DrawPatchColD(int x, const patch_t *patch, int col)
-{
-	IWindowSurface* surface = I_GetPrimarySurface();
-	const int surface_width = surface->getWidth(), surface_height = surface->getHeight();
-
-	// [RH] figure out how many times to repeat this column
-	// (for screens wider than 320 pixels)
-	const float mul = static_cast<float>(surface_width) / 320.0f;
-	const float fx = static_cast<float>(x);
-	const int repeat = static_cast<int>(floor(mul * (fx + 1)) - floor(mul * fx));
-	if (repeat == 0)
-		return;
-
-	// [RH] Remap virtual-x to real-x
-	x = static_cast<int>(floor(mul * x));
-
-	// [RH] Figure out per-row fixed-point step
-	const unsigned step = (200<<16) / surface_height;
-	const unsigned invstep = (surface_height<<16) / 200;
-
-	const tallpost_t *post = (tallpost_t *)((byte *)patch + LELONG(patch->columnofs[col]));
-	argb_t* desttop = (argb_t *)surface->getBuffer() + x;
-	const int pitch = surface->getPitchInPixels();
-
-	const shaderef_t pal = shaderef_t(&V_GetDefaultPalette()->maps, 0);
-
-	// step through the posts in a column
-	while (!post->end())
-	{
-		const byte* source = post->data();
-		argb_t* dest = desttop + ((post->topdelta*invstep)>>16)*pitch;
-		unsigned count = (post->length * invstep) >> 16;
-		int c = 0;
-		argb_t p;
-
-		switch (repeat)
-		{
-			case 1:
-				do
-				{
-					*dest = pal.shade(source[c>>16]);
-					dest += pitch;
-					c += step;
-				} while (--count);
-				break;
-			case 2:
-				do
-				{
-					p = pal.shade(source[c>>16]);
-					dest[0] = p;
-					dest[1] = p;
-					dest += pitch;
-					c += step;
-				} while (--count);
-				break;
-			case 3:
-				do
-				{
-					p = pal.shade(source[c>>16]);
-					dest[0] = p;
-					dest[1] = p;
-					dest[2] = p;
-					dest += pitch;
-					c += step;
-				} while (--count);
-				break;
-			case 4:
-				do
-				{
-					p = pal.shade(source[c>>16]);
-					dest[0] = p;
-					dest[1] = p;
-					dest[2] = p;
-					dest[3] = p;
-					dest += pitch;
-					c += step;
-				} while (--count);
-				break;
-			default:
-				{
-					do
-					{
-						p = pal.shade(source[c>>16]);
-						for (int count2 = repeat; count2; count2--) {
-							dest[count2] = p;
-						}
-						dest += pitch;
-						c += step;
-					} while (--count);
-				}
-				break;
-		}
-
-		post = post->next();
-	}
-}
-
-
-//
 // F_BunnyScroll
 //
+// Rewritten to use 2 canvases and create the scroll
+// by cropping the 2 canvas positions to the screen.
 void F_BunnyScroll()
 {
 	char		name[10];
 	static int	laststage;
 
-	const patch_t* p1 = W_CachePatch("PFUB2");
-	const patch_t* p2 = W_CachePatch("PFUB1");
+	const patch_t* p1 = W_CachePatch("PFUB1");
+	const patch_t* p2 = W_CachePatch("PFUB2");
 
+	I_FreeSurface(bunny1_surface);
+	I_FreeSurface(bunny2_surface);
+
+	IWindowSurface* primary_surface = I_GetPrimarySurface();
+
+	int surface_width  = primary_surface->getWidth(),
+	    surface_height = primary_surface->getHeight();
+
+	primary_surface->clear();
+
+	// Support widescreen bunny scroll
+	// PFUB2 and PFUB1 should be the same width
+
+	int bunnywidth = p1->width();
+	int bunnyheight = p1->height();
+
+	bunny1_surface = I_AllocateSurface(bunnywidth, bunnyheight, 8);
+	bunny2_surface = I_AllocateSurface(bunnywidth, bunnyheight, 8);
+
+	DCanvas* c1 = bunny1_surface->getDefaultCanvas();
+	DCanvas* c2 = bunny2_surface->getDefaultCanvas();
+
+	bunny1_surface->lock();
+	c1->DrawPatch(p1, 0, 0);
+	bunny1_surface->unlock();
+
+	bunny2_surface->lock();
+	c2->DrawPatch(p2, 0, 0);
+	bunny2_surface->unlock();
+
+	int p2offset = 0;
+
+	if (bunnywidth > 320)
+	{
+		// Widescreen mod PFUBs.
+		p2offset = bunnywidth - 320;
+	}
+
+	int bunnyextra = bunnywidth - 320;
+
+	float aspect_scale_ratio = (float)surface_height / (float)bunnyheight;
+	int frame_width = aspect_scale_ratio * bunnywidth;
+
+	int bunnyoverlap = bunnyextra * aspect_scale_ratio;
+
+	int initialp1x = surface_width - frame_width;
+	int initialp2x = surface_width - (frame_width * 2 - bunnyoverlap);
+
+	float scrollstep = (float)abs(initialp2x) / (float)320;
+
+	// Does this actually do anything?
 	V_MarkRect (0, 0, I_GetSurfaceWidth(), I_GetSurfaceHeight());
+
+	// We draw both canvases, overlapping where FPUB1 and 2
+	// overlap. We calculate X on both images, and scroll
+	// based on where we are in finalecount
 
 	int scrolled = 320 - (finalecount - 230) / 2;
 	if (scrolled > 320)
@@ -880,29 +748,42 @@ void F_BunnyScroll()
 	if (scrolled < 0)
 		scrolled = 0;
 
-	if (I_GetPrimarySurface()->getBitsPerPixel() == 8)
+	int p1x = initialp1x;
+	int p2x = initialp2x;
+
+	if (scrolled <= 0)
 	{
-		for (int x = 0; x < 320; x++)
-		{
-			if (x+scrolled < 320)
-				F_DrawPatchColP(x, p1, x+scrolled);
-			else
-				F_DrawPatchColP(x, p2, x+scrolled - 320);
-		}
+		p2x = 0;
+		p1x = frame_width;
+	}
+	else if (scrolled >= 320)
+	{
+		p1x = initialp1x;
+		p2x = initialp2x;
 	}
 	else
 	{
-		for (int x = 0; x < 320; x++)
-		{
-			if (x+scrolled < 320)
-				F_DrawPatchColD(x, p1, x+scrolled);
-			else
-				F_DrawPatchColD(x, p2, x+scrolled - 320);
-		}
+		// Progress both scrolls an equal amount
+		int progress = (320 * scrollstep) - (scrolled * scrollstep);
+		p1x = initialp1x + progress;
+		p2x = initialp2x + progress;
 	}
 
+	bunny1_surface->lock();
+	bunny2_surface->lock();
+	primary_surface->blitcrop(bunny1_surface, 0, 0, bunny1_surface->getWidth(),
+				bunny1_surface->getHeight(), p1x, 0, frame_width,
+				surface_height);
+	primary_surface->blitcrop(bunny2_surface, 0, 0, bunny2_surface->getWidth(),
+				bunny2_surface->getHeight(), p2x, 0, frame_width,
+				surface_height);
+	bunny1_surface->unlock();
+	bunny2_surface->unlock();
+
 	if (finalecount < 1130)
+	{
 		return;
+	}
 	if (finalecount < 1180)
 	{
 		screen->DrawPatchIndirect(W_CachePatch("END0"), (320-13*8)/2, (200-8*8)/2);

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -126,17 +126,14 @@ static int F_GetWidth()
 {
 	const int surface_width = I_GetPrimarySurface()->getWidth();
 	const int surface_height = I_GetPrimarySurface()->getHeight();
-	int width = 0;
 
 	if (I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight()))
-		width = surface_width;
+		return surface_width;
 
 	if (surface_width * 3 >= surface_height * 4)
-		width = surface_height * 4 / 3;
+		return surface_height * 4 / 3;
 	else
-		width = surface_width;
-
-	return width;
+		return surface_width;
 }
 
 

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -95,25 +95,22 @@ static int F_GetCWidth()
 {
 	const int surface_width = I_GetPrimarySurface()->getWidth();
 	const int surface_height = I_GetPrimarySurface()->getHeight();
-	int width = 0;
-
-	if (I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight()))
-		width = surface_width;
-
-	if (surface_width * 3 >= surface_height * 4)
-		width = surface_height * 4 / 3;
-	else
-		width = surface_width;
 
 	// Using widescreen assets? It may go off screen.
 	// Preserve the aspect ratio and make the box big
 	// Maybe too big? (it will be cropped if so)
 	if (finale_width > 320)
 	{
-		width = I_GetAspectCorrectWidth(surface_height, finale_height, finale_width);
+		return I_GetAspectCorrectWidth(surface_height, finale_height, finale_width);
 	}
 
-	return width;
+	if (I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight()))
+		return surface_width;
+
+	if (surface_width * 3 >= surface_height * 4)
+		return surface_height * 4 / 3;
+	else
+		return surface_width;
 }
 
 //

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -370,7 +370,7 @@ void F_TextWrite ()
 			    (byte*)W_CacheLumpNum(lump, PU_CACHE));
 
 			primary_surface->blitcrop(finale_surface, 0, 0, 320, 200,
-				x, y, screenblockWidth, screenblockHeight);
+				x, y, screenblockWidth, screenblockHeight, false);
 
 			finale_surface->unlock();
 		}
@@ -681,7 +681,7 @@ void F_CastDrawer()
 	const int x = (primary_surface->getWidth() - width) / 2;
 	const int y = (primary_surface->getHeight() - height) / 2;
 
-	primary_surface->blitcrop(cast_surface, 0, 0, finale_width, finale_height, x, y, width, height);
+	primary_surface->blitcrop(cast_surface, 0, 0, finale_width, finale_height, x, y, width, height, false);
 
 	cast_surface->unlock();
 
@@ -785,10 +785,10 @@ void F_BunnyScroll()
 	bunny2_surface->lock();
 	primary_surface->blitcrop(bunny1_surface, 0, 0, bunny1_surface->getWidth(),
 				bunny1_surface->getHeight(), p1x, 0, frame_width,
-				surface_height);
+				surface_height, false);
 	primary_surface->blitcrop(bunny2_surface, 0, 0, bunny2_surface->getWidth(),
 				bunny2_surface->getHeight(), p2x, 0, frame_width,
-				surface_height);
+				surface_height, false);
 	bunny1_surface->unlock();
 	bunny2_surface->unlock();
 
@@ -853,7 +853,7 @@ void F_DrawEndPic(const char* page)
 	finale_surface->getDefaultCanvas()->DrawPatch(background_patch, 0, 0);
 
 	primary_surface->blitcrop(finale_surface, 0, 0, finale_width, finale_height, x, y,
-		width, height);
+		width, height, false);
 
 	finale_surface->unlock();
 }

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -295,7 +295,10 @@ void F_TextWrite ()
 		lump = W_CheckNumForName(finalelump, ns_flats);
 		if (lump >= 0)
 		{
-			screen->FlatFill(x, y, width + x, height + y, (byte*)W_CacheLumpNum(lump, PU_CACHE));
+			// Support high resolution flats
+			unsigned int length = W_LumpLength(lump);
+
+			screen->FlatFill(x, y, width + x, height + y, length, (byte*)W_CacheLumpNum(lump, PU_CACHE));
 		}
 		break;
 	default:

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -347,7 +347,7 @@ void F_TextWrite ()
 		lump = W_CheckNumForName(finalelump, ns_global);
 		if (lump >= 0)
 		{
-			screen->DrawPatchFullScreen((patch_t*)W_CachePatch(lump, PU_CACHE));
+			screen->DrawPatchFullScreen((patch_t*)W_CachePatch(lump, PU_CACHE), true);
 		}
 		break;
 	case FINALE_FLAT:
@@ -367,7 +367,7 @@ void F_TextWrite ()
 			    (byte*)W_CacheLumpNum(lump, PU_CACHE));
 
 			primary_surface->blitcrop(finale_surface, 0, 0, 320, 200,
-			    x, y, screenblockWidth, screenblockHeight, false);
+			    x, y, screenblockWidth, screenblockHeight);
 
 			finale_surface->unlock();
 		}
@@ -678,7 +678,7 @@ void F_CastDrawer()
 	const int x = (primary_surface->getWidth() - width) / 2;
 	const int y = (primary_surface->getHeight() - height) / 2;
 
-	primary_surface->blitcrop(cast_surface, 0, 0, finale_width, finale_height, x, y, width, height, false);
+	primary_surface->blitcrop(cast_surface, 0, 0, finale_width, finale_height, x, y, width, height);
 
 	cast_surface->unlock();
 
@@ -782,10 +782,10 @@ void F_BunnyScroll()
 	bunny2_surface->lock();
 	primary_surface->blitcrop(bunny1_surface, 0, 0, bunny1_surface->getWidth(),
 	   bunny1_surface->getHeight(), p1x, 0, frame_width,
-	   surface_height, false);
+	   surface_height);
 	primary_surface->blitcrop(bunny2_surface, 0, 0, bunny2_surface->getWidth(),
 	   bunny2_surface->getHeight(), p2x, 0, frame_width,
-	   surface_height, false);
+	   surface_height);
 	bunny1_surface->unlock();
 	bunny2_surface->unlock();
 
@@ -850,7 +850,7 @@ void F_DrawEndPic(const char* page)
 	finale_surface->getDefaultCanvas()->DrawPatch(background_patch, 0, 0);
 
 	primary_surface->blitcrop(finale_surface, 0, 0, finale_width, finale_height, x, y,
-	   width, height, false);
+	   width, height);
 
 	finale_surface->unlock();
 }

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -110,9 +110,7 @@ static int F_GetCWidth()
 	// Maybe too big? (it will be cropped if so)
 	if (finale_width > 320)
 	{
-		float aspect_scale_ratio = (float)surface_height / (float)finale_height;
-		int newFinaleWidth = aspect_scale_ratio * finale_width;
-		width = newFinaleWidth;
+		width = I_GetAspectCorrectWidth(surface_height, finale_height, finale_width);
 	}
 
 	return width;
@@ -337,8 +335,7 @@ void F_TextWrite ()
 	// If it doesn't reach the side edges of viewport or over, scale it via
 	// top of surface and spill over the bottom and right
 	int screenblockHeight = height;
-	float aspect_scale_ratio = (float)screenblockHeight / (float)200.0f;
-	int screenblockWidth = aspect_scale_ratio * 320;
+	int screenblockWidth = I_GetAspectCorrectWidth(screenblockHeight, 200.0f, 320);
 
 	const int x = (primary_surface->getWidth() - screenblockWidth) / 2;
 	const int y = (primary_surface->getHeight() - height) / 2;
@@ -370,7 +367,7 @@ void F_TextWrite ()
 			    (byte*)W_CacheLumpNum(lump, PU_CACHE));
 
 			primary_surface->blitcrop(finale_surface, 0, 0, 320, 200,
-				x, y, screenblockWidth, screenblockHeight, false);
+			    x, y, screenblockWidth, screenblockHeight, false);
 
 			finale_surface->unlock();
 		}
@@ -784,11 +781,11 @@ void F_BunnyScroll()
 	bunny1_surface->lock();
 	bunny2_surface->lock();
 	primary_surface->blitcrop(bunny1_surface, 0, 0, bunny1_surface->getWidth(),
-				bunny1_surface->getHeight(), p1x, 0, frame_width,
-				surface_height, false);
+	   bunny1_surface->getHeight(), p1x, 0, frame_width,
+	   surface_height, false);
 	primary_surface->blitcrop(bunny2_surface, 0, 0, bunny2_surface->getWidth(),
-				bunny2_surface->getHeight(), p2x, 0, frame_width,
-				surface_height, false);
+	   bunny2_surface->getHeight(), p2x, 0, frame_width,
+	   surface_height, false);
 	bunny1_surface->unlock();
 	bunny2_surface->unlock();
 
@@ -853,7 +850,7 @@ void F_DrawEndPic(const char* page)
 	finale_surface->getDefaultCanvas()->DrawPatch(background_patch, 0, 0);
 
 	primary_surface->blitcrop(finale_surface, 0, 0, finale_width, finale_height, x, y,
-		width, height, false);
+	   width, height, false);
 
 	finale_surface->unlock();
 }

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -123,6 +123,9 @@ char				skullName[2][9] = {"M_SKULL1", "M_SKULL2"};
 // current menudef
 oldmenu_t *currentMenu;
 
+static int			help_height;
+static int			help_width;
+
 //
 // PROTOTYPES
 //
@@ -1159,7 +1162,22 @@ void M_Expansion(int choice)
 void M_DrawReadThis1()
 {
 	const patch_t *p = W_CachePatch(gameinfo.info.infoPage[0]);
-	screen->DrawPatchFullScreen(p);
+	help_width = p->width();
+	help_height = p->height();
+
+	if (help_width > 320)
+	{
+		// Create a canvas and stetch it
+		// for widescreen stuff. Make it
+		// respect aspect ratios
+
+		//screen->getSurface()->blitcrop(;
+		screen->DrawPatchFullScreen(p);
+	}
+	else
+	{
+		screen->DrawPatchFullScreen(p);
+	}
 }
 
 //

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -123,11 +123,6 @@ char				skullName[2][9] = {"M_SKULL1", "M_SKULL2"};
 // current menudef
 oldmenu_t *currentMenu;
 
-static int			help_height;
-static int			help_width;
-
-static IWindowSurface* help_surface = NULL;
-
 //
 // PROTOTYPES
 //
@@ -1156,84 +1151,6 @@ void M_Expansion(int choice)
 	M_SetupNextMenu(&NewDef);
 }
 
-int M_GetHelpHeight() 
-{
-	int surface_width = I_GetVideoWidth(), surface_height = I_GetVideoHeight();
-
-	int desth;
-
-	if (I_IsProtectedResolution(surface_width, surface_height))
-	{
-		desth = surface_height;
-	}
-	else if (surface_width * 3 >= surface_height * 4)
-	{
-		desth = surface_height;
-	}
-	else
-	{
-		desth = surface_width * 3 / 4;
-	}
-
-	return desth;
-}
-
-int M_GetHelpWidth()
-{
-	int surface_width = I_GetVideoWidth(), surface_height = I_GetVideoHeight();
-
-	int destw;
-
-	if (I_IsProtectedResolution(surface_width, surface_height))
-	{
-		destw = surface_width;
-	}
-	else if (surface_width * 3 >= surface_height * 4)
-	{
-		destw = surface_height * 4 / 3;
-	}
-	else
-	{
-		destw = surface_width;
-	}
-
-	if (help_width > 320)
-	{
-		destw = I_GetAspectCorrectWidth(surface_height, help_height, help_width);
-	}
-
-	return destw;
-}
-
-void M_DrawHelpToSurface(const patch_t* patch)
-{
-	IWindowSurface* primary_surface = I_GetPrimarySurface();
-
-	help_width = patch->width();
-	help_height = patch->height();
-
-	int surface_width = primary_surface->getWidth(),
-	    surface_height = primary_surface->getHeight();
-
-	int destw = M_GetHelpWidth(), desth = M_GetHelpHeight();
-
-	int x = (surface_width - destw) / 2;
-	int y = (surface_height - desth) / 2;
-
-	I_FreeSurface(help_surface);
-	help_surface = I_AllocateSurface(help_width, help_height, 8);
-
-	help_surface->lock();
-
-	help_surface->getDefaultCanvas()->DrawPatch(patch, 0, 0);
-
-	primary_surface->blitcrop(help_surface, 0, 0, help_surface->getWidth(),
-	   help_surface->getHeight(), x, y, destw, desth, true);
-
-	help_surface->unlock();
-}
-
-
 //
 // Read This Menus
 // Had a "quick hack to fix romero bug"
@@ -1241,7 +1158,7 @@ void M_DrawHelpToSurface(const patch_t* patch)
 void M_DrawReadThis1()
 {
 	const patch_t *p = W_CachePatch(gameinfo.info.infoPage[0]);
-	M_DrawHelpToSurface(p);
+	screen->DrawPatchFullScreen(p, false);
 }
 
 //
@@ -1250,7 +1167,7 @@ void M_DrawReadThis1()
 void M_DrawReadThis2()
 {
 	const patch_t *p = W_CachePatch(gameinfo.info.infoPage[1]);
-	M_DrawHelpToSurface(p);
+	screen->DrawPatchFullScreen(p, false);
 }
 
 //
@@ -1259,7 +1176,7 @@ void M_DrawReadThis2()
 void M_DrawReadThis3()
 {
 	const patch_t *p = W_CachePatch(gameinfo.info.infoPage[2]);
-	M_DrawHelpToSurface(p);
+	screen->DrawPatchFullScreen(p, false);
 }
 
 //

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1199,10 +1199,7 @@ int M_GetHelpWidth()
 
 	if (help_width > 320)
 	{
-
-		float aspect_scale_ratio = (float)surface_height / (float)help_height;
-		int newPageWidth = aspect_scale_ratio * help_width;
-		destw = newPageWidth;
+		destw = I_GetAspectCorrectWidth(surface_height, help_height, help_width);
 	}
 
 	return destw;
@@ -1231,7 +1228,7 @@ void M_DrawHelpToSurface(const patch_t* patch)
 	help_surface->getDefaultCanvas()->DrawPatch(patch, 0, 0);
 
 	primary_surface->blitcrop(help_surface, 0, 0, help_surface->getWidth(),
-		help_surface->getHeight(), x, y, destw, desth, true);
+	   help_surface->getHeight(), x, y, destw, desth, true);
 
 	help_surface->unlock();
 }

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1231,7 +1231,7 @@ void M_DrawHelpToSurface(const patch_t* patch)
 	help_surface->getDefaultCanvas()->DrawPatch(patch, 0, 0);
 
 	primary_surface->blitcrop(help_surface, 0, 0, help_surface->getWidth(),
-	                          help_surface->getHeight(), x, y, destw, desth);
+		help_surface->getHeight(), x, y, destw, desth, true);
 
 	help_surface->unlock();
 }

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -49,6 +49,9 @@
 // [RH] status bar position at bottom of screen
 extern	int		ST_Y;
 
+extern IWindowSurface* screenblocks_surface;
+extern IWindowSurface* scaled_screenblocks_surface;
+
 //
 // All drawing to the view buffer is accomplished in this file.
 // The other refresh files only know about ccordinates,
@@ -147,7 +150,6 @@ const int FuzzTable::table[FuzzTable::size] = {
 
 
 static FuzzTable fuzztable;
-
 
 // ============================================================================
 //
@@ -1470,26 +1472,70 @@ void R_DrawSlopeSpanD_c()
 
 /****************************************************/
 
-
-void R_DrawBorder(int x1, int y1, int x2, int y2)
+void R_InitializeScreenblocksCanvas()
 {
-	IWindowSurface* surface = R_GetRenderingSurface();
-	DCanvas* canvas = surface->getDefaultCanvas();
+	IWindowSurface* primary_surface = R_GetRenderingSurface();
+	int surface_width = primary_surface->getWidth(),
+	    surface_height = primary_surface->getHeight();
 
-	// Get dimensions of flat to fill as well in case its a large flat
-	int lumpnum = W_CheckNumForName(gameinfo.borderFlat, ns_flats);
+	// background
+	int lumpnum = W_CheckNumForName(::gameinfo.borderFlat, ns_flats);
+
+	// Draw screenblocks to a 320x200 surface and scale it based on viewport height
+	// If it doesn't reach the side edges of viewport or over, scale it via
+	// top of surface and spill over the bottom and right
+	float aspect_scale_ratio = (float)surface_height / (float)200.0f;
+	int screenblockWidth = aspect_scale_ratio * 320 > surface_width ? aspect_scale_ratio * 320 : surface_width;
+	int screenblockHeight = surface_height;
+
+	if (screenblocks_surface == NULL)
+		screenblocks_surface = I_AllocateSurface(320, 200, 8);
+	if (scaled_screenblocks_surface == NULL)
+		scaled_screenblocks_surface = I_AllocateSurface(surface_width, surface_height, 8);
+
+	screenblocks_surface->clear();
+	scaled_screenblocks_surface->clear();
+
+	screenblocks_surface->lock();
+	scaled_screenblocks_surface->lock();
+
+	scaled_screenblocks_surface->getDefaultCanvas();
+
 	if (lumpnum >= 0)
 	{
 		// Support high resolution flats
 		unsigned int length = W_LumpLength(lumpnum);
-
 		const byte* patch_data = (byte*)W_CacheLumpNum(lumpnum, PU_CACHE);
-		canvas->FlatFill(x1, y1, x2, y2, length, patch_data);
+
+		screenblocks_surface->getDefaultCanvas()->FlatFill(0, 0, 320, 200, length, patch_data);
 	}
 	else
 	{
-		canvas->Clear(x1, y1, x2, y2, argb_t(0, 0, 0));
+		screenblocks_surface->getDefaultCanvas()->Clear(0, 0, 320, 200, argb_t(0, 0, 0));
 	}
+
+	// Blit the smaller screenblocks into the big one
+	scaled_screenblocks_surface->blitcrop(screenblocks_surface, 0, 0, 320, 200,
+		0, 0, screenblockWidth, screenblockHeight);
+
+	screenblocks_surface->unlock();
+	scaled_screenblocks_surface->unlock();
+}
+
+void R_DrawBorder(int x1, int y1, int x2, int y2)
+{
+	IWindowSurface* primary_surface = R_GetRenderingSurface();
+
+	if (!scaled_screenblocks_surface || !screenblocks_surface)
+		R_InitializeScreenblocksCanvas();
+
+	scaled_screenblocks_surface->lock();
+
+	primary_surface->blit(scaled_screenblocks_surface, x1, y1, 
+		x1 + x2, y1 + y2,
+		x1, y1, x1 + x2, y1 + y2);
+
+	scaled_screenblocks_surface->unlock();
 }
 
 

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -1522,7 +1522,7 @@ void R_InitializeScreenblocksCanvas()
 
 	// Blit the smaller screenblocks into the big one
 	scaled_screenblocks_surface->blitcrop(screenblocks_surface, 0, 0, 320, 200,
-	   0, 0, screenblockWidth, screenblockHeight, false);
+	   0, 0, screenblockWidth, screenblockHeight);
 
 	screenblocks_surface->unlock();
 	scaled_screenblocks_surface->unlock();

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -1476,11 +1476,15 @@ void R_DrawBorder(int x1, int y1, int x2, int y2)
 	IWindowSurface* surface = R_GetRenderingSurface();
 	DCanvas* canvas = surface->getDefaultCanvas();
 
+	// Get dimensions of flat to fill as well in case its a large flat
 	int lumpnum = W_CheckNumForName(gameinfo.borderFlat, ns_flats);
 	if (lumpnum >= 0)
 	{
+		// Support high resolution flats
+		unsigned int length = W_LumpLength(lumpnum);
+
 		const byte* patch_data = (byte*)W_CacheLumpNum(lumpnum, PU_CACHE);
-		canvas->FlatFill(x1, y1, x2, y2, patch_data);
+		canvas->FlatFill(x1, y1, x2, y2, length, patch_data);
 	}
 	else
 	{

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -1484,8 +1484,7 @@ void R_InitializeScreenblocksCanvas()
 	// Draw screenblocks to a 320x200 surface and scale it based on viewport height
 	// If it doesn't reach the side edges of viewport or over, scale it via
 	// top of surface and spill over the bottom and right
-	float aspect_scale_ratio = (float)surface_height / (float)200.0f;
-	int screenblockWidth = aspect_scale_ratio * 320;
+	int screenblockWidth = I_GetAspectCorrectWidth(surface_height, 200.0f, 320);
 	int screenblockHeight = surface_height;
 
 	if (screenblockWidth < surface_width)
@@ -1523,7 +1522,7 @@ void R_InitializeScreenblocksCanvas()
 
 	// Blit the smaller screenblocks into the big one
 	scaled_screenblocks_surface->blitcrop(screenblocks_surface, 0, 0, 320, 200,
-		0, 0, screenblockWidth, screenblockHeight, false);
+	   0, 0, screenblockWidth, screenblockHeight, false);
 
 	screenblocks_surface->unlock();
 	scaled_screenblocks_surface->unlock();
@@ -1539,8 +1538,8 @@ void R_DrawBorder(int x1, int y1, int x2, int y2)
 	scaled_screenblocks_surface->lock();
 
 	primary_surface->blit(scaled_screenblocks_surface, x1, y1, 
-		x1 + x2, y1 + y2,
-		x1, y1, x1 + x2, y1 + y2);
+	   x1 + x2, y1 + y2,
+	   x1, y1, x1 + x2, y1 + y2);
 
 	scaled_screenblocks_surface->unlock();
 }

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -27,7 +27,7 @@
 #include "odamex.h"
 
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 
 #include "i_sdl.h"

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -1485,8 +1485,15 @@ void R_InitializeScreenblocksCanvas()
 	// If it doesn't reach the side edges of viewport or over, scale it via
 	// top of surface and spill over the bottom and right
 	float aspect_scale_ratio = (float)surface_height / (float)200.0f;
-	int screenblockWidth = aspect_scale_ratio * 320 > surface_width ? aspect_scale_ratio * 320 : surface_width;
+	int screenblockWidth = aspect_scale_ratio * 320;
 	int screenblockHeight = surface_height;
+
+	if (screenblockWidth < surface_width)
+	{
+		float width_scale_ratio = (float)surface_width / (float)screenblockWidth;
+		screenblockWidth *= width_scale_ratio;
+		screenblockHeight *= width_scale_ratio;
+	}
 
 	if (screenblocks_surface == NULL)
 		screenblocks_surface = I_AllocateSurface(320, 200, 8);

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -1523,7 +1523,7 @@ void R_InitializeScreenblocksCanvas()
 
 	// Blit the smaller screenblocks into the big one
 	scaled_screenblocks_surface->blitcrop(screenblocks_surface, 0, 0, 320, 200,
-		0, 0, screenblockWidth, screenblockHeight);
+		0, 0, screenblockWidth, screenblockHeight, false);
 
 	screenblocks_surface->unlock();
 	scaled_screenblocks_surface->unlock();

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -30,6 +30,7 @@
 #include <math.h>
 #include "m_random.h"
 #include "p_local.h"
+#include "gi.h"
 #include "r_local.h"
 #include "r_sky.h"
 #include "st_stuff.h"
@@ -148,6 +149,9 @@ int CorrectFieldOfView = 2048;
 fixed_t			render_lerp_amount;
 
 static void R_InitViewWindow();
+
+IWindowSurface* screenblocks_surface;
+IWindowSurface* scaled_screenblocks_surface;
 
 
 //
@@ -639,6 +643,8 @@ void R_Init()
 void STACK_ARGS R_Shutdown()
 {
     R_FreeTranslationTables();
+    I_FreeSurface(screenblocks_surface);
+		I_FreeSurface(scaled_screenblocks_surface);
 }
 
 

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -644,7 +644,7 @@ void STACK_ARGS R_Shutdown()
 {
     R_FreeTranslationTables();
     I_FreeSurface(screenblocks_surface);
-		I_FreeSurface(scaled_screenblocks_surface);
+    I_FreeSurface(scaled_screenblocks_surface);
 }
 
 

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1100,7 +1100,7 @@ void ST_Drawer()
 		ST_drawWidgets(st_needrefresh);
 
 		if (st_scale)
-			surface->blit(stnum_surface, 0, 0, stnum_surface->getWidth(), stnum_surface->getHeight(),
+			surface->blitcrop(stnum_surface, 0, 0, stnum_surface->getWidth(), stnum_surface->getHeight(),
 					ST_X, ST_Y, ST_WIDTH, ST_HEIGHT);	
 
 		stbar_surface->unlock();

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1090,10 +1090,10 @@ void ST_Drawer()
 
 			if (st_scale)
 				stnum_surface->blitcrop(stbar_surface, 0, 0, stbar_surface->getWidth(), stbar_surface->getHeight(),
-						0, 0, stnum_surface->getWidth(), stnum_surface->getHeight());
+						0, 0, stnum_surface->getWidth(), stnum_surface->getHeight(), false);
 			else
 				surface->blitcrop(stbar_surface, 0, 0, stbar_surface->getWidth(), stbar_surface->getHeight(),
-						ST_X, ST_Y, ST_WIDTH, ST_HEIGHT);
+						ST_X, ST_Y, ST_WIDTH, ST_HEIGHT, false);
 		}
 		
 		// refresh all widgets
@@ -1101,7 +1101,7 @@ void ST_Drawer()
 
 		if (st_scale)
 			surface->blitcrop(stnum_surface, 0, 0, stnum_surface->getWidth(), stnum_surface->getHeight(),
-					ST_X, ST_Y, ST_WIDTH, ST_HEIGHT);	
+					ST_X, ST_Y, ST_WIDTH, ST_HEIGHT, false);	
 
 		stbar_surface->unlock();
 		stnum_surface->unlock();

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1098,10 +1098,10 @@ void ST_Drawer()
 
 			if (st_scale)
 				stnum_surface->blitcrop(stbar_surface, 0, 0, stbar_surface->getWidth(), stbar_surface->getHeight(),
-						0, 0, stnum_surface->getWidth(), stnum_surface->getHeight(), false);
+						0, 0, stnum_surface->getWidth(), stnum_surface->getHeight());
 			else
 				surface->blitcrop(stbar_surface, 0, 0, stbar_surface->getWidth(), stbar_surface->getHeight(),
-						ST_X, ST_Y, ST_WIDTH, ST_HEIGHT, false);
+						ST_X, ST_Y, ST_WIDTH, ST_HEIGHT);
 		}
 		
 		// refresh all widgets
@@ -1109,7 +1109,7 @@ void ST_Drawer()
 
 		if (st_scale)
 			surface->blitcrop(stnum_surface, 0, 0, stnum_surface->getWidth(), stnum_surface->getHeight(),
-					ST_X, ST_Y, ST_WIDTH, ST_HEIGHT, false);	
+					ST_X, ST_Y, ST_WIDTH, ST_HEIGHT);	
 
 		stbar_surface->unlock();
 		stnum_surface->unlock();

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1089,10 +1089,10 @@ void ST_Drawer()
 			ST_refreshBackground();
 
 			if (st_scale)
-				stnum_surface->blit(stbar_surface, 0, 0, stbar_surface->getWidth(), stbar_surface->getHeight(),
+				stnum_surface->blitcrop(stbar_surface, 0, 0, stbar_surface->getWidth(), stbar_surface->getHeight(),
 						0, 0, stnum_surface->getWidth(), stnum_surface->getHeight());
 			else
-				surface->blit(stbar_surface, 0, 0, stbar_surface->getWidth(), stbar_surface->getHeight(),
+				surface->blitcrop(stbar_surface, 0, 0, stbar_surface->getWidth(), stbar_surface->getHeight(),
 						ST_X, ST_Y, ST_WIDTH, ST_HEIGHT);
 		}
 		

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -433,9 +433,13 @@ int ST_StatusBarHeight(int surface_width, int surface_height)
 		return 0;
 
 	if (st_scale)
+	{
 		return 32 * surface_height / 200;
+	}
 	else
+	{
 		return 32;
+	}
 }
 
 short ST_StatusBarWidth(int surface_width, int surface_height)
@@ -445,34 +449,24 @@ short ST_StatusBarWidth(int surface_width, int surface_height)
 		return 0;
 	}
 
-	short width = 0;
-
-	if (!st_scale)
-	{
-		return sbar_width;
-	}
-	else
-	{
-		if (sbar_width <= 0)
-		{
-			width = 320;
-		}
-		else
-		{
-			width = sbar_width;
-		}
-	}
-
+	
 	// [AM] Scale status bar width according to height, unless there isn't
 	//      enough room for it.  Fixes widescreen status bar scaling.
 	// [ML] A couple of minor changes for true 4:3 correctness...
 	short height = ST_StatusBarHeight(surface_width, surface_height);
 	if (I_IsProtectedResolution(surface_width, surface_height))
 	{
-		return (10 * height > width ? 10 * height : width);
+		return (10 * height > surface_width ? 10 * height : surface_width);
 	}
 
-	return 4 * surface_height / 3;
+	if (st_scale)
+	{
+		return (sbar_width / 80) * surface_height / 3;
+	}
+	else
+	{
+		return sbar_width;
+	}
 }
 
 int ST_StatusBarX(int surface_width, int surface_height)

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -128,6 +128,9 @@ extern bool simulated_connection;
 //		 Problem is, is the stuff rendered
 //		 into a buffer,
 //		 or into the frame buffer?
+// ---
+// Also, this stuff is for a 320x32 sbar size,
+// and is useless on any other size.
 
 // AMMO number pos.
 #define ST_AMMOWIDTH			3
@@ -272,6 +275,8 @@ static bool st_cursoron;
 
 // main bar left
 static lumpHandle_t sbar;
+
+static short sbar_width = 0;
 
 // 0-9, tall numbers
 // [RH] no longer static
@@ -433,21 +438,41 @@ int ST_StatusBarHeight(int surface_width, int surface_height)
 		return 32;
 }
 
-int ST_StatusBarWidth(int surface_width, int surface_height)
+short ST_StatusBarWidth(int surface_width, int surface_height)
 {
 	if (!R_StatusBarVisible())
+	{
 		return 0;
+	}
+
+	short width = 0;
 
 	if (!st_scale)
-		return 320;
+	{
+		return sbar_width;
+	}
+	else
+	{
+		if (sbar_width <= 0)
+		{
+			width = 320;
+		}
+		else
+		{
+			width = sbar_width;
+		}
+	}
 
 	// [AM] Scale status bar width according to height, unless there isn't
 	//      enough room for it.  Fixes widescreen status bar scaling.
 	// [ML] A couple of minor changes for true 4:3 correctness...
+	short height = ST_StatusBarHeight(surface_width, surface_height);
 	if (I_IsProtectedResolution(surface_width, surface_height))
-		return 10 * ST_StatusBarHeight(surface_width, surface_height);
-	else
-		return 4 * surface_height / 3;
+	{
+		return (10 * height > width ? 10 * height : width);
+	}
+
+	return 4 * surface_height / 3;
 }
 
 int ST_StatusBarX(int surface_width, int surface_height)
@@ -985,6 +1010,8 @@ static void ST_refreshBackground()
 	const IWindowSurface* surface = R_GetRenderingSurface();
 	const int surface_width = surface->getWidth(), surface_height = surface->getHeight();
 
+	int scaled_x = (sbar_width - 320) / 2;
+
 	// [RH] If screen is wider than the status bar, draw stuff around status bar.
 	if (surface_width > ST_WIDTH)
 	{
@@ -999,11 +1026,11 @@ static void ST_refreshBackground()
 
 	if (sv_gametype == GM_CTF)
 	{
-		stbar_canvas->DrawPatch(W_ResolvePatchHandle(flagsbg), ST_FLAGSBGX, ST_FLAGSBGY);
+		stbar_canvas->DrawPatch(W_ResolvePatchHandle(flagsbg), ST_FLAGSBGX + scaled_x, ST_FLAGSBGY);
 	}
 	else if (G_IsCoopGame())
 	{
-		stbar_canvas->DrawPatch(W_ResolvePatchHandle(armsbg), ST_ARMSBGX, ST_ARMSBGY);
+		stbar_canvas->DrawPatch(W_ResolvePatchHandle(armsbg), ST_ARMSBGX + scaled_x, ST_ARMSBGY);
 	}
 
 	if (multiplayer)
@@ -1036,10 +1063,10 @@ static void ST_refreshBackground()
 // on top of it.
 //
 // If st_scale is enabled, the status bar is drawn to an unscaled 320x32 pixel
-// off-screen surface stnum_surface. First stbar_surface (the status bar
-// background) is blitted to stnum_surface, then the widgets are then drawn
-// on top of it. Finally, stnum_surface is blitted onto the rendering surface
-// using scaling to match the size in 320x200 resolution.
+// off-screen surface stnum_surface. (or whatever its dimensions are in widescreen.)
+// First stbar_surface (the status bar background) is blitted to stnum_surface,
+// then the widgets are then drawn on top of it. Finally, stnum_surface is blitted
+// onto the rendering surface using scaling to match the size in 320x200 resolution.
 //
 // Now ST_Drawer recalculates the ST_WIDTH, ST_HEIGHT, ST_X, and ST_Y globals.
 //
@@ -1165,6 +1192,9 @@ static void ST_loadGraphics()
 
 	// status bar background bits
 	sbar = W_CachePatchHandle("STBAR", PU_STATIC);
+	// in tyool 2024, we have widescreen status bars
+	// and they're not always 320x32
+	sbar_width = W_ResolvePatchHandle(sbar)->width();
 
 	// face states
 	int facenum = 0;
@@ -1251,52 +1281,55 @@ static void ST_unloadData()
 
 void ST_createWidgets()
 {
+	int scaled_x = (sbar_width - 320) / 2;
 	// ready weapon ammo
-	w_ready.init(ST_AMMOX, ST_AMMOY, tallnum, &st_current_ammo, ST_AMMOWIDTH);
+	w_ready.init(ST_AMMOX + scaled_x, ST_AMMOY, tallnum, &st_current_ammo,
+	             ST_AMMOWIDTH);
 
 	// health percentage
-	w_health.init(ST_HEALTHX, ST_HEALTHY, tallnum, &st_health, tallpercent);
+	w_health.init(ST_HEALTHX + scaled_x, ST_HEALTHY, tallnum, &st_health,
+	              tallpercent);
 
 	// weapons owned
 	for (int i = 0; i < 6; i++)
 	{
-		w_arms[i].init(ST_ARMSX + (i % 3) * ST_ARMSXSPACE,
+		w_arms[i].init(ST_ARMSX + (i % 3) * ST_ARMSXSPACE + scaled_x,
 		               ST_ARMSY + (i / 3) * ST_ARMSYSPACE, arms[i], &st_weaponowned[i]);
 	}
 
 	// frags sum
-	w_frags.init(ST_FRAGSX, ST_FRAGSY, tallnum, &st_fragscount,
+	w_frags.init(ST_FRAGSX + scaled_x, ST_FRAGSY, tallnum, &st_fragscount,
 	             ST_FRAGSWIDTH);
 
 	// faces
-	w_faces.init(ST_FACESX, ST_FACESY, faces, &st_faceindex);
+	w_faces.init(ST_FACESX + scaled_x, ST_FACESY, faces, &st_faceindex);
 
 	// armor percentage - should be colored later
-	w_armor.init(ST_ARMORX, ST_ARMORY, tallnum, &st_armor, tallpercent);
+	w_armor.init(ST_ARMORX + scaled_x, ST_ARMORY, tallnum, &st_armor, tallpercent);
 
 	// keyboxes 0-2
-	w_keyboxes[0].init(ST_KEY0X, ST_KEY0Y, keys, &keyboxes[0]);
-	w_keyboxes[1].init(ST_KEY1X, ST_KEY1Y, keys, &keyboxes[1]);
-	w_keyboxes[2].init(ST_KEY2X, ST_KEY2Y, keys, &keyboxes[2]);
+	w_keyboxes[0].init(ST_KEY0X + scaled_x, ST_KEY0Y, keys, &keyboxes[0]);
+	w_keyboxes[1].init(ST_KEY1X + scaled_x, ST_KEY1Y, keys, &keyboxes[1]);
+	w_keyboxes[2].init(ST_KEY2X + scaled_x, ST_KEY2Y, keys, &keyboxes[2]);
 
 	// ammo count (all four kinds)
-	w_ammo[0].init(ST_AMMO0X, ST_AMMO0Y, shortnum, &st_ammo[0], ST_AMMO0WIDTH);
-	w_ammo[1].init(ST_AMMO1X, ST_AMMO1Y, shortnum, &st_ammo[1], ST_AMMO1WIDTH);
-	w_ammo[2].init(ST_AMMO2X, ST_AMMO2Y, shortnum, &st_ammo[2], ST_AMMO2WIDTH);
-	w_ammo[3].init(ST_AMMO3X, ST_AMMO3Y, shortnum, &st_ammo[3], ST_AMMO3WIDTH);
+	w_ammo[0].init(ST_AMMO0X + scaled_x, ST_AMMO0Y, shortnum, &st_ammo[0], ST_AMMO0WIDTH);
+	w_ammo[1].init(ST_AMMO1X + scaled_x, ST_AMMO1Y, shortnum, &st_ammo[1], ST_AMMO1WIDTH);
+	w_ammo[2].init(ST_AMMO2X + scaled_x, ST_AMMO2Y, shortnum, &st_ammo[2], ST_AMMO2WIDTH);
+	w_ammo[3].init(ST_AMMO3X + scaled_x, ST_AMMO3Y, shortnum, &st_ammo[3], ST_AMMO3WIDTH);
 
 	// max ammo count (all four kinds)
-	w_maxammo[0].init(ST_MAXAMMO0X, ST_MAXAMMO0Y, shortnum, &st_maxammo[0],
+	w_maxammo[0].init(ST_MAXAMMO0X + scaled_x, ST_MAXAMMO0Y, shortnum, &st_maxammo[0],
 	                  ST_MAXAMMO0WIDTH);
-	w_maxammo[1].init(ST_MAXAMMO1X, ST_MAXAMMO1Y, shortnum, &st_maxammo[1],
+	w_maxammo[1].init(ST_MAXAMMO1X + scaled_x, ST_MAXAMMO1Y, shortnum, &st_maxammo[1],
 	                  ST_MAXAMMO1WIDTH);
-	w_maxammo[2].init(ST_MAXAMMO2X, ST_MAXAMMO2Y, shortnum, &st_maxammo[2],
+	w_maxammo[2].init(ST_MAXAMMO2X + scaled_x, ST_MAXAMMO2Y, shortnum, &st_maxammo[2],
 	                  ST_MAXAMMO2WIDTH);
-	w_maxammo[3].init(ST_MAXAMMO3X, ST_MAXAMMO3Y, shortnum, &st_maxammo[3],
+	w_maxammo[3].init(ST_MAXAMMO3X + scaled_x, ST_MAXAMMO3Y, shortnum, &st_maxammo[3],
 	                  ST_MAXAMMO3WIDTH);
 
 	// Number of lives (not always rendered)
-	w_lives.init(ST_FX + 34, ST_FY + 25, shortnum, &st_lives, 2);
+	w_lives.init(ST_FX + 34 + scaled_x, ST_FY + 25, shortnum, &st_lives, 2);
 }
 
 void ST_Start()
@@ -1326,12 +1359,12 @@ void ST_Start()
 
 void ST_Init()
 {
-	if (stbar_surface == NULL)
-		stbar_surface = I_AllocateSurface(320, 32, 8);
-	if (stnum_surface == NULL)
-		stnum_surface = I_AllocateSurface(320, 32, 8);
-
 	ST_loadData();
+
+	if (stbar_surface == NULL)
+		stbar_surface = I_AllocateSurface(sbar_width, 32, 8);
+	if (stnum_surface == NULL)
+		stnum_surface = I_AllocateSurface(sbar_width, 32, 8);
 }
 
 void STACK_ARGS ST_Shutdown()

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -456,7 +456,7 @@ short ST_StatusBarWidth(int surface_width, int surface_height)
 	short height = ST_StatusBarHeight(surface_width, surface_height);
 	if (I_IsProtectedResolution(surface_width, surface_height))
 	{
-		return (10 * height > surface_width ? 10 * height : surface_width);
+		return (10 * height > sbar_width ? 10 * height : sbar_width);
 	}
 
 	if (st_scale)

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1367,6 +1367,8 @@ void STACK_ARGS ST_Shutdown()
 
 	I_FreeSurface(stbar_surface);
 	I_FreeSurface(stnum_surface);
+
+	sbar_width = 0;
 }
 
 

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -453,10 +453,18 @@ short ST_StatusBarWidth(int surface_width, int surface_height)
 	// [AM] Scale status bar width according to height, unless there isn't
 	//      enough room for it.  Fixes widescreen status bar scaling.
 	// [ML] A couple of minor changes for true 4:3 correctness...
-	short height = ST_StatusBarHeight(surface_width, surface_height);
 	if (I_IsProtectedResolution(surface_width, surface_height))
 	{
-		return (10 * height > sbar_width ? 10 * height : sbar_width);
+		int height = ST_StatusBarHeight(surface_width, surface_height);
+
+		if (sbar_width > 320)
+		{
+			return (height / 32) * sbar_width;
+		}
+		else
+		{
+			return 10 * height;
+		}
 	}
 
 	if (st_scale)

--- a/client/src/v_draw.cpp
+++ b/client/src/v_draw.cpp
@@ -570,6 +570,11 @@ void DCanvas::DrawWrapper(EWrapperCode drawer, const patch_t* patch, int x, int 
 	y -= patch->topoffset();
 	x -= patch->leftoffset();
 
+	// [FG] automatically center wide patches without horizontal offset
+	// (taken from dsda but inverted since we center above this)
+	if (patch->width() > 320 && patch->leftoffset() != 0)
+		x += (patch->width() - 320) / 2;
+
 #ifdef RANGECHECK
 	if (x < 0 ||x + patch->width() > surface_width || y < 0 || y + patch->height() > surface_height)
 	{

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -959,9 +959,10 @@ void DCanvas::FlatFill(int left, int top, int right, int bottom, unsigned int fl
 
 // [SL] Stretches a patch to fill the full-screen while maintaining a 4:3
 // aspect ratio. Pillarboxing is used in widescreen resolutions.
-void DCanvas::DrawPatchFullScreen(const patch_t* patch) const
+void DCanvas::DrawPatchFullScreen(const patch_t* patch, bool clear) const
 {
-	mSurface->clear();
+	if (clear)
+		mSurface->clear();
 
 	int surface_width = mSurface->getWidth(), surface_height = mSurface->getHeight();
 
@@ -982,6 +983,11 @@ void DCanvas::DrawPatchFullScreen(const patch_t* patch) const
 		destw = surface_width;
 		desth = surface_width * 3 / 4;
 	}
+
+	int width = patch->width();
+
+	if (width > 320)
+		destw = surface_width;
 
 	int x = (surface_width - destw) / 2;
 	int y = (surface_height - desth) / 2;

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -26,6 +26,7 @@
 #include "odamex.h"
 
 #include <assert.h>
+#include <cmath>
 
 #include "i_system.h"
 #include "i_video.h"
@@ -922,7 +923,7 @@ void DCanvas::FlatFill(int left, int top, int right, int bottom, unsigned int fl
 {
 	int surface_advance = mSurface->getPitchInPixels() - right + left;
 
-	int width = sqrt(flatlength);
+	int width = std::sqrt(flatlength);
 
 	if (mSurface->getBitsPerPixel() == 8)
 	{

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -849,14 +849,13 @@ void V_DrawFPSTicker()
 // There's no posts or columns in flats; the entire
 // thing is one big chunk of data assumed to be 64x64
 //
-// We need to be able to walk the flat bytes.
 // Even if the width is dynamic, a flat pixel
-// will always be 64 bytes
+// will always be 1 byte, and a flat length
+// will always sqrt to its height and width
+// (the same number)
 
 const byte* V_FindTransformedFlatPixel(int x, int y, unsigned int width, const byte* src)
 {
-	const int flat_pixel = 64;
-
 	float pixelcountx = x / static_cast<float>(width);
 	float pixelcounty = y / static_cast<float>(width);
 
@@ -931,13 +930,10 @@ void DCanvas::FlatFill(int left, int top, int right, int bottom, unsigned int fl
 
 		for (int y = top; y < bottom; y++)
 		{
-			int x = left;
-			while (x < right)
+			for (int x = left; x < right; x++)
 			{
-				int amount = std::min(64 - (x & 63), right - x);
-				memcpy(dest, src + ((y & 63) << 6) + (x & 63), amount);
-				dest += amount;
-				x += amount;
+				const byte* pixel = V_FindTransformedFlatPixel(x, y, width, src);
+				*dest++ = *pixel;
 			}
 
 			dest += surface_advance;

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -861,8 +861,8 @@ const byte* V_FindTransformedFlatPixel(int x, int y, unsigned int width, const b
 
 	float wholex, wholey = 0;
 
-	float flatxfrac = std::modff(pixelcountx, &wholex);
-	float flatyfrac = std::modff(pixelcounty, &wholey);
+	float flatxfrac = modff(pixelcountx, &wholex);
+	float flatyfrac = modff(pixelcounty, &wholey);
 
 	int flatx = 0;
 	int flaty = 0;

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -405,9 +405,7 @@ static int WI_GetWidth()
 	// Maybe too big? (it will be cropped if so)
 	if (inter_width > 320)
 	{
-		float aspect_scale_ratio = (float)surface_height / (float)inter_height;
-		int newPageWidth = aspect_scale_ratio * inter_width;
-		width = newPageWidth;
+		width = I_GetAspectCorrectWidth(surface_height, inter_height, inter_width);
 	}
 
 	return width;
@@ -492,7 +490,7 @@ void WI_drawOnLnode(int n, lumpHandle_t* c, int numpatches)
 		patch_t* ch = W_ResolvePatchHandle(c[i]);
 
 		canvas->DrawPatch(ch, lnodes[wbs->epsd][n].x + scaled_x,
-		                          lnodes[wbs->epsd][n].y);
+		                      lnodes[wbs->epsd][n].y);
 	}
 	else
 	{
@@ -528,7 +526,7 @@ void WI_slamBackground()
 		{
 			if (levels.findByName(names[wbs->epsd][i]).flags & LEVEL_VISITED)
 			{
-					WI_drawOnLnode(i, &splat, 1);
+				WI_drawOnLnode(i, &splat, 1);
 			}
 		}
 	}
@@ -540,8 +538,8 @@ void WI_slamBackground()
 
 
 	primary_surface->blitcrop(splat_surface, 0, 0, splat_surface->getWidth(), splat_surface->getHeight(),
-				(primary_surface->getWidth() - destw) / 2, (primary_surface->getHeight() - desth) / 2,
-				destw, desth, false);
+	   (primary_surface->getWidth() - destw) / 2, (primary_surface->getHeight() - desth) / 2,
+	   destw, desth, false);
 
 	background_surface->unlock();
 	splat_surface->unlock();

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1289,7 +1289,7 @@ void WI_updateStats()
 			if (nextlevel.enterpic[0])
 			{
 				// background
-			const patch_t* bg_patch = W_CachePatch(name.c_str());
+				const patch_t* bg_patch = W_CachePatch(name.c_str());
 
 				inter_width = bg_patch->width();
 				inter_height = bg_patch->height();

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -390,25 +390,21 @@ static int WI_GetWidth()
 	const int surface_width = I_GetPrimarySurface()->getWidth();
 	const int surface_height = I_GetPrimarySurface()->getHeight();
 
-	int width = 0;
-
-	if (I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight()))
-		width = surface_width;
-
-	if (surface_width * 3 >= surface_height * 4)
-		width = surface_height * 4 / 3;
-	else
-		width = surface_width;
-
 	// Using widescreen assets? It may go off screen.
 	// Preserve the aspect ratio and make the box big
 	// Maybe too big? (it will be cropped if so)
 	if (inter_width > 320)
 	{
-		width = I_GetAspectCorrectWidth(surface_height, inter_height, inter_width);
+		return I_GetAspectCorrectWidth(surface_height, inter_height, inter_width);
 	}
 
-	return width;
+	if (I_IsProtectedResolution(I_GetVideoWidth(), I_GetVideoHeight()))
+		return surface_width;
+
+	if (surface_width * 3 >= surface_height * 4)
+		return surface_height * 4 / 3;
+	else
+		return surface_width;
 }
 
 

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -516,7 +516,7 @@ void WI_slamBackground()
 	splat_surface->lock();
 
 	splat_surface->blitcrop(background_surface, 0, 0, background_surface->getWidth(), background_surface->getHeight(),
-				0, 0,	splat_surface->getWidth(), splat_surface->getHeight(), false);
+	   0, 0,	splat_surface->getWidth(), splat_surface->getHeight());
 
 	if (needsplat)
 	{
@@ -539,7 +539,7 @@ void WI_slamBackground()
 
 	primary_surface->blitcrop(splat_surface, 0, 0, splat_surface->getWidth(), splat_surface->getHeight(),
 	   (primary_surface->getWidth() - destw) / 2, (primary_surface->getHeight() - desth) / 2,
-	   destw, desth, false);
+	   destw, desth);
 
 	background_surface->unlock();
 	splat_surface->unlock();

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1289,12 +1289,11 @@ void WI_updateStats()
 			if (nextlevel.enterpic[0])
 			{
 				// background
-				const lumpHandle_t handle = W_CachePatchHandle(name.c_str());
+			const patch_t* bg_patch = W_CachePatch(name.c_str());
 
-				inter_width = W_ResolvePatchHandle(handle)->width();
-				inter_height = W_ResolvePatchHandle(handle)->height();
+				inter_width = bg_patch->width();
+				inter_height = bg_patch->height();
 
-				const patch_t* bg_patch = W_CachePatch(name.c_str());
 				background_surface =
 				    I_AllocateSurface(bg_patch->width(), bg_patch->height(), 8);
 				const DCanvas* canvas = background_surface->getDefaultCanvas();

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -717,7 +717,7 @@ void WI_updateAnimatedBack()
 				// gawd-awful hack for level anims
 
 				if (!(state == StatCount && i == 7)
-					&& (WI_MapToIndex (wbs->next) + 1) == a->data1)
+					&& WI_MapToIndex(wbs->next) == a->data1)
 				{
 					a->ctr++;
 					if (a->ctr == a->nanims)

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -518,7 +518,7 @@ void WI_slamBackground()
 	splat_surface->lock();
 
 	splat_surface->blitcrop(background_surface, 0, 0, background_surface->getWidth(), background_surface->getHeight(),
-				0, 0,	splat_surface->getWidth(), splat_surface->getHeight());
+				0, 0,	splat_surface->getWidth(), splat_surface->getHeight(), false);
 
 	if (needsplat)
 	{
@@ -541,7 +541,7 @@ void WI_slamBackground()
 
 	primary_surface->blitcrop(splat_surface, 0, 0, splat_surface->getWidth(), splat_surface->getHeight(),
 				(primary_surface->getWidth() - destw) / 2, (primary_surface->getHeight() - desth) / 2,
-				destw, desth);
+				destw, desth, false);
 
 	background_surface->unlock();
 	splat_surface->unlock();

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -702,13 +702,15 @@ void WI_drawAnimatedBack()
 	{
 		DCanvas* canvas = background_surface->getDefaultCanvas();
 
+		int scaled_x = (inter_width - 320) / 2;
+
 		background_surface->lock();
 
 		for (int i = 0; i < NUMANIMS[wbs->epsd]; i++)
 		{
 			animinfo_t* a = &anims[wbs->epsd][i];
 			if (a->ctr >= 0)
-				canvas->DrawPatch(a->p[a->ctr], a->loc.x, a->loc.y);
+				canvas->DrawPatch(a->p[a->ctr], a->loc.x + scaled_x, a->loc.y);
 		}
 
 		background_surface->unlock();

--- a/common/st_stuff.h
+++ b/common/st_stuff.h
@@ -39,7 +39,7 @@ extern int ST_WIDTH;
 extern int ST_X;
 extern int ST_Y;
 
-int ST_StatusBarWidth(int surface_width, int surface_height);
+short ST_StatusBarWidth(int surface_width, int surface_height);
 int ST_StatusBarHeight(int surface_width, int surface_height);
 int ST_StatusBarX(int surface_width, int surface_height);
 int ST_StatusBarY(int surface_width, int surface_height);

--- a/common/v_video.h
+++ b/common/v_video.h
@@ -133,7 +133,7 @@ public:
 	inline void DrawPatchClean (const patch_t *patch, int x, int y) const;
 	inline void DrawPatchCleanNoMove (const patch_t *patch, int x, int y) const;
 
-	void DrawPatchFullScreen(const patch_t* patch) const;
+	void DrawPatchFullScreen(const patch_t* patch, bool clear) const;
 
 	inline void DrawLucentPatch (const patch_t *patch, int x, int y) const;
 	inline void DrawLucentPatchStretched (const patch_t *patch, int x, int y, int dw, int dh) const;

--- a/common/v_video.h
+++ b/common/v_video.h
@@ -91,7 +91,7 @@ public:
 	void Dim (int x, int y, int width, int height) const;
 
 	// Fill an area with a 64x64 flat texture
-	void FlatFill (int left, int top, int right, int bottom, const byte *src) const;
+	void FlatFill (int left, int top, int right, int bottom, unsigned int flatlength, const byte *src) const;
 
 	// Set an area to a specified color
 	void Clear(int left, int top, int right, int bottom, argb_t color) const;


### PR DESCRIPTION
Again, apologies for the long PR but this is the summer of Odamex. On the menu _du jour_ is widescreen asset support, as well as scaled screenblocks and finale flats to enhance the widescreen experience. This PR uses (abuses?) WindowSurfaces in order to achieve widescreen drawing to crop the edges of the patch -- something our patch drawer cannot currently do.

We now support the following widescreen assets:
TITLEPIC
INTERPIC
DOOM 1 Episodes 1-3 WIMAPs
BOSSBACK
HELP/1
STBAR
CREDIT
ENDPIC
VICTORY2
PFUB1/2 aka BunnyScroll rewritten to use canvases

Also included is a cornucopia of fixes, which I will list here:

#327 - Added widescreen asset support, but did not touch the patch drawers.
#275 - Widescreen as well as transparent help is now supported
#924 - Related to #327, now the status bar in 1x1.wad works.
#669 - This is solved by drawing splats on their own surface, and then to the screen, to get proper scaling and not be overwritten by map animations
#671 - Solved due to an error in calculating current map
#668 - Solved due to an error in calculating how big the surface is before blitting to the screen

Also, as mentioned above, also added is both scaled screenblocks, as well as support for high definition flats in screenblocks. The screenblocks flat is drawn to a 320x200 surface, then scaled while preserving aspect ratio to the destination viewport. In order to keep aspect ratio, this may be a little bigger than the viewport in width or height -- this part gets cropped off.

This makes wads like PUSS25_LUNACY.wad display a better hud:

![image](https://github.com/user-attachments/assets/b88d7add-355b-4334-8ba6-3b51a2bfd52c)

Scaled screenblocks in DOOM/DOOM2:

![image](https://github.com/user-attachments/assets/15e0b8ab-7aef-4a3c-b81c-66e6484f27da)

![image](https://github.com/user-attachments/assets/265f6265-3c5b-4cfd-a325-72463a22aca9)

Test wads:
[odawidewads.zip](https://github.com/user-attachments/files/16465304/odawidewads.zip)

