### PR TITLE
[FEATURE] Add support for compressed ZDoom extended nodes

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -470,9 +470,7 @@ bool P_LoadXNOD(int lump)
 	}
 
 	if (len >= 8 && memcmp(data, "xNd4\0\0\0\0", 8) == 0)
-	{
 		I_Error("P_LoadXNOD: DeePBSP nodes are not supported.");
-	}
 
 	bool compressed = memcmp(data, "ZNOD", 4) == 0;
 
@@ -485,7 +483,8 @@ bool P_LoadXNOD(int lump)
 	byte *p;
 	// [EB] decompress compressed nodes
 	// adapted from Crispy Doom
-	if (compressed) {
+	if (compressed)
+	{
 		int outlen, err;
 		z_stream *zstream;
 
@@ -503,28 +502,28 @@ bool P_LoadXNOD(int lump)
 		zstream->avail_out = outlen;
 
 		if (inflateInit(zstream) != Z_OK)
-	    	I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression initialization!");
+			I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression initialization!");
 
 		// resize if output buffer runs full
 		while ((err = inflate(zstream, Z_SYNC_FLUSH)) == Z_OK)
 		{
-		    int outlen_old = outlen;
-		    outlen = 2 * outlen_old;
-		    output = (byte*)M_Realloc(output, outlen);
-		    zstream->next_out = output + outlen_old;
-		    zstream->avail_out = outlen - outlen_old;
+			int outlen_old = outlen;
+			outlen = 2 * outlen_old;
+			output = (byte*)M_Realloc(output, outlen);
+			zstream->next_out = output + outlen_old;
+			zstream->avail_out = outlen - outlen_old;
 		}
 
 		if (err != Z_STREAM_END)
-	    	I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression!");
+			I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression!");
 
 		fprintf(stderr, "P_LoadXNOD: ZDBSP nodes compression ratio %.3f\n",
-	    	    (float)zstream->total_out/zstream->total_in);
+				(float)zstream->total_out/zstream->total_in);
 
 		len = zstream->total_out;
 
 		if (inflateEnd(zstream) != Z_OK)
-	    	I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression shut-down!");
+			I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression shut-down!");
 
 		M_Free(zstream);
 		p = output;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -469,6 +469,11 @@ bool P_LoadXNOD(int lump)
 		return false;
 	}
 
+	if (len >= 8 && memcmp(data, "xNd4\0\0\0\0", 8) == 0)
+	{
+		I_Error("P_LoadXNOD: DeePBSP nodes are not supported.");
+	}
+
 	bool compressed = memcmp(data, "ZNOD", 4) == 0;
 
 	if (memcmp(data, "XNOD", 4) != 0 && !compressed)
@@ -511,15 +516,15 @@ bool P_LoadXNOD(int lump)
 		}
 
 		if (err != Z_STREAM_END)
-	    	I_Error("P_LoadNodes: Error during ZDBSP nodes decompression!");
+	    	I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression!");
 
-		fprintf(stderr, "P_LoadNodes: ZDBSP nodes compression ratio %.3f\n",
+		fprintf(stderr, "P_LoadXNOD: ZDBSP nodes compression ratio %.3f\n",
 	    	    (float)zstream->total_out/zstream->total_in);
 
 		len = zstream->total_out;
 
 		if (inflateEnd(zstream) != Z_OK)
-	    	I_Error("P_LoadNodes: Error during ZDBSP nodes decompression shut-down!");
+	    	I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression shut-down!");
 
 		M_Free(zstream);
 		p = output;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -461,9 +461,16 @@ bool P_LoadXNOD(int lump)
 {
 	size_t len = W_LumpLength(lump);
 	byte *data = (byte *) W_CacheLumpNum(lump, PU_STATIC);
+
+	if (len < 4)
+	{
+		Z_Free(data);
+		return false;
+	}
+
 	bool compressed = memcmp(data, "ZNOD", 4) == 0;
 
-	if (len < 4 || (memcmp(data, "XNOD", 4) != 0 && !compressed))
+	if (memcmp(data, "XNOD", 4) != 0 && !compressed)
 	{
 		Z_Free(data);
 		return false;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -461,6 +461,7 @@ bool P_LoadXNOD(int lump)
 {
 	size_t len = W_LumpLength(lump);
 	byte *data = (byte *) W_CacheLumpNum(lump, PU_STATIC);
+	byte* output = NULL;
 
 	if (len < 4)
 	{
@@ -480,8 +481,6 @@ bool P_LoadXNOD(int lump)
 	// [EB] decompress compressed nodes
 	// adapted from Crispy Doom
 	if (compressed) {
-		byte* output;
-		
 		int outlen, err;
 		z_stream *zstream;
 
@@ -517,14 +516,13 @@ bool P_LoadXNOD(int lump)
 		fprintf(stderr, "P_LoadNodes: ZDBSP nodes compression ratio %.3f\n",
 	    	    (float)zstream->total_out/zstream->total_in);
 
-		data = output;
 		len = zstream->total_out;
 
 		if (inflateEnd(zstream) != Z_OK)
 	    	I_Error("P_LoadNodes: Error during ZDBSP nodes decompression shut-down!");
 
 		M_Free(zstream);
-		p = data;
+		p = output;
 	}
 	else
 	{
@@ -646,6 +644,7 @@ bool P_LoadXNOD(int lump)
 	}
 
 	Z_Free(data);
+	Z_Free(output);
 
 	return true;
 }


### PR DESCRIPTION
Addresses #952

Odamex actually already supported uncompressed ZDoom extended nodes. This adds a check for compressed nodes and decompresses them if present.