### PR TITLE
[BUGFIX] Fix instances where negative column numbers may cause out of range memory errors

### DIFF
--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -478,7 +478,7 @@ tallpost_t* R_GetTextureColumn(int texnum, int colnum)
 	if (mask + 1 == width)
 		colnum &= mask;
 	else
-		colnum %= width;
+		colnum -= width * floor((float)colnum / (float)width);
 	int lump = texturecolumnlump[texnum][colnum];
 	int ofs = texturecolumnofs[texnum][colnum];
 

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -478,7 +478,7 @@ tallpost_t* R_GetTextureColumn(int texnum, int colnum)
 	if (mask + 1 == width)
 		colnum &= mask;
 	else
-		colnum -= width * floor((float)colnum / (float)width);
+		colnum -= width * std::floor((float)colnum / (float)width);
 	int lump = texturecolumnlump[texnum][colnum];
 	int ofs = texturecolumnofs[texnum][colnum];
 

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -45,6 +45,8 @@
 
 #include <ctype.h>
 
+#include <cmath>
+
 #include <algorithm>
 
 //


### PR DESCRIPTION
The fix https://github.com/odamex/odamex/commit/ee23581081e1d1917abbb941546fde23893571ea for non-power of 2 textures used a modulus calculation that famously doesn't use floor division. As such, negative numbers tend to freak it out. This fixes that.