### PR TITLE
Add support for DOOM + DOOM II Steam release

### DIFF
--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -174,6 +174,12 @@ static const char* steam_install_subdirs[] =
 	"steamapps\\common\\ultimate doom\\base",
 	"steamapps\\common\\DOOM 3 BFG Edition\\base\\wads",
 	"steamapps\\common\\master levels of doom\\master\\wads", //Let Odamex find the Master Levels pwads too
+	"steamapps\\common\\ultimate doom\\base\\doom2", //2024 Steam re-release additions here and below
+	"steamapps\\common\\ultimate doom\\base\\master\\wads",
+	"steamapps\\common\\ultimate doom\\base\\plutonia",
+	"steamapps\\common\\ultimate doom\\base\\tnt",
+	"steamapps\\common\\ultimate doom\\rerelease",
+	
 };
 
 

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -217,7 +217,7 @@ static const identData_t identdata[] = {
         "4E158D9953C79CCF97BD0663244CC6B6", // mMd5Sum
         TNT_PREFIX " v1.9",                 // mGroupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
-        400,                                // weight
+        350,                                // weight
     },
     {
         TNT_PREFIX " (DOOM + DOOM II)",     // mIdName
@@ -226,7 +226,7 @@ static const identData_t identdata[] = {
         "8974E3117ED4A1839C752D5E11AB1B7B", // mMd5Sum
         TNT_PREFIX " v1.9",                 // mGroupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
-        420,                                // weight
+        370,                                // weight
     },
     {
         TNT_PREFIX " v1.9 Anthology",       // mIdName
@@ -235,7 +235,7 @@ static const identData_t identdata[] = {
         "1D39E405BF6EE3DF69A8D2646C8D5C49", // mMd5Sum
         TNT_PREFIX " v1.9",                 // mGroupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
-        425,                                // weight
+        375,                                // weight
     },
 
     // ------------------------------------------------------------------------

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -217,7 +217,7 @@ static const identData_t identdata[] = {
         "4E158D9953C79CCF97BD0663244CC6B6", // mMd5Sum
         TNT_PREFIX " v1.9",                 // mGroupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
-        300,                                // weight
+        400,                                // weight
     },
     {
         TNT_PREFIX " (DOOM + DOOM II)",     // mIdName
@@ -226,7 +226,7 @@ static const identData_t identdata[] = {
         "8974E3117ED4A1839C752D5E11AB1B7B", // mMd5Sum
         TNT_PREFIX " v1.9",                 // mGroupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
-        320,                                // weight
+        420,                                // weight
     },
     {
         TNT_PREFIX " v1.9 Anthology",       // mIdName
@@ -235,7 +235,7 @@ static const identData_t identdata[] = {
         "1D39E405BF6EE3DF69A8D2646C8D5C49", // mMd5Sum
         TNT_PREFIX " v1.9",                 // mGroupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
-        325,                                // weight
+        425,                                // weight
     },
 
     // ------------------------------------------------------------------------

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -75,6 +75,15 @@ static const identData_t identdata[] = {
         DOOM2_PREFIX " v1.9",               // groupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
         100,                                // weight
+    },    
+    {
+        DOOM2_PREFIX " (DOOM + DOOM II)",   // idName
+        "DOOM2.WAD",                        // filename
+        "09B8A6AE",                         // crc32Sum
+        "9AA3CBF65B961D0BDAC98EC403B832E1", // md5Sum
+        DOOM2_PREFIX " v1.9",               // groupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        140,                                // weight
     },
     {
         DOOM2_PREFIX " Classic Unity v1.3", // idName
@@ -180,6 +189,15 @@ static const identData_t identdata[] = {
         300,                                // weight
     },
     {
+        PLUTONIA_PREFIX " (DOOM + DOOM II)",// mIdName
+        "PLUTONIA.WAD",                     // mFilename
+        "650B998D",                         // mCRC32Sum
+        "24037397056E919961005E08611623F4", // mMd5Sum
+        PLUTONIA_PREFIX " v1.9",            // groupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        320,                                // weight
+    },
+    {
         PLUTONIA_PREFIX " v1.9 Anthology",  // mIdName
         "PLUTONIA.WAD",                     // mFilename
         "15CD1448",                         // mCRC32Sum
@@ -202,6 +220,15 @@ static const identData_t identdata[] = {
         300,                                // weight
     },
     {
+        TNT_PREFIX " (DOOM + DOOM II)",     // mIdName
+        "TNT.WAD",                          // mFilename
+        "15F18DDB",                         // mCRC32Sum
+        "8974E3117ED4A1839C752D5E11AB1B7B", // mMd5Sum
+        TNT_PREFIX " v1.9",                 // mGroupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        320,                                // weight
+    },
+    {
         TNT_PREFIX " v1.9 Anthology",       // mIdName
         "TNT.WAD",                          // mFilename
         "D4BB05C0",                         // mCRC32Sum
@@ -222,6 +249,15 @@ static const identData_t identdata[] = {
         UDOOM_PREFIX " v1.9",               // mGroupName
         IDENT_COMMERCIAL | IDENT_IWAD,      // flags
         200,                                // weight
+    },
+    {
+        UDOOM_PREFIX " (DOOM + DOOM II)",   // mIdName
+        "DOOM.WAD",                         // mFilename
+        "CFF03D9F",                         // mCRC32Sum
+        "4461D4511386518E784C647E3128E7BC", // mMd5Sum
+        UDOOM_PREFIX " v1.9",               // mGroupName
+        IDENT_COMMERCIAL | IDENT_IWAD,      // flags
+        240,                                // weight
     },
     {
         UDOOM_PREFIX " Classic Unity v1.3", // mIdName


### PR DESCRIPTION
This PR adds IWAD finding and launching support for the DOOM + DOOM II iwads, as released on Steam in August 2024. This is a necessary fix because anyone that owned prior Doom releases on Steam are automatically upgraded to this release, which changes the location of the iwads. This means that, as of Aug 8, 3/4 of the main iwads won't appear in the Odamex launcher anymore. This PR corrects that and expands support.