### PR TITLE
[BUGFIX] Fix renderer not properly displaying non-power of 2 width textures

### DIFF
--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -473,7 +473,12 @@ byte* R_GetPatchColumnData(int lumpnum, int colnum)
 //
 tallpost_t* R_GetTextureColumn(int texnum, int colnum)
 {
-	colnum &= texturewidthmask[texnum];
+	short width = textures[texnum]->width;
+	int mask = texturewidthmask[texnum];
+	if (mask + 1 == width)
+		colnum &= mask;
+	else
+		colnum %= width;
 	int lump = texturecolumnlump[texnum][colnum];
 	int ofs = texturecolumnofs[texnum][colnum];
 


### PR DESCRIPTION
This was a simple fix, as it couldn't do the math if a texture width wasn't a power of 2. Now it will properly find the remainder if it can't figure this out via the mask. Fixes #571, makes PUSS25_LUNACY.WAD and other PUSS wads display properly since they are big fans of non-power of 2 width textures.

![image](https://github.com/user-attachments/assets/40e6e68b-ec3c-4877-a487-6d5a1cde6b4c)

![image](https://github.com/user-attachments/assets/ffaac02e-7cb2-4293-a140-eb99c9c4dba7)