### PR TITLE
Fix height transfer sector ceiling/floor plane visibility check (partial fix for bug 980)

### DIFF
--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -671,7 +671,7 @@ void R_Subsector (int num)
 
 	basecolormap = frontsector->colormap->maps;
 
-	ceilingplane = P_CeilingHeight(camera) > viewz ||
+	ceilingplane = P_CeilingHeight(viewx, viewy, frontsector) > viewz ||
 		frontsector->ceilingpic == skyflatnum ||
 		(frontsector->heightsec && 
 		!(frontsector->heightsec->MoreFlags & SECF_IGNOREHEIGHTSEC) && 
@@ -691,7 +691,7 @@ void R_Subsector (int num)
 	// killough 3/7/98: Add (x,y) offsets to flats, add deep water check
 	// killough 3/16/98: add floorlightlevel
 	// killough 10/98: add support for skies transferred from sidedefs
-	floorplane = P_FloorHeight(camera) < viewz || // killough 3/7/98
+	floorplane = P_FloorHeight(viewx, viewy, frontsector) < viewz || // killough 3/7/98
 		(frontsector->heightsec &&
 		!(frontsector->heightsec->MoreFlags & SECF_IGNOREHEIGHTSEC) &&
 		frontsector->heightsec->ceilingpic == skyflatnum) ?


### PR DESCRIPTION
Use the correct sector when determining which ceiling and floor planes are visible in height transfer sectors.

In the checks that determine whether floor & ceiling planes are visible, the old code calculates the ceiling and floor heights of the camera using the sector that the camera is in. However this does not take transfer height sectors into account. Instead, the sector that is returned by R_FakeFlat should be used, as ZDoom does [here](https://github.com/doomtech/zdoom-old/blob/1.23b33/src/r_bsp.cpp#L988).

Note that this does not entirely resolve [bug 930](https://github.com/odamex/odamex/issues/980). However this is a step in the right direction.