### PR TITLE
[BUGFIX] Fix pitch in MBF21 Monster Projectiles

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -1970,7 +1970,7 @@ void A_MonsterProjectile(AActor* actor)
 
 	// adjust pitch (approximated, using Doom's ye olde
 	// finetangent table; same method as monster aim)
-	mo->momz += FixedMul(mo->info->speed, pitch);
+	mo->momz += FixedMul(mo->info->speed, DegToSlope(pitch));
 
 	// adjust position
 	an = (actor->angle - ANG90) >> ANGLETOFINESHIFT;


### PR DESCRIPTION
Small fix for pitch in MBF21 monster projectiles (P_MonsterProjectile), the pitch degree wasn't being converted to slope. This fixes that.

Before:

https://github.com/user-attachments/assets/41085eb4-af82-4545-8dd6-7d023fc785f0

After:

https://github.com/user-attachments/assets/0c90bf6d-af33-4576-ad1e-3fab42062c7c

