### PR TITLE
[BUGFIX] Draw player sprite in front of box in player setup menu

### DIFF
--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1504,13 +1504,13 @@ static void M_PlayerSetupDrawer()
 		R_BuildPlayerTranslation(0, player_color);
 		V_ColorMap = translationref_t(translationtables, 0);
 
+		// Draw box surrounding fire and player:
+		screen->DrawPatchClean(W_CachePatch("M_PBOX"), 320 - 88 - 32 + 36,
+			PSetupDef.y + LINEHEIGHT * 3 + 22);
+
 		screen->DrawTranslatedPatchClean (W_CachePatch (sprframe->lump[0]),
 			320 - 52 - 32, PSetupDef.y + LINEHEIGHT*3 + 46);
 	}
-
-	// Draw box surrounding fire and player:
-	screen->DrawPatchClean (W_CachePatch ("M_PBOX"),
-		320 - 88 - 32 + 36, PSetupDef.y + LINEHEIGHT*3 + 22);
 
 	// Draw team setting
 	{


### PR DESCRIPTION
If the player sprite is too big for the box in the player setup menu, the box will clip over the player sprite. This update changes that behavior to draw the player sprite after the box:

![image](https://github.com/user-attachments/assets/12aa5595-c55a-453c-9e02-37d1cafa5ae3)

Fixes #839 