### PR TITLE
[BUGFIX] Fix wad command

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -137,8 +137,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 
 	C_HideConsole();
 
-	std::string str = JoinStrings(VectorArgs(argc, argv), " ");
-	std::string wadstr = C_QuoteString(str);
+	std::string wadstr = C_EscapeWadList(VectorArgs(argc, argv));
 	G_LoadWadString(wadstr);
 
 	D_StartTitle ();

--- a/common/c_dispatch.cpp
+++ b/common/c_dispatch.cpp
@@ -810,6 +810,22 @@ std::string C_QuoteString(const std::string &argstr)
 	return buffer.str();
 }
 
+// Take a string of inputted WADs and escape them indvidually
+// and add a space before loading them into the system.
+std::string C_EscapeWadList(const std::vector<std::string> wadlist)
+{
+	std::string wadstr;
+	for (size_t i = 0; i < wadlist.size(); i++)
+	{
+		if (i != 0)
+		{
+			wadstr += " ";
+		}
+		wadstr += C_QuoteString(wadlist.at(i));
+	}
+	return wadstr;
+}
+
 static int DumpHash (BOOL aliases)
 {
 	int count = 0;

--- a/common/c_dispatch.h
+++ b/common/c_dispatch.h
@@ -42,6 +42,9 @@ std::string BuildString (size_t argc, std::vector<std::string> args);
 // quote a string
 std::string C_QuoteString(const std::string &argstr);
 
+// escape a list of wads
+std::string C_EscapeWadList(const std::vector<std::string> wadlist);
+
 class DConsoleCommand : public DObject
 {
 	DECLARE_CLASS (DConsoleCommand, DObject)

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -173,8 +173,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	    return;
 	}
 
-	std::string str = JoinStrings(VectorArgs(argc, argv), " ");
-	std::string wadstr = C_QuoteString(str);
+	std::string wadstr = C_EscapeWadList(VectorArgs(argc, argv));
 	G_LoadWadString(wadstr);
 }
 END_COMMAND (wad)
@@ -239,15 +238,7 @@ void G_ChangeMap()
 
 		if (!Maplist::instance().lobbyempty())
 		{
-			std::string wadstr;
-			for (size_t i = 0; i < lobby_entry.wads.size(); i++)
-			{
-				if (i != 0)
-				{
-					wadstr += " ";
-				}
-				wadstr += C_QuoteString(lobby_entry.wads.at(i));
-			}
+			std::string wadstr = C_EscapeWadList(lobby_entry.wads);
 			G_LoadWadString(wadstr, lobby_entry.map);
 		}
 		else
@@ -264,15 +255,7 @@ void G_ChangeMap()
 				maplist_entry_t maplist_entry;
 				Maplist::instance().get_map_by_index(next_index, maplist_entry);
 
-				std::string wadstr;
-				for (size_t i = 0; i < maplist_entry.wads.size(); i++)
-				{
-					if (i != 0)
-					{
-						wadstr += " ";
-					}
-					wadstr += C_QuoteString(maplist_entry.wads.at(i));
-				}
+				std::string wadstr = C_EscapeWadList(maplist_entry.wads);
 				G_LoadWadString(wadstr, maplist_entry.map);
 
 				// Set the new map as the current map
@@ -298,16 +281,7 @@ void G_ChangeMap(size_t index) {
 		return;
 	}
 
-	std::string wadstr;
-	for (size_t i = 0; i < maplist_entry.wads.size(); i++)
-	{
-		if (i != 0)
-		{
-			wadstr += " ";
-		}
-		wadstr += C_QuoteString(maplist_entry.wads.at(i));
-	}
-
+	std::string wadstr = C_EscapeWadList(maplist_entry.wads);
 	G_LoadWadString(wadstr, maplist_entry.map);
 
 	// Set the new map as the current map

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4273,15 +4273,7 @@ void SV_RunTics()
 
 		if (!Maplist::instance().lobbyempty())
 		{
-			std::string wadstr;
-			for (size_t i = 0; i < lobby_entry.wads.size(); i++)
-			{
-				if (i != 0)
-				{
-					wadstr += " ";
-				}
-				wadstr += C_QuoteString(lobby_entry.wads.at(i));
-			}
+			std::string wadstr = C_EscapeWadList(lobby_entry.wads);
 			G_LoadWadString(wadstr, lobby_entry.map);
 		}
 		else


### PR DESCRIPTION
This PR fixes the wad command from previous changes. Previously the wad command would take the entire line as a potential WAD. I've fixed this to treat it like the maplist, where wads are split up into tokens unless not broken up by a quotes ("). I also made this into a function since it happens 6 times in the codebase and there's no function for it yet.

![image](https://github.com/user-attachments/assets/c1306936-81bd-4e66-b319-69846fd215db)
