### PR TITLE
Various minor control changes and fixes

### DIFF
--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -61,6 +61,7 @@ OBinding DefaultBindings[] =
 	{"leftalt", "+strafe"},
 	{"leftshift", "+speed"},
 	{"rightshift", "+speed"},
+	{"capslock", "toggleautorun"},
 	{"space", "+use"},
 	{"e", "+use"},
 	{"uparrow", "+forward"},
@@ -648,7 +649,7 @@ BEGIN_COMMAND(unambind)
 
 		if (iequals(lostr, "all"))
 			AutomapBindings.UnbindAll();
-		else 
+		else
 			AutomapBindings.UnbindKey(argv[1]);
 	}
 }

--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -65,7 +65,7 @@ OBinding DefaultBindings[] =
 	{"space", "+use"},
 	{"e", "+use"},
 	{"uparrow", "+forward"},
-	{"backarrow", "+back"},
+	{"downarrow", "+back"},
 	{"rightarrow", "+right"},
 	{"leftarrow", "+left"},
 	{"w", "+forward"},

--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -61,7 +61,7 @@ OBinding DefaultBindings[] =
 	{"leftalt", "+strafe"},
 	{"leftshift", "+speed"},
 	{"rightshift", "+speed"},
-	{"capslock", "toggleautorun"},
+	{"capslock", "togglerun"},
 	{"space", "+use"},
 	{"e", "+use"},
 	{"uparrow", "+forward"},

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -260,7 +260,7 @@ CVAR(				cl_disconnectalert, "1", "Plays a sound when a player quits",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
 CVAR_RANGE			(cl_chatsounds, "1", "Plays a sound when a chat message appears (0 = never, 1 = always, " \
-					"2 = only teamchat)", 
+					"2 = only teamchat)",
 					CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
 
 CVAR_RANGE(			cl_switchweapon, "1", "Switch upon weapon pickup (0 = never, 1 = always, " \
@@ -407,7 +407,7 @@ CVAR(				chasedemo, "0", "",
 CVAR(				cl_run, "1", "Always run",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)		// Always run? // [Toke - Defaults]
 
-CVAR(in_autosr50, "1", "+strife activates automatic SR50", CVARTYPE_BOOL,
+CVAR(in_autosr50, "1", "+strafe activates automatic SR50", CVARTYPE_BOOL,
      CVAR_CLIENTARCHIVE)
 
 CVAR(				cl_showspawns, "0", "Show spawn points as particle fountains",

--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -338,6 +338,17 @@ BEGIN_COMMAND (weapprev)
 }
 END_COMMAND (weapprev)
 
+BEGIN_COMMAND (toggleautorun)
+{
+	cvar_t *var = &cl_run;
+
+	var->Set(!var->value());
+
+	Printf(PRINT_HIGH, "Always run %s\n",
+			var->value() ? "on" : "off");
+}
+END_COMMAND (toggleautorun)
+
 extern constate_e ConsoleState;
 
 //
@@ -540,7 +551,7 @@ void G_BuildTiccmd(ticcmd_t *cmd)
 		forward -= (int)(((float)joyforward / (float)SHRT_MAX) * forwardmove[speed]);
 	}
 
-	if (!consoleplayer().spectator 
+	if (!consoleplayer().spectator
 		&& !Actions[ACTION_MLOOK] && !cl_mouselook && novert == 0)		// [Toke - Mouse] acts like novert.exe
 	{
 		forward += (int)(float(mousey) * m_forward);
@@ -598,7 +609,7 @@ void G_BuildTiccmd(ticcmd_t *cmd)
 		// [AM] LocalViewPitch is an offset on look.
 		cmd->pitch = look + (::localview.pitch >> 16);
 	}
-	
+
 	if (::localview.setangle)
 	{
 		// [AM] LocalViewAngle is a global angle, only pave over the existing
@@ -862,7 +873,7 @@ void G_Ticker (void)
 		{
 			if (it->ingame() && (it->playerstate == PST_REBORN || it->playerstate == PST_ENTER))
 			{
-				if (it->playerstate == PST_REBORN)	
+				if (it->playerstate == PST_REBORN)
 					it->doreborn = true;			// State only our will to lose the whole inventory in case of a reborn.
 				G_DoReborn(*it);
 			}
@@ -1184,7 +1195,7 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 		p.weaponowned[i] = false;
 
 	if (!sv_keepkeys && !sv_sharekeys)
-		P_ClearPlayerCards(p); 
+		P_ClearPlayerCards(p);
 
 	P_ClearPlayerPowerups(p);
 
@@ -1615,7 +1626,7 @@ void G_SaveGame (int slot, char *description)
 
 /**
  * @brief Create a filename for a savegame.
- * 
+ *
  * @param name Output string.
  * @param slot Slot number.
  */
@@ -1823,7 +1834,7 @@ void G_DoPlayDemo(bool justStreamInput)
 	else
 	{
 		// [RH] Allow for demos not loaded as lumps
-		std::string found = M_FindUserFileName(::defdemoname, ".lmp"); 
+		std::string found = M_FindUserFileName(::defdemoname, ".lmp");
 		if (found.empty())
 		{
 			Printf(PRINT_WARNING, "Could not find demo %s\n", ::defdemoname.c_str());
@@ -1912,7 +1923,7 @@ void G_DoPlayDemo(bool justStreamInput)
 				multiplayer = true;
 			else
 				multiplayer = false;
-	
+
 			serverside = true;
 
 			// [SL] 2012-12-26 - Backup any cvars that need to be set to default to
@@ -1993,7 +2004,7 @@ void G_TimeDemo(const char* name)
 	defdemoname = name;
 	gameaction = ga_playdemo;
 
-	IWindow* window = I_GetWindow();	
+	IWindow* window = I_GetWindow();
 	if (noblit)
 		window->disableRefresh();
 	else

--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -338,14 +338,14 @@ BEGIN_COMMAND (weapprev)
 }
 END_COMMAND (weapprev)
 
-BEGIN_COMMAND (toggleautorun)
+BEGIN_COMMAND (togglerun)
 {
 	cl_run.Set(!cl_run.value());
 
 	Printf(PRINT_HIGH, "Always run %s\n",
 			cl_run.value() ? "on" : "off");
 }
-END_COMMAND (toggleautorun)
+END_COMMAND (togglerun)
 
 extern constate_e ConsoleState;
 

--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -340,12 +340,10 @@ END_COMMAND (weapprev)
 
 BEGIN_COMMAND (toggleautorun)
 {
-	cvar_t *var = &cl_run;
-
-	var->Set(!var->value());
+	cl_run.Set(!cl_run.value());
 
 	Printf(PRINT_HIGH, "Always run %s\n",
-			var->value() ? "on" : "off");
+			cl_run.value() ? "on" : "off");
 }
 END_COMMAND (toggleautorun)
 

--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -388,18 +388,18 @@ void G_BuildTiccmd(ticcmd_t *cmd)
 	// let movement keys cancel each other out
 	if (strafe)
 	{
-		if (in_autosr50)
-		{
-			if (Actions[ACTION_MOVERIGHT])
-				side += sidemove[speed];
-			if (Actions[ACTION_MOVELEFT])
-				side -= sidemove[speed];
-		}
-		else
+		if (Actions[ACTION_RIGHT] || Actions[ACTION_LEFT])
 		{
 			if (Actions[ACTION_RIGHT])
 				side += sidemove[speed];
 			if (Actions[ACTION_LEFT])
+				side -= sidemove[speed];
+		}
+		else if (in_autosr50)
+		{
+			if (Actions[ACTION_MOVERIGHT])
+				side += sidemove[speed];
+			if (Actions[ACTION_MOVELEFT])
 				side -= sidemove[speed];
 		}
 	}

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -337,7 +337,7 @@ static menuitem_t ControlsItems[] = {
 	{ control,	"Turn left",			{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+left"} },
 	{ control,	"Turn right",			{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+right"} },
 	{ control,	"Run",					{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+speed"} },
-	{ control,	"Always Run",			{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"toggleautorun"} },
+	{ control,	"Always Run",			{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"togglerun"} },
 	{ control,	"Strafe",				{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+strafe"} },
 	{ control,	"Jump",					{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+jump"} },
 	{ control,	"Turn 180",				{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"turn180"} },

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -337,6 +337,7 @@ static menuitem_t ControlsItems[] = {
 	{ control,	"Turn left",			{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+left"} },
 	{ control,	"Turn right",			{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+right"} },
 	{ control,	"Run",					{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+speed"} },
+	{ control,	"Always Run",			{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"toggleautorun"} },
 	{ control,	"Strafe",				{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+strafe"} },
 	{ control,	"Jump",					{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"+jump"} },
 	{ control,	"Turn 180",				{NULL}, {0.0}, {0.0}, {0.0}, {(value_t *)"turn180"} },
@@ -1127,7 +1128,7 @@ static value_t VidFPSCaps[] = {
 	{ 60.0,		"60fps" },
 	{ 70.0,		"70fps" },
    	{ 105.0,	"105fps"},
-	{ 120.0,	"120fps" }, 
+	{ 120.0,	"120fps" },
 	{ 140.0,	"140fps"},
     	{ 144.0,	"144fps"},
     	{ 240.0,	"240fps"},
@@ -2004,7 +2005,7 @@ void M_OptResponder (event_t *ev)
 				S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
 			}
 		}
-		else if (Key_IsPageDownKey(ch, numlock)) 
+		else if (Key_IsPageDownKey(ch, numlock))
 		{
 			if (CanScrollDown)
 			{


### PR DESCRIPTION
Many other ports and games have caps lock by default bound to toggle running, and I believe Odamex should as well. Having it as a control in the key bindings menu, I think it should also have a nicer message than `"CL_RUN" IS ENABLED/DISABLED`, so with this change it displays `ALWAYS RUN ON/OFF`.

There are also a couple other minor changes here:
`+back` is now by default bound to `downarrow` instead of `backarrow`, as the latter is not a valid key.
`+right` and `+left` no longer do nothing when auto SR50 is enabled and `+strafe` is held.