### PR TITLE
[BUGFIX] Don't block avatars on Block Monster or Block Land Monster lines

### DIFF
--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -411,8 +411,8 @@ BOOL PIT_CheckLine (line_t *ld)
     {
 		if ((ld->flags &
 		     (ML_BLOCKING | ML_BLOCKEVERYTHING)) || // explicitly blocking everything
-		    (!tmthing->player && (ld->flags & ML_BLOCKMONSTERS)) || // block monsters only
-		    (!tmthing->player && (ld->flags & ML_BLOCKLANDMONSTERS) &&
+		    (!tmthing->player && tmthing->type != MT_AVATAR && (ld->flags & ML_BLOCKMONSTERS)) || // block monsters only
+		    (!tmthing->player && tmthing->type != MT_AVATAR && (ld->flags & ML_BLOCKLANDMONSTERS) &&
 		     !(tmthing->flags & MF_FLOAT)) || // [Blair] Block land monsters.
 		    (tmthing->player &&
 		     (ld->flags & ML_BLOCKPLAYERS))) // [Blair] Block players only


### PR DESCRIPTION
Does what it says. Don't block avatars when you want to block monsters, since they're technically player surrogates. Fixes #927 