### PR TITLE
[BUGFIX] Fix Boom shootable line specials not being repeatable

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -442,7 +442,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		{
 			return true;
 			//line->special = 0;
-		}						
+		}
 		break;
 
 	case 40:
@@ -470,7 +470,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		// killough 10/98: prevent zombies from exiting levels
 		if (bossaction || ((!(thing->player && thing->player->health <= 0)) &&
 		                   CheckIfExitIsGood(thing)))
-		{	
+		{
 			G_ExitLevel(0, 1);
 			return true;
 		}
@@ -603,7 +603,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		// CPhipps - change for lxdoom's compatibility handling
 		if (bossaction || ((!(thing->player && thing->player->health <= 0)) &&
 		                   CheckIfExitIsGood(thing)))
-		{			
+		{
 			G_SecretExitLevel(0, 1);
 			return true;
 		}
@@ -1815,7 +1815,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		return false;
 
 	// jff 02/04/98 add check here for generalized floor/ceil mover
-	
+
 	// pointer to line function is NULL by default, set non-null if
 	// line special is push or switch generalized linedef type
 	int (*linefunc)(line_t * line) = NULL;
@@ -2450,7 +2450,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_StopPlat(line->id);
 			reuse = false;
 			trigger = true;
-			
+
 			break;
 
 		case 164:
@@ -2515,7 +2515,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_LightTurnOn(line->id, -1);
 			reuse = false;
 			trigger = true;
-			
+
 			break;
 
 		case 170:
@@ -2524,7 +2524,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_LightTurnOn(line->id, 35);
 			reuse = false;
 			trigger = true;
-			
+
 			break;
 
 		case 171:
@@ -2533,7 +2533,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_LightTurnOn(line->id, 255);
 			reuse = false;
 			trigger = true;
-			
+
 			break;
 
 		case 172:
@@ -2542,7 +2542,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_StartLightStrobing(line->id, TICS(5), TICS(35));
 			reuse = false;
 			trigger = true;
-			
+
 			break;
 
 		case 173:
@@ -2551,7 +2551,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_TurnTagLightsOff(line->id);
 			reuse = false;
 			trigger = true;
-			
+
 			break;
 
 		case 174:
@@ -2748,7 +2748,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			          TICS(PLATWAIT), 0 * FRACUNIT, 0);
 			reuse = true;
 			trigger = true;
-			
+
 			break;
 
 		case 182:
@@ -2757,7 +2757,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_StopPlat(line->id);
 			reuse = true;
 			trigger = true;
-			
+
 			break;
 
 		case 183:
@@ -2853,7 +2853,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_LightTurnOn(line->id, -1);
 			reuse = true;
 			trigger = true;
-			
+
 			break;
 
 		case 193:
@@ -2871,7 +2871,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 			EV_TurnTagLightsOff(line->id);
 			reuse = true;
 			trigger = true;
-			
+
 			break;
 
 		case 195:
@@ -3227,7 +3227,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		EV_LightTurnOn(line->id, 255);
 		reuse = true;
 		trigger = true;
-		
+
 		break;
 
 	case 139:
@@ -3235,7 +3235,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		EV_LightTurnOn(line->id, 35);
 		reuse = true;
 		trigger = true;
-		
+
 		break;
 	}
 
@@ -3306,8 +3306,8 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 			if (line->flags & ML_SECRET) // they can't open secret doors either
 				return false;
 		}
-		if (!line->id) // e6y //jff 3/2/98 all gun generalized types require tag
-			return false;
+		// if (!line->id) // e6y //jff 3/2/98 all gun generalized types require tag
+		// 	return false;
 		linefunc = EV_DoGenDoor;
 	}
 	else if ((unsigned)line->special >= GenLockedBase)
@@ -3429,7 +3429,7 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 			if (thing && thing->player && thing->player->health <= 0)
 				break;
 			if (thing && CheckIfExitIsGood(thing))
-			{		
+			{
 				G_ExitLevel(0, 1);
 				return true;
 			}

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -98,11 +98,6 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
 				if ((line->special & FloorChange) || !(line->special & FloorModel))
 					return false; // FloorModel is "Allow Monsters" if FloorChange is 0
-			/*
-			if (!comperr(comperr_zerotag) &&
-			    !line->tag) // e6y //jff 2/27/98 all walk generalized types require tag
-			    return;
-			*/
 			linefunc = EV_DoGenFloor;
 		}
 		else if ((unsigned)line->special >= GenCeilingBase)
@@ -111,11 +106,6 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 				if ((line->special & CeilingChange) || !(line->special & CeilingModel))
 					return false; // CeilingModel is "Allow Monsters" if CeilingChange is
 					               // 0
-			/*
-			if (!comperr(comperr_zerotag) &&
-			    !line->tag) // e6y //jff 2/27/98 all walk generalized types require tag
-			    return;
-			*/
 			linefunc = EV_DoGenCeiling;
 		}
 		else if ((unsigned)line->special >= GenDoorBase)
@@ -127,11 +117,6 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 				if (line->flags & ML_SECRET) // they can't open secret doors either
 					return false;
 			}
-			/*
-			if (!comperr(comperr_zerotag) &&
-			    !line->tag) // e6y //3/2/98 move outside the monster check
-			    return;
-			*/
 			linefunc = EV_DoGenDoor;
 		}
 		else if ((unsigned)line->special >= GenLockedBase)
@@ -154,11 +139,6 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
 				if (!(line->special & LiftMonster))
 					return false; // monsters disallowed
-			/*
-			if (!comperr(comperr_zerotag) &&
-			    !line->tag) // e6y //jff 2/27/98 all walk generalized types require tag
-			    return;
-			*/
 			linefunc = EV_DoGenLift;
 		}
 		else if ((unsigned)line->special >= GenStairsBase)
@@ -166,11 +146,6 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
 				if (!(line->special & StairMonster))
 					return false; // monsters disallowed
-			/*
-			if (!comperr(comperr_zerotag) &&
-			    !line->tag) // e6y //jff 2/27/98 all walk generalized types require tag
-			    return;
-			*/
 			linefunc = EV_DoGenStairs;
 		}
 		else if ((unsigned)line->special >= GenCrusherBase)
@@ -180,11 +155,6 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
 				if (!(line->special & StairMonster))
 					return false; // monsters disallowed
-			/*
-			if (!comperr(comperr_zerotag) &&
-			    !line->tag) // e6y //jff 2/27/98 all walk generalized types require tag
-			    return;
-			*/
 			linefunc = EV_DoGenCrusher;
 		}
 
@@ -3283,9 +3253,6 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		if (!thing->player && thing->type != MT_AVATAR)
 			if ((line->special & FloorChange) || !(line->special & FloorModel))
 				return false; // FloorModel is "Allow Monsters" if FloorChange is 0
-		if (!line->id)        // e6y //jff 2/27/98 all gun generalized types require tag
-			return false;
-
 		linefunc = EV_DoGenFloor;
 	}
 	else if ((unsigned)line->special >= GenCeilingBase)
@@ -3293,8 +3260,6 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		if (!thing->player && thing->type != MT_AVATAR)
 			if ((line->special & CeilingChange) || !(line->special & CeilingModel))
 				return false; // CeilingModel is "Allow Monsters" if CeilingChange is 0
-		if (!line->id)        // jff 2/27/98 all gun generalized types require tag
-			return false;
 		linefunc = EV_DoGenCeiling;
 	}
 	else if ((unsigned)line->special >= GenDoorBase)
@@ -3306,8 +3271,6 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 			if (line->flags & ML_SECRET) // they can't open secret doors either
 				return false;
 		}
-		// if (!line->id) // e6y //jff 3/2/98 all gun generalized types require tag
-		// 	return false;
 		linefunc = EV_DoGenDoor;
 	}
 	else if ((unsigned)line->special >= GenLockedBase)
@@ -3322,9 +3285,6 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		}
 		else
 			return false;
-		if (!line->id) // e6y //jff 2/27/98 all gun generalized types require tag
-			return false;
-
 		linefunc = EV_DoGenLockedDoor;
 	}
 	else if ((unsigned)line->special >= GenLiftBase)
@@ -3339,8 +3299,6 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		if (!thing->player && thing->type != MT_AVATAR)
 			if (!(line->special & StairMonster))
 				return false; // monsters disallowed
-		if (!line->id)        // e6y //jff 2/27/98 all gun generalized types require tag
-			return false;
 		linefunc = EV_DoGenStairs;
 	}
 	else if ((unsigned)line->special >= GenCrusherBase)
@@ -3348,8 +3306,6 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		if (!thing->player && thing->type != MT_AVATAR)
 			if (!(line->special & StairMonster))
 				return false; // monsters disallowed
-		if (!line->id)        // e6y //jff 2/27/98 all gun generalized types require tag
-			return false;
 		linefunc = EV_DoGenCrusher;
 	}
 

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -381,6 +381,10 @@ bool P_IsSpecialBoomRepeatable(const short special)
 			return false;
 		case WalkMany:
 			return true;
+		case GunOnce:
+			return false;
+		case GunMany:
+			return true;
 		}
 	}
 

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -366,23 +366,13 @@ bool P_IsSpecialBoomRepeatable(const short special)
 		switch ((special & TriggerType) >> TriggerTypeShift)
 		{
 		case PushOnce:
-			return false;
-			break;
-		case PushMany:
-			return true;
-			break;
 		case SwitchOnce:
-			return false;
-			break;
-		case SwitchMany:
-			return true;
-			break;
 		case WalkOnce:
-			return false;
-		case WalkMany:
-			return true;
 		case GunOnce:
 			return false;
+		case PushMany:
+		case SwitchMany:
+		case WalkMany:
 		case GunMany:
 			return true;
 		}


### PR DESCRIPTION
Additionally removes the check for the line to have a tag to address #991. Different ports vary with respect to this behavior, with Odamex itself being inconsistent between the different trigger types, so I'm open to reverting this if desired or keeping the change.