### PR TITLE
[BUGFIX] Correct aspect ratio of widescreen assets

### DIFF
--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -543,7 +543,7 @@ void D_DoAdvanceDemo (void)
 		const patch_t* patch = W_CachePatch(pagename);
 
 		page_width = patch->width();
-		page_height = patch->height();
+		page_height = patch->height() + (patch->height() / 5);
 
 		I_FreeSurface(page_surface);
 

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -645,7 +645,7 @@ void F_CastDrawer()
 	const patch_t* background_patch = W_CachePatch("BOSSBACK");
 
 	finale_width = background_patch->width();
-	finale_height = background_patch->height();
+	finale_height = background_patch->height() + (background_patch->height() / 5);
 
 	I_FreeSurface(cast_surface);
 	cast_surface = I_AllocateSurface(finale_width, finale_height, 8);
@@ -710,7 +710,7 @@ void F_BunnyScroll()
 	// PFUB2 and PFUB1 should be the same width
 
 	int bunnywidth = p1->width();
-	int bunnyheight = p1->height();
+	int bunnyheight = p1->height() + (p1->height() / 5);
 
 	bunny1_surface = I_AllocateSurface(bunnywidth, bunnyheight, 8);
 	bunny2_surface = I_AllocateSurface(bunnywidth, bunnyheight, 8);
@@ -827,7 +827,7 @@ void F_DrawEndPic(const char* page)
 	const patch_t* background_patch = W_CachePatch(page);
 
 	finale_width = background_patch->width();
-	finale_height = background_patch->height();
+	finale_height = background_patch->height() + (background_patch->height() / 5);
 
 	I_FreeSurface(finale_surface);
 	finale_surface = I_AllocateSurface(finale_width, finale_height, 8);

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1328,7 +1328,7 @@ void WI_updateStats()
 				const patch_t* bg_patch = W_CachePatch(name.c_str());
 
 				inter_width = bg_patch->width();
-				inter_height = bg_patch->height();
+				inter_height = bg_patch->height() + (bg_patch->height() / 5);
 
 				background_surface =
 				    I_AllocateSurface(bg_patch->width(), bg_patch->height(), 8);


### PR DESCRIPTION
Currently, widescreen assets don't stretch as tall pixels like Doom did (it rendered on 320x200 but on 320x240 monitors, so it was stretched 20% vertically)

This emulates that behavior for widescreen assets.

(old)
![image](https://github.com/user-attachments/assets/48a68011-f593-411f-ae95-c882e9214c35)

vs

(new)
![image](https://github.com/user-attachments/assets/214bd22a-2698-4c6a-801a-43d1428d5786)
