### PR TITLE
Move minilzo to a separate library

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -212,6 +212,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
   endif()
 
   target_link_libraries(odamex ZLIB::ZLIB PNG::PNG)
+  target_link_libraries(odamex minilzo)
 
   if(WIN32)
     target_link_libraries(odamex winmm wsock32 shlwapi)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -120,6 +120,16 @@ function(lib_build)
   endif()
 endfunction()
 
+### minilzo ###
+
+if(BUILD_CLIENT OR BUILD_SERVER)
+  message(STATUS "Compiling minilzo...")
+
+  add_library(minilzo STATIC
+      "minilzo/lzoconf.h" "minilzo/lzodefs.h" "minilzo/minilzo.c" "minilzo/minilzo.h")
+  target_include_directories(minilzo PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/minilzo")
+endif()
+
 ### zlib ###
 
 if(BUILD_CLIENT OR BUILD_SERVER)

--- a/libraries/minilzo/COPYING
+++ b/libraries/minilzo/COPYING
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/libraries/minilzo/Makefile
+++ b/libraries/minilzo/Makefile
@@ -1,0 +1,100 @@
+#
+# a very simple Makefile for miniLZO
+#
+# Copyright (C) 1996-2017 Markus F.X.J. Oberhumer
+#
+
+PROGRAM = testmini
+SOURCES = testmini.c minilzo.c
+
+default:
+	@echo ""
+	@echo "Welcome to miniLZO. Please choose one of the following 'make' targets:"
+	@echo ""
+	@echo "    gcc:   gcc"
+	@echo "    unix:  hpux hpux9"
+	@echo "    win32: win32-bc win32-cygwin win32-dm win32-lccwin32"
+	@echo "           win32-intelc win32-mingw win32-vc win32-watcomc"
+	@echo "    dos32: dos32-djgpp2 dos32-wc"
+	@echo ""
+
+
+# Make sure that minilzo.h, lzoconf.h and lzodefs.h are in the
+# current dircectory. Otherwise you may want to adjust CPPFLAGS.
+CPPFLAGS = -I. -I../include/lzo
+
+GCC_CFLAGS = -s -Wall -O2 -fomit-frame-pointer
+
+
+#
+# gcc (generic)
+#
+
+gcc:
+	gcc $(CPPFLAGS) $(GCC_CFLAGS) -o $(PROGRAM) $(SOURCES)
+
+cc:
+	cc $(CPPFLAGS) -o $(PROGRAM) $(SOURCES)
+
+
+#
+# UNIX
+#
+
+hpux:
+	cc -Ae $(CPPFLAGS) -o $(PROGRAM) $(SOURCES)
+
+hpux9:
+	cc -Aa -D_HPUX_SOURCE $(CPPFLAGS) -o $(PROGRAM) $(SOURCES)
+
+
+#
+# Windows (32-bit)
+#
+
+win32-borlandc win32-bc:
+	bcc32 -O2 -d -w -w-aus $(CPPFLAGS) $(SOURCES)
+
+win32-cygwin32 win32-cygwin:
+	gcc -mcygwin $(CPPFLAGS) $(GCC_CFLAGS) -o $(PROGRAM).exe $(SOURCES)
+
+win32-digitalmars win32-dm:
+	dmc -mn -o -w- $(CPPFLAGS) $(SOURCES)
+
+win32-intelc win32-ic:
+	icl -nologo -MT -W3 -O2 -GF $(CPPFLAGS) $(SOURCES)
+
+win32-lccwin32:
+	@echo "NOTE: need lcc 2002-07-25 or newer, older versions have bugs"
+	lc -A -unused -O $(CPPFLAGS) $(SOURCES)
+
+win32-mingw32 win32-mingw:
+	gcc -mno-cygwin $(CPPFLAGS) $(GCC_CFLAGS) -o $(PROGRAM).exe $(SOURCES)
+
+win32-visualc win32-vc:
+	cl -nologo -MT -W3 -O2 -GF $(CPPFLAGS) $(SOURCES)
+
+win32-watcomc win32-wc:
+	wcl386 -bt=nt -zq -mf -5r -zc -w5 -oneatx $(CPPFLAGS) $(SOURCES)
+
+
+#
+# DOS (32-bit)
+#
+
+dos32-djgpp2 dos32-dj2:
+	gcc $(CPPFLAGS) $(GCC_CFLAGS) -o $(PROGRAM).exe $(SOURCES)
+
+dos32-watcomc dos32-wc:
+	wcl386 -zq -mf -bt=dos -l=dos4g -5r -ox -zc $(CPPFLAGS) $(SOURCES)
+
+
+#
+# other targets
+#
+
+clean:
+	rm -f $(PROGRAM) $(PROGRAM).exe $(PROGRAM).map $(PROGRAM).tds
+	rm -f *.err *.o *.obj
+
+.PHONY: default clean

--- a/libraries/minilzo/README.LZO
+++ b/libraries/minilzo/README.LZO
@@ -1,0 +1,123 @@
+
+ ============================================================================
+ miniLZO -- mini subset of the LZO real-time data compression library
+ ============================================================================
+
+ Author  : Markus Franz Xaver Johannes Oberhumer
+           <markus@oberhumer.com>
+           http://www.oberhumer.com/opensource/lzo/
+ Version : 2.10
+ Date    : 01 Mar 2017
+
+ I've created miniLZO for projects where it is inconvenient to
+ include (or require) the full LZO source code just because you
+ want to add a little bit of data compression to your application.
+
+ miniLZO implements the LZO1X-1 compressor and both the standard and
+ safe LZO1X decompressor. Apart from fast compression it also useful
+ for situations where you want to use pre-compressed data files (which
+ must have been compressed with LZO1X-999).
+
+ miniLZO consists of one C source file and three header files:
+    minilzo.c
+    minilzo.h, lzoconf.h, lzodefs.h
+
+ To use miniLZO just copy these files into your source directory, add
+ minilzo.c to your Makefile and #include minilzo.h from your program.
+ Note: you also must distribute this file ('README.LZO') with your project.
+
+ minilzo.o compiles to about 6 KiB (using gcc or Visual C on an i386), and
+ the sources are about 30 KiB when packed with zip - so there's no more
+ excuse that your application doesn't support data compression :-)
+
+ For more information, documentation, example programs and other support
+ files (like Makefiles and build scripts) please download the full LZO
+ package from
+    http://www.oberhumer.com/opensource/lzo/
+
+ Have fun,
+  Markus
+
+
+ P.S. minilzo.c is generated automatically from the LZO sources and
+      therefore functionality is completely identical
+
+
+ Appendix A: building miniLZO
+ ----------------------------
+ miniLZO is written such a way that it should compile and run
+ out-of-the-box on most machines.
+
+ If you are running on a very unusual architecture and lzo_init() fails then
+ you should first recompile with '-DLZO_DEBUG' to see what causes the failure.
+ The most probable case is something like 'sizeof(void *) != sizeof(size_t)'.
+ After identifying the problem you can compile by adding some defines
+ like '-DSIZEOF_VOID_P=8' to your Makefile.
+
+ The best solution is (of course) using Autoconf - if your project uses
+ Autoconf anyway just add '-DMINILZO_HAVE_CONFIG_H' to your compiler
+ flags when compiling minilzo.c. See the LZO distribution for an example
+ how to set up configure.ac.
+
+
+ Appendix B: list of public functions available in miniLZO
+ ---------------------------------------------------------
+ Library initialization
+    lzo_init()
+
+ Compression
+    lzo1x_1_compress()
+
+ Decompression
+    lzo1x_decompress()
+    lzo1x_decompress_safe()
+
+ Checksum functions
+    lzo_adler32()
+
+ Version functions
+    lzo_version()
+    lzo_version_string()
+    lzo_version_date()
+
+ Portable (but slow) string functions
+    lzo_memcmp()
+    lzo_memcpy()
+    lzo_memmove()
+    lzo_memset()
+
+
+ Appendix C: suggested macros for 'configure.ac' when using Autoconf
+ -------------------------------------------------------------------
+ Checks for typedefs and structures
+    AC_CHECK_TYPE(ptrdiff_t,long)
+    AC_TYPE_SIZE_T
+    AC_CHECK_SIZEOF(short)
+    AC_CHECK_SIZEOF(int)
+    AC_CHECK_SIZEOF(long)
+    AC_CHECK_SIZEOF(long long)
+    AC_CHECK_SIZEOF(__int64)
+    AC_CHECK_SIZEOF(void *)
+    AC_CHECK_SIZEOF(size_t)
+    AC_CHECK_SIZEOF(ptrdiff_t)
+
+ Checks for compiler characteristics
+    AC_C_CONST
+
+ Checks for library functions
+    AC_CHECK_FUNCS(memcmp memcpy memmove memset)
+
+
+ Appendix D: Copyright
+ ---------------------
+ LZO and miniLZO are Copyright (C) 1996-2017 Markus Franz Xaver Oberhumer
+ All Rights Reserved.
+
+ LZO and miniLZO are distributed under the terms of the GNU General
+ Public License (GPL).  See the file COPYING.
+
+ Special licenses for commercial and other applications which
+ are not willing to accept the GNU General Public License
+ are available by contacting the author.
+
+

--- a/libraries/minilzo/lzoconf.h
+++ b/libraries/minilzo/lzoconf.h
@@ -2,7 +2,7 @@
 
    This file is part of the LZO real-time data compression library.
 
-   Copyright (C) 1996-2014 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1996-2017 Markus Franz Xaver Johannes Oberhumer
    All Rights Reserved.
 
    The LZO library is free software; you can redistribute it and/or
@@ -29,9 +29,9 @@
 #ifndef __LZOCONF_H_INCLUDED
 #define __LZOCONF_H_INCLUDED 1
 
-#define LZO_VERSION             0x2080
-#define LZO_VERSION_STRING      "2.08"
-#define LZO_VERSION_DATE        "Jun 29 2014"
+#define LZO_VERSION             0x20a0  /* 2.10 */
+#define LZO_VERSION_STRING      "2.10"
+#define LZO_VERSION_DATE        "Mar 01 2017"
 
 /* internal Autoconf configuration file - only used when building LZO */
 #if defined(LZO_HAVE_CONFIG_H)
@@ -57,7 +57,7 @@
 
 /* get OS and architecture defines */
 #ifndef __LZODEFS_H_INCLUDED
-#include "lzodefs.h"
+#include <lzo/lzodefs.h>
 #endif
 
 
@@ -94,25 +94,29 @@ extern "C" {
 #    if (LZO_OS_WIN64)
      typedef unsigned __int64   lzo_uint;
      typedef __int64            lzo_int;
+#    define LZO_TYPEOF_LZO_INT  LZO_TYPEOF___INT64
 #    else
      typedef lzo_ullong_t       lzo_uint;
      typedef lzo_llong_t        lzo_int;
+#    define LZO_TYPEOF_LZO_INT  LZO_TYPEOF_LONG_LONG
 #    endif
-#    define LZO_SIZEOF_LZO_UINT 8
+#    define LZO_SIZEOF_LZO_INT  8
 #    define LZO_UINT_MAX        0xffffffffffffffffull
 #    define LZO_INT_MAX         9223372036854775807LL
 #    define LZO_INT_MIN         (-1LL - LZO_INT_MAX)
 #  elif (LZO_ABI_IP32L64) /* MIPS R5900 */
      typedef unsigned int       lzo_uint;
      typedef int                lzo_int;
-#    define LZO_SIZEOF_LZO_UINT LZO_SIZEOF_INT
+#    define LZO_SIZEOF_LZO_INT  LZO_SIZEOF_INT
+#    define LZO_TYPEOF_LZO_INT  LZO_TYPEOF_INT
 #    define LZO_UINT_MAX        UINT_MAX
 #    define LZO_INT_MAX         INT_MAX
 #    define LZO_INT_MIN         INT_MIN
 #  elif (ULONG_MAX >= LZO_0xffffffffL)
      typedef unsigned long      lzo_uint;
      typedef long               lzo_int;
-#    define LZO_SIZEOF_LZO_UINT LZO_SIZEOF_LONG
+#    define LZO_SIZEOF_LZO_INT  LZO_SIZEOF_LONG
+#    define LZO_TYPEOF_LZO_INT  LZO_TYPEOF_LONG
 #    define LZO_UINT_MAX        ULONG_MAX
 #    define LZO_INT_MAX         LONG_MAX
 #    define LZO_INT_MIN         LONG_MIN
@@ -122,7 +126,7 @@ extern "C" {
 #endif
 
 /* The larger type of lzo_uint and lzo_uint32_t. */
-#if (LZO_SIZEOF_LZO_UINT >= 4)
+#if (LZO_SIZEOF_LZO_INT >= 4)
 #  define lzo_xint              lzo_uint
 #else
 #  define lzo_xint              lzo_uint32_t
@@ -131,7 +135,8 @@ extern "C" {
 typedef int lzo_bool;
 
 /* sanity checks */
-LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_uint) == LZO_SIZEOF_LZO_UINT)
+LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int)  == LZO_SIZEOF_LZO_INT)
+LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_uint) == LZO_SIZEOF_LZO_INT)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_xint) >= sizeof(lzo_uint))
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_xint) >= sizeof(lzo_uint32_t))
 
@@ -163,14 +168,14 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_xint) >= sizeof(lzo_uint32_t))
 #endif
 
 /* Older LZO versions used to support ancient systems and memory models
- * like 16-bit MSDOS with __huge pointers and Cray PVP, but these
+ * such as 16-bit MSDOS with __huge pointers or Cray PVP, but these
  * obsolete configurations are not supported any longer.
  */
 #if defined(__LZO_MMODEL_HUGE)
-#error "__LZO_MMODEL_HUGE is unsupported"
+#error "__LZO_MMODEL_HUGE memory model is unsupported"
 #endif
 #if (LZO_MM_PVP)
-#error "LZO_MM_PVP is unsupported"
+#error "LZO_MM_PVP memory model is unsupported"
 #endif
 #if (LZO_SIZEOF_INT < 4)
 #error "LZO_SIZEOF_INT < 4 is unsupported"
@@ -221,13 +226,13 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(char *)   == sizeof(lzo_bytep))
 
 /* __cdecl calling convention for public C and assembly functions */
 #if !defined(LZO_PUBLIC)
-#  define LZO_PUBLIC(_rettype)  __LZO_EXPORT1 _rettype __LZO_EXPORT2 __LZO_CDECL
+#  define LZO_PUBLIC(r)         __LZO_EXPORT1 r __LZO_EXPORT2 __LZO_CDECL
 #endif
 #if !defined(LZO_EXTERN)
-#  define LZO_EXTERN(_rettype)  __LZO_EXTERN_C LZO_PUBLIC(_rettype)
+#  define LZO_EXTERN(r)         __LZO_EXTERN_C LZO_PUBLIC(r)
 #endif
 #if !defined(LZO_PRIVATE)
-#  define LZO_PRIVATE(_rettype) static _rettype __LZO_CDECL
+#  define LZO_PRIVATE(r)        static r  __LZO_CDECL
 #endif
 
 /* function types */
@@ -399,6 +404,10 @@ LZO_EXTERN(unsigned) __lzo_align_gap(const lzo_voidp p, lzo_uint size);
 /* deprecated types */
 typedef union { lzo_bytep a; lzo_uint b; } __lzo_pu_u;
 typedef union { lzo_bytep a; lzo_uint32_t b; } __lzo_pu32_u;
+/* deprecated defines */
+#if !defined(LZO_SIZEOF_LZO_UINT)
+#  define LZO_SIZEOF_LZO_UINT   LZO_SIZEOF_LZO_INT
+#endif
 
 #if defined(LZO_CFG_COMPAT)
 

--- a/libraries/minilzo/lzodefs.h
+++ b/libraries/minilzo/lzodefs.h
@@ -2,7 +2,7 @@
 
    This file is part of the LZO real-time data compression library.
 
-   Copyright (C) 1996-2014 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1996-2017 Markus Franz Xaver Johannes Oberhumer
    All Rights Reserved.
 
    The LZO library is free software; you can redistribute it and/or
@@ -39,6 +39,33 @@
 #  if !defined(__LONG_MAX__)
 #    define __LONG_MAX__ 9223372036854775807L
 #  endif
+#endif
+#if 0
+#elif !defined(__LZO_LANG_OVERRIDE)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__ASSEMBLER__)
+#  if (__ASSEMBLER__+0) <= 0
+#    error "__ASSEMBLER__"
+#  else
+#    define LZO_LANG_ASSEMBLER  1
+#  endif
+#elif defined(__cplusplus)
+#  if (__cplusplus+0) <= 0
+#    error "__cplusplus"
+#  elif (__cplusplus < 199711L)
+#    define LZO_LANG_CXX        1
+#  elif defined(_MSC_VER) && defined(_MSVC_LANG) && (_MSVC_LANG+0 >= 201402L) && 1
+#    define LZO_LANG_CXX        _MSVC_LANG
+#  else
+#    define LZO_LANG_CXX        __cplusplus
+#  endif
+#  define LZO_LANG_CPLUSPLUS    LZO_LANG_CXX
+#else
+#  if defined(__STDC_VERSION__) && (__STDC_VERSION__+0 >= 199409L)
+#    define LZO_LANG_C          __STDC_VERSION__
+#  else
+#    define LZO_LANG_C          1
+#  endif
+#endif
 #endif
 #if !defined(LZO_CFG_NO_DISABLE_WUNDEF)
 #if defined(__ARMCC_VERSION)
@@ -135,9 +162,11 @@
 #  endif
 #endif
 #endif
-#if defined(_MSC_VER) && defined(M_I86HM) && (UINT_MAX == LZO_0xffffL)
+#if (UINT_MAX == LZO_0xffffL)
+#if defined(_MSC_VER) && defined(M_I86HM)
 #  define ptrdiff_t long
 #  define _PTRDIFF_T_DEFINED 1
+#endif
 #endif
 #if (UINT_MAX == LZO_0xffffL)
 #  undef __LZO_RENAME_A
@@ -287,7 +316,7 @@
 #define LZO_CPP_ECONCAT6(a,b,c,d,e,f)   LZO_CPP_CONCAT6(a,b,c,d,e,f)
 #define LZO_CPP_ECONCAT7(a,b,c,d,e,f,g) LZO_CPP_CONCAT7(a,b,c,d,e,f,g)
 #endif
-#define __LZO_MASK_GEN(o,b)     (((((o) << ((b)-!!(b))) - (o)) << 1) + (o)*!!(b))
+#define __LZO_MASK_GEN(o,b)     (((((o) << ((b)-((b)!=0))) - (o)) << 1) + (o)*((b)!=0))
 #if 1 && defined(__cplusplus)
 #  if !defined(__STDC_CONSTANT_MACROS)
 #    define __STDC_CONSTANT_MACROS 1
@@ -398,7 +427,7 @@
 #elif defined(__TOS__) || defined(__atarist__)
 #  define LZO_OS_TOS            1
 #  define LZO_INFO_OS           "tos"
-#elif defined(macintosh) && !defined(__ppc__)
+#elif defined(macintosh) && !defined(__arm__) && !defined(__i386__) && !defined(__ppc__) && !defined(__x64_64__)
 #  define LZO_OS_MACCLASSIC     1
 #  define LZO_INFO_OS           "macclassic"
 #elif defined(__VMS)
@@ -538,6 +567,12 @@
 #  define LZO_CC_ARMCC          __ARMCC_VERSION
 #  define LZO_INFO_CC           "ARM C Compiler"
 #  define LZO_INFO_CCVER        __VERSION__
+#elif defined(__clang__) && defined(__c2__) && defined(__c2_version__) && defined(_MSC_VER)
+#  define LZO_CC_CLANG          (__clang_major__ * 0x10000L + (__clang_minor__-0) * 0x100 + (__clang_patchlevel__-0))
+#  define LZO_CC_CLANG_C2       _MSC_VER
+#  define LZO_CC_CLANG_VENDOR_MICROSOFT 1
+#  define LZO_INFO_CC           "clang/c2"
+#  define LZO_INFO_CCVER        LZO_PP_MACRO_EXPAND(__c2_version__)
 #elif defined(__clang__) && defined(__llvm__) && defined(__VERSION__)
 #  if defined(__clang_major__) && defined(__clang_minor__) && defined(__clang_patchlevel__)
 #    define LZO_CC_CLANG        (__clang_major__ * 0x10000L + (__clang_minor__-0) * 0x100 + (__clang_patchlevel__-0))
@@ -549,8 +584,18 @@
 #  elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__VERSION__)
 #    define LZO_CC_CLANG_GNUC   (__GNUC__ * 0x10000L + (__GNUC_MINOR__-0) * 0x100 + (__GNUC_PATCHLEVEL__-0))
 #  endif
-#  define LZO_INFO_CC           "clang"
-#  define LZO_INFO_CCVER        __VERSION__
+#  if defined(__APPLE_CC__)
+#    define LZO_CC_CLANG_VENDOR_APPLE 1
+#    define LZO_INFO_CC         "clang/apple"
+#  else
+#    define LZO_CC_CLANG_VENDOR_LLVM 1
+#    define LZO_INFO_CC         "clang"
+#  endif
+#  if defined(__clang_version__)
+#    define LZO_INFO_CCVER      __clang_version__
+#  else
+#    define LZO_INFO_CCVER      __VERSION__
+#  endif
 #elif defined(__llvm__) && defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__VERSION__)
 #  if defined(__GNUC_PATCHLEVEL__)
 #    define LZO_CC_LLVM_GNUC    (__GNUC__ * 0x10000L + (__GNUC_MINOR__-0) * 0x100 + (__GNUC_PATCHLEVEL__-0))
@@ -770,7 +815,7 @@
 #elif (LZO_OS_DOS16 || LZO_OS_OS216 || LZO_OS_WIN16)
 #  define LZO_ARCH_I086             1
 #  define LZO_INFO_ARCH             "i086"
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(_M_ARM64)
 #  define LZO_ARCH_ARM64            1
 #  define LZO_INFO_ARCH             "arm64"
 #elif defined(__alpha__) || defined(__alpha) || defined(_M_ALPHA)
@@ -782,21 +827,10 @@
 #elif defined(__amd64__) || defined(__x86_64__) || defined(_M_AMD64)
 #  define LZO_ARCH_AMD64            1
 #  define LZO_INFO_ARCH             "amd64"
-#elif defined(__thumb__) || (defined(_M_ARM) && defined(_M_THUMB))
-#  define LZO_ARCH_ARM              1
-#  define LZO_ARCH_ARM_THUMB        1
-#  define LZO_INFO_ARCH             "arm_thumb"
-#elif defined(__IAR_SYSTEMS_ICC__) && defined(__ICCARM__)
-#  define LZO_ARCH_ARM              1
-#  if defined(__CPU_MODE__) && ((__CPU_MODE__-0) == 1)
-#    define LZO_ARCH_ARM_THUMB      1
-#    define LZO_INFO_ARCH           "arm_thumb"
-#  elif defined(__CPU_MODE__) && ((__CPU_MODE__-0) == 2)
-#    define LZO_INFO_ARCH           "arm"
-#  else
-#    define LZO_INFO_ARCH           "arm"
-#  endif
 #elif defined(__arm__) || defined(_M_ARM)
+#  define LZO_ARCH_ARM              1
+#  define LZO_INFO_ARCH             "arm"
+#elif defined(__IAR_SYSTEMS_ICC__) && defined(__ICCARM__)
 #  define LZO_ARCH_ARM              1
 #  define LZO_INFO_ARCH             "arm"
 #elif (UINT_MAX <= LZO_0xffffL) && defined(__AVR__)
@@ -871,6 +905,15 @@
 #elif defined(__powerpc__) || defined(__powerpc) || defined(__ppc__) || defined(__PPC__) || defined(_M_PPC) || defined(_ARCH_PPC) || defined(_ARCH_PWR)
 #  define LZO_ARCH_POWERPC          1
 #  define LZO_INFO_ARCH             "powerpc"
+#elif defined(__powerpc64__) || defined(__powerpc64) || defined(__ppc64__) || defined(__PPC64__)
+#  define LZO_ARCH_POWERPC          1
+#  define LZO_INFO_ARCH             "powerpc"
+#elif defined(__powerpc64le__) || defined(__powerpc64le) || defined(__ppc64le__) || defined(__PPC64LE__)
+#  define LZO_ARCH_POWERPC          1
+#  define LZO_INFO_ARCH             "powerpc"
+#elif defined(__riscv)
+#  define LZO_ARCH_RISCV            1
+#  define LZO_INFO_ARCH             "riscv"
 #elif defined(__s390__) || defined(__s390) || defined(__s390x__) || defined(__s390x)
 #  define LZO_ARCH_S390             1
 #  define LZO_INFO_ARCH             "s390"
@@ -904,6 +947,23 @@
 #  define LZO_ARCH_UNKNOWN          1
 #  define LZO_INFO_ARCH             "unknown"
 #endif
+#endif
+#if !defined(LZO_ARCH_ARM_THUMB2)
+#if (LZO_ARCH_ARM)
+#  if defined(__thumb__) || defined(__thumb) || defined(_M_THUMB)
+#    if defined(__thumb2__)
+#      define LZO_ARCH_ARM_THUMB2   1
+#    elif 1 && defined(__TARGET_ARCH_THUMB) && ((__TARGET_ARCH_THUMB)+0 >= 4)
+#      define LZO_ARCH_ARM_THUMB2   1
+#    elif 1 && defined(_MSC_VER) && defined(_M_THUMB) && ((_M_THUMB)+0 >= 7)
+#      define LZO_ARCH_ARM_THUMB2   1
+#    endif
+#  endif
+#endif
+#endif
+#if (LZO_ARCH_ARM_THUMB2)
+#  undef  LZO_INFO_ARCH
+#  define LZO_INFO_ARCH             "arm_thumb2"
 #endif
 #if 1 && (LZO_ARCH_UNKNOWN) && (LZO_OS_DOS32 || LZO_OS_OS2)
 #  error "FIXME - missing define for CPU architecture"
@@ -947,13 +1007,10 @@
 #if (LZO_ARCH_I386 && !LZO_ARCH_X86) || (!LZO_ARCH_I386 && LZO_ARCH_X86)
 #  error "unexpected configuration - check your compiler defines"
 #endif
-#if (LZO_ARCH_ARM_THUMB && !LZO_ARCH_ARM)
+#if (LZO_ARCH_ARM_THUMB1 && !LZO_ARCH_ARM)
 #  error "unexpected configuration - check your compiler defines"
 #endif
-#if (LZO_ARCH_ARM_THUMB1 && !LZO_ARCH_ARM_THUMB)
-#  error "unexpected configuration - check your compiler defines"
-#endif
-#if (LZO_ARCH_ARM_THUMB2 && !LZO_ARCH_ARM_THUMB)
+#if (LZO_ARCH_ARM_THUMB2 && !LZO_ARCH_ARM)
 #  error "unexpected configuration - check your compiler defines"
 #endif
 #if (LZO_ARCH_ARM_THUMB1 && LZO_ARCH_ARM_THUMB2)
@@ -985,7 +1042,9 @@
 #  if !defined(LZO_TARGET_FEATURE_SSE2)
 #    if defined(__SSE2__)
 #      define LZO_TARGET_FEATURE_SSE2       1
-#    elif defined(_MSC_VER) && ((defined(_M_IX86_FP) && ((_M_IX86_FP)+0 >= 2)) || defined(_M_AMD64))
+#    elif defined(_MSC_VER) && (defined(_M_IX86_FP) && ((_M_IX86_FP)+0 >= 2))
+#      define LZO_TARGET_FEATURE_SSE2       1
+#    elif (LZO_CC_INTELC_MSC || LZO_CC_MSC) && defined(_M_AMD64)
 #      define LZO_TARGET_FEATURE_SSE2       1
 #    endif
 #  endif
@@ -1034,7 +1093,11 @@
 #endif
 #if (LZO_ARCH_ARM)
 #  if !defined(LZO_TARGET_FEATURE_NEON)
-#    if defined(__ARM_NEON__)
+#    if defined(__ARM_NEON) && ((__ARM_NEON)+0)
+#      define LZO_TARGET_FEATURE_NEON       1
+#    elif 1 && defined(__ARM_NEON__) && ((__ARM_NEON__)+0)
+#      define LZO_TARGET_FEATURE_NEON       1
+#    elif 1 && defined(__TARGET_FEATURE_NEON) && ((__TARGET_FEATURE_NEON)+0)
 #      define LZO_TARGET_FEATURE_NEON       1
 #    endif
 #  endif
@@ -1105,7 +1168,7 @@
 #    error "unexpected configuration - check your compiler defines"
 #  endif
 #endif
-#ifdef __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 #if (LZO_CC_BORLANDC && (__BORLANDC__ >= 0x0200))
@@ -1128,7 +1191,7 @@ extern "C" {
 #else
 #  error "FIXME - implement LZO_MM_AHSHIFT"
 #endif
-#ifdef __cplusplus
+#if defined(__cplusplus)
 }
 #endif
 #endif
@@ -1214,11 +1277,52 @@ extern "C" {
 #  define __lzo_gnuc_extension__    __extension__
 #elif (LZO_CC_IBMC >= 600)
 #  define __lzo_gnuc_extension__    __extension__
-#else
 #endif
 #endif
 #if !defined(__lzo_gnuc_extension__)
 #  define __lzo_gnuc_extension__    /*empty*/
+#endif
+#if !defined(lzo_has_builtin)
+#if (LZO_CC_CLANG) && defined(__has_builtin)
+#  define lzo_has_builtin           __has_builtin
+#endif
+#endif
+#if !defined(lzo_has_builtin)
+#  define lzo_has_builtin(x)        0
+#endif
+#if !defined(lzo_has_attribute)
+#if (LZO_CC_CLANG) && defined(__has_attribute)
+#  define lzo_has_attribute         __has_attribute
+#endif
+#endif
+#if !defined(lzo_has_attribute)
+#  define lzo_has_attribute(x)      0
+#endif
+#if !defined(lzo_has_declspec_attribute)
+#if (LZO_CC_CLANG) && defined(__has_declspec_attribute)
+#  define lzo_has_declspec_attribute        __has_declspec_attribute
+#endif
+#endif
+#if !defined(lzo_has_declspec_attribute)
+#  define lzo_has_declspec_attribute(x)     0
+#endif
+#if !defined(lzo_has_feature)
+#if (LZO_CC_CLANG) && defined(__has_feature)
+#  define lzo_has_feature         __has_feature
+#endif
+#endif
+#if !defined(lzo_has_feature)
+#  define lzo_has_feature(x)        0
+#endif
+#if !defined(lzo_has_extension)
+#if (LZO_CC_CLANG) && defined(__has_extension)
+#  define lzo_has_extension         __has_extension
+#elif (LZO_CC_CLANG) && defined(__has_feature)
+#  define lzo_has_extension         __has_feature
+#endif
+#endif
+#if !defined(lzo_has_extension)
+#  define lzo_has_extension(x)      0
 #endif
 #if !defined(LZO_CFG_USE_NEW_STYLE_CASTS) && defined(__cplusplus) && 0
 #  if (LZO_CC_GNUC && (LZO_CC_GNUC < 0x020800ul))
@@ -1356,7 +1460,7 @@ extern "C" {
 #  elif (LZO_CC_MSC && (_MSC_VER < 900))
 #    define LZO_UNUSED(var)         if (&var) ; else
 #  elif (LZO_CC_KEILC)
-#    define LZO_UNUSED(var)         {LZO_EXTERN_C int lzo_unused__[1-2*!(sizeof(var)>0)];}
+#    define LZO_UNUSED(var)         {extern int lzo_unused__[1-2*!(sizeof(var)>0)]; (void)lzo_unused__;}
 #  elif (LZO_CC_PACIFICC)
 #    define LZO_UNUSED(var)         ((void) sizeof(var))
 #  elif (LZO_CC_WATCOMC) && defined(__cplusplus)
@@ -1364,6 +1468,9 @@ extern "C" {
 #  else
 #    define LZO_UNUSED(var)         ((void) &var)
 #  endif
+#endif
+#if !defined(LZO_UNUSED_RESULT)
+#  define LZO_UNUSED_RESULT(var)    LZO_UNUSED(var)
 #endif
 #if !defined(LZO_UNUSED_FUNC)
 #  if (LZO_CC_BORLANDC && (__BORLANDC__ >= 0x0600))
@@ -1377,7 +1484,7 @@ extern "C" {
 #  elif (LZO_CC_MSC)
 #    define LZO_UNUSED_FUNC(func)   ((void) &func)
 #  elif (LZO_CC_KEILC || LZO_CC_PELLESC)
-#    define LZO_UNUSED_FUNC(func)   {LZO_EXTERN_C int lzo_unused_func__[1-2*!(sizeof((int)func)>0)];}
+#    define LZO_UNUSED_FUNC(func)   {extern int lzo_unused__[1-2*!(sizeof((int)func)>0)]; (void)lzo_unused__;}
 #  else
 #    define LZO_UNUSED_FUNC(func)   ((void) func)
 #  endif
@@ -1783,6 +1890,7 @@ extern "C" {
 #elif (LZO_CC_INTELC && (__INTEL_COMPILER >= 800))
 #  define __lzo_likely(e)       (__builtin_expect(!!(e),1))
 #  define __lzo_unlikely(e)     (__builtin_expect(!!(e),0))
+#elif (LZO_CC_CLANG && LZO_CC_CLANG_C2)
 #elif (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || LZO_CC_LLVM || LZO_CC_PATHSCALE)
 #  define __lzo_likely(e)       (__builtin_expect(!!(e),1))
 #  define __lzo_unlikely(e)     (__builtin_expect(!!(e),0))
@@ -1793,21 +1901,28 @@ extern "C" {
 #  define __lzo_HAVE_likely 1
 #  endif
 #else
-#  define __lzo_likely(e)       (e)
+#  define __lzo_likely(e)           (e)
+#endif
+#if defined(__lzo_very_likely)
+#  ifndef __lzo_HAVE_very_likely
+#  define __lzo_HAVE_very_likely 1
+#  endif
+#else
+#  define __lzo_very_likely(e)      __lzo_likely(e)
 #endif
 #if defined(__lzo_unlikely)
 #  ifndef __lzo_HAVE_unlikely
 #  define __lzo_HAVE_unlikely 1
 #  endif
 #else
-#  define __lzo_unlikely(e)     (e)
+#  define __lzo_unlikely(e)         (e)
 #endif
-#if !defined(__lzo_static_unused_void_func)
-#  if 1 && (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || (LZO_CC_GNUC >= 0x020700ul) || LZO_CC_INTELC_GNUC || LZO_CC_LLVM || LZO_CC_PATHSCALE || LZO_CC_PGI)
-#    define __lzo_static_unused_void_func(f)    static void __attribute__((__unused__)) f(void)
-#  else
-#    define __lzo_static_unused_void_func(f)    static __lzo_inline void f(void)
+#if defined(__lzo_very_unlikely)
+#  ifndef __lzo_HAVE_very_unlikely
+#  define __lzo_HAVE_very_unlikely 1
 #  endif
+#else
+#  define __lzo_very_unlikely(e)    __lzo_unlikely(e)
 #endif
 #if !defined(__lzo_loop_forever)
 #  if (LZO_CC_IBMC)
@@ -1817,7 +1932,7 @@ extern "C" {
 #  endif
 #endif
 #if !defined(__lzo_unreachable)
-#if (LZO_CC_CLANG && (LZO_CC_CLANG >= 0x020800ul))
+#if (LZO_CC_CLANG && (LZO_CC_CLANG >= 0x020800ul)) && lzo_has_builtin(__builtin_unreachable)
 #  define __lzo_unreachable()       __builtin_unreachable();
 #elif (LZO_CC_GNUC >= 0x040500ul)
 #  define __lzo_unreachable()       __builtin_unreachable();
@@ -1834,6 +1949,15 @@ extern "C" {
 #  define __lzo_unreachable()       ((void)0);
 #  else
 #  define __lzo_unreachable()       __lzo_loop_forever();
+#  endif
+#endif
+#if !defined(lzo_unused_funcs_impl)
+#  if 1 && (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || (LZO_CC_GNUC >= 0x020700ul) || LZO_CC_INTELC_GNUC || LZO_CC_LLVM || LZO_CC_PATHSCALE || LZO_CC_PGI)
+#    define lzo_unused_funcs_impl(r,f)  static r __attribute__((__unused__)) f
+#  elif 1 && (LZO_CC_BORLANDC || LZO_CC_GNUC)
+#    define lzo_unused_funcs_impl(r,f)  static r f
+#  else
+#    define lzo_unused_funcs_impl(r,f)  __lzo_static_forceinline r f
 #  endif
 #endif
 #ifndef __LZO_CTA_NAME
@@ -1861,6 +1985,8 @@ extern "C" {
 #if !defined(LZO_COMPILE_TIME_ASSERT)
 #  if (LZO_CC_AZTECC)
 #    define LZO_COMPILE_TIME_ASSERT(e)  {typedef int __LZO_CTA_NAME(lzo_cta_t__)[1-!(e)];}
+#  elif (LZO_CC_CLANG && (LZO_CC_CLANG >= 0x030000ul))
+#    define LZO_COMPILE_TIME_ASSERT(e)  {typedef int __LZO_CTA_NAME(lzo_cta_t__)[1-2*!(e)] __attribute__((__unused__));}
 #  elif (LZO_CC_DMC || LZO_CC_PACIFICC || LZO_CC_SYMANTECC || LZO_CC_ZORTECHC)
 #    define LZO_COMPILE_TIME_ASSERT(e)  switch(0) case 1:case !(e):break;
 #  elif (LZO_CC_GNUC) && defined(__CHECKER__) && defined(__SPARSE_CHECKER__)
@@ -1877,11 +2003,16 @@ extern "C" {
 #    define LZO_COMPILE_TIME_ASSERT(e)  {typedef int __LZO_CTA_NAME(lzo_cta_t__)[1-2*!(e)];}
 #  endif
 #endif
+#if (LZO_LANG_ASSEMBLER)
+#  undef LZO_COMPILE_TIME_ASSERT_HEADER
+#  define LZO_COMPILE_TIME_ASSERT_HEADER(e)  /*empty*/
+#else
 LZO_COMPILE_TIME_ASSERT_HEADER(1 == 1)
 #if defined(__cplusplus)
 extern "C" { LZO_COMPILE_TIME_ASSERT_HEADER(2 == 2) }
 #endif
 LZO_COMPILE_TIME_ASSERT_HEADER(3 == 3)
+#endif
 #if (LZO_ARCH_I086 || LZO_ARCH_I386) && (LZO_OS_DOS16 || LZO_OS_DOS32 || LZO_OS_OS2 || LZO_OS_OS216 || LZO_OS_WIN16 || LZO_OS_WIN32 || LZO_OS_WIN64)
 #  if (LZO_CC_GNUC || LZO_CC_HIGHC || LZO_CC_NDPC || LZO_CC_PACIFICC)
 #  elif (LZO_CC_DMC || LZO_CC_SYMANTECC || LZO_CC_ZORTECHC)
@@ -1948,7 +2079,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(3 == 3)
 #if !defined(LZO_HAVE_WINDOWS_H)
 #if (LZO_OS_CYGWIN || (LZO_OS_EMX && defined(__RSXNT__)) || LZO_OS_WIN32 || LZO_OS_WIN64)
 #  if (LZO_CC_WATCOMC && (__WATCOMC__ < 1000))
-#  elif (LZO_OS_WIN32 && LZO_CC_GNUC) && defined(__PW32__)
+#  elif ((LZO_OS_WIN32 && defined(__PW32__)) && (LZO_CC_GNUC && (LZO_CC_GNUC < 0x030000ul)))
 #  elif ((LZO_OS_CYGWIN || defined(__MINGW32__)) && (LZO_CC_GNUC && (LZO_CC_GNUC < 0x025f00ul)))
 #  else
 #    define LZO_HAVE_WINDOWS_H 1
@@ -1956,6 +2087,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(3 == 3)
 #endif
 #endif
 #endif
+#define LZO_SIZEOF_CHAR             1
 #ifndef LZO_SIZEOF_SHORT
 #if defined(SIZEOF_SHORT)
 #  define LZO_SIZEOF_SHORT          (SIZEOF_SHORT)
@@ -2154,12 +2286,12 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_LONG == sizeof(long))
 #  define LZO_WORDSIZE              8
 #elif (LZO_ARCH_AMD64)
 #  define LZO_WORDSIZE              8
+#elif (LZO_ARCH_ARM64)
+#  define LZO_WORDSIZE              8
 #elif (LZO_ARCH_AVR)
 #  define LZO_WORDSIZE              1
 #elif (LZO_ARCH_H8300)
-#  if defined(__NORMAL_MODE__)
-#    define LZO_WORDSIZE            4
-#  elif defined(__H8300H__) || defined(__H8300S__) || defined(__H8300SX__)
+#  if defined(__H8300H__) || defined(__H8300S__) || defined(__H8300SX__)
 #    define LZO_WORDSIZE            4
 #  else
 #    define LZO_WORDSIZE            2
@@ -2202,11 +2334,15 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(long) == 8)
 #elif (LZO_ARCH_C166 || LZO_ARCH_MCS51 || LZO_ARCH_MCS251 || LZO_ARCH_MSP430)
 #  define LZO_SIZEOF_VOID_P         2
 #elif (LZO_ARCH_H8300)
-#  if defined(__NORMAL_MODE__)
-#    define LZO_SIZEOF_VOID_P       2
-#  elif defined(__H8300H__) || defined(__H8300S__) || defined(__H8300SX__)
-#    define LZO_SIZEOF_VOID_P       4
+#  if defined(__H8300H__) || defined(__H8300S__) || defined(__H8300SX__)
+     LZO_COMPILE_TIME_ASSERT_HEADER(LZO_WORDSIZE == 4)
+#    if defined(__NORMAL_MODE__)
+#      define LZO_SIZEOF_VOID_P     2
+#    else
+#      define LZO_SIZEOF_VOID_P     4
+#    endif
 #  else
+     LZO_COMPILE_TIME_ASSERT_HEADER(LZO_WORDSIZE == 2)
 #    define LZO_SIZEOF_VOID_P       2
 #  endif
 #  if (LZO_CC_GNUC && (LZO_CC_GNUC < 0x040000ul)) && (LZO_SIZEOF_INT == 4)
@@ -2296,7 +2432,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #  define LZO_ABI_BIG_ENDIAN        1
 #elif (LZO_ARCH_IA64) && (LZO_OS_POSIX_LINUX || LZO_OS_WIN64)
 #  define LZO_ABI_LITTLE_ENDIAN     1
-#elif (LZO_ARCH_ALPHA || LZO_ARCH_AMD64 || LZO_ARCH_BLACKFIN || LZO_ARCH_CRIS || LZO_ARCH_I086 || LZO_ARCH_I386 || LZO_ARCH_MSP430)
+#elif (LZO_ARCH_ALPHA || LZO_ARCH_AMD64 || LZO_ARCH_BLACKFIN || LZO_ARCH_CRIS || LZO_ARCH_I086 || LZO_ARCH_I386 || LZO_ARCH_MSP430 || LZO_ARCH_RISCV)
 #  define LZO_ABI_LITTLE_ENDIAN     1
 #elif (LZO_ARCH_AVR32 || LZO_ARCH_M68K || LZO_ARCH_S390 || LZO_ARCH_SPU)
 #  define LZO_ABI_BIG_ENDIAN        1
@@ -2310,9 +2446,13 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
 #  define LZO_ABI_LITTLE_ENDIAN     1
+#elif 1 && (LZO_ARCH_ARM) && defined(__ARM_BIG_ENDIAN) && ((__ARM_BIG_ENDIAN)+0)
+#  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && (LZO_ARCH_ARM) && defined(__ARMEB__) && !defined(__ARMEL__)
 #  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && (LZO_ARCH_ARM) && defined(__ARMEL__) && !defined(__ARMEB__)
+#  define LZO_ABI_LITTLE_ENDIAN     1
+#elif 1 && (LZO_ARCH_ARM) && defined(_MSC_VER) && defined(_WIN32)
 #  define LZO_ABI_LITTLE_ENDIAN     1
 #elif 1 && (LZO_ARCH_ARM && LZO_CC_ARMCC_ARMCC)
 #  if defined(__BIG_ENDIAN) && defined(__LITTLE_ENDIAN)
@@ -2323,9 +2463,13 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #    define LZO_ABI_LITTLE_ENDIAN   1
 #  endif
 #  define LZO_ABI_LITTLE_ENDIAN     1
+#elif 1 && (LZO_ARCH_ARM64) && defined(__ARM_BIG_ENDIAN) && ((__ARM_BIG_ENDIAN)+0)
+#  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && (LZO_ARCH_ARM64) && defined(__AARCH64EB__) && !defined(__AARCH64EL__)
 #  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && (LZO_ARCH_ARM64) && defined(__AARCH64EL__) && !defined(__AARCH64EB__)
+#  define LZO_ABI_LITTLE_ENDIAN     1
+#elif 1 && (LZO_ARCH_ARM64) && defined(_MSC_VER) && defined(_WIN32)
 #  define LZO_ABI_LITTLE_ENDIAN     1
 #elif 1 && (LZO_ARCH_MIPS) && defined(__MIPSEB__) && !defined(__MIPSEL__)
 #  define LZO_ABI_BIG_ENDIAN        1
@@ -2367,6 +2511,12 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #elif (LZO_SIZEOF_INT == 4 && LZO_SIZEOF_LONG == 8 && LZO_SIZEOF_VOID_P == 4)
 #  define LZO_ABI_IP32L64       1
 #  define LZO_INFO_ABI_PM       "ip32l64"
+#endif
+#if (LZO_SIZEOF_INT == 4 && LZO_SIZEOF_VOID_P == 4 && LZO_WORDSIZE == 8)
+#  define LZO_ABI_IP32W64       1
+#  ifndef LZO_INFO_ABI_PM
+#  define LZO_INFO_ABI_PM       "ip32w64"
+#  endif
 #endif
 #if 0
 #elif !defined(__LZO_LIBC_OVERRIDE)
@@ -2455,20 +2605,43 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #  endif
 #elif (LZO_ARCH_ARM)
 #  if defined(__ARM_FEATURE_UNALIGNED)
+#   if ((__ARM_FEATURE_UNALIGNED)+0)
 #    ifndef LZO_OPT_UNALIGNED16
 #    define LZO_OPT_UNALIGNED16             1
 #    endif
 #    ifndef LZO_OPT_UNALIGNED32
 #    define LZO_OPT_UNALIGNED32             1
 #    endif
-#  elif defined(__TARGET_ARCH_ARM) && ((__TARGET_ARCH_ARM+0) >= 7)
+#   endif
+#  elif 1 && (LZO_ARCH_ARM_THUMB2)
 #    ifndef LZO_OPT_UNALIGNED16
 #    define LZO_OPT_UNALIGNED16             1
 #    endif
 #    ifndef LZO_OPT_UNALIGNED32
 #    define LZO_OPT_UNALIGNED32             1
 #    endif
-#  elif defined(__TARGET_ARCH_ARM) && ((__TARGET_ARCH_ARM+0) >= 6) && !defined(__TARGET_PROFILE_M)
+#  elif 1 && defined(__ARM_ARCH) && ((__ARM_ARCH)+0 >= 7)
+#    ifndef LZO_OPT_UNALIGNED16
+#    define LZO_OPT_UNALIGNED16             1
+#    endif
+#    ifndef LZO_OPT_UNALIGNED32
+#    define LZO_OPT_UNALIGNED32             1
+#    endif
+#  elif 1 && defined(__TARGET_ARCH_ARM) && ((__TARGET_ARCH_ARM)+0 >= 7)
+#    ifndef LZO_OPT_UNALIGNED16
+#    define LZO_OPT_UNALIGNED16             1
+#    endif
+#    ifndef LZO_OPT_UNALIGNED32
+#    define LZO_OPT_UNALIGNED32             1
+#    endif
+#  elif 1 && defined(__TARGET_ARCH_ARM) && ((__TARGET_ARCH_ARM)+0 >= 6) && (defined(__TARGET_PROFILE_A) || defined(__TARGET_PROFILE_R))
+#    ifndef LZO_OPT_UNALIGNED16
+#    define LZO_OPT_UNALIGNED16             1
+#    endif
+#    ifndef LZO_OPT_UNALIGNED32
+#    define LZO_OPT_UNALIGNED32             1
+#    endif
+#  elif 1 && defined(_MSC_VER) && defined(_M_ARM) && ((_M_ARM)+0 >= 7)
 #    ifndef LZO_OPT_UNALIGNED16
 #    define LZO_OPT_UNALIGNED16             1
 #    endif
@@ -2520,7 +2693,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #elif (LZO_ARCH_POWERPC)
 #  define LZO_OPT_PREFER_PREINC             1
 #  define LZO_OPT_PREFER_PREDEC             1
-#  if (LZO_ABI_BIG_ENDIAN)
+#  if (LZO_ABI_BIG_ENDIAN) || (LZO_WORDSIZE == 8)
 #    ifndef LZO_OPT_UNALIGNED16
 #    define LZO_OPT_UNALIGNED16             1
 #    endif
@@ -2531,6 +2704,19 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #      ifndef LZO_OPT_UNALIGNED64
 #      define LZO_OPT_UNALIGNED64           1
 #      endif
+#    endif
+#  endif
+#elif (LZO_ARCH_RISCV)
+#  define LZO_OPT_AVOID_UINT_INDEX          1
+#  ifndef LZO_OPT_UNALIGNED16
+#  define LZO_OPT_UNALIGNED16               1
+#  endif
+#  ifndef LZO_OPT_UNALIGNED32
+#  define LZO_OPT_UNALIGNED32               1
+#  endif
+#  if (LZO_WORDSIZE == 8)
+#    ifndef LZO_OPT_UNALIGNED64
+#    define LZO_OPT_UNALIGNED64             1
 #    endif
 #  endif
 #elif (LZO_ARCH_S390)
@@ -2624,32 +2810,61 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #if (!(LZO_SIZEOF_PTRDIFF_T+0 > 0 && LZO_SIZEOF_SIZE_T+0 > 0 && LZO_SIZEOF_VOID_P+0 > 0))
 #  error "missing defines for sizes"
 #endif
+#define LZO_TYPEOF_CHAR             1u
+#define LZO_TYPEOF_SHORT            2u
+#define LZO_TYPEOF_INT              3u
+#define LZO_TYPEOF_LONG             4u
+#define LZO_TYPEOF_LONG_LONG        5u
+#define LZO_TYPEOF___INT8           17u
+#define LZO_TYPEOF___INT16          18u
+#define LZO_TYPEOF___INT32          19u
+#define LZO_TYPEOF___INT64          20u
+#define LZO_TYPEOF___INT128         21u
+#define LZO_TYPEOF___INT256         22u
+#define LZO_TYPEOF___MODE_QI        33u
+#define LZO_TYPEOF___MODE_HI        34u
+#define LZO_TYPEOF___MODE_SI        35u
+#define LZO_TYPEOF___MODE_DI        36u
+#define LZO_TYPEOF___MODE_TI        37u
+#define LZO_TYPEOF_CHAR_P           129u
 #if !defined(lzo_llong_t)
 #if (LZO_SIZEOF_LONG_LONG+0 > 0)
-__lzo_gnuc_extension__ typedef long long lzo_llong_t__;
-__lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
+#  if !(LZO_LANG_ASSEMBLER)
+   __lzo_gnuc_extension__ typedef long long lzo_llong_t__;
+   __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
+#  endif
 #  define lzo_llong_t               lzo_llong_t__
 #  define lzo_ullong_t              lzo_ullong_t__
 #endif
 #endif
 #if !defined(lzo_int16e_t)
-#if (LZO_SIZEOF_LONG == 2)
+#if (LZO_CFG_PREFER_TYPEOF_ACC_INT16E_T == LZO_TYPEOF_SHORT) && (LZO_SIZEOF_SHORT != 2)
+#  undef LZO_CFG_PREFER_TYPEOF_ACC_INT16E_T
+#endif
+#if (LZO_SIZEOF_LONG == 2) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT16E_T == LZO_TYPEOF_SHORT)
 #  define lzo_int16e_t              long
 #  define lzo_uint16e_t             unsigned long
-#elif (LZO_SIZEOF_INT == 2)
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF_LONG
+#elif (LZO_SIZEOF_INT == 2) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT16E_T == LZO_TYPEOF_SHORT)
 #  define lzo_int16e_t              int
 #  define lzo_uint16e_t             unsigned int
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF_INT
 #elif (LZO_SIZEOF_SHORT == 2)
 #  define lzo_int16e_t              short int
 #  define lzo_uint16e_t             unsigned short int
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF_SHORT
 #elif 1 && !(LZO_CFG_TYPE_NO_MODE_HI) && (LZO_CC_CLANG || (LZO_CC_GNUC >= 0x025f00ul) || LZO_CC_LLVM)
+#  if !(LZO_LANG_ASSEMBLER)
    typedef int lzo_int16e_hi_t__ __attribute__((__mode__(__HI__)));
    typedef unsigned int lzo_uint16e_hi_t__ __attribute__((__mode__(__HI__)));
+#  endif
 #  define lzo_int16e_t              lzo_int16e_hi_t__
 #  define lzo_uint16e_t             lzo_uint16e_hi_t__
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF___MODE_HI
 #elif (LZO_SIZEOF___INT16 == 2)
 #  define lzo_int16e_t              __int16
 #  define lzo_uint16e_t             unsigned __int16
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF___INT16
 #else
 #endif
 #endif
@@ -2659,33 +2874,47 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
    LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int16e_t) == LZO_SIZEOF_LZO_INT16E_T)
 #endif
 #if !defined(lzo_int32e_t)
-#if (LZO_SIZEOF_LONG == 4)
+#if (LZO_CFG_PREFER_TYPEOF_ACC_INT32E_T == LZO_TYPEOF_INT) && (LZO_SIZEOF_INT != 4)
+#  undef LZO_CFG_PREFER_TYPEOF_ACC_INT32E_T
+#endif
+#if (LZO_SIZEOF_LONG == 4) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT32E_T == LZO_TYPEOF_INT)
 #  define lzo_int32e_t              long int
 #  define lzo_uint32e_t             unsigned long int
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF_LONG
 #elif (LZO_SIZEOF_INT == 4)
 #  define lzo_int32e_t              int
 #  define lzo_uint32e_t             unsigned int
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF_INT
 #elif (LZO_SIZEOF_SHORT == 4)
 #  define lzo_int32e_t              short int
 #  define lzo_uint32e_t             unsigned short int
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF_SHORT
 #elif (LZO_SIZEOF_LONG_LONG == 4)
 #  define lzo_int32e_t              lzo_llong_t
 #  define lzo_uint32e_t             lzo_ullong_t
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF_LONG_LONG
 #elif 1 && !(LZO_CFG_TYPE_NO_MODE_SI) && (LZO_CC_CLANG || (LZO_CC_GNUC >= 0x025f00ul) || LZO_CC_LLVM) && (__INT_MAX__+0 > 2147483647L)
+#  if !(LZO_LANG_ASSEMBLER)
    typedef int lzo_int32e_si_t__ __attribute__((__mode__(__SI__)));
    typedef unsigned int lzo_uint32e_si_t__ __attribute__((__mode__(__SI__)));
+#  endif
 #  define lzo_int32e_t              lzo_int32e_si_t__
 #  define lzo_uint32e_t             lzo_uint32e_si_t__
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF___MODE_SI
 #elif 1 && !(LZO_CFG_TYPE_NO_MODE_SI) && (LZO_CC_GNUC >= 0x025f00ul) && defined(__AVR__) && (__LONG_MAX__+0 == 32767L)
+#  if !(LZO_LANG_ASSEMBLER)
    typedef int lzo_int32e_si_t__ __attribute__((__mode__(__SI__)));
    typedef unsigned int lzo_uint32e_si_t__ __attribute__((__mode__(__SI__)));
+#  endif
 #  define lzo_int32e_t              lzo_int32e_si_t__
 #  define lzo_uint32e_t             lzo_uint32e_si_t__
 #  define LZO_INT32_C(c)            (c##LL)
 #  define LZO_UINT32_C(c)           (c##ULL)
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF___MODE_SI
 #elif (LZO_SIZEOF___INT32 == 4)
 #  define lzo_int32e_t              __int32
 #  define lzo_uint32e_t             unsigned __int32
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF___INT32
 #else
 #endif
 #endif
@@ -2696,21 +2925,28 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #endif
 #if !defined(lzo_int64e_t)
 #if (LZO_SIZEOF___INT64 == 8)
-#  if (LZO_CC_BORLANDC) && !(LZO_CFG_TYPE_PREFER___INT64)
-#    define LZO_CFG_TYPE_PREFER___INT64 1
+#  if (LZO_CC_BORLANDC) && !defined(LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T)
+#    define LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T  LZO_TYPEOF___INT64
 #  endif
+#endif
+#if (LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF_LONG_LONG) && (LZO_SIZEOF_LONG_LONG != 8)
+#  undef LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T
+#endif
+#if (LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF___INT64) && (LZO_SIZEOF___INT64 != 8)
+#  undef LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T
 #endif
 #if (LZO_SIZEOF_INT == 8) && (LZO_SIZEOF_INT < LZO_SIZEOF_LONG)
 #  define lzo_int64e_t              int
 #  define lzo_uint64e_t             unsigned int
-#  define LZO_SIZEOF_LZO_INT64E_T   LZO_SIZEOF_INT
-#elif (LZO_SIZEOF_LONG == 8)
+#  define LZO_TYPEOF_LZO_INT64E_T   LZO_TYPEOF_INT
+#elif (LZO_SIZEOF_LONG == 8) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF_LONG_LONG) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF___INT64)
 #  define lzo_int64e_t              long int
 #  define lzo_uint64e_t             unsigned long int
-#  define LZO_SIZEOF_LZO_INT64E_T   LZO_SIZEOF_LONG
-#elif (LZO_SIZEOF_LONG_LONG == 8) && !(LZO_CFG_TYPE_PREFER___INT64)
+#  define LZO_TYPEOF_LZO_INT64E_T   LZO_TYPEOF_LONG
+#elif (LZO_SIZEOF_LONG_LONG == 8) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF___INT64)
 #  define lzo_int64e_t              lzo_llong_t
 #  define lzo_uint64e_t             lzo_ullong_t
+#  define LZO_TYPEOF_LZO_INT64E_T   LZO_TYPEOF_LONG_LONG
 #  if (LZO_CC_BORLANDC)
 #    define LZO_INT64_C(c)          ((c) + 0ll)
 #    define LZO_UINT64_C(c)         ((c) + 0ull)
@@ -2721,10 +2957,10 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #    define LZO_INT64_C(c)          (c##LL)
 #    define LZO_UINT64_C(c)         (c##ULL)
 #  endif
-#  define LZO_SIZEOF_LZO_INT64E_T   LZO_SIZEOF_LONG_LONG
 #elif (LZO_SIZEOF___INT64 == 8)
 #  define lzo_int64e_t              __int64
 #  define lzo_uint64e_t             unsigned __int64
+#  define LZO_TYPEOF_LZO_INT64E_T   LZO_TYPEOF___INT64
 #  if (LZO_CC_BORLANDC)
 #    define LZO_INT64_C(c)          ((c) + 0i64)
 #    define LZO_UINT64_C(c)         ((c) + 0ui64)
@@ -2732,11 +2968,11 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #    define LZO_INT64_C(c)          (c##i64)
 #    define LZO_UINT64_C(c)         (c##ui64)
 #  endif
-#  define LZO_SIZEOF_LZO_INT64E_T   LZO_SIZEOF___INT64
 #else
 #endif
 #endif
 #if defined(lzo_int64e_t)
+#  define LZO_SIZEOF_LZO_INT64E_T   8
    LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64e_t) == 8)
    LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64e_t) == LZO_SIZEOF_LZO_INT64E_T)
 #endif
@@ -2745,14 +2981,17 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #  define lzo_int32l_t              lzo_int32e_t
 #  define lzo_uint32l_t             lzo_uint32e_t
 #  define LZO_SIZEOF_LZO_INT32L_T   LZO_SIZEOF_LZO_INT32E_T
+#  define LZO_TYPEOF_LZO_INT32L_T   LZO_TYPEOF_LZO_INT32E_T
 #elif (LZO_SIZEOF_INT >= 4) && (LZO_SIZEOF_INT < LZO_SIZEOF_LONG)
 #  define lzo_int32l_t              int
 #  define lzo_uint32l_t             unsigned int
 #  define LZO_SIZEOF_LZO_INT32L_T   LZO_SIZEOF_INT
+#  define LZO_TYPEOF_LZO_INT32L_T   LZO_SIZEOF_INT
 #elif (LZO_SIZEOF_LONG >= 4)
 #  define lzo_int32l_t              long int
 #  define lzo_uint32l_t             unsigned long int
 #  define LZO_SIZEOF_LZO_INT32L_T   LZO_SIZEOF_LONG
+#  define LZO_TYPEOF_LZO_INT32L_T   LZO_SIZEOF_LONG
 #else
 #  error "lzo_int32l_t"
 #endif
@@ -2766,6 +3005,7 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #  define lzo_int64l_t              lzo_int64e_t
 #  define lzo_uint64l_t             lzo_uint64e_t
 #  define LZO_SIZEOF_LZO_INT64L_T   LZO_SIZEOF_LZO_INT64E_T
+#  define LZO_TYPEOF_LZO_INT64L_T   LZO_TYPEOF_LZO_INT64E_T
 #else
 #endif
 #endif
@@ -2778,10 +3018,12 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #  define lzo_int32f_t              lzo_int64l_t
 #  define lzo_uint32f_t             lzo_uint64l_t
 #  define LZO_SIZEOF_LZO_INT32F_T   LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_TYPEOF_LZO_INT32F_T   LZO_TYPEOF_LZO_INT64L_T
 #else
 #  define lzo_int32f_t              lzo_int32l_t
 #  define lzo_uint32f_t             lzo_uint32l_t
 #  define LZO_SIZEOF_LZO_INT32F_T   LZO_SIZEOF_LZO_INT32L_T
+#  define LZO_TYPEOF_LZO_INT32F_T   LZO_TYPEOF_LZO_INT32L_T
 #endif
 #endif
 #if 1
@@ -2793,6 +3035,7 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #  define lzo_int64f_t              lzo_int64l_t
 #  define lzo_uint64f_t             lzo_uint64l_t
 #  define LZO_SIZEOF_LZO_INT64F_T   LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_TYPEOF_LZO_INT64F_T   LZO_TYPEOF_LZO_INT64L_T
 #else
 #endif
 #endif
@@ -2803,33 +3046,43 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #if !defined(lzo_intptr_t)
 #if 1 && (LZO_OS_OS400 && (LZO_SIZEOF_VOID_P == 16))
 #  define __LZO_INTPTR_T_IS_POINTER 1
-   typedef char*                    lzo_intptr_t;
-   typedef char*                    lzo_uintptr_t;
+#  if !(LZO_LANG_ASSEMBLER)
+   typedef char *                   lzo_intptr_t;
+   typedef char *                   lzo_uintptr_t;
+#  endif
 #  define lzo_intptr_t              lzo_intptr_t
 #  define lzo_uintptr_t             lzo_uintptr_t
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_VOID_P
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_CHAR_P
 #elif (LZO_CC_MSC && (_MSC_VER >= 1300) && (LZO_SIZEOF_VOID_P == 4) && (LZO_SIZEOF_INT == 4))
+#  if !(LZO_LANG_ASSEMBLER)
    typedef __w64 int                lzo_intptr_t;
    typedef __w64 unsigned int       lzo_uintptr_t;
+#  endif
 #  define lzo_intptr_t              lzo_intptr_t
 #  define lzo_uintptr_t             lzo_uintptr_t
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_INT
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_INT
 #elif (LZO_SIZEOF_SHORT == LZO_SIZEOF_VOID_P) && (LZO_SIZEOF_INT > LZO_SIZEOF_VOID_P)
 #  define lzo_intptr_t              short
 #  define lzo_uintptr_t             unsigned short
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_SHORT
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_SHORT
 #elif (LZO_SIZEOF_INT >= LZO_SIZEOF_VOID_P) && (LZO_SIZEOF_INT < LZO_SIZEOF_LONG)
 #  define lzo_intptr_t              int
 #  define lzo_uintptr_t             unsigned int
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_INT
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_INT
 #elif (LZO_SIZEOF_LONG >= LZO_SIZEOF_VOID_P)
 #  define lzo_intptr_t              long
 #  define lzo_uintptr_t             unsigned long
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_LONG
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_LONG
 #elif (LZO_SIZEOF_LZO_INT64L_T >= LZO_SIZEOF_VOID_P)
 #  define lzo_intptr_t              lzo_int64l_t
 #  define lzo_uintptr_t             lzo_uint64l_t
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_LZO_INT64L_T
 #else
 #  error "lzo_intptr_t"
 #endif
@@ -2843,34 +3096,43 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #if (LZO_WORDSIZE == LZO_SIZEOF_LZO_INTPTR_T) && !(__LZO_INTPTR_T_IS_POINTER)
 #  define lzo_word_t                lzo_uintptr_t
 #  define lzo_sword_t               lzo_intptr_t
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_LZO_INTPTR_T
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_LZO_INTPTR_T
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_LZO_INTPTR_T
 #elif (LZO_WORDSIZE == LZO_SIZEOF_LONG)
 #  define lzo_word_t                unsigned long
 #  define lzo_sword_t               long
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_LONG
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_LONG
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_LONG
 #elif (LZO_WORDSIZE == LZO_SIZEOF_INT)
 #  define lzo_word_t                unsigned int
 #  define lzo_sword_t               int
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_INT
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_INT
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_INT
 #elif (LZO_WORDSIZE == LZO_SIZEOF_SHORT)
 #  define lzo_word_t                unsigned short
 #  define lzo_sword_t               short
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_SHORT
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_SHORT
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_SHORT
 #elif (LZO_WORDSIZE == 1)
 #  define lzo_word_t                unsigned char
 #  define lzo_sword_t               signed char
-#  define LZO_SIZEOF_LZO_WORD_T 1
+#  define LZO_SIZEOF_LZO_WORD_T     1
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_CHAR
 #elif (LZO_WORDSIZE == LZO_SIZEOF_LZO_INT64L_T)
 #  define lzo_word_t                lzo_uint64l_t
 #  define lzo_sword_t               lzo_int64l_t
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_SIZEOF_LZO_INT64L_T
 #elif (LZO_ARCH_SPU) && (LZO_CC_GNUC)
 #if 0
+#  if !(LZO_LANG_ASSEMBLER)
    typedef unsigned lzo_word_t  __attribute__((__mode__(__V16QI__)));
    typedef int      lzo_sword_t __attribute__((__mode__(__V16QI__)));
+#  endif
 #  define lzo_word_t                lzo_word_t
 #  define lzo_sword_t               lzo_sword_t
 #  define LZO_SIZEOF_LZO_WORD_T     16
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF___MODE_V16QI
 #endif
 #else
 #  error "lzo_word_t"
@@ -2885,6 +3147,7 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #define lzo_int8_t                  signed char
 #define lzo_uint8_t                 unsigned char
 #define LZO_SIZEOF_LZO_INT8_T       1
+#define LZO_TYPEOF_LZO_INT8_T       LZO_TYPEOF_CHAR
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int8_t) == 1)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int8_t) == sizeof(lzo_uint8_t))
 #endif
@@ -2892,6 +3155,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int8_t) == sizeof(lzo_uint8_t))
 #define lzo_int16_t                 lzo_int16e_t
 #define lzo_uint16_t                lzo_uint16e_t
 #define LZO_SIZEOF_LZO_INT16_T      LZO_SIZEOF_LZO_INT16E_T
+#define LZO_TYPEOF_LZO_INT16_T      LZO_TYPEOF_LZO_INT16E_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int16_t) == 2)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int16_t) == sizeof(lzo_uint16_t))
 #endif
@@ -2899,6 +3163,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int16_t) == sizeof(lzo_uint16_t))
 #define lzo_int32_t                 lzo_int32e_t
 #define lzo_uint32_t                lzo_uint32e_t
 #define LZO_SIZEOF_LZO_INT32_T      LZO_SIZEOF_LZO_INT32E_T
+#define LZO_TYPEOF_LZO_INT32_T      LZO_TYPEOF_LZO_INT32E_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int32_t) == 4)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int32_t) == sizeof(lzo_uint32_t))
 #endif
@@ -2906,6 +3171,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int32_t) == sizeof(lzo_uint32_t))
 #define lzo_int64_t                 lzo_int64e_t
 #define lzo_uint64_t                lzo_uint64e_t
 #define LZO_SIZEOF_LZO_INT64_T      LZO_SIZEOF_LZO_INT64E_T
+#define LZO_TYPEOF_LZO_INT64_T      LZO_TYPEOF_LZO_INT64E_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64_t) == 8)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64_t) == sizeof(lzo_uint64_t))
 #endif
@@ -2913,6 +3179,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64_t) == sizeof(lzo_uint64_t))
 #define lzo_int_least32_t           lzo_int32l_t
 #define lzo_uint_least32_t          lzo_uint32l_t
 #define LZO_SIZEOF_LZO_INT_LEAST32_T LZO_SIZEOF_LZO_INT32L_T
+#define LZO_TYPEOF_LZO_INT_LEAST32_T LZO_TYPEOF_LZO_INT32L_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least32_t) >= 4)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least32_t) == sizeof(lzo_uint_least32_t))
 #endif
@@ -2920,6 +3187,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least32_t) == sizeof(lzo_uint_leas
 #define lzo_int_least64_t           lzo_int64l_t
 #define lzo_uint_least64_t          lzo_uint64l_t
 #define LZO_SIZEOF_LZO_INT_LEAST64_T LZO_SIZEOF_LZO_INT64L_T
+#define LZO_TYPEOF_LZO_INT_LEAST64_T LZO_TYPEOF_LZO_INT64L_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least64_t) >= 8)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least64_t) == sizeof(lzo_uint_least64_t))
 #endif
@@ -2927,6 +3195,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least64_t) == sizeof(lzo_uint_leas
 #define lzo_int_fast32_t           lzo_int32f_t
 #define lzo_uint_fast32_t          lzo_uint32f_t
 #define LZO_SIZEOF_LZO_INT_FAST32_T LZO_SIZEOF_LZO_INT32F_T
+#define LZO_TYPEOF_LZO_INT_FAST32_T LZO_TYPEOF_LZO_INT32F_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast32_t) >= 4)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast32_t) == sizeof(lzo_uint_fast32_t))
 #endif
@@ -2934,6 +3203,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast32_t) == sizeof(lzo_uint_fast3
 #define lzo_int_fast64_t           lzo_int64f_t
 #define lzo_uint_fast64_t          lzo_uint64f_t
 #define LZO_SIZEOF_LZO_INT_FAST64_T LZO_SIZEOF_LZO_INT64F_T
+#define LZO_TYPEOF_LZO_INT_FAST64_T LZO_TYPEOF_LZO_INT64F_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast64_t) >= 8)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast64_t) == sizeof(lzo_uint_fast64_t))
 #endif

--- a/libraries/minilzo/minilzo.c
+++ b/libraries/minilzo/minilzo.c
@@ -2,7 +2,7 @@
 
    This file is part of the LZO real-time data compression library.
 
-   Copyright (C) 1996-2014 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1996-2017 Markus Franz Xaver Johannes Oberhumer
    All Rights Reserved.
 
    The LZO library is free software; you can redistribute it and/or
@@ -59,6 +59,33 @@
 #  if !defined(__LONG_MAX__)
 #    define __LONG_MAX__ 9223372036854775807L
 #  endif
+#endif
+#if 0
+#elif !defined(__LZO_LANG_OVERRIDE)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__ASSEMBLER__)
+#  if (__ASSEMBLER__+0) <= 0
+#    error "__ASSEMBLER__"
+#  else
+#    define LZO_LANG_ASSEMBLER  1
+#  endif
+#elif defined(__cplusplus)
+#  if (__cplusplus+0) <= 0
+#    error "__cplusplus"
+#  elif (__cplusplus < 199711L)
+#    define LZO_LANG_CXX        1
+#  elif defined(_MSC_VER) && defined(_MSVC_LANG) && (_MSVC_LANG+0 >= 201402L) && 1
+#    define LZO_LANG_CXX        _MSVC_LANG
+#  else
+#    define LZO_LANG_CXX        __cplusplus
+#  endif
+#  define LZO_LANG_CPLUSPLUS    LZO_LANG_CXX
+#else
+#  if defined(__STDC_VERSION__) && (__STDC_VERSION__+0 >= 199409L)
+#    define LZO_LANG_C          __STDC_VERSION__
+#  else
+#    define LZO_LANG_C          1
+#  endif
+#endif
 #endif
 #if !defined(LZO_CFG_NO_DISABLE_WUNDEF)
 #if defined(__ARMCC_VERSION)
@@ -155,9 +182,11 @@
 #  endif
 #endif
 #endif
-#if defined(_MSC_VER) && defined(M_I86HM) && (UINT_MAX == LZO_0xffffL)
+#if (UINT_MAX == LZO_0xffffL)
+#if defined(_MSC_VER) && defined(M_I86HM)
 #  define ptrdiff_t long
 #  define _PTRDIFF_T_DEFINED 1
+#endif
 #endif
 #if (UINT_MAX == LZO_0xffffL)
 #  undef __LZO_RENAME_A
@@ -307,7 +336,7 @@
 #define LZO_CPP_ECONCAT6(a,b,c,d,e,f)   LZO_CPP_CONCAT6(a,b,c,d,e,f)
 #define LZO_CPP_ECONCAT7(a,b,c,d,e,f,g) LZO_CPP_CONCAT7(a,b,c,d,e,f,g)
 #endif
-#define __LZO_MASK_GEN(o,b)     (((((o) << ((b)-!!(b))) - (o)) << 1) + (o)*!!(b))
+#define __LZO_MASK_GEN(o,b)     (((((o) << ((b)-((b)!=0))) - (o)) << 1) + (o)*((b)!=0))
 #if 1 && defined(__cplusplus)
 #  if !defined(__STDC_CONSTANT_MACROS)
 #    define __STDC_CONSTANT_MACROS 1
@@ -418,7 +447,7 @@
 #elif defined(__TOS__) || defined(__atarist__)
 #  define LZO_OS_TOS            1
 #  define LZO_INFO_OS           "tos"
-#elif defined(macintosh) && !defined(__ppc__)
+#elif defined(macintosh) && !defined(__arm__) && !defined(__i386__) && !defined(__ppc__) && !defined(__x64_64__)
 #  define LZO_OS_MACCLASSIC     1
 #  define LZO_INFO_OS           "macclassic"
 #elif defined(__VMS)
@@ -558,6 +587,12 @@
 #  define LZO_CC_ARMCC          __ARMCC_VERSION
 #  define LZO_INFO_CC           "ARM C Compiler"
 #  define LZO_INFO_CCVER        __VERSION__
+#elif defined(__clang__) && defined(__c2__) && defined(__c2_version__) && defined(_MSC_VER)
+#  define LZO_CC_CLANG          (__clang_major__ * 0x10000L + (__clang_minor__-0) * 0x100 + (__clang_patchlevel__-0))
+#  define LZO_CC_CLANG_C2       _MSC_VER
+#  define LZO_CC_CLANG_VENDOR_MICROSOFT 1
+#  define LZO_INFO_CC           "clang/c2"
+#  define LZO_INFO_CCVER        LZO_PP_MACRO_EXPAND(__c2_version__)
 #elif defined(__clang__) && defined(__llvm__) && defined(__VERSION__)
 #  if defined(__clang_major__) && defined(__clang_minor__) && defined(__clang_patchlevel__)
 #    define LZO_CC_CLANG        (__clang_major__ * 0x10000L + (__clang_minor__-0) * 0x100 + (__clang_patchlevel__-0))
@@ -569,8 +604,18 @@
 #  elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__VERSION__)
 #    define LZO_CC_CLANG_GNUC   (__GNUC__ * 0x10000L + (__GNUC_MINOR__-0) * 0x100 + (__GNUC_PATCHLEVEL__-0))
 #  endif
-#  define LZO_INFO_CC           "clang"
-#  define LZO_INFO_CCVER        __VERSION__
+#  if defined(__APPLE_CC__)
+#    define LZO_CC_CLANG_VENDOR_APPLE 1
+#    define LZO_INFO_CC         "clang/apple"
+#  else
+#    define LZO_CC_CLANG_VENDOR_LLVM 1
+#    define LZO_INFO_CC         "clang"
+#  endif
+#  if defined(__clang_version__)
+#    define LZO_INFO_CCVER      __clang_version__
+#  else
+#    define LZO_INFO_CCVER      __VERSION__
+#  endif
 #elif defined(__llvm__) && defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__VERSION__)
 #  if defined(__GNUC_PATCHLEVEL__)
 #    define LZO_CC_LLVM_GNUC    (__GNUC__ * 0x10000L + (__GNUC_MINOR__-0) * 0x100 + (__GNUC_PATCHLEVEL__-0))
@@ -790,7 +835,7 @@
 #elif (LZO_OS_DOS16 || LZO_OS_OS216 || LZO_OS_WIN16)
 #  define LZO_ARCH_I086             1
 #  define LZO_INFO_ARCH             "i086"
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(_M_ARM64)
 #  define LZO_ARCH_ARM64            1
 #  define LZO_INFO_ARCH             "arm64"
 #elif defined(__alpha__) || defined(__alpha) || defined(_M_ALPHA)
@@ -802,21 +847,10 @@
 #elif defined(__amd64__) || defined(__x86_64__) || defined(_M_AMD64)
 #  define LZO_ARCH_AMD64            1
 #  define LZO_INFO_ARCH             "amd64"
-#elif defined(__thumb__) || (defined(_M_ARM) && defined(_M_THUMB))
-#  define LZO_ARCH_ARM              1
-#  define LZO_ARCH_ARM_THUMB        1
-#  define LZO_INFO_ARCH             "arm_thumb"
-#elif defined(__IAR_SYSTEMS_ICC__) && defined(__ICCARM__)
-#  define LZO_ARCH_ARM              1
-#  if defined(__CPU_MODE__) && ((__CPU_MODE__-0) == 1)
-#    define LZO_ARCH_ARM_THUMB      1
-#    define LZO_INFO_ARCH           "arm_thumb"
-#  elif defined(__CPU_MODE__) && ((__CPU_MODE__-0) == 2)
-#    define LZO_INFO_ARCH           "arm"
-#  else
-#    define LZO_INFO_ARCH           "arm"
-#  endif
 #elif defined(__arm__) || defined(_M_ARM)
+#  define LZO_ARCH_ARM              1
+#  define LZO_INFO_ARCH             "arm"
+#elif defined(__IAR_SYSTEMS_ICC__) && defined(__ICCARM__)
 #  define LZO_ARCH_ARM              1
 #  define LZO_INFO_ARCH             "arm"
 #elif (UINT_MAX <= LZO_0xffffL) && defined(__AVR__)
@@ -891,6 +925,15 @@
 #elif defined(__powerpc__) || defined(__powerpc) || defined(__ppc__) || defined(__PPC__) || defined(_M_PPC) || defined(_ARCH_PPC) || defined(_ARCH_PWR)
 #  define LZO_ARCH_POWERPC          1
 #  define LZO_INFO_ARCH             "powerpc"
+#elif defined(__powerpc64__) || defined(__powerpc64) || defined(__ppc64__) || defined(__PPC64__)
+#  define LZO_ARCH_POWERPC          1
+#  define LZO_INFO_ARCH             "powerpc"
+#elif defined(__powerpc64le__) || defined(__powerpc64le) || defined(__ppc64le__) || defined(__PPC64LE__)
+#  define LZO_ARCH_POWERPC          1
+#  define LZO_INFO_ARCH             "powerpc"
+#elif defined(__riscv)
+#  define LZO_ARCH_RISCV            1
+#  define LZO_INFO_ARCH             "riscv"
 #elif defined(__s390__) || defined(__s390) || defined(__s390x__) || defined(__s390x)
 #  define LZO_ARCH_S390             1
 #  define LZO_INFO_ARCH             "s390"
@@ -924,6 +967,23 @@
 #  define LZO_ARCH_UNKNOWN          1
 #  define LZO_INFO_ARCH             "unknown"
 #endif
+#endif
+#if !defined(LZO_ARCH_ARM_THUMB2)
+#if (LZO_ARCH_ARM)
+#  if defined(__thumb__) || defined(__thumb) || defined(_M_THUMB)
+#    if defined(__thumb2__)
+#      define LZO_ARCH_ARM_THUMB2   1
+#    elif 1 && defined(__TARGET_ARCH_THUMB) && ((__TARGET_ARCH_THUMB)+0 >= 4)
+#      define LZO_ARCH_ARM_THUMB2   1
+#    elif 1 && defined(_MSC_VER) && defined(_M_THUMB) && ((_M_THUMB)+0 >= 7)
+#      define LZO_ARCH_ARM_THUMB2   1
+#    endif
+#  endif
+#endif
+#endif
+#if (LZO_ARCH_ARM_THUMB2)
+#  undef  LZO_INFO_ARCH
+#  define LZO_INFO_ARCH             "arm_thumb2"
 #endif
 #if 1 && (LZO_ARCH_UNKNOWN) && (LZO_OS_DOS32 || LZO_OS_OS2)
 #  error "FIXME - missing define for CPU architecture"
@@ -967,13 +1027,10 @@
 #if (LZO_ARCH_I386 && !LZO_ARCH_X86) || (!LZO_ARCH_I386 && LZO_ARCH_X86)
 #  error "unexpected configuration - check your compiler defines"
 #endif
-#if (LZO_ARCH_ARM_THUMB && !LZO_ARCH_ARM)
+#if (LZO_ARCH_ARM_THUMB1 && !LZO_ARCH_ARM)
 #  error "unexpected configuration - check your compiler defines"
 #endif
-#if (LZO_ARCH_ARM_THUMB1 && !LZO_ARCH_ARM_THUMB)
-#  error "unexpected configuration - check your compiler defines"
-#endif
-#if (LZO_ARCH_ARM_THUMB2 && !LZO_ARCH_ARM_THUMB)
+#if (LZO_ARCH_ARM_THUMB2 && !LZO_ARCH_ARM)
 #  error "unexpected configuration - check your compiler defines"
 #endif
 #if (LZO_ARCH_ARM_THUMB1 && LZO_ARCH_ARM_THUMB2)
@@ -1005,7 +1062,9 @@
 #  if !defined(LZO_TARGET_FEATURE_SSE2)
 #    if defined(__SSE2__)
 #      define LZO_TARGET_FEATURE_SSE2       1
-#    elif defined(_MSC_VER) && ((defined(_M_IX86_FP) && ((_M_IX86_FP)+0 >= 2)) || defined(_M_AMD64))
+#    elif defined(_MSC_VER) && (defined(_M_IX86_FP) && ((_M_IX86_FP)+0 >= 2))
+#      define LZO_TARGET_FEATURE_SSE2       1
+#    elif (LZO_CC_INTELC_MSC || LZO_CC_MSC) && defined(_M_AMD64)
 #      define LZO_TARGET_FEATURE_SSE2       1
 #    endif
 #  endif
@@ -1054,7 +1113,11 @@
 #endif
 #if (LZO_ARCH_ARM)
 #  if !defined(LZO_TARGET_FEATURE_NEON)
-#    if defined(__ARM_NEON__)
+#    if defined(__ARM_NEON) && ((__ARM_NEON)+0)
+#      define LZO_TARGET_FEATURE_NEON       1
+#    elif 1 && defined(__ARM_NEON__) && ((__ARM_NEON__)+0)
+#      define LZO_TARGET_FEATURE_NEON       1
+#    elif 1 && defined(__TARGET_FEATURE_NEON) && ((__TARGET_FEATURE_NEON)+0)
 #      define LZO_TARGET_FEATURE_NEON       1
 #    endif
 #  endif
@@ -1125,7 +1188,7 @@
 #    error "unexpected configuration - check your compiler defines"
 #  endif
 #endif
-#ifdef __cplusplus
+#if defined(__cplusplus)
 extern "C" {
 #endif
 #if (LZO_CC_BORLANDC && (__BORLANDC__ >= 0x0200))
@@ -1148,7 +1211,7 @@ extern "C" {
 #else
 #  error "FIXME - implement LZO_MM_AHSHIFT"
 #endif
-#ifdef __cplusplus
+#if defined(__cplusplus)
 }
 #endif
 #endif
@@ -1234,11 +1297,52 @@ extern "C" {
 #  define __lzo_gnuc_extension__    __extension__
 #elif (LZO_CC_IBMC >= 600)
 #  define __lzo_gnuc_extension__    __extension__
-#else
 #endif
 #endif
 #if !defined(__lzo_gnuc_extension__)
 #  define __lzo_gnuc_extension__    /*empty*/
+#endif
+#if !defined(lzo_has_builtin)
+#if (LZO_CC_CLANG) && defined(__has_builtin)
+#  define lzo_has_builtin           __has_builtin
+#endif
+#endif
+#if !defined(lzo_has_builtin)
+#  define lzo_has_builtin(x)        0
+#endif
+#if !defined(lzo_has_attribute)
+#if (LZO_CC_CLANG) && defined(__has_attribute)
+#  define lzo_has_attribute         __has_attribute
+#endif
+#endif
+#if !defined(lzo_has_attribute)
+#  define lzo_has_attribute(x)      0
+#endif
+#if !defined(lzo_has_declspec_attribute)
+#if (LZO_CC_CLANG) && defined(__has_declspec_attribute)
+#  define lzo_has_declspec_attribute        __has_declspec_attribute
+#endif
+#endif
+#if !defined(lzo_has_declspec_attribute)
+#  define lzo_has_declspec_attribute(x)     0
+#endif
+#if !defined(lzo_has_feature)
+#if (LZO_CC_CLANG) && defined(__has_feature)
+#  define lzo_has_feature         __has_feature
+#endif
+#endif
+#if !defined(lzo_has_feature)
+#  define lzo_has_feature(x)        0
+#endif
+#if !defined(lzo_has_extension)
+#if (LZO_CC_CLANG) && defined(__has_extension)
+#  define lzo_has_extension         __has_extension
+#elif (LZO_CC_CLANG) && defined(__has_feature)
+#  define lzo_has_extension         __has_feature
+#endif
+#endif
+#if !defined(lzo_has_extension)
+#  define lzo_has_extension(x)      0
 #endif
 #if !defined(LZO_CFG_USE_NEW_STYLE_CASTS) && defined(__cplusplus) && 0
 #  if (LZO_CC_GNUC && (LZO_CC_GNUC < 0x020800ul))
@@ -1376,7 +1480,7 @@ extern "C" {
 #  elif (LZO_CC_MSC && (_MSC_VER < 900))
 #    define LZO_UNUSED(var)         if (&var) ; else
 #  elif (LZO_CC_KEILC)
-#    define LZO_UNUSED(var)         {LZO_EXTERN_C int lzo_unused__[1-2*!(sizeof(var)>0)];}
+#    define LZO_UNUSED(var)         {extern int lzo_unused__[1-2*!(sizeof(var)>0)]; (void)lzo_unused__;}
 #  elif (LZO_CC_PACIFICC)
 #    define LZO_UNUSED(var)         ((void) sizeof(var))
 #  elif (LZO_CC_WATCOMC) && defined(__cplusplus)
@@ -1384,6 +1488,9 @@ extern "C" {
 #  else
 #    define LZO_UNUSED(var)         ((void) &var)
 #  endif
+#endif
+#if !defined(LZO_UNUSED_RESULT)
+#  define LZO_UNUSED_RESULT(var)    LZO_UNUSED(var)
 #endif
 #if !defined(LZO_UNUSED_FUNC)
 #  if (LZO_CC_BORLANDC && (__BORLANDC__ >= 0x0600))
@@ -1397,7 +1504,7 @@ extern "C" {
 #  elif (LZO_CC_MSC)
 #    define LZO_UNUSED_FUNC(func)   ((void) &func)
 #  elif (LZO_CC_KEILC || LZO_CC_PELLESC)
-#    define LZO_UNUSED_FUNC(func)   {LZO_EXTERN_C int lzo_unused_func__[1-2*!(sizeof((int)func)>0)];}
+#    define LZO_UNUSED_FUNC(func)   {extern int lzo_unused__[1-2*!(sizeof((int)func)>0)]; (void)lzo_unused__;}
 #  else
 #    define LZO_UNUSED_FUNC(func)   ((void) func)
 #  endif
@@ -1803,6 +1910,7 @@ extern "C" {
 #elif (LZO_CC_INTELC && (__INTEL_COMPILER >= 800))
 #  define __lzo_likely(e)       (__builtin_expect(!!(e),1))
 #  define __lzo_unlikely(e)     (__builtin_expect(!!(e),0))
+#elif (LZO_CC_CLANG && LZO_CC_CLANG_C2)
 #elif (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || LZO_CC_LLVM || LZO_CC_PATHSCALE)
 #  define __lzo_likely(e)       (__builtin_expect(!!(e),1))
 #  define __lzo_unlikely(e)     (__builtin_expect(!!(e),0))
@@ -1813,21 +1921,28 @@ extern "C" {
 #  define __lzo_HAVE_likely 1
 #  endif
 #else
-#  define __lzo_likely(e)       (e)
+#  define __lzo_likely(e)           (e)
+#endif
+#if defined(__lzo_very_likely)
+#  ifndef __lzo_HAVE_very_likely
+#  define __lzo_HAVE_very_likely 1
+#  endif
+#else
+#  define __lzo_very_likely(e)      __lzo_likely(e)
 #endif
 #if defined(__lzo_unlikely)
 #  ifndef __lzo_HAVE_unlikely
 #  define __lzo_HAVE_unlikely 1
 #  endif
 #else
-#  define __lzo_unlikely(e)     (e)
+#  define __lzo_unlikely(e)         (e)
 #endif
-#if !defined(__lzo_static_unused_void_func)
-#  if 1 && (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || (LZO_CC_GNUC >= 0x020700ul) || LZO_CC_INTELC_GNUC || LZO_CC_LLVM || LZO_CC_PATHSCALE || LZO_CC_PGI)
-#    define __lzo_static_unused_void_func(f)    static void __attribute__((__unused__)) f(void)
-#  else
-#    define __lzo_static_unused_void_func(f)    static __lzo_inline void f(void)
+#if defined(__lzo_very_unlikely)
+#  ifndef __lzo_HAVE_very_unlikely
+#  define __lzo_HAVE_very_unlikely 1
 #  endif
+#else
+#  define __lzo_very_unlikely(e)    __lzo_unlikely(e)
 #endif
 #if !defined(__lzo_loop_forever)
 #  if (LZO_CC_IBMC)
@@ -1837,7 +1952,7 @@ extern "C" {
 #  endif
 #endif
 #if !defined(__lzo_unreachable)
-#if (LZO_CC_CLANG && (LZO_CC_CLANG >= 0x020800ul))
+#if (LZO_CC_CLANG && (LZO_CC_CLANG >= 0x020800ul)) && lzo_has_builtin(__builtin_unreachable)
 #  define __lzo_unreachable()       __builtin_unreachable();
 #elif (LZO_CC_GNUC >= 0x040500ul)
 #  define __lzo_unreachable()       __builtin_unreachable();
@@ -1854,6 +1969,15 @@ extern "C" {
 #  define __lzo_unreachable()       ((void)0);
 #  else
 #  define __lzo_unreachable()       __lzo_loop_forever();
+#  endif
+#endif
+#if !defined(lzo_unused_funcs_impl)
+#  if 1 && (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || (LZO_CC_GNUC >= 0x020700ul) || LZO_CC_INTELC_GNUC || LZO_CC_LLVM || LZO_CC_PATHSCALE || LZO_CC_PGI)
+#    define lzo_unused_funcs_impl(r,f)  static r __attribute__((__unused__)) f
+#  elif 1 && (LZO_CC_BORLANDC || LZO_CC_GNUC)
+#    define lzo_unused_funcs_impl(r,f)  static r f
+#  else
+#    define lzo_unused_funcs_impl(r,f)  __lzo_static_forceinline r f
 #  endif
 #endif
 #ifndef __LZO_CTA_NAME
@@ -1881,6 +2005,8 @@ extern "C" {
 #if !defined(LZO_COMPILE_TIME_ASSERT)
 #  if (LZO_CC_AZTECC)
 #    define LZO_COMPILE_TIME_ASSERT(e)  {typedef int __LZO_CTA_NAME(lzo_cta_t__)[1-!(e)];}
+#  elif (LZO_CC_CLANG && (LZO_CC_CLANG >= 0x030000ul))
+#    define LZO_COMPILE_TIME_ASSERT(e)  {typedef int __LZO_CTA_NAME(lzo_cta_t__)[1-2*!(e)] __attribute__((__unused__));}
 #  elif (LZO_CC_DMC || LZO_CC_PACIFICC || LZO_CC_SYMANTECC || LZO_CC_ZORTECHC)
 #    define LZO_COMPILE_TIME_ASSERT(e)  switch(0) case 1:case !(e):break;
 #  elif (LZO_CC_GNUC) && defined(__CHECKER__) && defined(__SPARSE_CHECKER__)
@@ -1897,11 +2023,16 @@ extern "C" {
 #    define LZO_COMPILE_TIME_ASSERT(e)  {typedef int __LZO_CTA_NAME(lzo_cta_t__)[1-2*!(e)];}
 #  endif
 #endif
+#if (LZO_LANG_ASSEMBLER)
+#  undef LZO_COMPILE_TIME_ASSERT_HEADER
+#  define LZO_COMPILE_TIME_ASSERT_HEADER(e)  /*empty*/
+#else
 LZO_COMPILE_TIME_ASSERT_HEADER(1 == 1)
 #if defined(__cplusplus)
 extern "C" { LZO_COMPILE_TIME_ASSERT_HEADER(2 == 2) }
 #endif
 LZO_COMPILE_TIME_ASSERT_HEADER(3 == 3)
+#endif
 #if (LZO_ARCH_I086 || LZO_ARCH_I386) && (LZO_OS_DOS16 || LZO_OS_DOS32 || LZO_OS_OS2 || LZO_OS_OS216 || LZO_OS_WIN16 || LZO_OS_WIN32 || LZO_OS_WIN64)
 #  if (LZO_CC_GNUC || LZO_CC_HIGHC || LZO_CC_NDPC || LZO_CC_PACIFICC)
 #  elif (LZO_CC_DMC || LZO_CC_SYMANTECC || LZO_CC_ZORTECHC)
@@ -1968,7 +2099,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(3 == 3)
 #if !defined(LZO_HAVE_WINDOWS_H)
 #if (LZO_OS_CYGWIN || (LZO_OS_EMX && defined(__RSXNT__)) || LZO_OS_WIN32 || LZO_OS_WIN64)
 #  if (LZO_CC_WATCOMC && (__WATCOMC__ < 1000))
-#  elif (LZO_OS_WIN32 && LZO_CC_GNUC) && defined(__PW32__)
+#  elif ((LZO_OS_WIN32 && defined(__PW32__)) && (LZO_CC_GNUC && (LZO_CC_GNUC < 0x030000ul)))
 #  elif ((LZO_OS_CYGWIN || defined(__MINGW32__)) && (LZO_CC_GNUC && (LZO_CC_GNUC < 0x025f00ul)))
 #  else
 #    define LZO_HAVE_WINDOWS_H 1
@@ -1976,6 +2107,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(3 == 3)
 #endif
 #endif
 #endif
+#define LZO_SIZEOF_CHAR             1
 #ifndef LZO_SIZEOF_SHORT
 #if defined(SIZEOF_SHORT)
 #  define LZO_SIZEOF_SHORT          (SIZEOF_SHORT)
@@ -2174,12 +2306,12 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_LONG == sizeof(long))
 #  define LZO_WORDSIZE              8
 #elif (LZO_ARCH_AMD64)
 #  define LZO_WORDSIZE              8
+#elif (LZO_ARCH_ARM64)
+#  define LZO_WORDSIZE              8
 #elif (LZO_ARCH_AVR)
 #  define LZO_WORDSIZE              1
 #elif (LZO_ARCH_H8300)
-#  if defined(__NORMAL_MODE__)
-#    define LZO_WORDSIZE            4
-#  elif defined(__H8300H__) || defined(__H8300S__) || defined(__H8300SX__)
+#  if defined(__H8300H__) || defined(__H8300S__) || defined(__H8300SX__)
 #    define LZO_WORDSIZE            4
 #  else
 #    define LZO_WORDSIZE            2
@@ -2222,11 +2354,15 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(long) == 8)
 #elif (LZO_ARCH_C166 || LZO_ARCH_MCS51 || LZO_ARCH_MCS251 || LZO_ARCH_MSP430)
 #  define LZO_SIZEOF_VOID_P         2
 #elif (LZO_ARCH_H8300)
-#  if defined(__NORMAL_MODE__)
-#    define LZO_SIZEOF_VOID_P       2
-#  elif defined(__H8300H__) || defined(__H8300S__) || defined(__H8300SX__)
-#    define LZO_SIZEOF_VOID_P       4
+#  if defined(__H8300H__) || defined(__H8300S__) || defined(__H8300SX__)
+     LZO_COMPILE_TIME_ASSERT_HEADER(LZO_WORDSIZE == 4)
+#    if defined(__NORMAL_MODE__)
+#      define LZO_SIZEOF_VOID_P     2
+#    else
+#      define LZO_SIZEOF_VOID_P     4
+#    endif
 #  else
+     LZO_COMPILE_TIME_ASSERT_HEADER(LZO_WORDSIZE == 2)
 #    define LZO_SIZEOF_VOID_P       2
 #  endif
 #  if (LZO_CC_GNUC && (LZO_CC_GNUC < 0x040000ul)) && (LZO_SIZEOF_INT == 4)
@@ -2316,7 +2452,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #  define LZO_ABI_BIG_ENDIAN        1
 #elif (LZO_ARCH_IA64) && (LZO_OS_POSIX_LINUX || LZO_OS_WIN64)
 #  define LZO_ABI_LITTLE_ENDIAN     1
-#elif (LZO_ARCH_ALPHA || LZO_ARCH_AMD64 || LZO_ARCH_BLACKFIN || LZO_ARCH_CRIS || LZO_ARCH_I086 || LZO_ARCH_I386 || LZO_ARCH_MSP430)
+#elif (LZO_ARCH_ALPHA || LZO_ARCH_AMD64 || LZO_ARCH_BLACKFIN || LZO_ARCH_CRIS || LZO_ARCH_I086 || LZO_ARCH_I386 || LZO_ARCH_MSP430 || LZO_ARCH_RISCV)
 #  define LZO_ABI_LITTLE_ENDIAN     1
 #elif (LZO_ARCH_AVR32 || LZO_ARCH_M68K || LZO_ARCH_S390 || LZO_ARCH_SPU)
 #  define LZO_ABI_BIG_ENDIAN        1
@@ -2330,9 +2466,13 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
 #  define LZO_ABI_LITTLE_ENDIAN     1
+#elif 1 && (LZO_ARCH_ARM) && defined(__ARM_BIG_ENDIAN) && ((__ARM_BIG_ENDIAN)+0)
+#  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && (LZO_ARCH_ARM) && defined(__ARMEB__) && !defined(__ARMEL__)
 #  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && (LZO_ARCH_ARM) && defined(__ARMEL__) && !defined(__ARMEB__)
+#  define LZO_ABI_LITTLE_ENDIAN     1
+#elif 1 && (LZO_ARCH_ARM) && defined(_MSC_VER) && defined(_WIN32)
 #  define LZO_ABI_LITTLE_ENDIAN     1
 #elif 1 && (LZO_ARCH_ARM && LZO_CC_ARMCC_ARMCC)
 #  if defined(__BIG_ENDIAN) && defined(__LITTLE_ENDIAN)
@@ -2343,9 +2483,13 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #    define LZO_ABI_LITTLE_ENDIAN   1
 #  endif
 #  define LZO_ABI_LITTLE_ENDIAN     1
+#elif 1 && (LZO_ARCH_ARM64) && defined(__ARM_BIG_ENDIAN) && ((__ARM_BIG_ENDIAN)+0)
+#  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && (LZO_ARCH_ARM64) && defined(__AARCH64EB__) && !defined(__AARCH64EL__)
 #  define LZO_ABI_BIG_ENDIAN        1
 #elif 1 && (LZO_ARCH_ARM64) && defined(__AARCH64EL__) && !defined(__AARCH64EB__)
+#  define LZO_ABI_LITTLE_ENDIAN     1
+#elif 1 && (LZO_ARCH_ARM64) && defined(_MSC_VER) && defined(_WIN32)
 #  define LZO_ABI_LITTLE_ENDIAN     1
 #elif 1 && (LZO_ARCH_MIPS) && defined(__MIPSEB__) && !defined(__MIPSEL__)
 #  define LZO_ABI_BIG_ENDIAN        1
@@ -2387,6 +2531,12 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #elif (LZO_SIZEOF_INT == 4 && LZO_SIZEOF_LONG == 8 && LZO_SIZEOF_VOID_P == 4)
 #  define LZO_ABI_IP32L64       1
 #  define LZO_INFO_ABI_PM       "ip32l64"
+#endif
+#if (LZO_SIZEOF_INT == 4 && LZO_SIZEOF_VOID_P == 4 && LZO_WORDSIZE == 8)
+#  define LZO_ABI_IP32W64       1
+#  ifndef LZO_INFO_ABI_PM
+#  define LZO_INFO_ABI_PM       "ip32w64"
+#  endif
 #endif
 #if 0
 #elif !defined(__LZO_LIBC_OVERRIDE)
@@ -2475,20 +2625,43 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #  endif
 #elif (LZO_ARCH_ARM)
 #  if defined(__ARM_FEATURE_UNALIGNED)
+#   if ((__ARM_FEATURE_UNALIGNED)+0)
 #    ifndef LZO_OPT_UNALIGNED16
 #    define LZO_OPT_UNALIGNED16             1
 #    endif
 #    ifndef LZO_OPT_UNALIGNED32
 #    define LZO_OPT_UNALIGNED32             1
 #    endif
-#  elif defined(__TARGET_ARCH_ARM) && ((__TARGET_ARCH_ARM+0) >= 7)
+#   endif
+#  elif 1 && (LZO_ARCH_ARM_THUMB2)
 #    ifndef LZO_OPT_UNALIGNED16
 #    define LZO_OPT_UNALIGNED16             1
 #    endif
 #    ifndef LZO_OPT_UNALIGNED32
 #    define LZO_OPT_UNALIGNED32             1
 #    endif
-#  elif defined(__TARGET_ARCH_ARM) && ((__TARGET_ARCH_ARM+0) >= 6) && !defined(__TARGET_PROFILE_M)
+#  elif 1 && defined(__ARM_ARCH) && ((__ARM_ARCH)+0 >= 7)
+#    ifndef LZO_OPT_UNALIGNED16
+#    define LZO_OPT_UNALIGNED16             1
+#    endif
+#    ifndef LZO_OPT_UNALIGNED32
+#    define LZO_OPT_UNALIGNED32             1
+#    endif
+#  elif 1 && defined(__TARGET_ARCH_ARM) && ((__TARGET_ARCH_ARM)+0 >= 7)
+#    ifndef LZO_OPT_UNALIGNED16
+#    define LZO_OPT_UNALIGNED16             1
+#    endif
+#    ifndef LZO_OPT_UNALIGNED32
+#    define LZO_OPT_UNALIGNED32             1
+#    endif
+#  elif 1 && defined(__TARGET_ARCH_ARM) && ((__TARGET_ARCH_ARM)+0 >= 6) && (defined(__TARGET_PROFILE_A) || defined(__TARGET_PROFILE_R))
+#    ifndef LZO_OPT_UNALIGNED16
+#    define LZO_OPT_UNALIGNED16             1
+#    endif
+#    ifndef LZO_OPT_UNALIGNED32
+#    define LZO_OPT_UNALIGNED32             1
+#    endif
+#  elif 1 && defined(_MSC_VER) && defined(_M_ARM) && ((_M_ARM)+0 >= 7)
 #    ifndef LZO_OPT_UNALIGNED16
 #    define LZO_OPT_UNALIGNED16             1
 #    endif
@@ -2540,7 +2713,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #elif (LZO_ARCH_POWERPC)
 #  define LZO_OPT_PREFER_PREINC             1
 #  define LZO_OPT_PREFER_PREDEC             1
-#  if (LZO_ABI_BIG_ENDIAN)
+#  if (LZO_ABI_BIG_ENDIAN) || (LZO_WORDSIZE == 8)
 #    ifndef LZO_OPT_UNALIGNED16
 #    define LZO_OPT_UNALIGNED16             1
 #    endif
@@ -2551,6 +2724,19 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #      ifndef LZO_OPT_UNALIGNED64
 #      define LZO_OPT_UNALIGNED64           1
 #      endif
+#    endif
+#  endif
+#elif (LZO_ARCH_RISCV)
+#  define LZO_OPT_AVOID_UINT_INDEX          1
+#  ifndef LZO_OPT_UNALIGNED16
+#  define LZO_OPT_UNALIGNED16               1
+#  endif
+#  ifndef LZO_OPT_UNALIGNED32
+#  define LZO_OPT_UNALIGNED32               1
+#  endif
+#  if (LZO_WORDSIZE == 8)
+#    ifndef LZO_OPT_UNALIGNED64
+#    define LZO_OPT_UNALIGNED64             1
 #    endif
 #  endif
 #elif (LZO_ARCH_S390)
@@ -2644,32 +2830,61 @@ LZO_COMPILE_TIME_ASSERT_HEADER(LZO_SIZEOF_PTRDIFF_T == sizeof(ptrdiff_t))
 #if (!(LZO_SIZEOF_PTRDIFF_T+0 > 0 && LZO_SIZEOF_SIZE_T+0 > 0 && LZO_SIZEOF_VOID_P+0 > 0))
 #  error "missing defines for sizes"
 #endif
+#define LZO_TYPEOF_CHAR             1u
+#define LZO_TYPEOF_SHORT            2u
+#define LZO_TYPEOF_INT              3u
+#define LZO_TYPEOF_LONG             4u
+#define LZO_TYPEOF_LONG_LONG        5u
+#define LZO_TYPEOF___INT8           17u
+#define LZO_TYPEOF___INT16          18u
+#define LZO_TYPEOF___INT32          19u
+#define LZO_TYPEOF___INT64          20u
+#define LZO_TYPEOF___INT128         21u
+#define LZO_TYPEOF___INT256         22u
+#define LZO_TYPEOF___MODE_QI        33u
+#define LZO_TYPEOF___MODE_HI        34u
+#define LZO_TYPEOF___MODE_SI        35u
+#define LZO_TYPEOF___MODE_DI        36u
+#define LZO_TYPEOF___MODE_TI        37u
+#define LZO_TYPEOF_CHAR_P           129u
 #if !defined(lzo_llong_t)
 #if (LZO_SIZEOF_LONG_LONG+0 > 0)
-__lzo_gnuc_extension__ typedef long long lzo_llong_t__;
-__lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
+#  if !(LZO_LANG_ASSEMBLER)
+   __lzo_gnuc_extension__ typedef long long lzo_llong_t__;
+   __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
+#  endif
 #  define lzo_llong_t               lzo_llong_t__
 #  define lzo_ullong_t              lzo_ullong_t__
 #endif
 #endif
 #if !defined(lzo_int16e_t)
-#if (LZO_SIZEOF_LONG == 2)
+#if (LZO_CFG_PREFER_TYPEOF_ACC_INT16E_T == LZO_TYPEOF_SHORT) && (LZO_SIZEOF_SHORT != 2)
+#  undef LZO_CFG_PREFER_TYPEOF_ACC_INT16E_T
+#endif
+#if (LZO_SIZEOF_LONG == 2) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT16E_T == LZO_TYPEOF_SHORT)
 #  define lzo_int16e_t              long
 #  define lzo_uint16e_t             unsigned long
-#elif (LZO_SIZEOF_INT == 2)
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF_LONG
+#elif (LZO_SIZEOF_INT == 2) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT16E_T == LZO_TYPEOF_SHORT)
 #  define lzo_int16e_t              int
 #  define lzo_uint16e_t             unsigned int
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF_INT
 #elif (LZO_SIZEOF_SHORT == 2)
 #  define lzo_int16e_t              short int
 #  define lzo_uint16e_t             unsigned short int
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF_SHORT
 #elif 1 && !(LZO_CFG_TYPE_NO_MODE_HI) && (LZO_CC_CLANG || (LZO_CC_GNUC >= 0x025f00ul) || LZO_CC_LLVM)
+#  if !(LZO_LANG_ASSEMBLER)
    typedef int lzo_int16e_hi_t__ __attribute__((__mode__(__HI__)));
    typedef unsigned int lzo_uint16e_hi_t__ __attribute__((__mode__(__HI__)));
+#  endif
 #  define lzo_int16e_t              lzo_int16e_hi_t__
 #  define lzo_uint16e_t             lzo_uint16e_hi_t__
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF___MODE_HI
 #elif (LZO_SIZEOF___INT16 == 2)
 #  define lzo_int16e_t              __int16
 #  define lzo_uint16e_t             unsigned __int16
+#  define LZO_TYPEOF_LZO_INT16E_T   LZO_TYPEOF___INT16
 #else
 #endif
 #endif
@@ -2679,33 +2894,47 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
    LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int16e_t) == LZO_SIZEOF_LZO_INT16E_T)
 #endif
 #if !defined(lzo_int32e_t)
-#if (LZO_SIZEOF_LONG == 4)
+#if (LZO_CFG_PREFER_TYPEOF_ACC_INT32E_T == LZO_TYPEOF_INT) && (LZO_SIZEOF_INT != 4)
+#  undef LZO_CFG_PREFER_TYPEOF_ACC_INT32E_T
+#endif
+#if (LZO_SIZEOF_LONG == 4) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT32E_T == LZO_TYPEOF_INT)
 #  define lzo_int32e_t              long int
 #  define lzo_uint32e_t             unsigned long int
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF_LONG
 #elif (LZO_SIZEOF_INT == 4)
 #  define lzo_int32e_t              int
 #  define lzo_uint32e_t             unsigned int
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF_INT
 #elif (LZO_SIZEOF_SHORT == 4)
 #  define lzo_int32e_t              short int
 #  define lzo_uint32e_t             unsigned short int
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF_SHORT
 #elif (LZO_SIZEOF_LONG_LONG == 4)
 #  define lzo_int32e_t              lzo_llong_t
 #  define lzo_uint32e_t             lzo_ullong_t
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF_LONG_LONG
 #elif 1 && !(LZO_CFG_TYPE_NO_MODE_SI) && (LZO_CC_CLANG || (LZO_CC_GNUC >= 0x025f00ul) || LZO_CC_LLVM) && (__INT_MAX__+0 > 2147483647L)
+#  if !(LZO_LANG_ASSEMBLER)
    typedef int lzo_int32e_si_t__ __attribute__((__mode__(__SI__)));
    typedef unsigned int lzo_uint32e_si_t__ __attribute__((__mode__(__SI__)));
+#  endif
 #  define lzo_int32e_t              lzo_int32e_si_t__
 #  define lzo_uint32e_t             lzo_uint32e_si_t__
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF___MODE_SI
 #elif 1 && !(LZO_CFG_TYPE_NO_MODE_SI) && (LZO_CC_GNUC >= 0x025f00ul) && defined(__AVR__) && (__LONG_MAX__+0 == 32767L)
+#  if !(LZO_LANG_ASSEMBLER)
    typedef int lzo_int32e_si_t__ __attribute__((__mode__(__SI__)));
    typedef unsigned int lzo_uint32e_si_t__ __attribute__((__mode__(__SI__)));
+#  endif
 #  define lzo_int32e_t              lzo_int32e_si_t__
 #  define lzo_uint32e_t             lzo_uint32e_si_t__
 #  define LZO_INT32_C(c)            (c##LL)
 #  define LZO_UINT32_C(c)           (c##ULL)
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF___MODE_SI
 #elif (LZO_SIZEOF___INT32 == 4)
 #  define lzo_int32e_t              __int32
 #  define lzo_uint32e_t             unsigned __int32
+#  define LZO_TYPEOF_LZO_INT32E_T   LZO_TYPEOF___INT32
 #else
 #endif
 #endif
@@ -2716,21 +2945,28 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #endif
 #if !defined(lzo_int64e_t)
 #if (LZO_SIZEOF___INT64 == 8)
-#  if (LZO_CC_BORLANDC) && !(LZO_CFG_TYPE_PREFER___INT64)
-#    define LZO_CFG_TYPE_PREFER___INT64 1
+#  if (LZO_CC_BORLANDC) && !defined(LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T)
+#    define LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T  LZO_TYPEOF___INT64
 #  endif
+#endif
+#if (LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF_LONG_LONG) && (LZO_SIZEOF_LONG_LONG != 8)
+#  undef LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T
+#endif
+#if (LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF___INT64) && (LZO_SIZEOF___INT64 != 8)
+#  undef LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T
 #endif
 #if (LZO_SIZEOF_INT == 8) && (LZO_SIZEOF_INT < LZO_SIZEOF_LONG)
 #  define lzo_int64e_t              int
 #  define lzo_uint64e_t             unsigned int
-#  define LZO_SIZEOF_LZO_INT64E_T   LZO_SIZEOF_INT
-#elif (LZO_SIZEOF_LONG == 8)
+#  define LZO_TYPEOF_LZO_INT64E_T   LZO_TYPEOF_INT
+#elif (LZO_SIZEOF_LONG == 8) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF_LONG_LONG) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF___INT64)
 #  define lzo_int64e_t              long int
 #  define lzo_uint64e_t             unsigned long int
-#  define LZO_SIZEOF_LZO_INT64E_T   LZO_SIZEOF_LONG
-#elif (LZO_SIZEOF_LONG_LONG == 8) && !(LZO_CFG_TYPE_PREFER___INT64)
+#  define LZO_TYPEOF_LZO_INT64E_T   LZO_TYPEOF_LONG
+#elif (LZO_SIZEOF_LONG_LONG == 8) && !(LZO_CFG_PREFER_TYPEOF_ACC_INT64E_T == LZO_TYPEOF___INT64)
 #  define lzo_int64e_t              lzo_llong_t
 #  define lzo_uint64e_t             lzo_ullong_t
+#  define LZO_TYPEOF_LZO_INT64E_T   LZO_TYPEOF_LONG_LONG
 #  if (LZO_CC_BORLANDC)
 #    define LZO_INT64_C(c)          ((c) + 0ll)
 #    define LZO_UINT64_C(c)         ((c) + 0ull)
@@ -2741,10 +2977,10 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #    define LZO_INT64_C(c)          (c##LL)
 #    define LZO_UINT64_C(c)         (c##ULL)
 #  endif
-#  define LZO_SIZEOF_LZO_INT64E_T   LZO_SIZEOF_LONG_LONG
 #elif (LZO_SIZEOF___INT64 == 8)
 #  define lzo_int64e_t              __int64
 #  define lzo_uint64e_t             unsigned __int64
+#  define LZO_TYPEOF_LZO_INT64E_T   LZO_TYPEOF___INT64
 #  if (LZO_CC_BORLANDC)
 #    define LZO_INT64_C(c)          ((c) + 0i64)
 #    define LZO_UINT64_C(c)         ((c) + 0ui64)
@@ -2752,11 +2988,11 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #    define LZO_INT64_C(c)          (c##i64)
 #    define LZO_UINT64_C(c)         (c##ui64)
 #  endif
-#  define LZO_SIZEOF_LZO_INT64E_T   LZO_SIZEOF___INT64
 #else
 #endif
 #endif
 #if defined(lzo_int64e_t)
+#  define LZO_SIZEOF_LZO_INT64E_T   8
    LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64e_t) == 8)
    LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64e_t) == LZO_SIZEOF_LZO_INT64E_T)
 #endif
@@ -2765,14 +3001,17 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #  define lzo_int32l_t              lzo_int32e_t
 #  define lzo_uint32l_t             lzo_uint32e_t
 #  define LZO_SIZEOF_LZO_INT32L_T   LZO_SIZEOF_LZO_INT32E_T
+#  define LZO_TYPEOF_LZO_INT32L_T   LZO_TYPEOF_LZO_INT32E_T
 #elif (LZO_SIZEOF_INT >= 4) && (LZO_SIZEOF_INT < LZO_SIZEOF_LONG)
 #  define lzo_int32l_t              int
 #  define lzo_uint32l_t             unsigned int
 #  define LZO_SIZEOF_LZO_INT32L_T   LZO_SIZEOF_INT
+#  define LZO_TYPEOF_LZO_INT32L_T   LZO_SIZEOF_INT
 #elif (LZO_SIZEOF_LONG >= 4)
 #  define lzo_int32l_t              long int
 #  define lzo_uint32l_t             unsigned long int
 #  define LZO_SIZEOF_LZO_INT32L_T   LZO_SIZEOF_LONG
+#  define LZO_TYPEOF_LZO_INT32L_T   LZO_SIZEOF_LONG
 #else
 #  error "lzo_int32l_t"
 #endif
@@ -2786,6 +3025,7 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #  define lzo_int64l_t              lzo_int64e_t
 #  define lzo_uint64l_t             lzo_uint64e_t
 #  define LZO_SIZEOF_LZO_INT64L_T   LZO_SIZEOF_LZO_INT64E_T
+#  define LZO_TYPEOF_LZO_INT64L_T   LZO_TYPEOF_LZO_INT64E_T
 #else
 #endif
 #endif
@@ -2798,10 +3038,12 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #  define lzo_int32f_t              lzo_int64l_t
 #  define lzo_uint32f_t             lzo_uint64l_t
 #  define LZO_SIZEOF_LZO_INT32F_T   LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_TYPEOF_LZO_INT32F_T   LZO_TYPEOF_LZO_INT64L_T
 #else
 #  define lzo_int32f_t              lzo_int32l_t
 #  define lzo_uint32f_t             lzo_uint32l_t
 #  define LZO_SIZEOF_LZO_INT32F_T   LZO_SIZEOF_LZO_INT32L_T
+#  define LZO_TYPEOF_LZO_INT32F_T   LZO_TYPEOF_LZO_INT32L_T
 #endif
 #endif
 #if 1
@@ -2813,6 +3055,7 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #  define lzo_int64f_t              lzo_int64l_t
 #  define lzo_uint64f_t             lzo_uint64l_t
 #  define LZO_SIZEOF_LZO_INT64F_T   LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_TYPEOF_LZO_INT64F_T   LZO_TYPEOF_LZO_INT64L_T
 #else
 #endif
 #endif
@@ -2823,33 +3066,43 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #if !defined(lzo_intptr_t)
 #if 1 && (LZO_OS_OS400 && (LZO_SIZEOF_VOID_P == 16))
 #  define __LZO_INTPTR_T_IS_POINTER 1
-   typedef char*                    lzo_intptr_t;
-   typedef char*                    lzo_uintptr_t;
+#  if !(LZO_LANG_ASSEMBLER)
+   typedef char *                   lzo_intptr_t;
+   typedef char *                   lzo_uintptr_t;
+#  endif
 #  define lzo_intptr_t              lzo_intptr_t
 #  define lzo_uintptr_t             lzo_uintptr_t
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_VOID_P
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_CHAR_P
 #elif (LZO_CC_MSC && (_MSC_VER >= 1300) && (LZO_SIZEOF_VOID_P == 4) && (LZO_SIZEOF_INT == 4))
+#  if !(LZO_LANG_ASSEMBLER)
    typedef __w64 int                lzo_intptr_t;
    typedef __w64 unsigned int       lzo_uintptr_t;
+#  endif
 #  define lzo_intptr_t              lzo_intptr_t
 #  define lzo_uintptr_t             lzo_uintptr_t
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_INT
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_INT
 #elif (LZO_SIZEOF_SHORT == LZO_SIZEOF_VOID_P) && (LZO_SIZEOF_INT > LZO_SIZEOF_VOID_P)
 #  define lzo_intptr_t              short
 #  define lzo_uintptr_t             unsigned short
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_SHORT
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_SHORT
 #elif (LZO_SIZEOF_INT >= LZO_SIZEOF_VOID_P) && (LZO_SIZEOF_INT < LZO_SIZEOF_LONG)
 #  define lzo_intptr_t              int
 #  define lzo_uintptr_t             unsigned int
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_INT
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_INT
 #elif (LZO_SIZEOF_LONG >= LZO_SIZEOF_VOID_P)
 #  define lzo_intptr_t              long
 #  define lzo_uintptr_t             unsigned long
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_LONG
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_LONG
 #elif (LZO_SIZEOF_LZO_INT64L_T >= LZO_SIZEOF_VOID_P)
 #  define lzo_intptr_t              lzo_int64l_t
 #  define lzo_uintptr_t             lzo_uint64l_t
 #  define LZO_SIZEOF_LZO_INTPTR_T   LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_TYPEOF_LZO_INTPTR_T   LZO_TYPEOF_LZO_INT64L_T
 #else
 #  error "lzo_intptr_t"
 #endif
@@ -2863,34 +3116,43 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #if (LZO_WORDSIZE == LZO_SIZEOF_LZO_INTPTR_T) && !(__LZO_INTPTR_T_IS_POINTER)
 #  define lzo_word_t                lzo_uintptr_t
 #  define lzo_sword_t               lzo_intptr_t
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_LZO_INTPTR_T
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_LZO_INTPTR_T
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_LZO_INTPTR_T
 #elif (LZO_WORDSIZE == LZO_SIZEOF_LONG)
 #  define lzo_word_t                unsigned long
 #  define lzo_sword_t               long
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_LONG
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_LONG
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_LONG
 #elif (LZO_WORDSIZE == LZO_SIZEOF_INT)
 #  define lzo_word_t                unsigned int
 #  define lzo_sword_t               int
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_INT
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_INT
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_INT
 #elif (LZO_WORDSIZE == LZO_SIZEOF_SHORT)
 #  define lzo_word_t                unsigned short
 #  define lzo_sword_t               short
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_SHORT
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_SHORT
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_SHORT
 #elif (LZO_WORDSIZE == 1)
 #  define lzo_word_t                unsigned char
 #  define lzo_sword_t               signed char
-#  define LZO_SIZEOF_LZO_WORD_T 1
+#  define LZO_SIZEOF_LZO_WORD_T     1
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF_CHAR
 #elif (LZO_WORDSIZE == LZO_SIZEOF_LZO_INT64L_T)
 #  define lzo_word_t                lzo_uint64l_t
 #  define lzo_sword_t               lzo_int64l_t
-#  define LZO_SIZEOF_LZO_WORD_T LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_SIZEOF_LZO_WORD_T     LZO_SIZEOF_LZO_INT64L_T
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_SIZEOF_LZO_INT64L_T
 #elif (LZO_ARCH_SPU) && (LZO_CC_GNUC)
 #if 0
+#  if !(LZO_LANG_ASSEMBLER)
    typedef unsigned lzo_word_t  __attribute__((__mode__(__V16QI__)));
    typedef int      lzo_sword_t __attribute__((__mode__(__V16QI__)));
+#  endif
 #  define lzo_word_t                lzo_word_t
 #  define lzo_sword_t               lzo_sword_t
 #  define LZO_SIZEOF_LZO_WORD_T     16
+#  define LZO_TYPEOF_LZO_WORD_T     LZO_TYPEOF___MODE_V16QI
 #endif
 #else
 #  error "lzo_word_t"
@@ -2905,6 +3167,7 @@ __lzo_gnuc_extension__ typedef unsigned long long lzo_ullong_t__;
 #define lzo_int8_t                  signed char
 #define lzo_uint8_t                 unsigned char
 #define LZO_SIZEOF_LZO_INT8_T       1
+#define LZO_TYPEOF_LZO_INT8_T       LZO_TYPEOF_CHAR
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int8_t) == 1)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int8_t) == sizeof(lzo_uint8_t))
 #endif
@@ -2912,6 +3175,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int8_t) == sizeof(lzo_uint8_t))
 #define lzo_int16_t                 lzo_int16e_t
 #define lzo_uint16_t                lzo_uint16e_t
 #define LZO_SIZEOF_LZO_INT16_T      LZO_SIZEOF_LZO_INT16E_T
+#define LZO_TYPEOF_LZO_INT16_T      LZO_TYPEOF_LZO_INT16E_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int16_t) == 2)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int16_t) == sizeof(lzo_uint16_t))
 #endif
@@ -2919,6 +3183,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int16_t) == sizeof(lzo_uint16_t))
 #define lzo_int32_t                 lzo_int32e_t
 #define lzo_uint32_t                lzo_uint32e_t
 #define LZO_SIZEOF_LZO_INT32_T      LZO_SIZEOF_LZO_INT32E_T
+#define LZO_TYPEOF_LZO_INT32_T      LZO_TYPEOF_LZO_INT32E_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int32_t) == 4)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int32_t) == sizeof(lzo_uint32_t))
 #endif
@@ -2926,6 +3191,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int32_t) == sizeof(lzo_uint32_t))
 #define lzo_int64_t                 lzo_int64e_t
 #define lzo_uint64_t                lzo_uint64e_t
 #define LZO_SIZEOF_LZO_INT64_T      LZO_SIZEOF_LZO_INT64E_T
+#define LZO_TYPEOF_LZO_INT64_T      LZO_TYPEOF_LZO_INT64E_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64_t) == 8)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64_t) == sizeof(lzo_uint64_t))
 #endif
@@ -2933,6 +3199,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int64_t) == sizeof(lzo_uint64_t))
 #define lzo_int_least32_t           lzo_int32l_t
 #define lzo_uint_least32_t          lzo_uint32l_t
 #define LZO_SIZEOF_LZO_INT_LEAST32_T LZO_SIZEOF_LZO_INT32L_T
+#define LZO_TYPEOF_LZO_INT_LEAST32_T LZO_TYPEOF_LZO_INT32L_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least32_t) >= 4)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least32_t) == sizeof(lzo_uint_least32_t))
 #endif
@@ -2940,6 +3207,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least32_t) == sizeof(lzo_uint_leas
 #define lzo_int_least64_t           lzo_int64l_t
 #define lzo_uint_least64_t          lzo_uint64l_t
 #define LZO_SIZEOF_LZO_INT_LEAST64_T LZO_SIZEOF_LZO_INT64L_T
+#define LZO_TYPEOF_LZO_INT_LEAST64_T LZO_TYPEOF_LZO_INT64L_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least64_t) >= 8)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least64_t) == sizeof(lzo_uint_least64_t))
 #endif
@@ -2947,6 +3215,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_least64_t) == sizeof(lzo_uint_leas
 #define lzo_int_fast32_t           lzo_int32f_t
 #define lzo_uint_fast32_t          lzo_uint32f_t
 #define LZO_SIZEOF_LZO_INT_FAST32_T LZO_SIZEOF_LZO_INT32F_T
+#define LZO_TYPEOF_LZO_INT_FAST32_T LZO_TYPEOF_LZO_INT32F_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast32_t) >= 4)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast32_t) == sizeof(lzo_uint_fast32_t))
 #endif
@@ -2954,6 +3223,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast32_t) == sizeof(lzo_uint_fast3
 #define lzo_int_fast64_t           lzo_int64f_t
 #define lzo_uint_fast64_t          lzo_uint64f_t
 #define LZO_SIZEOF_LZO_INT_FAST64_T LZO_SIZEOF_LZO_INT64F_T
+#define LZO_TYPEOF_LZO_INT_FAST64_T LZO_TYPEOF_LZO_INT64F_T
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast64_t) >= 8)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast64_t) == sizeof(lzo_uint_fast64_t))
 #endif
@@ -3020,7 +3290,7 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast64_t) == sizeof(lzo_uint_fast6
 #undef LZO_HAVE_CONFIG_H
 #include "minilzo.h"
 
-#if !defined(MINILZO_VERSION) || (MINILZO_VERSION != 0x2080)
+#if !defined(MINILZO_VERSION) || (MINILZO_VERSION != 0x20a0)
 #  error "version mismatch in miniLZO source files"
 #endif
 
@@ -3042,13 +3312,23 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast64_t) == sizeof(lzo_uint_fast6
 #if defined(__LZOCONF_H) || defined(__LZOCONF_H_INCLUDED)
 #  error "include this file first"
 #endif
-#include "lzo/lzoconf.h"
+#if defined(LZO_CFG_BUILD_DLL) && (LZO_CFG_BUILD_DLL+0) && !defined(__LZO_EXPORT1) && !defined(__LZO_EXPORT2) && 0
+#ifndef __LZODEFS_H_INCLUDED
+#if defined(LZO_HAVE_CONFIG_H)
+#  include <config.h>
+#endif
+#include <limits.h>
+#include <stddef.h>
+#include <lzo/lzodefs.h>
+#endif
+#endif
+#include <lzo/lzoconf.h>
 #if defined(LZO_CFG_EXTRA_CONFIG_HEADER2)
 #  include LZO_CFG_EXTRA_CONFIG_HEADER2
 #endif
 #endif
 
-#if (LZO_VERSION < 0x2080) || !defined(__LZOCONF_H_INCLUDED)
+#if !defined(__LZOCONF_H_INCLUDED) || (LZO_VERSION+0 != 0x20a0)
 #  error "version mismatch"
 #endif
 
@@ -3065,6 +3345,9 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast64_t) == sizeof(lzo_uint_fast6
 #if (LZO_CC_MSC && (_MSC_VER >= 1800))
 #  pragma warning(disable: 4746)
 #endif
+#if (LZO_CC_INTELC && (__INTEL_COMPILER >= 900))
+#  pragma warning(disable: 1684)
+#endif
 
 #if (LZO_CC_SUNPROC)
 #if !defined(__cplusplus)
@@ -3072,6 +3355,32 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(lzo_int_fast64_t) == sizeof(lzo_uint_fast6
 #  pragma error_messages(off,E_LOOP_NOT_ENTERED_AT_TOP)
 #  pragma error_messages(off,E_STATEMENT_NOT_REACHED)
 #endif
+#endif
+
+#if !defined(__LZO_NOEXPORT1)
+#  define __LZO_NOEXPORT1       /*empty*/
+#endif
+#if !defined(__LZO_NOEXPORT2)
+#  define __LZO_NOEXPORT2       /*empty*/
+#endif
+
+#if 1
+#  define LZO_PUBLIC_DECL(r)    LZO_EXTERN(r)
+#endif
+#if 1
+#  define LZO_PUBLIC_IMPL(r)    LZO_PUBLIC(r)
+#endif
+#if !defined(LZO_LOCAL_DECL)
+#  define LZO_LOCAL_DECL(r)     __LZO_EXTERN_C LZO_LOCAL_IMPL(r)
+#endif
+#if !defined(LZO_LOCAL_IMPL)
+#  define LZO_LOCAL_IMPL(r)     __LZO_NOEXPORT1 r __LZO_NOEXPORT2 __LZO_CDECL
+#endif
+#if 1
+#  define LZO_STATIC_DECL(r)    LZO_PRIVATE(r)
+#endif
+#if 1
+#  define LZO_STATIC_IMPL(r)    LZO_PRIVATE(r)
 #endif
 
 #if defined(__LZO_IN_MINILZO) || (LZO_CFG_FREESTANDING)
@@ -3269,6 +3578,9 @@ __lzo_static_forceinline unsigned lzo_bitops_ctlz32_func(lzo_uint32_t v)
 #elif (LZO_BITOPS_USE_GNUC_BITSCAN) && (LZO_SIZEOF_INT == 4)
     unsigned r; r = (unsigned) __builtin_clz(v); return r;
 #define lzo_bitops_ctlz32(v)    ((unsigned) __builtin_clz(v))
+#elif (LZO_BITOPS_USE_GNUC_BITSCAN) && (LZO_SIZEOF_LONG == 8) && (LZO_WORDSIZE >= 8)
+    unsigned r; r = (unsigned) __builtin_clzl(v); return r ^ 32;
+#define lzo_bitops_ctlz32(v)    (((unsigned) __builtin_clzl(v)) ^ 32)
 #else
     LZO_UNUSED(v); return 0;
 #endif
@@ -3338,25 +3650,20 @@ __lzo_static_forceinline unsigned lzo_bitops_cttz64_func(lzo_uint64_t v)
 }
 #endif
 
-#if 1 && (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || (LZO_CC_GNUC >= 0x020700ul) || LZO_CC_INTELC_GNUC || LZO_CC_LLVM || LZO_CC_PATHSCALE || LZO_CC_PGI)
-static void __attribute__((__unused__))
-#else
-__lzo_static_forceinline void
-#endif
-lzo_bitops_unused_funcs(void)
+lzo_unused_funcs_impl(void, lzo_bitops_unused_funcs)(void)
 {
+    LZO_UNUSED_FUNC(lzo_bitops_unused_funcs);
     LZO_UNUSED_FUNC(lzo_bitops_ctlz32_func);
     LZO_UNUSED_FUNC(lzo_bitops_cttz32_func);
 #if defined(lzo_uint64_t)
     LZO_UNUSED_FUNC(lzo_bitops_ctlz64_func);
     LZO_UNUSED_FUNC(lzo_bitops_cttz64_func);
 #endif
-    LZO_UNUSED_FUNC(lzo_bitops_unused_funcs);
 }
 
 #if defined(__lzo_alignof) && !(LZO_CFG_NO_UNALIGNED)
-#ifndef __lzo_memops_tcheck
-#define __lzo_memops_tcheck(t,a,b) ((void)0, sizeof(t) == (a) && __lzo_alignof(t) == (b))
+#if !defined(lzo_memops_tcheck__) && 0
+#define lzo_memops_tcheck__(t,a,b) ((void)0, sizeof(t) == (a) && __lzo_alignof(t) == (b))
 #endif
 #endif
 #ifndef lzo_memops_TU0p
@@ -3473,9 +3780,9 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(*(lzo_memops_TU1p)0)==1)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(*(lzo_memops_TU2p)0)==2)
 #define LZO_MEMOPS_COPY2(dd,ss) \
     * (lzo_memops_TU2p) (lzo_memops_TU0p) (dd) = * (const lzo_memops_TU2p) (const lzo_memops_TU0p) (ss)
-#elif defined(__lzo_memops_tcheck)
+#elif defined(lzo_memops_tcheck__)
 #define LZO_MEMOPS_COPY2(dd,ss) \
-    LZO_BLOCK_BEGIN if (__lzo_memops_tcheck(lzo_memops_TU2,2,1)) { \
+    LZO_BLOCK_BEGIN if (lzo_memops_tcheck__(lzo_memops_TU2,2,1)) { \
         * (lzo_memops_TU2p) (lzo_memops_TU0p) (dd) = * (const lzo_memops_TU2p) (const lzo_memops_TU0p) (ss); \
     } else { LZO_MEMOPS_MOVE2(dd,ss); } LZO_BLOCK_END
 #else
@@ -3485,9 +3792,9 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(*(lzo_memops_TU2p)0)==2)
 LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(*(lzo_memops_TU4p)0)==4)
 #define LZO_MEMOPS_COPY4(dd,ss) \
     * (lzo_memops_TU4p) (lzo_memops_TU0p) (dd) = * (const lzo_memops_TU4p) (const lzo_memops_TU0p) (ss)
-#elif defined(__lzo_memops_tcheck)
+#elif defined(lzo_memops_tcheck__)
 #define LZO_MEMOPS_COPY4(dd,ss) \
-    LZO_BLOCK_BEGIN if (__lzo_memops_tcheck(lzo_memops_TU4,4,1)) { \
+    LZO_BLOCK_BEGIN if (lzo_memops_tcheck__(lzo_memops_TU4,4,1)) { \
         * (lzo_memops_TU4p) (lzo_memops_TU0p) (dd) = * (const lzo_memops_TU4p) (const lzo_memops_TU0p) (ss); \
     } else { LZO_MEMOPS_MOVE4(dd,ss); } LZO_BLOCK_END
 #else
@@ -3504,9 +3811,9 @@ LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(*(lzo_memops_TU8p)0)==8)
 #elif (LZO_OPT_UNALIGNED32)
 #define LZO_MEMOPS_COPY8(dd,ss) \
     LZO_BLOCK_BEGIN LZO_MEMOPS_COPY4(dd,ss); LZO_MEMOPS_COPY4((lzo_memops_TU1p)(lzo_memops_TU0p)(dd)+4,(const lzo_memops_TU1p)(const lzo_memops_TU0p)(ss)+4); LZO_BLOCK_END
-#elif defined(__lzo_memops_tcheck)
+#elif defined(lzo_memops_tcheck__)
 #define LZO_MEMOPS_COPY8(dd,ss) \
-    LZO_BLOCK_BEGIN if (__lzo_memops_tcheck(lzo_memops_TU8,8,1)) { \
+    LZO_BLOCK_BEGIN if (lzo_memops_tcheck__(lzo_memops_TU8,8,1)) { \
         * (lzo_memops_TU8p) (lzo_memops_TU0p) (dd) = * (const lzo_memops_TU8p) (const lzo_memops_TU0p) (ss); \
     } else { LZO_MEMOPS_MOVE8(dd,ss); } LZO_BLOCK_END
 #else
@@ -3540,7 +3847,7 @@ __lzo_static_forceinline lzo_uint16_t lzo_memops_get_le16(const lzo_voidp ss)
     return v;
 }
 #if (LZO_OPT_UNALIGNED16) && (LZO_ABI_LITTLE_ENDIAN)
-#define LZO_MEMOPS_GET_LE16(ss)    * (const lzo_memops_TU2p) (const lzo_memops_TU0p) (ss)
+#define LZO_MEMOPS_GET_LE16(ss)    (* (const lzo_memops_TU2p) (const lzo_memops_TU0p) (ss))
 #else
 #define LZO_MEMOPS_GET_LE16(ss)    lzo_memops_get_le16(ss)
 #endif
@@ -3562,13 +3869,13 @@ __lzo_static_forceinline lzo_uint32_t lzo_memops_get_le32(const lzo_voidp ss)
     return v;
 }
 #if (LZO_OPT_UNALIGNED32) && (LZO_ABI_LITTLE_ENDIAN)
-#define LZO_MEMOPS_GET_LE32(ss)    * (const lzo_memops_TU4p) (const lzo_memops_TU0p) (ss)
+#define LZO_MEMOPS_GET_LE32(ss)    (* (const lzo_memops_TU4p) (const lzo_memops_TU0p) (ss))
 #else
 #define LZO_MEMOPS_GET_LE32(ss)    lzo_memops_get_le32(ss)
 #endif
 
 #if (LZO_OPT_UNALIGNED64) && (LZO_ABI_LITTLE_ENDIAN)
-#define LZO_MEMOPS_GET_LE64(ss)    * (const lzo_memops_TU8p) (const lzo_memops_TU0p) (ss)
+#define LZO_MEMOPS_GET_LE64(ss)    (* (const lzo_memops_TU8p) (const lzo_memops_TU0p) (ss))
 #endif
 
 __lzo_static_forceinline lzo_uint16_t lzo_memops_get_ne16(const lzo_voidp ss)
@@ -3578,7 +3885,8 @@ __lzo_static_forceinline lzo_uint16_t lzo_memops_get_ne16(const lzo_voidp ss)
     return v;
 }
 #if (LZO_OPT_UNALIGNED16)
-#define LZO_MEMOPS_GET_NE16(ss)    * (const lzo_memops_TU2p) (const lzo_memops_TU0p) (ss)
+LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(*(lzo_memops_TU2p)0)==2)
+#define LZO_MEMOPS_GET_NE16(ss)    (* (const lzo_memops_TU2p) (const lzo_memops_TU0p) (ss))
 #else
 #define LZO_MEMOPS_GET_NE16(ss)    lzo_memops_get_ne16(ss)
 #endif
@@ -3590,13 +3898,15 @@ __lzo_static_forceinline lzo_uint32_t lzo_memops_get_ne32(const lzo_voidp ss)
     return v;
 }
 #if (LZO_OPT_UNALIGNED32)
-#define LZO_MEMOPS_GET_NE32(ss)    * (const lzo_memops_TU4p) (const lzo_memops_TU0p) (ss)
+LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(*(lzo_memops_TU4p)0)==4)
+#define LZO_MEMOPS_GET_NE32(ss)    (* (const lzo_memops_TU4p) (const lzo_memops_TU0p) (ss))
 #else
 #define LZO_MEMOPS_GET_NE32(ss)    lzo_memops_get_ne32(ss)
 #endif
 
 #if (LZO_OPT_UNALIGNED64)
-#define LZO_MEMOPS_GET_NE64(ss)    * (const lzo_memops_TU8p) (const lzo_memops_TU0p) (ss)
+LZO_COMPILE_TIME_ASSERT_HEADER(sizeof(*(lzo_memops_TU8p)0)==8)
+#define LZO_MEMOPS_GET_NE64(ss)    (* (const lzo_memops_TU8p) (const lzo_memops_TU0p) (ss))
 #endif
 
 __lzo_static_forceinline void lzo_memops_put_le16(lzo_voidp dd, lzo_uint16_t vv)
@@ -3661,13 +3971,9 @@ __lzo_static_forceinline void lzo_memops_put_ne32(lzo_voidp dd, lzo_uint32_t vv)
 #define LZO_MEMOPS_PUT_NE32(dd,vv) lzo_memops_put_ne32(dd,vv)
 #endif
 
-#if 1 && (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || (LZO_CC_GNUC >= 0x020700ul) || LZO_CC_INTELC_GNUC || LZO_CC_LLVM || LZO_CC_PATHSCALE || LZO_CC_PGI)
-static void __attribute__((__unused__))
-#else
-__lzo_static_forceinline void
-#endif
-lzo_memops_unused_funcs(void)
+lzo_unused_funcs_impl(void, lzo_memops_unused_funcs)(void)
 {
+    LZO_UNUSED_FUNC(lzo_memops_unused_funcs);
     LZO_UNUSED_FUNC(lzo_memops_get_le16);
     LZO_UNUSED_FUNC(lzo_memops_get_le32);
     LZO_UNUSED_FUNC(lzo_memops_get_ne16);
@@ -3676,7 +3982,6 @@ lzo_memops_unused_funcs(void)
     LZO_UNUSED_FUNC(lzo_memops_put_le32);
     LZO_UNUSED_FUNC(lzo_memops_put_ne16);
     LZO_UNUSED_FUNC(lzo_memops_put_ne32);
-    LZO_UNUSED_FUNC(lzo_memops_unused_funcs);
 }
 
 #endif
@@ -3889,11 +4194,16 @@ __lzo_align_gap(const lzo_voidp ptr, lzo_uint size)
 #error "__LZO_UINTPTR_T_IS_POINTER is unsupported"
 #else
     lzo_uintptr_t p, n;
+    if (size < 2) return 0;
     p = __lzo_ptr_linear(ptr);
+#if 0
     n = (((p + size - 1) / size) * size) - p;
+#else
+    if ((size & (size - 1)) != 0)
+        return 0;
+    n = size; n = ((p + n - 1) & ~(n - 1)) - p;
 #endif
-
-    assert(size > 0);
+#endif
     assert((long)n >= 0);
     assert(n <= size);
     return (unsigned)n;
@@ -3906,23 +4216,25 @@ __lzo_align_gap(const lzo_voidp ptr, lzo_uint size)
  * keep this copyright string in the executable of your product.
  */
 
-static const char __lzo_copyright[] =
+static const char lzo_copyright_[] =
 #if !defined(__LZO_IN_MINLZO)
     LZO_VERSION_STRING;
 #else
     "\r\n\n"
     "LZO data compression library.\n"
-    "$Copyright: LZO Copyright (C) 1996-2014 Markus Franz Xaver Johannes Oberhumer\n"
+    "$Copyright: LZO Copyright (C) 1996-2017 Markus Franz Xaver Johannes Oberhumer\n"
     "<markus@oberhumer.com>\n"
     "http://www.oberhumer.com $\n\n"
-    "$Id$\n"
+    "$Id: LZO version: v" LZO_VERSION_STRING ", " LZO_VERSION_DATE " $\n"
     "$Info: " LZO_INFO_STRING " $\n";
 #endif
+static const char lzo_version_string_[] = LZO_VERSION_STRING;
+static const char lzo_version_date_[] = LZO_VERSION_DATE;
 
 LZO_PUBLIC(const lzo_bytep)
 lzo_copyright(void)
 {
-    return (const lzo_bytep) __lzo_copyright;
+    return (const lzo_bytep) lzo_copyright_;
 }
 
 LZO_PUBLIC(unsigned)
@@ -3934,25 +4246,25 @@ lzo_version(void)
 LZO_PUBLIC(const char *)
 lzo_version_string(void)
 {
-    return LZO_VERSION_STRING;
+    return lzo_version_string_;
 }
 
 LZO_PUBLIC(const char *)
 lzo_version_date(void)
 {
-    return LZO_VERSION_DATE;
+    return lzo_version_date_;
 }
 
 LZO_PUBLIC(const lzo_charp)
 _lzo_version_string(void)
 {
-    return LZO_VERSION_STRING;
+    return lzo_version_string_;
 }
 
 LZO_PUBLIC(const lzo_charp)
 _lzo_version_date(void)
 {
-    return LZO_VERSION_DATE;
+    return lzo_version_date_;
 }
 
 #define LZO_BASE 65521u
@@ -4324,7 +4636,7 @@ int __far __pascal LibMain ( int a, short b, short c, long d )
 #endif
 
 #if !defined(__LZO_IN_MINILZO)
-#include "lzo/lzo1x.h"
+#include <lzo/lzo1x.h>
 #endif
 
 #ifndef LZO_EOF_CODE
@@ -4516,7 +4828,7 @@ extern "C" {
 
 #if !defined(DVAL_ASSERT)
 #if defined(__LZO_HASH_INCREMENTAL) && !defined(NDEBUG)
-#if (LZO_CC_CLANG || (LZO_CC_GNUC >= 0x020700ul) || LZO_CC_LLVM)
+#if 1 && (LZO_CC_ARMCC_GNUC || LZO_CC_CLANG || (LZO_CC_GNUC >= 0x020700ul) || LZO_CC_INTELC_GNUC || LZO_CC_LLVM || LZO_CC_PATHSCALE || LZO_CC_PGI)
 static void __attribute__((__unused__))
 #else
 static void

--- a/libraries/minilzo/minilzo.h
+++ b/libraries/minilzo/minilzo.h
@@ -2,7 +2,7 @@
 
    This file is part of the LZO real-time data compression library.
 
-   Copyright (C) 1996-2014 Markus Franz Xaver Johannes Oberhumer
+   Copyright (C) 1996-2017 Markus Franz Xaver Johannes Oberhumer
    All Rights Reserved.
 
    The LZO library is free software; you can redistribute it and/or
@@ -32,15 +32,25 @@
  */
 
 
-#ifndef __MINILZO_H
-#define __MINILZO_H 1
+#ifndef __MINILZO_H_INCLUDED
+#define __MINILZO_H_INCLUDED 1
 
-#define MINILZO_VERSION         0x2080
+#define MINILZO_VERSION         0x20a0  /* 2.10 */
 
-#ifdef __LZOCONF_H
+#if defined(__LZOCONF_H_INCLUDED)
 #  error "you cannot use both LZO and miniLZO"
 #endif
 
+/* internal Autoconf configuration file - only used when building miniLZO */
+#ifdef MINILZO_HAVE_CONFIG_H
+#  include <config.h>
+#endif
+#include <limits.h>
+#include <stddef.h>
+
+#ifndef __LZODEFS_H_INCLUDED
+#include "lzodefs.h"
+#endif
 #undef LZO_HAVE_CONFIG_H
 #include "lzoconf.h"
 
@@ -92,3 +102,5 @@ lzo1x_decompress_safe   ( const lzo_bytep src, lzo_uint  src_len,
 
 #endif /* already included */
 
+
+/* vim:set ts=4 sw=4 et: */

--- a/libraries/minilzo/testmini.c
+++ b/libraries/minilzo/testmini.c
@@ -1,0 +1,148 @@
+/* testmini.c -- very simple test program for the miniLZO library
+
+   This file is part of the LZO real-time data compression library.
+
+   Copyright (C) 1996-2017 Markus Franz Xaver Johannes Oberhumer
+   All Rights Reserved.
+
+   The LZO library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of
+   the License, or (at your option) any later version.
+
+   The LZO library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with the LZO library; see the file COPYING.
+   If not, write to the Free Software Foundation, Inc.,
+   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+   Markus F.X.J. Oberhumer
+   <markus@oberhumer.com>
+   http://www.oberhumer.com/opensource/lzo/
+ */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+
+
+/*************************************************************************
+// This program shows the basic usage of the LZO library.
+// We will compress a block of data and decompress again.
+//
+// For more information, documentation, example programs and other support
+// files (like Makefiles and build scripts) please download the full LZO
+// package from
+//    http://www.oberhumer.com/opensource/lzo/
+**************************************************************************/
+
+/* First let's include "minizo.h". */
+
+#include "minilzo.h"
+
+
+/* We want to compress the data block at 'in' with length 'IN_LEN' to
+ * the block at 'out'. Because the input block may be incompressible,
+ * we must provide a little more output space in case that compression
+ * is not possible.
+ */
+
+#define IN_LEN      (128*1024ul)
+#define OUT_LEN     (IN_LEN + IN_LEN / 16 + 64 + 3)
+
+static unsigned char __LZO_MMODEL in  [ IN_LEN ];
+static unsigned char __LZO_MMODEL out [ OUT_LEN ];
+
+
+/* Work-memory needed for compression. Allocate memory in units
+ * of 'lzo_align_t' (instead of 'char') to make sure it is properly aligned.
+ */
+
+#define HEAP_ALLOC(var,size) \
+    lzo_align_t __LZO_MMODEL var [ ((size) + (sizeof(lzo_align_t) - 1)) / sizeof(lzo_align_t) ]
+
+static HEAP_ALLOC(wrkmem, LZO1X_1_MEM_COMPRESS);
+
+
+/*************************************************************************
+//
+**************************************************************************/
+
+int main(int argc, char *argv[])
+{
+    int r;
+    lzo_uint in_len;
+    lzo_uint out_len;
+    lzo_uint new_len;
+
+    if (argc < 0 && argv == NULL)   /* avoid warning about unused args */
+        return 0;
+
+    printf("\nLZO real-time data compression library (v%s, %s).\n",
+           lzo_version_string(), lzo_version_date());
+    printf("Copyright (C) 1996-2017 Markus Franz Xaver Johannes Oberhumer\nAll Rights Reserved.\n\n");
+
+
+/*
+ * Step 1: initialize the LZO library
+ */
+    if (lzo_init() != LZO_E_OK)
+    {
+        printf("internal error - lzo_init() failed !!!\n");
+        printf("(this usually indicates a compiler bug - try recompiling\nwithout optimizations, and enable '-DLZO_DEBUG' for diagnostics)\n");
+        return 3;
+    }
+
+/*
+ * Step 2: prepare the input block that will get compressed.
+ *         We just fill it with zeros in this example program,
+ *         but you would use your real-world data here.
+ */
+    in_len = IN_LEN;
+    lzo_memset(in,0,in_len);
+
+/*
+ * Step 3: compress from 'in' to 'out' with LZO1X-1
+ */
+    r = lzo1x_1_compress(in,in_len,out,&out_len,wrkmem);
+    if (r == LZO_E_OK)
+        printf("compressed %lu bytes into %lu bytes\n",
+            (unsigned long) in_len, (unsigned long) out_len);
+    else
+    {
+        /* this should NEVER happen */
+        printf("internal error - compression failed: %d\n", r);
+        return 2;
+    }
+    /* check for an incompressible block */
+    if (out_len >= in_len)
+    {
+        printf("This block contains incompressible data.\n");
+        return 0;
+    }
+
+/*
+ * Step 4: decompress again, now going from 'out' to 'in'
+ */
+    new_len = in_len;
+    r = lzo1x_decompress(out,out_len,in,&new_len,NULL);
+    if (r == LZO_E_OK && new_len == in_len)
+        printf("decompressed %lu bytes back into %lu bytes\n",
+            (unsigned long) out_len, (unsigned long) in_len);
+    else
+    {
+        /* this should NEVER happen */
+        printf("internal error - decompression failed: %d\n", r);
+        return 1;
+    }
+
+    printf("\nminiLZO simple compression test passed.\n");
+    return 0;
+}
+
+
+/* vim:set ts=4 sw=4 et: */

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -52,6 +52,7 @@ if(WIN32)
   target_include_directories(odasrv PRIVATE win32)
 endif()
 target_link_libraries(odasrv ZLIB::ZLIB odamex-common odaproto)
+target_link_libraries(odasrv minilzo)
 
 if(USE_INTERNAL_JSONCPP)
   target_link_libraries(odasrv jsoncpp_lib_static)


### PR DESCRIPTION
`minilzo` was previously compiled inside the `common` directory.  This commit moves the library out to a separate location, as well as ensuring that we're using the latest released version.