### PR TITLE
Fix Fedora Workflow

### DIFF
--- a/ci/fedora.Dockerfile
+++ b/ci/fedora.Dockerfile
@@ -4,9 +4,6 @@ WORKDIR odamex
 
 COPY . .
 
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-
 # Packages
 RUN set -x && \
     dnf -y install gcc-c++ alsa-lib-devel libcurl-devel \


### PR DESCRIPTION
Some of the changes in the CentOS workflow in `stable` made it to the Fedora workflow in `protobreak`. This reverts those changes so that the build doesn't fail prematurely.