### PR TITLE
[BUGFIX] Display levelnames specified in MAPINFO on intermission screens

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -245,7 +245,7 @@ void MIType_MustConfirm(OScanner& os, bool newStyleMapInfo, void* data, unsigned
 		if (os.compareTokenNoCase("="))
 		{
 			info.must_confirm_text.clear();
-			
+
 			do
 			{
 				os.mustScan();
@@ -770,7 +770,7 @@ void MIType_Map07Special(OScanner& os, bool newStyleMapInfo, void* data, unsigne
 	// mancubus
 	bossactionvector.push_back(bossaction_t());
 	std::vector<bossaction_t>::iterator it = (bossactionvector.end() - 1);
-	
+
 	it->type = MT_FATSO;
 	it->special = 23;
 	it->tag = 666;
@@ -778,7 +778,7 @@ void MIType_Map07Special(OScanner& os, bool newStyleMapInfo, void* data, unsigne
 	// arachnotron
 	bossactionvector.push_back(bossaction_t());
 	it = (bossactionvector.end() - 1);
-	
+
 	it->type = MT_BABY;
 	it->special = 30;
 	it->tag = 667;
@@ -949,7 +949,7 @@ bool ScanAndSetRealNum(OScanner& os, fixed_t& num)
 		return false;
 	}
 	num = FLOAT2FIXED(os.getTokenFloat());
-	
+
 	return true;
 }
 
@@ -969,12 +969,12 @@ bool InterpretLines(const std::string& name, std::vector<mline_t>& lines)
 		    true,         // cComments
 		};
 		OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));
-		
+
 		while (os.scan())
 		{
 			os.unScan();
 			mline_t ml;
-			
+
 			if (!ScanAndCompareString(os, "(")) break;
 			if (!ScanAndSetRealNum(os, ml.a.x)) break;
 			if (!ScanAndCompareString(os, ",")) break;
@@ -1606,7 +1606,7 @@ void ParseMapInfoLump(int lump, const char* lumpname)
 				    LEVEL_NOINTERMISSION | LEVEL_EVENLIGHTING | LEVEL_SNDSEQTOTALCTRL;
 			}
 
-			// Build upon already defined levels, that way we don't miss any defaults 
+			// Build upon already defined levels, that way we don't miss any defaults
 			bool levelExists = levels.findByName(map_name).exists();
 
 			// Find the level.
@@ -1643,6 +1643,7 @@ void ParseMapInfoLump(int lump, const char* lumpname)
 			{
 				info.level_name = os.getToken();
 			}
+			info.pname.clear();
 
 			MapInfoDataSetter<level_pwad_info_t> setter(info);
 			ParseMapInfoLower<level_pwad_info_t>(os, setter);


### PR DESCRIPTION
Looks like back in #844 I missed that this affects MAPINFO as well as UMAPINFO. Here's the fix for that as well.