### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
       should_skip: ${{ steps.check_skip.outputs.should_skip }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check for build skip
         id: check_skip
         run: bash ci/check-skip.sh
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Prepare build
@@ -46,7 +46,7 @@ jobs:
       USE_SDL12: 1
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Prepare build
@@ -63,7 +63,7 @@ jobs:
       CXX: /usr/bin/clang++
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Prepare build
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Run build
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Run build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Prepare artifact
       run: bash ci/ubuntu-artifact.sh
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Odamex-Linux-x86_64
         path: 'build/artifact/*'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
       should_skip: ${{ steps.check_skip.outputs.should_skip }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check for build skip
         id: check_skip
         run: bash ci/check-skip.sh
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Prepare build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,7 +71,7 @@ jobs:
         B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
         B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
     - name: Upload artifact to Github
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Odamex-Win-x64
         path: 'build/artifact/*'
@@ -101,7 +101,7 @@ jobs:
         B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
         B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
     - name: Upload artifact to Github
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Odamex-Win-x32
         path: 'build/artifact/*'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
       should_skip: ${{ steps.check_skip.outputs.should_skip }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check for build skip
         id: check_skip
         run: bash ci/check-skip.sh
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Install Python packages
@@ -80,7 +80,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Install Python packages

--- a/ci/check-skip.sh
+++ b/ci/check-skip.sh
@@ -13,7 +13,7 @@ printf "GITHUB_EVENT_PATH=%s\n" "${GITHUB_EVENT_PATH}"
 
 if [[ $GITHUB_EVENT_NAME != "pull_request" ]]; then
     echo "==> Event is not a pull request, build will proceed."
-    echo "::set-output name=should_skip::false"
+    echo "should_skip=false" >> $GITHUB_OUTPUT
     exit 0
 fi
 
@@ -22,10 +22,10 @@ printf "GITHUB_PR_REPOSITORY=%s\n" "${GITHUB_PR_REPOSITORY}"
 
 if [[ $GITHUB_REPOSITORY != $GITHUB_PR_REPOSITORY ]]; then
     echo "==> Pull request came from an outside repository, build will proceed."
-    echo "::set-output name=should_skip::false"
+    echo "should_skip=false" >> $GITHUB_OUTPUT
     exit 0
 fi
 
 echo "==> Internal pull request detected, skipping build."
-echo "::set-output name=should_skip::true"
+echo "should_skip=true" >> $GITHUB_OUTPUT
 exit 0


### PR DESCRIPTION
This just updates the workflows to use current versions of `upload-artifact` and `checkout`, as well as changing the usage of `set-output` so that we are no longer using deprecated versions and features. Actions using v2 and older of `upload-artifact` now always fail, so this is needed to keep the CI functioning.