### PR TITLE
[BUGFIX] Allow quotes for "wad" command on both client and server

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -138,7 +138,8 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	C_HideConsole();
 
 	std::string str = JoinStrings(VectorArgs(argc, argv), " ");
-	G_LoadWadString(str);
+	std::string wadstr = C_QuoteString(str);
+	G_LoadWadString(wadstr);
 
 	D_StartTitle ();
 	CL_QuitNetGame(NQ_SILENT);

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -174,7 +174,8 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	}
 
 	std::string str = JoinStrings(VectorArgs(argc, argv), " ");
-	G_LoadWadString(str);
+	std::string wadstr = C_QuoteString(str);
+	G_LoadWadString(wadstr);
 }
 END_COMMAND (wad)
 


### PR DESCRIPTION
Previously, quoted wads (for wads with spaces) wouldn't work with the wad command on both client or server. This update properly escapes those wad file names.