### PR TITLE
[BUGFIX] Prevent voodoo dolls from affecting player viewheight in single player

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1775,7 +1775,7 @@ void P_ZMovement(AActor *mo)
 		return;
 	}
 
-	if (mo->player)
+	if (mo->player && !P_IsVoodooDoll(mo))
 		P_PlayerSmoothStepUp(mo);
 
 	// ZDoom applies gravity earlier in the function than vanilla


### PR DESCRIPTION
This was an easy fix for #917, I had this in the `interpolate-more-things` branch but since it wasn't interpolation-related, I broke it out into its own PR for a fix.