### PR TITLE
[FEATURE] ID24 SKYDEFS support

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
   list(APPEND CLIENT_SDL_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/client.rc")
 endif()
 
-# Include console folders if compiling 
+# Include console folders if compiling
 if (GCONSOLE)
   if (NSWITCH)
     set(CLIENT_DIR ${CLIENT_DIR} switch)  # Nintendo Switch
@@ -76,7 +76,7 @@ if(ENABLE_PORTMIDI)
     set(PORTMIDI_LIBRARY "portmidi")
     set(PORTMIDI_LIBRARIES ${PORTMIDI_LIBRARY})
     set(PORTMIDI_DIR ../libraries/portmidi)
-    set(PORTMIDI_INCLUDE_DIR ${PORTMIDI_DIR}/pm_common/ ${PORTMIDI_DIR}/porttime/)  
+    set(PORTMIDI_INCLUDE_DIR ${PORTMIDI_DIR}/pm_common/ ${PORTMIDI_DIR}/porttime/)
 
     if(APPLE)
       find_library(COREFOUNDATION_LIBRARY CoreFoundation)
@@ -204,6 +204,14 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
   if(NOT GCONSOLE)
     target_include_directories(odamex PRIVATE gui)
     target_link_libraries(odamex fltk::fltk fltk::images)
+  endif()
+
+  if(USE_INTERNAL_JSONCPP)
+    target_link_libraries(odamex jsoncpp_lib_static)
+  else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(JSONCPP jsoncpp REQUIRED IMPORTED_TARGET)
+    target_link_libraries(odamex PkgConfig::JSONCPP)
   endif()
 
   if(ENABLE_PORTMIDI)

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -548,6 +548,7 @@ void G_DoLoadLevel (int position)
 	// [RH] Fetch sky parameters from level_locals_t.
 	// [ML] 5/11/06 - remove sky2 remenants
 	// [SL] 2012-03-19 - Add sky2 back
+	// [EB] 9/6/2024 - remove sky1 (now using SKYDEFS), sky2 left for hexen style non doublesky sky2
 	// TODO: remove this except for sky2 stuff (for non doublesky use of sky2)
 	sky1texture = R_TextureNumForName(level.skypic.c_str());
 	if (!level.skypic2.empty())

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -547,17 +547,20 @@ void G_DoLoadLevel (int position)
 		// [ML] 5/11/06 - remove sky2 remenants
 		// [SL] 2012-03-19 - Add sky2 back
 		sky1texture = R_TextureNumForName(level.skypic.c_str());
-		sky1scrolldelta = level.sky1ScrollDelta;
+		sky1scrollxdelta = level.sky1ScrollDelta;
 		if (!level.skypic2.empty())
 		{
 			sky2texture = R_TextureNumForName(level.skypic2.c_str());
-			sky2scrolldelta = level.sky2ScrollDelta;
+			sky2scrollxdelta = level.sky2ScrollDelta;
 		}
 		else
 		{
 			sky2texture = 0;
-			sky2scrolldelta = 0;
+			sky2scrollxdelta = 0;
 		}
+		sky1scrollydelta = 0;
+		sky2scrollydelta = 0;
+
 	}
 
 	sky1columnoffset = 0;

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -551,7 +551,7 @@ void G_DoLoadLevel (int position)
 	// [EB] 9/6/2024 - remove sky1 (now using SKYDEFS), sky2 left for hexen style non doublesky sky2
 	// TODO: remove this except for sky2 stuff (for non doublesky use of sky2)
 	sky1texture = R_TextureNumForName(level.skypic.c_str());
-	if (!level.skypic2.empty())
+	if (!level.skypic2.empty() && !(level.flags & LEVEL_DOUBLESKY))
 	{
 		sky2texture = R_TextureNumForName(level.skypic2.c_str());
 		sky2scrollxdelta = level.sky2ScrollDelta;

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -539,35 +539,31 @@ void G_DoLoadLevel (int position)
 	//	setting one.
 	skyflatnum = R_FlatNumForName ( SKYFLATNAME );
 
-	if(!R_LoadSkyDef(level.skypic))
+	R_SetDefaultSky(level.skypic.c_str());
+
+	R_InitSkiesForLevel();
+
+	// DOOM determines the sky texture to be used
+	// depending on the current episode, and the game version.
+	// [RH] Fetch sky parameters from level_locals_t.
+	// [ML] 5/11/06 - remove sky2 remenants
+	// [SL] 2012-03-19 - Add sky2 back
+	// TODO: remove this except for sky2 stuff (for non doublesky use of sky2)
+	sky1texture = R_TextureNumForName(level.skypic.c_str());
+	if (!level.skypic2.empty())
 	{
-		// DOOM determines the sky texture to be used
-		// depending on the current episode, and the game version.
-		// [RH] Fetch sky parameters from level_locals_t.
-		// [ML] 5/11/06 - remove sky2 remenants
-		// [SL] 2012-03-19 - Add sky2 back
-		sky1texture = R_TextureNumForName(level.skypic.c_str());
-		sky1scrollxdelta = level.sky1ScrollDelta;
-		if (!level.skypic2.empty())
-		{
-			sky2texture = R_TextureNumForName(level.skypic2.c_str());
-			sky2scrollxdelta = level.sky2ScrollDelta;
-		}
-		else
-		{
-			sky2texture = 0;
-			sky2scrollxdelta = 0;
-		}
-		sky1scrollydelta = 0;
-		sky2scrollydelta = 0;
-
+		sky2texture = R_TextureNumForName(level.skypic2.c_str());
+		sky2scrollxdelta = level.sky2ScrollDelta;
 	}
-
-	sky1columnoffset = 0;
+	else
+	{
+		sky2texture = 0;
+		sky2scrollxdelta = 0;
+	}
 	sky2columnoffset = 0;
 
 	// [RH] Set up details about sky rendering
-	R_InitSkyMap ();
+	R_InitSkyMap();
 
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -539,27 +539,29 @@ void G_DoLoadLevel (int position)
 	//	setting one.
 	skyflatnum = R_FlatNumForName ( SKYFLATNAME );
 
-	// DOOM determines the sky texture to be used
-	// depending on the current episode, and the game version.
-	// [RH] Fetch sky parameters from level_locals_t.
-	// [ML] 5/11/06 - remove sky2 remenants
-	// [SL] 2012-03-19 - Add sky2 back
-	sky1texture = R_TextureNumForName (level.skypic.c_str());
-	sky1scrolldelta = level.sky1ScrollDelta;
-	sky1columnoffset = 0;
-	sky2columnoffset = 0;
-	if (!level.skypic2.empty())
+	if(!R_LoadSkyDef(level.skypic))
 	{
-		sky2texture = R_TextureNumForName(level.skypic2.c_str());
-		sky2scrolldelta = level.sky2ScrollDelta;
-	}
-	else
-	{
-		sky2texture = 0;
-		sky2scrolldelta = 0;
+		// DOOM determines the sky texture to be used
+		// depending on the current episode, and the game version.
+		// [RH] Fetch sky parameters from level_locals_t.
+		// [ML] 5/11/06 - remove sky2 remenants
+		// [SL] 2012-03-19 - Add sky2 back
+		sky1texture = R_TextureNumForName(level.skypic.c_str());
+		sky1scrolldelta = level.sky1ScrollDelta;
+		if (!level.skypic2.empty())
+		{
+			sky2texture = R_TextureNumForName(level.skypic2.c_str());
+			sky2scrolldelta = level.sky2ScrollDelta;
+		}
+		else
+		{
+			sky2texture = 0;
+			sky2scrolldelta = 0;
+		}
 	}
 
-	R_LoadSkyDef(level.skypic);
+	sky1columnoffset = 0;
+	sky2columnoffset = 0;
 
 	// [RH] Set up details about sky rendering
 	R_InitSkyMap ();

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -144,7 +144,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	CL_QuitNetGame(NQ_SILENT);
 	S_StopMusic();
 	currentmusic = gameinfo.titleMusic.c_str();
-	
+
 	S_StartMusic(currentmusic.c_str());
 }
 END_COMMAND (wad)
@@ -157,7 +157,7 @@ EXTERN_CVAR(sv_allowjump)
 
 //
 // G_DoNewGame
-// Is called whenever a new Singleplayer game will be started. 
+// Is called whenever a new Singleplayer game will be started.
 //
 void G_DoNewGame (void)
 {
@@ -291,7 +291,7 @@ void G_InitNew (const char *mapname)
 	viewactive = true;
 
 	D_SetupUserInfo();
-	
+
 	level.mapname = mapname;
 
 	// [AM}] WDL stats (for testing purposes)
@@ -559,6 +559,8 @@ void G_DoLoadLevel (int position)
 		sky2scrolldelta = 0;
 	}
 
+	R_LoadSkyDef(level.skypic);
+
 	// [RH] Set up details about sky rendering
 	R_InitSkyMap ();
 
@@ -687,7 +689,7 @@ void G_WorldDone()
 	// Sort out default options to pass to F_StartFinale
 	finale_options_t options = { 0 };
 	options.music = !level.intermusic.empty() ? level.intermusic.c_str() : thiscluster.messagemusic.c_str();
-	
+
 	if (!level.interbackdrop.empty())
 	{
 		options.flat = level.interbackdrop.c_str();
@@ -700,7 +702,7 @@ void G_WorldDone()
 	{
 		options.flat = &thiscluster.finaleflat[0];
 	}
-	
+
 	if (secretexit)
 	{
 		options.text = (!level.intertextsecret.empty()) ? level.intertextsecret.c_str() : thiscluster.exittext;

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -541,13 +541,15 @@ void G_DoLoadLevel (int position)
 
 	R_SetDefaultSky(level.skypic.c_str());
 
+	R_InitSkiesForLevel();
+
 	// DOOM determines the sky texture to be used
 	// depending on the current episode, and the game version.
 	// [RH] Fetch sky parameters from level_locals_t.
 	// [ML] 5/11/06 - remove sky2 remenants
 	// [SL] 2012-03-19 - Add sky2 back
 	// [EB] 9/6/2024 - remove sky1 (now using SKYDEFS), sky2 left for hexen style non doublesky sky2
-	// TODO: remove this except for sky2 stuff (for non doublesky use of sky2)
+	// MIA TODO: remove this except for sky2 stuff (for non doublesky use of sky2)
 	sky1texture = R_TextureNumForName(level.skypic.c_str());
 	if (!level.skypic2.empty() && !(level.flags & LEVEL_DOUBLESKY))
 	{
@@ -663,7 +665,7 @@ void G_DoLoadLevel (int position)
 	level.starttime = I_MSTime() * TICRATE / 1000;
 	G_UnSnapshotLevel (!savegamerestore);	// [RH] Restore the state of the level.
     P_DoDeferedScripts ();	// [RH] Do script actions that were triggered on another map.
-	R_InitSkiesForLevel();
+
 	::levelstate.reset();
 
 	C_FlushDisplay ();

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -541,8 +541,6 @@ void G_DoLoadLevel (int position)
 
 	R_SetDefaultSky(level.skypic.c_str());
 
-	R_InitSkiesForLevel();
-
 	// DOOM determines the sky texture to be used
 	// depending on the current episode, and the game version.
 	// [RH] Fetch sky parameters from level_locals_t.
@@ -665,7 +663,7 @@ void G_DoLoadLevel (int position)
 	level.starttime = I_MSTime() * TICRATE / 1000;
 	G_UnSnapshotLevel (!savegamerestore);	// [RH] Restore the state of the level.
     P_DoDeferedScripts ();	// [RH] Do script actions that were triggered on another map.
-
+	R_InitSkiesForLevel();
 	::levelstate.reset();
 
 	C_FlushDisplay ();

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -85,6 +85,7 @@ void (*R_DrawFuzzColumn)(void);
 void (*R_DrawTranslucentColumn)(void);
 void (*R_DrawTranslatedColumn)(void);
 void (*R_DrawTlatedLucentColumn)(void);
+void (*R_DrawSkyForegroundColumn)(void);
 void (*R_DrawSpan)(void);
 void (*R_DrawSlopeSpan)(void);
 void (*R_FillColumn)(void);
@@ -315,9 +316,9 @@ static void R_BuildFontTranslation(int color_num, argb_t start_color, argb_t end
 
 /**
  * @brief Apply a soft light filter using Pegtop's formula.
- * 
+ *
  * @see https://en.wikipedia.org/wiki/Blend_modes#Soft_Light
- * 
+ *
  * @param bot Bottom channel value.
  * @param top Top channel value.
  * @return Filtered value.
@@ -359,7 +360,7 @@ void R_InitTranslationTables()
 	// [Toke - fix13]
 	// denis - cleaned this up somewhat
 	translationtables = (byte *)(((ptrdiff_t)translationtablesmem + 255) & ~255);
-	
+
 	// [RH] Each player now gets their own translation table
 	//		(soon to be palettes). These are set up during
 	//		netgame arbitration and as-needed rather than
@@ -391,15 +392,15 @@ void R_InitTranslationTables()
 	Ranges = translationtables + (MAXPLAYERS+3)*256;
 
 	R_BuildFontTranslation(CR_BRICK,	argb_t(0xFF, 0xB8, 0xB8), argb_t(0x47, 0x00, 0x00));
-	R_BuildFontTranslation(CR_TAN,		argb_t(0xFF, 0xEB, 0xDF), argb_t(0x33, 0x2B, 0x13));	
-	R_BuildFontTranslation(CR_GRAY,		argb_t(0xEF, 0xEF, 0xEF), argb_t(0x27, 0x27, 0x27));	
-	R_BuildFontTranslation(CR_GREEN,	argb_t(0x77, 0xFF, 0x6F), argb_t(0x0B, 0x17, 0x07));	
-	R_BuildFontTranslation(CR_BROWN,	argb_t(0xBF, 0xA7, 0x8F), argb_t(0x53, 0x3F, 0x2F));	
-	R_BuildFontTranslation(CR_GOLD,		argb_t(0xFF, 0xFF, 0x73), argb_t(0x73, 0x2B, 0x00));	
+	R_BuildFontTranslation(CR_TAN,		argb_t(0xFF, 0xEB, 0xDF), argb_t(0x33, 0x2B, 0x13));
+	R_BuildFontTranslation(CR_GRAY,		argb_t(0xEF, 0xEF, 0xEF), argb_t(0x27, 0x27, 0x27));
+	R_BuildFontTranslation(CR_GREEN,	argb_t(0x77, 0xFF, 0x6F), argb_t(0x0B, 0x17, 0x07));
+	R_BuildFontTranslation(CR_BROWN,	argb_t(0xBF, 0xA7, 0x8F), argb_t(0x53, 0x3F, 0x2F));
+	R_BuildFontTranslation(CR_GOLD,		argb_t(0xFF, 0xFF, 0x73), argb_t(0x73, 0x2B, 0x00));
 	R_BuildFontTranslation(CR_RED,		argb_t(0xFF, 0x00, 0x00), argb_t(0x3F, 0x00, 0x00));
-	R_BuildFontTranslation(CR_BLUE,		argb_t(0x00, 0x00, 0xFF), argb_t(0x00, 0x00, 0x27));	
-	R_BuildFontTranslation(CR_ORANGE,	argb_t(0xFF, 0x80, 0x00), argb_t(0x20, 0x00, 0x00));	
-	R_BuildFontTranslation(CR_WHITE,	argb_t(0xFF, 0xFF, 0xFF), argb_t(0x24, 0x24, 0x24));	
+	R_BuildFontTranslation(CR_BLUE,		argb_t(0x00, 0x00, 0xFF), argb_t(0x00, 0x00, 0x27));
+	R_BuildFontTranslation(CR_ORANGE,	argb_t(0xFF, 0x80, 0x00), argb_t(0x20, 0x00, 0x00));
+	R_BuildFontTranslation(CR_WHITE,	argb_t(0xFF, 0xFF, 0xFF), argb_t(0x24, 0x24, 0x24));
 	R_BuildFontTranslation(CR_YELLOW,	argb_t(0xFC, 0xD0, 0x43), argb_t(0x27, 0x27, 0x27));
 	R_BuildFontTranslation(CR_BLACK,	argb_t(0x50, 0x50, 0x50), argb_t(0x13, 0x13, 0x13));
 	R_BuildFontTranslation(CR_LIGHTBLUE,argb_t(0xB4, 0xB4, 0xFF), argb_t(0x00, 0x00, 0x73));
@@ -424,7 +425,7 @@ void R_BuildClassicPlayerTranslation (int player, int color)
 {
 	const palette_t* pal = V_GetDefaultPalette();
 	int i;
-	
+
 	if (color == 1) // Indigo
 		for (i = 0x70; i < 0x80; i++)
 		{
@@ -434,13 +435,13 @@ void R_BuildClassicPlayerTranslation (int player, int color)
 	else if (color == 2) // Brown
 		for (i = 0x70; i < 0x80; i++)
 		{
-			translationtables[i+(player * 256)] = 0x40 + (i&0xf);	
+			translationtables[i+(player * 256)] = 0x40 + (i&0xf);
 			translationRGB[player][i - 0x70] = pal->basecolors[translationtables[i+(player * 256)]];
 		}
 	else if (color == 3) // Red
 		for (i = 0x70; i < 0x80; i++)
 		{
-			translationtables[i+(player * 256)] = 0x20 + (i&0xf);	
+			translationtables[i+(player * 256)] = 0x20 + (i&0xf);
 			translationRGB[player][i - 0x70] = pal->basecolors[translationtables[i+(player * 256)]];
 		}
 }
@@ -547,14 +548,14 @@ void R_BlankSpan()
 //
 // R_FillColumnGeneric
 //
-// Templated version of a function to fill a column with a solid color. 
+// Templated version of a function to fill a column with a solid color.
 // The data type of the destination pixels and a color-remapping functor
 // are passed as template parameters.
 //
 template<typename PIXEL_T, typename COLORFUNC>
 static forceinline void R_FillColumnGeneric(PIXEL_T* dest, const drawcolumn_t& drawcolumn)
 {
-#ifdef RANGECHECK 
+#ifdef RANGECHECK
 	if (drawcolumn.x < 0 || drawcolumn.x >= viewwidth || drawcolumn.yl < 0 || drawcolumn.yh >= viewheight)
 	{
 		Printf (PRINT_HIGH, "R_FillColumn: %i to %i at %i\n", drawcolumn.yl, drawcolumn.yh, drawcolumn.x);
@@ -574,7 +575,7 @@ static forceinline void R_FillColumnGeneric(PIXEL_T* dest, const drawcolumn_t& d
 		colorfunc(color, dest);
 		dest += pitch;
 	} while (--count);
-} 
+}
 
 
 //
@@ -593,7 +594,7 @@ static forceinline void R_FillColumnGeneric(PIXEL_T* dest, const drawcolumn_t& d
 template<typename PIXEL_T, typename COLORFUNC>
 static forceinline void R_DrawColumnGeneric(PIXEL_T* dest, const drawcolumn_t& drawcolumn)
 {
-#ifdef RANGECHECK 
+#ifdef RANGECHECK
 	if (drawcolumn.x < 0 || drawcolumn.x >= viewwidth || drawcolumn.yl < 0 || drawcolumn.yh >= viewheight)
 	{
 		Printf (PRINT_HIGH, "R_DrawColumn: %i to %i at %i\n", drawcolumn.yl, drawcolumn.yh, drawcolumn.x);
@@ -607,7 +608,7 @@ static forceinline void R_DrawColumnGeneric(PIXEL_T* dest, const drawcolumn_t& d
 	if (count <= 0)
 		return;
 
-	const fixed_t fracstep = drawcolumn.iscale; 
+	const fixed_t fracstep = drawcolumn.iscale;
 	fixed_t frac = drawcolumn.texturefrac;
 
 	const int texheight = drawcolumn.textureheight;
@@ -746,7 +747,7 @@ static forceinline void R_DrawLevelSpanGeneric(PIXEL_T* dest, const drawspan_t& 
 	int count = drawspan.x2 - drawspan.x1 + 1;
 	if (count <= 0)
 		return;
-	
+
 	dsfixed_t xfrac = drawspan.xfrac;
 	dsfixed_t yfrac = drawspan.yfrac;
 	const dsfixed_t xstep = drawspan.xstep;
@@ -799,11 +800,11 @@ static forceinline void R_DrawSlopedSpanGeneric(PIXEL_T* dest, const drawspan_t&
 	int count = drawspan.x2 - drawspan.x1 + 1;
 	if (count <= 0)
 		return;
-	
+
 	float iu = drawspan.iu, iv = drawspan.iv;
 	const float ius = drawspan.iustep, ivs = drawspan.ivstep;
 	float id = drawspan.id, ids = drawspan.idstep;
-	
+
 	int ltindex = 0;
 
 	shaderef_t colormap;
@@ -964,7 +965,7 @@ public:
 	{
 		const palindex_t fg = colormap.index(c);
 		const palindex_t bg = *dest;
-				
+
 		*dest = rt_blend2<palindex_t>(bg, bga, fg, fga);
 	}
 
@@ -983,7 +984,7 @@ private:
 class PaletteTranslatedColormapFunc
 {
 public:
-	PaletteTranslatedColormapFunc(const drawcolumn_t& drawcolumn) : 
+	PaletteTranslatedColormapFunc(const drawcolumn_t& drawcolumn) :
 			colormap(drawcolumn.colormap), translation(drawcolumn.translation) { }
 
 	forceinline void operator()(byte c, palindex_t* dest) const
@@ -1028,6 +1029,21 @@ private:
 	const shaderef_t* colormap;
 };
 
+class PaletteSkyForegroundColormapFunc
+{
+public:
+	PaletteSkyForegroundColormapFunc(const drawcolumn_t& drawcolumn) : colormap(drawcolumn.colormap) {}
+
+	PaletteSkyForegroundColormapFunc(const drawspan_t& drawspan) : colormap(drawspan.colormap) {}
+
+	forceinline void operator()(byte c, palindex_t* dest) const
+	{
+		*dest = c == 0 ? *dest : colormap.index(c);
+	}
+
+private:
+	const shaderef_t& colormap;
+};
 
 // ----------------------------------------------------------------------------
 //
@@ -1118,7 +1134,7 @@ void R_DrawTranslatedColumnP()
 // R_DrawTlatedLucentColumnP
 //
 // Renders a translucent column to the 8bpp palettized screen buffer with
-// color-remapping from the source buffer dcol.source and scaled by dcol.iscale. 
+// color-remapping from the source buffer dcol.source and scaled by dcol.iscale.
 // The translation table is supplied by dcol.translation and the amount of
 // translucency is controlled by dcol.translevel. Shading is performed using
 // dcol.colormap.
@@ -1128,6 +1144,18 @@ void R_DrawTlatedLucentColumnP()
 	R_DrawColumnGeneric<palindex_t, PaletteTranslatedTranslucentColormapFunc>(FB_COLDEST_P, dcol);
 }
 
+//
+// R_DrawSkyForegroundColumnP
+//
+// Renders a column to the 8bpp palettized screen buffer from the source buffer
+// dcol.source and scaled by dcol.iscale. Shading is performed using dcol.colormap.
+// Palette index 0 is treated as transparent.
+// This is because we can't use SKYTRAN.
+//
+void R_DrawSkyForegroundColumnP()
+{
+	R_DrawColumnGeneric<palindex_t, PaletteSkyForegroundColormapFunc>(FB_COLDEST_P, dcol);
+}
 
 // ----------------------------------------------------------------------------
 //
@@ -1152,7 +1180,7 @@ void R_FillSpanP()
 // R_FillTranslucentSpanP
 //
 // Fills a span in the 8bpp palettized screen buffer with a solid color,
-// determined by dspan.color using translucency. Shading is performed 
+// determined by dspan.color using translucency. Shading is performed
 // using dspan.colormap.
 //
 void R_FillTranslucentSpanP()
@@ -1263,7 +1291,7 @@ public:
 	{
 		argb_t fg = colormap.shade(c);
 		argb_t bg = *dest;
-		*dest = alphablend2a(bg, bga, fg, fga);	
+		*dest = alphablend2a(bg, bga, fg, fga);
 	}
 
 private:
@@ -1324,6 +1352,22 @@ public:
 
 private:
 	const shaderef_t* colormap;
+};
+
+class DirectSkyForegroundColormapFunc
+{
+public:
+	DirectSkyForegroundColormapFunc(const drawcolumn_t& drawcolumn) : colormap(drawcolumn.colormap) {}
+
+	DirectSkyForegroundColormapFunc(const drawspan_t& drawspan) : colormap(drawspan.colormap) {}
+
+	forceinline void operator()(byte c, argb_t* dest) const
+	{
+		*dest = c == 0 ? *dest : colormap.shade(c);
+	}
+
+private:
+	const shaderef_t& colormap;
 };
 
 
@@ -1405,7 +1449,7 @@ void R_DrawTranslatedColumnD()
 // R_DrawTlatedLucentColumnD
 //
 // Renders a translucent column to the 32bpp ARGB8888 screen buffer with
-// color-remapping from the source buffer dcol.source and scaled by dcol.iscale. 
+// color-remapping from the source buffer dcol.source and scaled by dcol.iscale.
 // The translation table is supplied by dcol.translation and the amount of
 // translucency is controlled by dcol.translevel. Shading is performed using
 // dcol.colormap.
@@ -1415,6 +1459,18 @@ void R_DrawTlatedLucentColumnD()
 	R_DrawColumnGeneric<argb_t, DirectTranslatedTranslucentColormapFunc>(FB_COLDEST_D, dcol);
 }
 
+//
+// R_DrawSkyForegroundColumnD
+//
+// Renders a column to the 32bpp ARGB8888 screen buffer from the source buffer
+// dcol.source and scaled by dcol.iscale. Shading is performed using dcol.colormap.
+// Palette index 0 is treated as transparent.
+// This is because we can't use SKYTRAN.
+//
+void R_DrawSkyForegroundColumnD()
+{
+	R_DrawColumnGeneric<argb_t, DirectSkyForegroundColormapFunc>(FB_COLDEST_D, dcol);
+}
 
 // ----------------------------------------------------------------------------
 //
@@ -1439,7 +1495,7 @@ void R_FillSpanD()
 // R_FillTranslucentSpanD
 //
 // Fills a span in the 32bpp ARGB8888 screen buffer with a solid color,
-// determined by dspan.color using translucency. Shading is performed 
+// determined by dspan.color using translucency. Shading is performed
 // using dspan.colormap.
 //
 void R_FillTranslucentSpanD()
@@ -1537,7 +1593,7 @@ void R_DrawBorder(int x1, int y1, int x2, int y2)
 
 	scaled_screenblocks_surface->lock();
 
-	primary_surface->blit(scaled_screenblocks_surface, x1, y1, 
+	primary_surface->blit(scaled_screenblocks_surface, x1, y1,
 	   x1 + x2, y1 + y2,
 	   x1, y1, x1 + x2, y1 + y2);
 
@@ -1679,7 +1735,7 @@ static bool detect_optimizations()
 // and the current CPU also supports it.
 //
 static bool R_IsOptimizationAvailable(r_optimize_kind kind)
-{ 
+{
 	return std::find(optimizations_available.begin(), optimizations_available.end(), kind)
 			!= optimizations_available.end();
 }
@@ -1790,6 +1846,7 @@ void R_InitColumnDrawers ()
 		R_DrawTranslucentColumn	= R_DrawTranslucentColumnP;
 		R_DrawTranslatedColumn	= R_DrawTranslatedColumnP;
 		R_DrawTlatedLucentColumn = R_DrawTlatedLucentColumnP;
+		R_DrawSkyForegroundColumn= R_DrawSkyForegroundColumnP;
 		R_DrawSlopeSpan			= R_DrawSlopeSpanP;
 		R_DrawSpan				= R_DrawSpanP;
 		R_FillColumn			= R_FillColumnP;
@@ -1804,6 +1861,7 @@ void R_InitColumnDrawers ()
 		R_DrawTranslucentColumn	= R_DrawTranslucentColumnD;
 		R_DrawTranslatedColumn	= R_DrawTranslatedColumnD;
 		R_DrawTlatedLucentColumn = R_DrawTlatedLucentColumnD;
+		R_DrawSkyForegroundColumn= R_DrawSkyForegroundColumnD;
 		R_DrawSlopeSpan			= R_DrawSlopeSpanD;
 		R_DrawSpan				= R_DrawSpanD;
 		R_FillColumn			= R_FillColumnD;

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -182,7 +182,7 @@ IWindowSurface* R_GetRenderingSurface()
 // R_PointOnSide
 //
 // Determines which side of a line the point (x, y) is on.
-// Returns side 0 (front) or 1 (back) 
+// Returns side 0 (front) or 1 (back)
 //
 int R_PointOnSide(fixed_t x, fixed_t y, fixed_t xl, fixed_t yl, fixed_t xh, fixed_t yh)
 {
@@ -201,7 +201,7 @@ int R_PointOnSide(fixed_t x, fixed_t y, fixed_t xl, fixed_t yl, fixed_t xh, fixe
 //
 int R_PointOnSide(fixed_t x, fixed_t y, const node_t *node)
 {
-	return R_PointOnSide(x, y, node->x, node->y, node->x + node->dx, node->y + node->dy); 
+	return R_PointOnSide(x, y, node->x, node->y, node->x + node->dx, node->y + node->dy);
 }
 
 //
@@ -313,7 +313,7 @@ fixed_t R_PointToDist2(fixed_t dx, fixed_t dy)
 void R_RotatePoint(fixed_t x, fixed_t y, angle_t ang, fixed_t &tx, fixed_t &ty)
 {
 	int index = ang >> ANGLETOFINESHIFT;
-	
+
 	tx = FixedMul(x, finecosine[index]) - FixedMul(y, finesine[index]);
 	ty = FixedMul(x, finesine[index]) + FixedMul(y, finecosine[index]);
 }
@@ -327,7 +327,7 @@ void R_RotatePoint(fixed_t x, fixed_t y, angle_t ang, fixed_t &tx, fixed_t &ty)
 // right endpoint is rclip percent of the way between the left and right
 // endpoints
 //
-void R_ClipLine(const v2fixed_t* in1, const v2fixed_t* in2, 
+void R_ClipLine(const v2fixed_t* in1, const v2fixed_t* in2,
 				int32_t lclip, int32_t rclip,
 				v2fixed_t* out1, v2fixed_t* out2)
 {
@@ -367,11 +367,11 @@ bool R_ClipLineToFrustum(const v2fixed_t* v1, const v2fixed_t* v2, fixed_t clipd
 	v2fixed_t p1 = *v1, p2 = *v2;
 
 	lclip = 0;
-	rclip = CLIPUNIT; 
+	rclip = CLIPUNIT;
 
 	// Clip portions of the line that are behind the view plane
 	if (p1.y < clipdist)
-	{      
+	{
 		// reject the line entirely if the whole thing is behind the view plane.
 		if (p2.y < clipdist)
 			return false;
@@ -420,7 +420,7 @@ bool R_ClipLineToFrustum(const v2fixed_t* v1, const v2fixed_t* v2, fixed_t clipd
 	if (p2.x > yc2)
 	{
 		// clip line at right edge of the screen
-		fixed_t den = p2.x - p1.x - yc2 + yc1;	
+		fixed_t den = p2.x - p1.x - yc2 + yc1;
 		if (den == 0)
 			return false;
 
@@ -572,7 +572,7 @@ void R_DrawLine(const v3fixed_t* inpt1, const v3fixed_t* inpt2, byte color)
 		{
 			R_DrawPixel(x, y, color);
 			if (y == y2)
-				return;		
+				return;
 
 			if (d >= 0)
 			{
@@ -639,6 +639,7 @@ void R_Init()
 void STACK_ARGS R_Shutdown()
 {
     R_FreeTranslationTables();
+	R_ClearSkyDefs();
 }
 
 
@@ -1036,7 +1037,7 @@ void R_RenderPlayerView(player_t* player)
 	{
 		argb_t color = gametic & 8 ? argb_t(0, 0, 0) : argb_t(0, 0, 255);
 		int x1 = viewwindowx, y1 = viewwindowy;
-		int x2 = viewwindowx + viewwidth - 1, y2 = viewwindowy + viewheight - 1; 
+		int x2 = viewwindowx + viewwidth - 1, y2 = viewwindowy + viewheight - 1;
 
 		surface->getDefaultCanvas()->Clear(x1, y1, x2, y2, color);
 	}
@@ -1053,7 +1054,7 @@ void R_RenderPlayerView(player_t* player)
 		int flags2_backup = camera->flags2;
 		camera->flags2 |= MF2_DONTDRAW;
 		R_RenderBSPNode(numnodes - 1);
-		camera->flags2 = flags2_backup; 
+		camera->flags2 = flags2_backup;
 	}
 	else
 		R_RenderBSPNode(numnodes - 1);	// The head node is the last node output.
@@ -1176,14 +1177,14 @@ static void R_InitViewWindow()
 
 	surface->lock();
 
-	// Calculate viewwidth & viewheight based on the amount of window border 
+	// Calculate viewwidth & viewheight based on the amount of window border
 	viewwidth = R_ViewWidth(surface_width, surface_height);
 	viewheight = R_ViewHeight(surface_width, surface_height);
 	viewwindowx = R_ViewWindowX(surface_width, surface_height);
 	viewwindowy = R_ViewWindowY(surface_width, surface_height);
 
 	if (setblocks == 10 || setblocks == 11 || setblocks == 12)
-		freelookviewheight = surface_height; 
+		freelookviewheight = surface_height;
 	else
 		freelookviewheight = ((setblocks * surface_height) / 10) & ~7;
 

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -1010,6 +1010,21 @@ void R_SetTranslatedLucentDrawFuncs()
 	}
 }
 
+void R_SetSkyForegroundDrawFuncs()
+{
+	if (nodrawers)
+	{
+		R_SetBlankDrawFuncs();
+	}
+	else if (r_drawflat)
+	{
+		R_SetFlatDrawFuncs();
+	}
+	else
+	{
+		colfunc = R_DrawSkyForegroundColumn;
+	}
+}
 
 //
 // R_RenderPlayerView

--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -138,12 +138,12 @@ void R_MapSlopedPlane(int y, int x1, int x2)
 	v3float_t s;
 	s.x = x1 - centerx;
 	s.y = y - centery + 1.0f;
-	s.z = xfoc; 
+	s.z = xfoc;
 
 	dspan.iu = M_DotProductVec3f(&s, &a) * flatwidth;
 	dspan.iv = M_DotProductVec3f(&s, &b) * flatheight;
 	dspan.id = M_DotProductVec3f(&s, &c);
-	
+
 	dspan.iustep = a.x * flatwidth;
 	dspan.ivstep = b.x * flatheight;
 	dspan.idstep = c.x;
@@ -176,14 +176,14 @@ void R_MapSlopedPlane(int y, int x1, int x2)
 		{
 			int index = (int)(map >> FRACBITS) + 1;
 			index -= (foggy ? 0 : extralight << 2);
-			
+
 			if (index < 0)
 				dspan.slopelighting[i] = basecolormap;
 			else if (index >= NUMCOLORMAPS)
 				dspan.slopelighting[i] = basecolormap.with((NUMCOLORMAPS - 1));
 			else
 				dspan.slopelighting[i] = basecolormap.with(index);
-			
+
 			map += step;
 		}
 	}
@@ -221,7 +221,7 @@ void R_MapLevelPlane(int y, int x1, int x2)
 	dspan.ystep = FixedMul(pl_ystepscale, slope);
 
 	dspan.xfrac = pl_viewxtrans +
-				FixedMul(FixedMul(pl_viewcos, distance), pl_xscale) + 
+				FixedMul(FixedMul(pl_viewcos, distance), pl_xscale) +
 				(x1 - centerx) * dspan.xstep;
 	dspan.yfrac = pl_viewytrans -
 				FixedMul(FixedMul(pl_viewsin, distance), pl_yscale) +
@@ -413,7 +413,7 @@ void R_MakeSpans(visplane_t *pl, void(*spanfunc)(int, int, int))
 		unsigned int b1 = pl->bottom[x-1];
 		unsigned int t2 = pl->top[x];
 		unsigned int b2 = pl->bottom[x];
-		
+
 		for (; t1 < t2 && t1 <= b1; t1++)
 			spanfunc(t1, spanstart[t1], x-1);
 		for (; b1 > b2 && b1 >= t1; b1--)
@@ -496,11 +496,11 @@ void R_DrawSlopedPlane(visplane_t *pl)
 	M_TranslateVec3f(&p, &viewpos, rotation);
 	M_TranslateVec3f(&t, &viewpos, rotation);
 	M_TranslateVec3f(&s, &viewpos, rotation);
-	
+
 	// Subtract p from t and s, making t and s into direction vectors
 	M_SubVec3f(&t, &t, &p);
 	M_SubVec3f(&s, &s, &p);
-	
+
 	M_CrossProductVec3f(&a, &p, &s);
 	M_CrossProductVec3f(&b, &t, &p);
 	M_CrossProductVec3f(&c, &t, &s);
@@ -511,9 +511,9 @@ void R_DrawSlopedPlane(visplane_t *pl)
 
 	a.y *= ifocratio;
 	b.y *= ifocratio;
-	c.y *= ifocratio;		
-	
-	// (SoM) More help from randy. I was totally lost on this... 
+	c.y *= ifocratio;
+
+	// (SoM) More help from randy. I was totally lost on this...
 	float scalenumer = FIXED2FLOAT(finetangent[FINEANGLES/4+CorrectFieldOfView/2]);
 	float ixscale = scalenumer / flatwidth;
 	float iyscale = scalenumer / flatheight;
@@ -523,12 +523,12 @@ void R_DrawSlopedPlane(visplane_t *pl)
 	angle_t fovang = ANG(consoleplayer().fov / 2.0f);
 	float slopetan = FIXED2FLOAT(finetangent[fovang >> ANGLETOFINESHIFT]);
 	float slopevis = 8.0 * slopetan * 16.0 * 320.0 / float(I_GetSurfaceWidth());
-	
+
 	plight = (slopevis * ixscale * iyscale) / (zat - viewpos.z);
 	shade = 256.0 * 2.0 - (pl->lightlevel + 16.0) * 256.0 / 128.0;
 
 	basecolormap = pl->colormap;	// [RH] set basecolormap
-   
+
 	R_MakeSpans(pl, R_MapSlopedPlane);
 }
 
@@ -557,7 +557,7 @@ void R_DrawLevelPlane(visplane_t *pl)
 	{
 		const fixed_t pl_cos = finecosine[pl->angle >> ANGLETOFINESHIFT];
 		const fixed_t pl_sin = finesine[pl->angle >> ANGLETOFINESHIFT];
-		
+
 		pl_viewx = FixedMul(viewx, pl_cos) - FixedMul(viewy, pl_sin);
 		pl_viewy = -(FixedMul(viewx, pl_sin) + FixedMul(viewy, pl_cos));
 	}
@@ -569,7 +569,7 @@ void R_DrawLevelPlane(visplane_t *pl)
 	// cache a calculation used by R_MapLevelPlane
 	pl_viewxtrans = FixedMul(pl_viewx + pl->xoffs, pl->xscale) << 10;
 	pl_viewytrans = FixedMul(pl_viewy + pl->yoffs, pl->yscale) << 10;
-	
+
 	basecolormap = pl->colormap;	// [RH] set basecolormap
 
 	// [SL] 2012-02-05 - Plane's height should be constant for all (x,y)
@@ -596,7 +596,7 @@ void R_DrawPlanes (void)
 	R_ResetDrawFuncs();
 
 	dspan.color = 3;
-	
+
 	for (i = 0; i < MAXVISPLANES; i++)
 	{
 		for (pl = visplanes[i]; pl; pl = pl->next)
@@ -605,7 +605,7 @@ void R_DrawPlanes (void)
 				continue;
 
 			// sky flat
-			if (pl->picnum == skyflatnum || pl->picnum & PL_SKYFLAT)
+			if (pl->picnum == skyflatnum || pl->picnum & PL_SKYFLAT || R_IsSkyFlat(pl->picnum))
 			{
 				R_RenderSkyRange(pl);
 			}
@@ -616,7 +616,7 @@ void R_DrawPlanes (void)
 
 				dspan.color += 4;	// [RH] color if r_drawflat is 1
 				dspan.source = (byte *)W_CacheLumpNum (firstflat + useflatnum, PU_STATIC);
-										   
+
 				// [RH] warp a flat if desired
 				if (flatwarp[useflatnum])
 				{
@@ -659,7 +659,7 @@ void R_DrawPlanes (void)
 						dspan.source = warped;
 					}
 				}
-				
+
 				pl->top[pl->maxx+1] = viewheight;
 				pl->top[pl->minx-1] = viewheight;
 
@@ -667,7 +667,7 @@ void R_DrawPlanes (void)
 					R_DrawLevelPlane(pl);
 				else
 					R_DrawSlopedPlane(pl);
-					
+
 				Z_ChangeTag (dspan.source, PU_CACHE);
 			}
 		}

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -119,8 +119,6 @@ struct sky_t
 OHashTable<std::string, sky_t*> skylookup;
 OHashTable<int32_t, sky_t*> skyflatlookup;
 
-// MIA TODO: delete skies created with R_GetSky at end of level so things like in correct scroll speeds from MAPINFO on maps using same texture but different speeds dont happen
-
 //
 // R_InitXToViewAngle
 //
@@ -537,6 +535,27 @@ void R_InitSkiesForLevel()
 void R_SetDefaultSky(const char* sky)
 {
 	sky_t* skydef = R_GetSky(sky, true);
+	// make sure that if mapinfo sets a scroll speed we use that
+	// to not mess up wads without skydefs that reuse textures with different scroll speeds
+	// setting a scroll speed in mapinfo and in a skydef is undefined behavior
+	if (level.flags & LEVEL_DOUBLESKY)
+	{
+		if (level.sky1ScrollDelta != 0)
+		{
+			skydef->foreground.scrollx = level.sky1ScrollDelta;
+		}
+		if (level.sky2ScrollDelta != 0)
+		{
+			skydef->background.scrollx = level.sky2ScrollDelta;
+		}
+	}
+	else
+	{
+		if (level.sky1ScrollDelta != 0)
+		{
+			skydef->background.scrollx = level.sky1ScrollDelta;
+		}
+	}
 	skyflatlookup[R_FlatNumForName(SKYFLATNAME)] = skydef;
 }
 

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -51,6 +51,7 @@ EXTERN_CVAR(r_skypalette)
 // sky mapping
 //
 int 		skyflatnum;
+// MIA TODO: remove sky1 variables
 int 		sky1texture,    sky2texture;
 fixed_t		sky1texturemid, sky2texturemid;
 fixed_t		skyscale;
@@ -131,6 +132,8 @@ static void R_InitXToViewAngle()
 
 void R_GenerateLookup(int texnum, int *const errors); // from r_data.cpp
 
+
+// MIA TODO: iterate over skymaps to do this stuff
 void R_InitSkyMap()
 {
 	fixed_t fskyheight;

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -597,12 +597,13 @@ static inline void R_BlastSkyForegroundColumn(void (*drawfunc)(void))
 	{
 		tallpost_t* post = dcol.post;
 
+		int yl = dcol.yl;
+		int yh = dcol.yh;
+
 		while (!post->end())
 		{
-			int topscreen = centeryfrac - dcol.texturemid + INT2FIXED(1) * post->topdelta + 1;
-
-			// dcol.yl = (topscreen) >> FRACBITS;
-			// dcol.yh = (topscreen + INT2FIXED(1) * post->length) >> FRACBITS;
+			dcol.yl = yl;
+			dcol.yh = yh;
 
 			dcol.texturefrac = dcol.texturemid - (post->topdelta << FRACBITS) + (dcol.yl - centery + 1) * dcol.iscale;
 

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -290,41 +290,41 @@ std::unordered_map<int32_t, skyflat_t*>	skyflatlookup;
 void R_InitSkyDefs()
 {
 	skyflatnum = R_FlatNumForName( SKYFLATNAME );
-	texturecomposite_t* skyflatcomposite = flatlookup[skyflatnum];
+	// texturecomposite_t* skyflatcomposite = flatlookup[skyflatnum];
 
-	defaultskyflat = (skyflat_t*)Z_Malloc(sizeof( skyflat_t ), PU_STATIC, nullptr);
-	*defaultskyflat = { skyflatcomposite, nullptr };
+	// defaultskyflat = (skyflat_t*)Z_Malloc(sizeof( skyflat_t ), PU_STATIC, nullptr);
+	// *defaultskyflat = { skyflatcomposite, nullptr };
 
-	skyflatlookup[skyflatnum] = defaultskyflat;
-	skyflatcomposite->skyflat = defaultskyflat;
+	// skyflatlookup[skyflatnum] = defaultskyflat;
+	// skyflatcomposite->skyflat = defaultskyflat;
 
 	auto ParseSkydef = [](const Json::Value& elem, const JSONLumpVersion& version) -> jsonlumpresult_t
 	{
-		const Json::Value& skyarray = elem[ "skies" ];
-		const Json::Value& flatmappings = elem[ "flatmapping" ];
+		const Json::Value& skyarray = elem["skies"];
+		const Json::Value& flatmappings = elem["flatmapping"];
 
 		if(!(skyarray.isArray() || skyarray.isNull())) return JL_PARSEERROR;
 		if(!(flatmappings.isArray() || flatmappings.isNull())) return JL_PARSEERROR;
 
 		for(const Json::Value& skyelem : skyarray)
 		{
-			const Json::Value& type     = skyelem[ "type" ];
+			const Json::Value& type     = skyelem["type"];
 
-			const Json::Value& skytex   = skyelem[ "name" ];
-			const Json::Value& mid      = skyelem[ "mid" ];
-			const Json::Value& scrollx  = skyelem[ "scrollx" ];
-			const Json::Value& scrolly  = skyelem[ "scrolly" ];
-			const Json::Value& scalex   = skyelem[ "scalex" ];
-			const Json::Value& scaley   = skyelem[ "scaley" ];
+			const Json::Value& skytex   = skyelem["name"];
+			const Json::Value& mid      = skyelem["mid"];
+			const Json::Value& scrollx  = skyelem["scrollx"];
+			const Json::Value& scrolly  = skyelem["scrolly"];
+			const Json::Value& scalex   = skyelem["scalex"];
+			const Json::Value& scaley   = skyelem["scaley"];
 
-			const Json::Value& fireelem	= skyelem[ "fire" ];
-			const Json::Value& foreelem = skyelem[ "foregroundtex" ];
+			const Json::Value& fireelem	= skyelem["fire"];
+			const Json::Value& foreelem = skyelem["foregroundtex"];
 
 			auto skytype = static_cast<skytype_t>(type.asInt());
 			if(skytype < SKY_NORMAL || skytype > SKY_DOUBLESKY) return JL_PARSEERROR;
 
 			std::string skytexname = skytex.asString();
-			int32_t tex = R_TextureNumForName( skytexname.c_str() );
+			int32_t tex = R_TextureNumForName(skytexname.c_str());
 			if(tex < 0) return JL_PARSEERROR;
 
 			if(!mid.isNumeric()
@@ -342,7 +342,7 @@ void R_InitSkyDefs()
 
 			constexpr double_t ticratescale = 1.0 / TICRATE;
 
-			sky->background.texture = texturelookup[tex];
+			// sky->background.texture = texturelookup[tex];
 			sky->background.texnum  = tex;
 			sky->background.mid     = DOUBLE2FIXED(mid.asDouble());
 			sky->background.scrollx = DOUBLE2FIXED(scrollx.asDouble() * ticratescale);
@@ -391,7 +391,7 @@ void R_InitSkyDefs()
 					return JL_PARSEERROR;
 				}
 
-				sky->foreground.texture = texturelookup[foretex];
+				// sky->foreground.texture = texturelookup[foretex];
 				sky->foreground.texnum  = foretex;
 				sky->foreground.mid     = DOUBLE2FIXED(foremid.asDouble());
 				sky->foreground.scrollx = DOUBLE2FIXED(forescrollx.asDouble() * ticratescale);
@@ -404,7 +404,7 @@ void R_InitSkyDefs()
 				if(!fireelem.isNull() || !foreelem.isNull()) return JL_PARSEERROR;
 			}
 
-			skylookup[skytexname] = sky;
+			// skylookup[skytexname] = sky;
 		}
 
 		// TODO: flatmappings

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -133,7 +133,7 @@ static void R_InitXToViewAngle()
 void R_GenerateLookup(int texnum, int *const errors); // from r_data.cpp
 
 
-// MIA TODO: iterate over skymaps to do this stuff
+// MIA TODO: iterate over skies to do this stuff
 void R_InitSkyMap()
 {
 	fixed_t fskyheight;
@@ -302,7 +302,7 @@ void R_InitSkyDefs()
 			auto skytype = static_cast<skytype_t>(type.asInt());
 			if(skytype < SKY_NORMAL || skytype > SKY_DOUBLESKY) return JL_PARSEERROR;
 
-			std::string skytexname = skytex.asString();
+			OLumpName skytexname = skytex.asString();
 			int32_t tex = R_TextureNumForName(skytexname.c_str());
 			if(tex < 0) return JL_PARSEERROR;
 
@@ -355,7 +355,7 @@ void R_InitSkyDefs()
 				const Json::Value& forescalex  = foreelem["scalex"];
 				const Json::Value& forescaley  = foreelem["scaley"];
 
-				std::string foreskytexname = foreskytex.asString();
+				OLumpName foreskytexname = foreskytex.asString();
 				int32_t foretex = R_TextureNumForName(foreskytexname.c_str());
 				if(foretex < 0) return JL_PARSEERROR;
 
@@ -380,7 +380,7 @@ void R_InitSkyDefs()
 				if(!fireelem.isNull() || !foreelem.isNull()) return JL_PARSEERROR;
 			}
 
-			skylookup[skytexname] = sky;
+			skylookup[skytexname.c_str()] = sky;
 		}
 
 		for(const Json::Value& flatentry : flatmappings)
@@ -403,7 +403,7 @@ void R_InitSkyDefs()
 
 	jsonlumpresult_t result =  M_ParseJSONLump("SKYDEFS", "skydefs", { 1, 0, 0 }, ParseSkydef);
 	if (result != JL_SUCCESS && result != JL_NOTFOUND)
-		I_Error("R_InitSkyDefs: SKYDEFS JSON error: %s", jsonLumpResultToString(result));
+		I_Error("R_InitSkyDefs: SKYDEFS JSON error: %s", M_JSONLumpResultToString(result));
 }
 
 void R_ClearSkyDefs()

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -749,12 +749,6 @@ void R_RenderSkyRange(visplane_t* pl)
 
 	const palette_t* pal = V_GetDefaultPalette();
 
-	dcol.iscale = FixedMul(skyiscale, sky1scaley) >> skystretch;
-	dcol.texturemid = sky1mid + ((backskytex == -1) ? frontrow_offset : 0);
-	dcol.textureheight = textureheight[frontskytex]; // both skies are forced to be the same height anyway
-	dcol.texturefrac = dcol.texturemid + (dcol.yl - centery) * dcol.iscale;
-	skyplane = pl;
-
 	// set up the appropriate colormap for the sky
 	if (fixedlightlev)
 	{
@@ -776,6 +770,12 @@ void R_RenderSkyRange(visplane_t* pl)
 
 	if (backskytex != -1)
 	{
+		dcol.iscale = FixedMul(skyiscale, sky2scaley) >> skystretch;
+		dcol.texturemid = sky2mid + backrow_offset;
+		dcol.textureheight = textureheight[backskytex]; // both skies are forced to be the same height anyway
+		dcol.texturefrac = dcol.texturemid + (dcol.yl - centery) * dcol.iscale;
+		skyplane = pl;
+
 		for (int x = pl->minx; x <= pl->maxx; x++)
 		{
 			int sky2colnum = ((((viewangle + xtoviewangle[x]) ^ skyflip) >> sky2shift) + back_offset) >> FRACBITS;
@@ -787,6 +787,11 @@ void R_RenderSkyRange(visplane_t* pl)
 		R_RenderColumnRange(pl->minx, pl->maxx, (int*)pl->top, (int*)pl->bottom,
 				skyposts, SkyBackgroundColumnBlaster, false, columnmethod);
 	}
+
+	dcol.iscale = FixedMul(skyiscale, sky1scaley) >> skystretch;
+	dcol.texturemid = sky1mid + frontrow_offset;
+	dcol.textureheight = textureheight[frontskytex]; // both skies are forced to be the same height anyway
+	dcol.texturefrac = dcol.texturemid + (dcol.yl - centery) * dcol.iscale;
 
 	for (int x = pl->minx; x <= pl->maxx; x++)
 	{

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -30,6 +30,7 @@
 
 #include "m_fixed.h"
 #include "m_jsonlump.h"
+#include "m_random.h"
 #include "r_data.h"
 #include "r_draw.h"
 #include "r_main.h"
@@ -425,7 +426,7 @@ static void R_UpdateFireSky(sky_t* sky)
 		int fireindex = sky->numfireentries - 1;
         for (int y = tex->height - 2; y >= 0; y--)
 		{
-			int rand = ((int)std::round(((double) std::rand() / (RAND_MAX)) * 3.0)) & 3;
+			int rand = (int)(M_RandomFloat() * 3.0) & 3;
 			fireindex = fireindex - (1 & rand);
 			fireindex = MAX(0, MIN(fireindex, sky->numfireentries - 1));
             spreadFire(y, coldata, sky->firepalette[fireindex]);

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -119,6 +119,7 @@ struct sky_t
 OHashTable<std::string, sky_t*> skylookup;
 OHashTable<int32_t, sky_t*> skyflatlookup;
 
+// MIA TODO: delete skies created with R_GetSky at end of level so things like in correct scroll speeds from MAPINFO on maps using same texture but different speeds dont happen
 
 //
 // R_InitXToViewAngle
@@ -187,8 +188,10 @@ void R_InitSkyMap()
 
 	for (auto& skypair : skylookup)
 	{
-		// do the stuff below for each sky
+		// do the stuff below for each sky maybe???
 	}
+
+	// sky_t* defaultsky = skyflatlookup[skyflatnum];
 
 	if (sky2texture && textureheight[sky1texture] != textureheight[sky2texture])
 	{
@@ -197,6 +200,7 @@ void R_InitSkyMap()
 	}
 
 	fskyheight = textureheight[sky1texture];
+	// fskyheight = textureheight[defaultsky->background.texnum];
 
 	if (fskyheight <= (128 << FRACBITS))
 	{
@@ -252,6 +256,7 @@ sky_t* R_GetSky(const char* name, bool create)
 	sky->background.scalex = INT2FIXED(1);
 	sky->background.scaley = INT2FIXED(1);
 	sky->background.scrolly = INT2FIXED(0);
+	// MIA TODO: set mid using whats done with the initskymaps instead of just 100
 	sky->background.mid = INT2FIXED(100);
 	if (level.flags & LEVEL_DOUBLESKY)
 	{
@@ -595,6 +600,8 @@ void R_RenderSkyRange(visplane_t* pl)
 	fixed_t sky2scalex = INT2FIXED(1);
 	fixed_t sky1scaley = INT2FIXED(1);
 	fixed_t sky2scaley = INT2FIXED(1);
+	fixed_t sky1mid = sky1texturemid;
+	fixed_t sky2mid = sky2texturemid;
 
 	if (skyflat != skyflatlookup.end())
 	{
@@ -612,6 +619,8 @@ void R_RenderSkyRange(visplane_t* pl)
 			sky2scalex = sky->background.scalex;
 			sky1scaley = sky->foreground.scaley;
 			sky2scaley = sky->background.scaley;
+			sky1mid    = sky->foreground.mid;
+			sky2mid    = sky->background.mid;
 		}
 		else
 		{
@@ -621,6 +630,7 @@ void R_RenderSkyRange(visplane_t* pl)
 			frontrow_offset = sky->background.curry;
 			sky1scalex = sky->background.scalex;
 			sky1scaley = sky->background.scaley;
+			sky1mid    = sky->background.mid;
 		}
 	}
 	else if (pl->picnum == int(PL_SKYFLAT))
@@ -665,7 +675,7 @@ void R_RenderSkyRange(visplane_t* pl)
 	const palette_t* pal = V_GetDefaultPalette();
 
 	dcol.iscale = FixedMul(skyiscale, sky1scaley) >> skystretch;
-	dcol.texturemid = sky1texturemid + frontrow_offset;
+	dcol.texturemid = sky1mid + ((backskytex == -1) ? frontrow_offset : 0);
 	dcol.textureheight = textureheight[frontskytex]; // both skies are forced to be the same height anyway
 	dcol.texturefrac = dcol.texturemid + (dcol.yl - centery) * dcol.iscale;
 	skyplane = pl;

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -182,37 +182,6 @@ void R_InitSkyMap()
 	R_InitXToViewAngle();
 }
 
-// //
-// // sky mapping
-// //
-// int 		skyflatnum;
-// int 		sky1texture,	sky2texture;
-// fixed_t		skytexturemid;
-// fixed_t		skyscale;
-// int			skystretch;
-// fixed_t		skyheight;
-// fixed_t		skyiscale;
-
-// int			sky1shift,		sky2shift;
-// fixed_t		sky1scrolldelta,	sky2scrolldelta;
-// fixed_t		sky1columnoffset,	sky2columnoffset;
-
-// // The xtoviewangleangle[] table maps a screen pixel
-// // to the lowest viewangle that maps back to x ranges
-// // from clipangle to -clipangle.
-// static angle_t xtoviewangle[MAXWIDTH + 1];
-
-// CVAR_FUNC_IMPL(r_stretchsky)
-// {
-// 	R_InitSkyMap ();
-// }
-
-// char SKYFLATNAME[8] = "F_SKY1";
-
-
-// static tallpost_t* skyposts[MAXWIDTH];
-// static byte compositeskybuffer[MAXWIDTH][512]; // holds doublesky composite sky to blit to the screen
-
 typedef enum
 {
 	SKY_NORMAL,
@@ -260,6 +229,7 @@ skyflat_t* defaultskyflat = nullptr;
 OHashTable<std::string, sky_t*> skylookup;
 // OHashTable<int32_t, skyflat_t*> skyflatlookup;
 
+// [EB] adapted from Rum n Raisin r_sky.cpp
 void R_InitSkyDefs()
 {
 	// skyflatnum = R_FlatNumForName(SKYFLATNAME);
@@ -407,14 +377,15 @@ void R_InitSkyDefs()
 		I_Error("SKYDEFS error %d", result);
 }
 
-void R_LoadSkyDef(const OLumpName& skytex)
+bool R_LoadSkyDef(const OLumpName& skytex)
 {
 	const sky_t* sky = skylookup[std::string(skytex.c_str())];
 	if (sky == nullptr)
-		return;
+		return false;
 	switch(sky->type)
 	{
 		case SKY_NORMAL:
+			level.flags &= ~LEVEL_DOUBLESKY;
 			sky1texture = sky->background.texnum;
 			sky1scrolldelta = sky->background.scrollx;
 			sky2texture = 0;
@@ -430,6 +401,7 @@ void R_LoadSkyDef(const OLumpName& skytex)
 			sky2scrolldelta = sky->background.scrollx;
 			break;
 	}
+	return true;
 }
 
 //

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -447,7 +447,7 @@ void R_InitFireSky(sky_t* sky)
 {
 	int texnum = sky->background.texnum;
 	texture_t* tex = textures[texnum];
-	sky->firetexturedata = (byte*)Z_Malloc(sizeof(byte) * tex->width * tex->height, PU_STATIC, nullptr);
+	sky->firetexturedata = (byte*)Z_Malloc(sizeof(byte) * tex->width * tex->height, PU_LEVEL, nullptr);
     for (int i = 0 ; i < tex->width*tex->height; i++)
 	{
 		sky->firetexturedata[i] = 0;
@@ -490,11 +490,11 @@ void R_UpdateSkies()
 // TODO: in R_PreCacheLevel, check if any of the skyflats are present and activate the corresponding skies
 void R_ActivateSky(sky_t* sky)
 {
-	sky->active = true;
 	if (sky->type == SKY_FIRE)
 	{
 		R_InitFireSky(sky);
 	}
+	sky->active = true;
 }
 
 void R_InitSkiesForLevel()

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -59,9 +59,7 @@ fixed_t		skyiscale;
 
 int			sky1shift,        sky2shift;
 fixed_t		sky2scrollxdelta;
-fixed_t		sky1columnoffset, sky2columnoffset;
-fixed_t		sky1scrollydelta, sky2scrollydelta;
-fixed_t		sky1rowoffset,    sky2rowoffset;
+fixed_t		sky2columnoffset;
 
 // The xtoviewangleangle[] table maps a screen pixel
 // to the lowest viewangle that maps back to x ranges

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -872,9 +872,16 @@ void R_RenderSkyRange(visplane_t* pl)
 						transfound = false;
 					}
 				}
-				std::memcpy(destpost->data(), skypost->data() + desttopdelta, skypost->length - desttopdelta);
-				destpost->length = skypost->length - desttopdelta;
-				destpost->topdelta = skypost->topdelta + desttopdelta;
+				if (transfound)
+				{
+					destpost->length = 0;
+				}
+				else
+				{
+					std::memcpy(destpost->data(), skypost->data() + desttopdelta, skypost->length - desttopdelta);
+					destpost->length = skypost->length - desttopdelta;
+					destpost->topdelta = skypost->topdelta + desttopdelta;
+				}
 				destpost = destpost->next();
 				skypost = skypost->next();
 			}

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -295,13 +295,13 @@ void R_InitSkyDefs()
 			if(sky->type == SKY_FIRE)
 			{
 				// TODO: fireskies
-				// if(!fireelem.isObject()) return JL_PARSEERROR;
+				if(!fireelem.isObject()) return JL_PARSEERROR;
 
-				// const Json::Value& firepalette    = fireelem[ "palette" ];
-				// const Json::Value& fireupdatetime = fireelem[ "updatetime" ];
+				const Json::Value& firepalette    = fireelem["palette"];
+				const Json::Value& fireupdatetime = fireelem["updatetime"];
 
-				// if(!firepalette.isArray()) return JL_PARSEERROR;
-				// sky->numfireentries = (int32_t)firepalette.size();
+				if(!firepalette.isArray()) return JL_PARSEERROR;
+				sky->numfireentries = (int32_t)firepalette.size();
 				// byte* output = sky->firepalette = (byte*)Z_MallocZero( sizeof( byte ) * sky->numfireentries, PU_STATIC, nullptr );
 				// for(const Json::Value& palentry : firepalette)
 				// {
@@ -374,7 +374,12 @@ void R_InitSkyDefs()
 
 	jsonlumpresult_t result =  M_ParseJSONLump("SKYDEFS", "skydefs", { 1, 0, 0 }, ParseSkydef);
 	if (result != JL_SUCCESS && result != JL_NOTFOUND)
-		I_Error("SKYDEFS error %d", result);
+		I_Error("R_InitSkyDefs: SKYDEFS JSON error: %s", jsonLumpResultToString(result));
+}
+
+void R_ClearSkyDefs()
+{
+	skylookup.clear();
 }
 
 bool R_LoadSkyDef(const OLumpName& skytex)

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -382,50 +382,6 @@ void R_ClearSkyDefs()
 	skylookup.clear();
 }
 
-bool R_InitSkiesForLevel(const OLumpName& skytex)
-{
-	for(auto& skypair : skylookup)
-	{
-		// TODO: change to false and correctly set if sky is active elsewhere
-		skypair.second->active = true;
-		skypair.second->foreground.currx = 0;
-		skypair.second->foreground.curry = 0;
-		skypair.second->background.currx = 0;
-		skypair.second->background.curry = 0;
-	}
-	// const sky_t* sky = skylookup[std::string(skytex.c_str())];
-	// if (sky == nullptr)
-	// 	return false;
-	// switch(sky->type)
-	// {
-	// 	case SKY_NORMAL:
-	// 		level.flags &= ~LEVEL_DOUBLESKY;
-	// 		sky1texture = sky->background.texnum;
-	// 		sky1scrollxdelta = sky->background.scrollx;
-	// 		sky1scrollydelta = sky->background.scrolly;
-	// 		sky1texturemid = sky->background.mid;
-	// 		sky2texture = 0;
-	// 		sky2scrollxdelta = 0;
-	// 		sky2scrollydelta = 0;
-	// 		sky2texturemid = 0;
-	// 		break;
-	// 	case SKY_FIRE:
-	// 		break;
-	// 	case SKY_DOUBLESKY:
-	// 		level.flags |= LEVEL_DOUBLESKY;
-	// 		sky1texture = sky->foreground.texnum;
-	// 		sky1scrollxdelta = sky->foreground.scrollx;
-	// 		sky1scrollydelta = sky->foreground.scrolly;
-	// 		sky1texturemid = sky->foreground.mid;
-	// 		sky2texture = sky->background.texnum;
-	// 		sky2scrollxdelta = sky->background.scrollx;
-	// 		sky2scrollydelta = sky->background.scrolly;
-	// 		sky2texturemid = sky->background.mid;
-	// 		break;
-	// }
-	return true;
-}
-
 static void R_UpdateFireSky(sky_t* sky)
 {
 
@@ -520,7 +476,8 @@ void R_SetDefaultSky(const char* sky)
 	defaultskyflat->sky = skydef;
 }
 
-void R_ActivateSky( sky_t* sky )
+// TODO: in R_PreCacheLevel, check if any of the skyflats are present and activate the corresponding skies
+void R_ActivateSky(sky_t* sky)
 {
 	sky->active = true;
 }

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -422,14 +422,14 @@ void R_ClearSkyDefs()
 	skyflatlookup.clear();
 }
 
-void spreadFire(int src, byte* firePixels, int FIRE_WIDTH, int numfire)
+void spreadFire(int src, byte* firepixels, int width)
 {
-	byte pixel = firePixels[src];
+	byte pixel = firepixels[src];
 	if(pixel == 0) {
-		firePixels[src - FIRE_WIDTH] = 0;
+		firepixels[src - width] = 0;
 	} else {
 		int rand = (int)std::round(M_RandomFloat() * 3.0) & 3;
-		firePixels[(src - rand + 1) - FIRE_WIDTH] = pixel - (rand & 1);
+		firepixels[(src - rand + 1) - width] = pixel - (rand & 1);
 	}
 }
 
@@ -442,7 +442,7 @@ static void R_UpdateFireSky(sky_t* sky, bool init = false)
 	{
         for (int y = 1; y < tex->height; y++)
 		{
-            spreadFire(y * tex->width + x, sky->firetexturedata, tex->width, sky->numfireentries);
+            spreadFire(y * tex->width + x, sky->firetexturedata, tex->width);
         }
     }
 	byte* coldata;

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -283,12 +283,12 @@ void R_InitSkyDefs()
 
 			sky->type = skytype;
 
-			constexpr double_t ticratescale = 1.0 / TICRATE;
+			constexpr float_t ticratescale = 1.0 / TICRATE;
 
 			sky->background.texnum  = tex;
 			sky->background.mid     = FLOAT2FIXED(mid.asFloat());
-			sky->background.scrollx = FLOAT2FIXED(scrollx.asFloat());
-			sky->background.scrolly = FLOAT2FIXED(scrolly.asFloat());
+			sky->background.scrollx = FLOAT2FIXED(scrollx.asFloat() * ticratescale);
+			sky->background.scrolly = FLOAT2FIXED(scrolly.asFloat() * ticratescale);
 			sky->background.scalex  = FLOAT2FIXED(scalex.asFloat());
 			sky->background.scaley  = FLOAT2FIXED(scaley.asFloat());
 
@@ -335,8 +335,8 @@ void R_InitSkyDefs()
 
 				sky->foreground.texnum  = foretex;
 				sky->foreground.mid     = FLOAT2FIXED(foremid.asFloat());
-				sky->foreground.scrollx = FLOAT2FIXED(forescrollx.asFloat());
-				sky->foreground.scrolly = FLOAT2FIXED(forescrolly.asFloat());
+				sky->foreground.scrollx = FLOAT2FIXED(forescrollx.asFloat() * ticratescale);
+				sky->foreground.scrolly = FLOAT2FIXED(forescrolly.asFloat() * ticratescale);
 				sky->foreground.scalex  = FLOAT2FIXED(forescalex.asFloat());
 				sky->foreground.scaley  = FLOAT2FIXED(forescaley.asFloat());
 			}

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -417,7 +417,6 @@ void R_LoadSkyDef(const OLumpName& skytex)
 		case SKY_NORMAL:
 			sky1texture = sky->background.texnum;
 			sky1scrolldelta = sky->background.scrollx;
-			level.sky1ScrollDelta = sky->foreground.scrollx;
 			sky2texture = 0;
 			sky2scrolldelta = 0;
 			break;
@@ -427,10 +426,8 @@ void R_LoadSkyDef(const OLumpName& skytex)
 			level.flags |= LEVEL_DOUBLESKY;
 			sky1texture = sky->foreground.texnum;
 			sky1scrolldelta = sky->foreground.scrollx;
-			level.sky1ScrollDelta = sky->foreground.scrollx;
 			sky2texture = sky->background.texnum;
 			sky2scrolldelta = sky->background.scrollx;
-			level.sky2ScrollDelta = sky->background.scrollx;
 			break;
 	}
 }

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -309,7 +309,7 @@ void R_InitSkyDefs()
 				}
 				sky->fireticrate = (int32_t)(fireupdatetime.asFloat() * TICRATE);
 			}
-			else if(sky->type = SKY_DOUBLESKY)
+			else if(sky->type == SKY_DOUBLESKY)
 			{
 				if(!foreelem.isObject()) return JL_PARSEERROR;
 

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -363,12 +363,10 @@ void R_InitSkyDefs()
 			std::string skyname = skyelem.asString();
 			sky_t* sky = R_GetSky(skyname.c_str(), true);
 
-	// 		texturecomposite_t* flatcomposite = flatlookup[ flatnum ];
-	// 		skyflat_t* newflat = (skyflat_t*)Z_MallocZero( sizeof( skyflat_t ), PU_STATIC, nullptr );
-	// 		*newflat = { flatcomposite, sky };
+			skyflat_t* newflat = (skyflat_t*)Z_Malloc(sizeof( skyflat_t ), PU_STATIC, nullptr);
+			*newflat = { flatnum, sky };
 
-	// 		skyflatlookup[ flatnum ] = newflat;
-	// 		flatcomposite->skyflat = newflat;
+			skyflatlookup[flatnum] = newflat;
 		}
 
 		return JL_SUCCESS;
@@ -554,7 +552,10 @@ inline bool R_PostDataIsTransparent(byte* data)
 	return false;
 }
 
-
+bool R_IsSkyFlat(int flatnum)
+{
+	return skyflatlookup.count(flatnum);
+}
 
 //
 // R_RenderSkyRange

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -51,9 +51,8 @@ EXTERN_CVAR(r_skypalette)
 // sky mapping
 //
 int 		skyflatnum;
-// MIA TODO: remove sky1 variables
 int 		sky1texture,    sky2texture;
-fixed_t		sky1texturemid, sky2texturemid;
+fixed_t		defaultskytexturemid;
 fixed_t		skyscale;
 int			skystretch;
 fixed_t		skyheight;
@@ -74,7 +73,6 @@ CVAR_FUNC_IMPL(r_stretchsky)
 }
 
 char SKYFLATNAME[8] = "F_SKY1";
-
 
 static tallpost_t* skyposts[MAXWIDTH];
 static byte transparentskybuffer[MAXWIDTH][512]; // holds foreground sky with transparency to blit to the screen
@@ -174,8 +172,6 @@ static void R_InitXToViewAngle()
 
 void R_GenerateLookup(int texnum, int *const errors); // from r_data.cpp
 
-
-// MIA TODO: iterate over skies to do this stuff
 void R_InitSkyMap()
 {
 	fixed_t fskyheight;
@@ -187,30 +183,18 @@ void R_InitSkyMap()
 	if (gamestate != GS_LEVEL)
 		return;
 
-	for (auto& skypair : skylookup)
-	{
-		// do the stuff below for each sky maybe???
-	}
+	sky_t* defaultsky = skyflatlookup[skyflatnum];
 
-	// sky_t* defaultsky = skyflatlookup[skyflatnum];
-
-	if (sky2texture && textureheight[sky1texture] != textureheight[sky2texture])
-	{
-		Printf (PRINT_HIGH,"\x1f+Both sky textures must be the same height.\x1f-\n");
-		sky2texture = sky1texture;
-	}
-
-	fskyheight = textureheight[sky1texture];
-	// fskyheight = textureheight[defaultsky->background.texnum];
+	fskyheight = textureheight[defaultsky->background.texnum];
 
 	if (fskyheight <= (128 << FRACBITS))
 	{
-		sky1texturemid = 200/2*FRACUNIT;
+		defaultskytexturemid = 200/2*FRACUNIT;
 		skystretch = (r_stretchsky == 1) || consoleplayer().spectator || (r_stretchsky == 2 && sv_freelook && cl_mouselook);
 	}
 	else
 	{
-		sky1texturemid = 199<<FRACBITS;//textureheight[sky1texture]-1;
+		defaultskytexturemid = 199<<FRACBITS;
 		skystretch = 0;
 	}
 	skyheight = fskyheight << skystretch;
@@ -644,8 +628,8 @@ void R_RenderSkyRange(visplane_t* pl)
 	fixed_t sky2scalex = INT2FIXED(1);
 	fixed_t sky1scaley = INT2FIXED(1);
 	fixed_t sky2scaley = INT2FIXED(1);
-	fixed_t sky1mid = sky1texturemid;
-	fixed_t sky2mid = sky2texturemid;
+	fixed_t sky1mid = defaultskytexturemid;
+	fixed_t sky2mid = defaultskytexturemid;
 
 	if (skyflat != skyflatlookup.end())
 	{
@@ -708,7 +692,7 @@ void R_RenderSkyRange(visplane_t* pl)
 		front_offset = (-side->textureoffset) >> 6;
 
 		// Vertical offset allows careful sky positioning.
-		sky1texturemid = side->rowoffset - 28*FRACUNIT;
+		defaultskytexturemid = side->rowoffset - 28*FRACUNIT;
 
 		// We sometimes flip the picture horizontally.
 		//

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -316,11 +316,11 @@ void R_InitSkyDefs()
 			constexpr double_t ticratescale = 1.0 / TICRATE;
 
 			sky->background.texnum  = tex;
-			sky->background.mid     = DOUBLE2FIXED(mid.asDouble());
-			sky->background.scrollx = DOUBLE2FIXED(scrollx.asDouble() * ticratescale);
-			sky->background.scrolly = DOUBLE2FIXED(scrolly.asDouble() * ticratescale);
-			sky->background.scalex  = DOUBLE2FIXED(scalex.asDouble());
-			sky->background.scaley  = DOUBLE2FIXED(scaley.asDouble());
+			sky->background.mid     = FLOAT2FIXED(mid.asFloat());
+			sky->background.scrollx = FLOAT2FIXED(scrollx.asFloat());
+			sky->background.scrolly = FLOAT2FIXED(scrolly.asFloat());
+			sky->background.scalex  = FLOAT2FIXED(scalex.asFloat());
+			sky->background.scaley  = FLOAT2FIXED(scaley.asFloat());
 
 			if(sky->type == SKY_FIRE)
 			{
@@ -364,11 +364,11 @@ void R_InitSkyDefs()
 				}
 
 				sky->foreground.texnum  = foretex;
-				sky->foreground.mid     = DOUBLE2FIXED(foremid.asDouble());
-				sky->foreground.scrollx = DOUBLE2FIXED(forescrollx.asDouble() * ticratescale);
-				sky->foreground.scrolly = DOUBLE2FIXED(forescrolly.asDouble() * ticratescale);
-				sky->foreground.scalex  = DOUBLE2FIXED(forescalex.asDouble());
-				sky->foreground.scaley  = DOUBLE2FIXED(forescaley.asDouble());
+				sky->foreground.mid     = FLOAT2FIXED(foremid.asFloat());
+				sky->foreground.scrollx = FLOAT2FIXED(forescrollx.asFloat());
+				sky->foreground.scrolly = FLOAT2FIXED(forescrolly.asFloat());
+				sky->foreground.scalex  = FLOAT2FIXED(forescalex.asFloat());
+				sky->foreground.scaley  = FLOAT2FIXED(forescaley.asFloat());
 			}
 			else
 			{
@@ -416,7 +416,8 @@ void R_LoadSkyDef(const OLumpName& skytex)
 	{
 		case SKY_NORMAL:
 			sky1texture = sky->background.texnum;
-			sky1scrolldelta = sky->foreground.scrollx;
+			sky1scrolldelta = sky->background.scrollx;
+			level.sky1ScrollDelta = sky->foreground.scrollx;
 			sky2texture = 0;
 			sky2scrolldelta = 0;
 			break;
@@ -425,11 +426,11 @@ void R_LoadSkyDef(const OLumpName& skytex)
 		case SKY_DOUBLESKY:
 			level.flags |= LEVEL_DOUBLESKY;
 			sky1texture = sky->foreground.texnum;
-			// sky1scrolldelta = sky->foreground.scrollx;
-			sky1scrolldelta = FLOAT2FIXED(0.15f);
+			sky1scrolldelta = sky->foreground.scrollx;
+			level.sky1ScrollDelta = sky->foreground.scrollx;
 			sky2texture = sky->background.texnum;
-			// sky2scrolldelta = sky->background.scrollx;
-			sky2scrolldelta = FLOAT2FIXED(0.075f);
+			sky2scrolldelta = sky->background.scrollx;
+			level.sky2ScrollDelta = sky->background.scrollx;
 			break;
 	}
 }

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -487,7 +487,6 @@ void R_UpdateSkies()
 	}
 }
 
-// TODO: in R_PreCacheLevel, check if any of the skyflats are present and activate the corresponding skies
 void R_ActivateSky(sky_t* sky)
 {
 	if (sky->type == SKY_FIRE)
@@ -495,6 +494,19 @@ void R_ActivateSky(sky_t* sky)
 		R_InitFireSky(sky);
 	}
 	sky->active = true;
+}
+
+void R_ActivateSkies(const byte* hitlist, std::vector<int>& skytextures)
+{
+	for(auto& skypair : skyflatlookup)
+	{
+		if (hitlist[skypair.first])
+			R_ActivateSky(skypair.second);
+
+		skytextures.push_back(skypair.second->background.texnum);
+		if (skypair.second->type == SKY_DOUBLESKY)
+			skytextures.push_back(skypair.second->foreground.texnum);
+	}
 }
 
 void R_InitSkiesForLevel()
@@ -506,8 +518,6 @@ void R_InitSkiesForLevel()
 		skypair.second->foreground.curry = 0;
 		skypair.second->background.currx = 0;
 		skypair.second->background.curry = 0;
-		// TODO: remove this and call from correct place
-		R_ActivateSky(skypair.second);
 	}
 }
 

--- a/common/m_jsonlump.cpp
+++ b/common/m_jsonlump.cpp
@@ -26,6 +26,8 @@
 
 #include "m_jsonlump.h"
 
+#include "i_system.h"
+
 #include <string>
 #include <regex>
 
@@ -35,7 +37,7 @@ static std::regex TypeMatchRegex = std::regex( TypeMatchRegexString );
 constexpr const char* VersionMatchRegexString = "^(\\d+)\\.(\\d+)\\.(\\d+)$";
 static std::regex VersionMatchRegex = std::regex( VersionMatchRegexString );
 
-jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, const JSONLumpFunc& parsefunc)
+jsonlumpresult_t M_ParseJSONLump(int lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, const JSONLumpFunc& parsefunc)
 {
 	if(lumpindex < 0 || W_LumpLength(lumpindex) <= 0)
 	{
@@ -53,6 +55,7 @@ jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, co
     if(!reader->parse(jsondata, jsondata + W_LumpLength(lumpindex), &root, &errs))
     {
         delete reader;
+        I_Error("M_ParseJSONLump: JSON parsing error in lump %s:\n%s", W_LumpName(lumpindex), errs.c_str());
         return JL_PARSEERROR;
     }
 

--- a/common/m_jsonlump.cpp
+++ b/common/m_jsonlump.cpp
@@ -22,8 +22,6 @@
 //-----------------------------------------------------------------------------
 
 
-#pragma once
-
 #include "odamex.h"
 
 #include "m_jsonlump.h"
@@ -53,14 +51,17 @@ jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, co
     std::string errs;
 
     if(!reader->parse(jsondata, jsondata + W_LumpLength(lumpindex), &root, &errs))
+    {
+        delete reader;
         return JL_PARSEERROR;
+    }
 
     delete reader;
 
-	const Json::Value& type			= root["type"];
-	const Json::Value& version		= root["version"];
-	const Json::Value& metadata		= root["metadata"];
-	const Json::Value& data			= root["data"];
+	const Json::Value& type     = root["type"];
+	const Json::Value& version  = root["version"];
+	const Json::Value& metadata = root["metadata"];
+	const Json::Value& data     = root["data"];
 
 	std::smatch versionmatch;
 	std::string versionstr = version.asString();
@@ -89,7 +90,7 @@ jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, co
 	{
 		stoi(versionmatch[1].str()),
 		stoi(versionmatch[2].str()),
-		stoi(versionmatch[3].str()),
+		stoi(versionmatch[3].str())
 	};
 
 	if(versiondata > maxversion)
@@ -99,5 +100,3 @@ jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, co
 
 	return parsefunc(data, versiondata);
 }
-
-VERSION_CONTROL (m_jsonlump_cpp, "$Id$")

--- a/common/m_jsonlump.cpp
+++ b/common/m_jsonlump.cpp
@@ -18,6 +18,7 @@
 //
 // DESCRIPTION:
 //  JSON lump parsing for ID24
+//  Adapted from Rum n Raisin Doom m_jsonlump.cpp
 //
 //-----------------------------------------------------------------------------
 

--- a/common/m_jsonlump.cpp
+++ b/common/m_jsonlump.cpp
@@ -1,0 +1,103 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 1998-2006 by Randy Heit (ZDoom).
+// Copyright (C) 2006-2024 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  JSON lump parsing for ID24
+//
+//-----------------------------------------------------------------------------
+
+
+#pragma once
+
+#include "odamex.h"
+
+#include "m_jsonlump.h"
+
+#include <string>
+#include <regex>
+
+constexpr const char* TypeMatchRegexString = "^[a-z0-9_-]+$";
+static std::regex TypeMatchRegex = std::regex( TypeMatchRegexString );
+
+constexpr const char* VersionMatchRegexString = "^(\\d+)\\.(\\d+)\\.(\\d+)$";
+static std::regex VersionMatchRegex = std::regex( VersionMatchRegexString );
+
+jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, const JSONLumpFunc& parsefunc)
+{
+	if(lumpindex < 0 || W_LumpLength(lumpindex) <= 0)
+	{
+		return JL_NOTFOUND;
+	}
+
+	const char* jsondata = (const char*)W_CacheLumpNum(lumpindex, PU_STATIC);
+
+    Json::CharReaderBuilder builder;
+    builder["collectComments"] = false;
+    Json::CharReader* reader = builder.newCharReader();
+    Json::Value root;
+    std::string errs;
+
+    if(!reader->parse(jsondata, jsondata + W_LumpLength(lumpindex), &root, &errs))
+        return JL_PARSEERROR;
+
+    delete reader;
+
+	const Json::Value& type			= root["type"];
+	const Json::Value& version		= root["version"];
+	const Json::Value& metadata		= root["metadata"];
+	const Json::Value& data			= root["data"];
+
+	std::smatch versionmatch;
+	std::string versionstr = version.asString();
+
+	if(root.size() != 4
+	   || !type.isString()
+	   || !version.isString()
+	   || !metadata.isObject()
+	   || !data.isObject())
+	{
+		return JL_MALFORMEDROOT;
+	}
+
+	if(!std::regex_match(lumptype, TypeMatchRegex)
+	   || type.asString() != lumptype)
+	{
+		return JL_TYPEMISMATCH;
+	}
+
+	if(!std::regex_search(versionstr, versionmatch, VersionMatchRegex))
+	{
+		return JL_BADVERSIONFORMATTING;
+	}
+
+	JSONLumpVersion versiondata =
+	{
+		stoi(versionmatch[1].str()),
+		stoi(versionmatch[2].str()),
+		stoi(versionmatch[3].str()),
+	};
+
+	if(versiondata > maxversion)
+	{
+		return JL_VERSIONMISMATCH;
+	}
+
+	return parsefunc(data, versiondata);
+}
+
+VERSION_CONTROL (m_jsonlump_cpp, "$Id$")

--- a/common/m_jsonlump.cpp
+++ b/common/m_jsonlump.cpp
@@ -18,7 +18,7 @@
 //
 // DESCRIPTION:
 //  JSON lump parsing for ID24
-//  Adapted from Rum n Raisin Doom m_jsonlump.cpp
+//  Adapted from Rum and Raisin Doom m_jsonlump.cpp
 //
 //-----------------------------------------------------------------------------
 

--- a/common/m_jsonlump.cpp
+++ b/common/m_jsonlump.cpp
@@ -32,10 +32,10 @@
 #include <regex>
 
 constexpr const char* TypeMatchRegexString = "^[a-z0-9_-]+$";
-static std::regex TypeMatchRegex = std::regex( TypeMatchRegexString );
+static std::regex TypeMatchRegex = std::regex(TypeMatchRegexString);
 
 constexpr const char* VersionMatchRegexString = "^(\\d+)\\.(\\d+)\\.(\\d+)$";
-static std::regex VersionMatchRegex = std::regex( VersionMatchRegexString );
+static std::regex VersionMatchRegex = std::regex(VersionMatchRegexString);
 
 jsonlumpresult_t M_ParseJSONLump(int lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, const JSONLumpFunc& parsefunc)
 {

--- a/common/m_jsonlump.h
+++ b/common/m_jsonlump.h
@@ -18,7 +18,7 @@
 //
 // DESCRIPTION:
 //  JSON lump parsing for ID24
-//  Adapted from Rum n Raisin Doom m_jsonlump.h
+//  Adapted from Rum and Raisin Doom m_jsonlump.h
 //
 //-----------------------------------------------------------------------------
 

--- a/common/m_jsonlump.h
+++ b/common/m_jsonlump.h
@@ -91,7 +91,7 @@ static constexpr const char* JSON_LUMP_RESULT_ERROR_STRINGS[] =
 	"JL_PARSEERROR"
 };
 
-constexpr const char* jsonLumpResultToString(jsonlumpresult_t jlr)
+constexpr const char* M_JSONLumpResultToString(jsonlumpresult_t jlr)
 {
 	return JSON_LUMP_RESULT_ERROR_STRINGS[jlr];
 }

--- a/common/m_jsonlump.h
+++ b/common/m_jsonlump.h
@@ -22,6 +22,8 @@
 //-----------------------------------------------------------------------------
 
 
+#pragma once
+
 #include "odamex.h"
 
 #include "doomtype.h"
@@ -92,5 +94,3 @@ inline jsonlumpresult_t M_ParseJSONLump(const char* lumpname, const char* lumpty
 {
 	return M_ParseJSONLump(W_CheckNumForName(lumpname), lumptype, maxversion, parsefunc);
 }
-
-VERSION_CONTROL (m_jsonlump_h, "$Id$")

--- a/common/m_jsonlump.h
+++ b/common/m_jsonlump.h
@@ -18,6 +18,7 @@
 //
 // DESCRIPTION:
 //  JSON lump parsing for ID24
+//  Adapted from Rum n Raisin Doom m_jsonlump.h
 //
 //-----------------------------------------------------------------------------
 

--- a/common/m_jsonlump.h
+++ b/common/m_jsonlump.h
@@ -80,6 +80,22 @@ typedef enum
 	JL_PARSEERROR
 } jsonlumpresult_t;
 
+static constexpr const char* JSON_LUMP_RESULT_ERROR_STRINGS[] =
+{
+	"JL_SUCCESS",
+	"JL_NOTFOUND",
+	"JL_MALFORMEDROOT",
+	"JL_TYPEMISMATCH",
+	"JL_BADVERSIONFORMATTING",
+	"JL_VERSIONMISMATCH",
+	"JL_PARSEERROR"
+};
+
+constexpr const char* jsonLumpResultToString(jsonlumpresult_t jlr)
+{
+	return JSON_LUMP_RESULT_ERROR_STRINGS[jlr];
+}
+
 using JSONLumpFunc = std::function<jsonlumpresult_t(const Json::Value& elem, const JSONLumpVersion& version)>;
 
 jsonlumpresult_t M_ParseJSONLump(int lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, const JSONLumpFunc& parsefunc);

--- a/common/m_jsonlump.h
+++ b/common/m_jsonlump.h
@@ -33,8 +33,6 @@
 
 #include <json/json.h>
 
-typedef int32_t lumpindex_t;
-
 struct JSONLumpVersion
 {
 	int32_t major;
@@ -83,9 +81,9 @@ typedef enum
 
 using JSONLumpFunc = std::function<jsonlumpresult_t(const Json::Value& elem, const JSONLumpVersion& version)>;
 
-jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, const JSONLumpFunc& parsefunc);
+jsonlumpresult_t M_ParseJSONLump(int lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, const JSONLumpFunc& parsefunc);
 
-inline jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, JSONLumpFunc&& parsefunc)
+inline jsonlumpresult_t M_ParseJSONLump(int lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, JSONLumpFunc&& parsefunc)
 {
 	return M_ParseJSONLump(lumpindex, lumptype, maxversion, parsefunc);
 }

--- a/common/m_jsonlump.h
+++ b/common/m_jsonlump.h
@@ -69,7 +69,7 @@ struct JSONLumpVersion
 	}
 };
 
-typedef enum
+enum jsonlumpresult_t
 {
 	JL_SUCCESS,
 	JL_NOTFOUND,
@@ -78,7 +78,7 @@ typedef enum
 	JL_BADVERSIONFORMATTING,
 	JL_VERSIONMISMATCH,
 	JL_PARSEERROR
-} jsonlumpresult_t;
+};
 
 static constexpr const char* JSON_LUMP_RESULT_ERROR_STRINGS[] =
 {

--- a/common/m_jsonlump.h
+++ b/common/m_jsonlump.h
@@ -1,0 +1,96 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 1998-2006 by Randy Heit (ZDoom).
+// Copyright (C) 2006-2024 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  JSON lump parsing for ID24
+//
+//-----------------------------------------------------------------------------
+
+
+#include "odamex.h"
+
+#include "doomtype.h"
+#include "w_wad.h"
+
+#include <functional>
+
+#include <json/json.h>
+
+typedef int32_t lumpindex_t;
+
+struct JSONLumpVersion
+{
+	int32_t major;
+	int32_t minor;
+	int32_t revision;
+
+	constexpr bool operator > (const JSONLumpVersion& rhs) const
+	{
+		return major > rhs.major
+			|| minor > rhs.minor
+			|| revision > rhs.revision;
+	}
+
+	constexpr bool operator >= (const JSONLumpVersion& rhs) const
+	{
+		return major >= rhs.major
+			|| minor >= rhs.minor
+			|| revision >= rhs.revision;
+	}
+
+	constexpr bool operator < (const JSONLumpVersion& rhs) const
+	{
+		return major < rhs.major
+			|| minor < rhs.minor
+			|| revision < rhs.revision;
+	}
+
+	constexpr bool operator <= (const JSONLumpVersion& rhs) const
+	{
+		return major <= rhs.major
+			|| minor <= rhs.minor
+			|| revision <= rhs.revision;
+	}
+};
+
+typedef enum
+{
+	JL_SUCCESS,
+	JL_NOTFOUND,
+	JL_MALFORMEDROOT,
+	JL_TYPEMISMATCH,
+	JL_BADVERSIONFORMATTING,
+	JL_VERSIONMISMATCH,
+	JL_PARSEERROR
+} jsonlumpresult_t;
+
+using JSONLumpFunc = std::function<jsonlumpresult_t(const Json::Value& elem, const JSONLumpVersion& version)>;
+
+jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, const JSONLumpFunc& parsefunc);
+
+inline jsonlumpresult_t M_ParseJSONLump(lumpindex_t lumpindex, const char* lumptype, const JSONLumpVersion& maxversion, JSONLumpFunc&& parsefunc)
+{
+	return M_ParseJSONLump(lumpindex, lumptype, maxversion, parsefunc);
+}
+
+inline jsonlumpresult_t M_ParseJSONLump(const char* lumpname, const char* lumptype, const JSONLumpVersion& maxversion, JSONLumpFunc&& parsefunc)
+{
+	return M_ParseJSONLump(W_CheckNumForName(lumpname), lumptype, maxversion, parsefunc);
+}
+
+VERSION_CONTROL (m_jsonlump_h, "$Id$")

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2273,8 +2273,12 @@ void P_UpdateSpecials (void)
 	}
 
 	// Update sky column offsets
-	sky1columnoffset += sky1scrolldelta & 0xffffff;
-	sky2columnoffset += sky2scrolldelta & 0xffffff;
+	sky1columnoffset += sky1scrollxdelta & 0xffffff;
+	sky2columnoffset += sky2scrollxdelta & 0xffffff;
+
+	// Update sky row offsets
+	sky1rowoffset += sky1scrollydelta & 0xffffff;
+	sky2rowoffset += sky2scrollydelta & 0xffffff;
 }
 
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2272,13 +2272,7 @@ void P_UpdateSpecials (void)
 		}
 	}
 
-	// Update sky column offsets
-	sky1columnoffset += sky1scrollxdelta & 0xffffff;
-	sky2columnoffset += sky2scrollxdelta & 0xffffff;
-
-	// Update sky row offsets
-	sky1rowoffset += sky1scrollydelta & 0xffffff;
-	sky2rowoffset += sky2scrollydelta & 0xffffff;
+	R_UpdateSkies();
 }
 
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -215,10 +215,10 @@ int P_IsUnderDamage(AActor* actor)
 }
 
 /*
-* 
+*
 * P_IsFriendlyThing
 * @brief Helper function to determine if a particular thing is of friendly origin.
-* 
+*
 * @param actor Source actor
 * @param friendshiptest Thing to test friendliness
 */
@@ -580,7 +580,7 @@ static void P_InitAnimDefs ()
 	}
     catch (CRecoverableError &)
     {
-	    
+
     }
 }
 
@@ -1459,7 +1459,7 @@ int P_FindSectorFromTagOrLine(int tag, const line_t* line, int start)
 
 /*
 * @brief checks to see if a ZDoom-style door can be unlocked.
-* 
+*
 * @param player: Player to key check
 * @param lock: ZDoom lock type
 * All ZDoom lock types are supported but Odamex is missing
@@ -2273,8 +2273,8 @@ void P_UpdateSpecials (void)
 	}
 
 	// Update sky column offsets
-	sky1columnoffset += level.sky1ScrollDelta & 0xffffff;
-	sky2columnoffset += level.sky2ScrollDelta & 0xffffff;
+	sky1columnoffset += sky1scrolldelta & 0xffffff;
+	sky2columnoffset += sky2scrolldelta & 0xffffff;
 }
 
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2272,7 +2272,7 @@ void P_UpdateSpecials (void)
 		}
 	}
 
-	sky2columnoffset += sky2scrollxdelta & 0xffffff;
+	sky2columnoffset += sky2scrollxdelta;
 
 	#ifdef CLIENT_APP
 	R_UpdateSkies();

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2272,7 +2272,7 @@ void P_UpdateSpecials (void)
 		}
 	}
 
-	sky2columnoffset += sky2scrollxdelta;
+	sky2columnoffset += sky2scrollxdelta & 0xffffff;
 
 	#ifdef CLIENT_APP
 	R_UpdateSkies();

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2272,7 +2272,9 @@ void P_UpdateSpecials (void)
 		}
 	}
 
+	#ifdef CLIENT_APP
 	R_UpdateSkies();
+	#endif
 }
 
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2272,6 +2272,8 @@ void P_UpdateSpecials (void)
 		}
 	}
 
+	sky2columnoffset += sky2scrollxdelta & 0xffffff;
+
 	#ifdef CLIENT_APP
 	R_UpdateSkies();
 	#endif

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -1115,6 +1115,9 @@ void R_PrecacheLevel (void)
 		if (hitlist[i])
 			W_CacheLumpNum (firstflat + i, PU_CACHE);
 
+	std::vector<int> skytextures;
+	R_ActivateSkies(hitlist, skytextures);
+
 	// Precache textures.
 	memset (hitlist, 0, numtextures);
 
@@ -1137,6 +1140,11 @@ void R_PrecacheLevel (void)
 
 	hitlist[sky1texture] = 1;
 	hitlist[sky2texture] = 1;
+
+	for (int skytexture : skytextures)
+	{
+		hitlist[skytexture] = 1;
+	}
 
 	for (i = numtextures - 1; i >= 0; i--)
 	{

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -332,7 +332,7 @@ void R_GenerateComposite (int texnum)
 				post->length++;
 
 			// copy opaque pixels from the temporary back into the column
-			memcpy(post->data(), tmpdata + post->topdelta, post->length);	
+			memcpy(post->data(), tmpdata + post->topdelta, post->length);
 			post = post->next();
 		}
 	}
@@ -365,8 +365,8 @@ void R_GenerateLookup(int texnum, int *const errors)
 	unsigned short *patchcount = new unsigned short[texture->width];
 	unsigned short *postcount = new unsigned short[texture->width];
 
-	memset(patchcount, 0, sizeof(unsigned short) * texture->width);	
-	memset(postcount, 0, sizeof(unsigned short) * texture->width);	
+	memset(patchcount, 0, sizeof(unsigned short) * texture->width);
+	memset(postcount, 0, sizeof(unsigned short) * texture->width);
 
 	const texpatch_t *texpatch = texture->patches;
 
@@ -387,9 +387,9 @@ void R_GenerateLookup(int texnum, int *const errors)
 			// to fix Medusa bug while allowing for transparent multipatches.
 
 			const tallpost_t *post = (tallpost_t*)((byte*)patch + LELONG(cofs[x]));
-	
+
 			// NOTE: this offset will be rewritten later if a composite is generated
-			// for this texture (eg, there's more than one patch)	
+			// for this texture (eg, there's more than one patch)
 			texturecolumnofs[texnum][x] = (byte *)post - (byte *)patch;
 
 			patchcount[x]++;
@@ -410,7 +410,7 @@ void R_GenerateLookup(int texnum, int *const errors)
 	int csize = 0;
 
 	// [RH] Always create a composite texture for multipatch textures
-	// or tall textures in order to keep things simpler.	
+	// or tall textures in order to keep things simpler.
 	bool needcomposite = (texture->patchcount > 1 || texture->height > 254);
 
 	// [SL] Check for columns without patches.
@@ -444,9 +444,9 @@ void R_GenerateLookup(int texnum, int *const errors)
 			csize += 4 * postcount[x] + 2 + texture->height;
 		}
 	}
-	
+
 	texturecompositesize[texnum] = csize;
-	
+
 	delete [] patchcount;
 	delete [] postcount;
 }
@@ -665,7 +665,7 @@ void R_InitTextures (void)
 		texturewidthmask[i] = j-1;
 
 		textureheight[i] = texture->height << FRACBITS;
-			
+
 		// [RH] Special for beta 29: Values of 0 will use the tx/ty cvars
 		// to determine scaling instead of defaulting to 8. I will likely
 		// remove this once I finish the betas, because by then, users
@@ -943,7 +943,7 @@ int R_ColormapNumForName(const char* name)
 	if (strnicmp(name, "COLORMAP", 8) != 0)
 	{
 		int lump = W_CheckNumForName(name, ns_colormaps);
-		
+
 		if (lump != -1)
 			return lump - firstfakecmap + 1;
 	}
@@ -991,6 +991,7 @@ void R_InitData()
 	R_InitTextures();
 	R_InitFlats();
 	R_InitSpriteLumps();
+	R_InitSkyDefs();
 
 	// haleyjd 01/28/10: also initialize tantoangle_acc table
 	Table_InitTanToAngle();

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -1138,7 +1138,6 @@ void R_PrecacheLevel (void)
 	// [RH] Possibly two sky textures now.
 	// [ML] 5/11/06 - Not anymore!
 
-	hitlist[sky1texture] = 1;
 	hitlist[sky2texture] = 1;
 
 	for (int skytexture : skytextures)

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -1116,7 +1116,9 @@ void R_PrecacheLevel (void)
 			W_CacheLumpNum (firstflat + i, PU_CACHE);
 
 	std::vector<int> skytextures;
+	#ifdef CLIENT_APP
 	R_ActivateSkies(hitlist, skytextures);
+	#endif
 
 	// Precache textures.
 	memset (hitlist, 0, numtextures);

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -991,7 +991,9 @@ void R_InitData()
 	R_InitTextures();
 	R_InitFlats();
 	R_InitSpriteLumps();
+	#ifdef CLIENT_APP
 	R_InitSkyDefs();
+	#endif
 
 	// haleyjd 01/28/10: also initialize tantoangle_acc table
 	Table_InitTanToAngle();

--- a/common/r_draw.h
+++ b/common/r_draw.h
@@ -26,7 +26,7 @@
 #include "r_intrin.h"
 #include "r_defs.h"
 
-typedef struct 
+typedef struct
 {
 	byte*				source;
 	byte*				destination;
@@ -40,7 +40,7 @@ typedef struct
 	int					x;
 	int					yl;
 	int					yh;
-	
+
 	fixed_t				iscale;
 	fixed_t				texturemid;
 	fixed_t				texturefrac;
@@ -113,6 +113,9 @@ extern void (*R_DrawTranslucentColumn)(void);
 extern void (*R_DrawTranslatedColumn)(void);
 
 extern void (*R_DrawTlatedLucentColumn)(void);
+
+// [EB] Draw sky foreground with palette 0 transparency
+extern void (*R_DrawSkyForegroundColumn)(void);
 
 // Span blitting for rows, floor/ceiling.
 // No Sepctre effect needed.

--- a/common/r_main.h
+++ b/common/r_main.h
@@ -147,7 +147,7 @@ bool R_CheckProjectionY(int &y1, int &y2);
 void R_RotatePoint(fixed_t x, fixed_t y, angle_t ang, fixed_t &tx, fixed_t &ty);
 bool R_ClipLineToFrustum(const v2fixed_t* v1, const v2fixed_t* v2, fixed_t clipdist, int32_t& lclip, int32_t& rclip);
 
-void R_ClipLine(const v2fixed_t* in1, const v2fixed_t* in2, 
+void R_ClipLine(const v2fixed_t* in1, const v2fixed_t* in2,
 				int32_t lclip, int32_t rclip,
 				v2fixed_t* out1, v2fixed_t* out2);
 void R_ClipLine(const vertex_t* in1, const vertex_t* in2,
@@ -213,6 +213,7 @@ void R_SetFuzzDrawFuncs();
 void R_SetLucentDrawFuncs();
 void R_SetTranslatedDrawFuncs();
 void R_SetTranslatedLucentDrawFuncs();
+void R_SetSkyForegroundDrawFuncs();
 
 inline byte shaderef_t::ramp() const
 {

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -37,7 +37,6 @@ extern fixed_t	sky1texturemid;
 extern fixed_t	sky2texturemid;
 extern int		skystretch;
 extern fixed_t	skyiscale;
-extern fixed_t	skyscale;
 extern fixed_t	skyheight;
 
 EXTERN_CVAR (r_stretchsky)

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -27,10 +27,8 @@
 // SKY, store the number for name.
 extern char SKYFLATNAME[8];
 
-extern int      sky1shift;				//		[ML] 5/11/06 - remove sky2 remenants
-extern int      sky2shift;
-extern int      sky1texture;				//		""
-extern int      sky2texture;				//		""
+extern int      sky1texture;
+extern int      sky2texture;
 extern fixed_t	sky2scrollxdelta;
 extern fixed_t	sky2columnoffset;
 extern fixed_t	sky1texturemid;

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -49,5 +49,6 @@ void R_InitSkiesForLevel();
 void R_ClearSkyDefs();
 void R_SetDefaultSky(const char* sky);
 void R_UpdateSkies();
+bool R_IsSkyFlat(int flatnum);
 
 void R_RenderSkyRange(visplane_t* pl);

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -31,8 +31,6 @@ extern int      sky1texture;
 extern int      sky2texture;
 extern fixed_t	sky2scrollxdelta;
 extern fixed_t	sky2columnoffset;
-extern fixed_t	sky1texturemid;
-extern fixed_t	sky2texturemid;
 extern int		skystretch;
 extern fixed_t	skyiscale;
 extern fixed_t	skyheight;

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -50,5 +50,6 @@ void R_ClearSkyDefs();
 void R_SetDefaultSky(const char* sky);
 void R_UpdateSkies();
 bool R_IsSkyFlat(int flatnum);
+void R_ActivateSkies(const byte* hitlist, std::vector<int>& skytextures);
 
 void R_RenderSkyRange(visplane_t* pl);

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -44,6 +44,7 @@ extern fixed_t	skyheight;
 EXTERN_CVAR (r_stretchsky)
 
 // Called whenever the sky changes.
-void R_InitSkyMap		();
+void R_InitSkyMap();
+void R_InitSkyDefs();
 
 void R_RenderSkyRange(visplane_t* pl);

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -31,14 +31,8 @@ extern int      sky1shift;				//		[ML] 5/11/06 - remove sky2 remenants
 extern int      sky2shift;
 extern int      sky1texture;				//		""
 extern int      sky2texture;				//		""
-extern fixed_t	sky1scrollxdelta;
 extern fixed_t	sky2scrollxdelta;
-extern fixed_t	sky1scrollydelta;
-extern fixed_t	sky2scrollydelta;
-extern fixed_t	sky1columnoffset;
 extern fixed_t	sky2columnoffset;
-extern fixed_t	sky1rowoffset;
-extern fixed_t	sky2rowoffset;
 extern fixed_t	sky1texturemid;
 extern fixed_t	sky2texturemid;
 extern int		skystretch;
@@ -51,7 +45,9 @@ EXTERN_CVAR (r_stretchsky)
 // Called whenever the sky changes.
 void R_InitSkyMap();
 void R_InitSkyDefs();
-bool R_LoadSkyDef(const OLumpName& skytex);
+void R_InitSkiesForLevel();
 void R_ClearSkyDefs();
+void R_SetDefaultSky(const char* sky);
+void R_UpdateSkies();
 
 void R_RenderSkyRange(visplane_t* pl);

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -27,15 +27,20 @@
 // SKY, store the number for name.
 extern char SKYFLATNAME[8];
 
-extern int		sky1shift;				//		[ML] 5/11/06 - remove sky2 remenants
-
-extern int 		sky1texture;				//		""
-extern int 		sky2texture;				//		""
-extern fixed_t	sky1scrolldelta;
-extern fixed_t	sky2scrolldelta;
+extern int      sky1shift;				//		[ML] 5/11/06 - remove sky2 remenants
+extern int      sky2shift;
+extern int      sky1texture;				//		""
+extern int      sky2texture;				//		""
+extern fixed_t	sky1scrollxdelta;
+extern fixed_t	sky2scrollxdelta;
+extern fixed_t	sky1scrollydelta;
+extern fixed_t	sky2scrollydelta;
 extern fixed_t	sky1columnoffset;
 extern fixed_t	sky2columnoffset;
-extern fixed_t	skytexturemid;
+extern fixed_t	sky1rowoffset;
+extern fixed_t	sky2rowoffset;
+extern fixed_t	sky1texturemid;
+extern fixed_t	sky2texturemid;
 extern int		skystretch;
 extern fixed_t	skyiscale;
 extern fixed_t	skyscale;

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -46,6 +46,6 @@ EXTERN_CVAR (r_stretchsky)
 // Called whenever the sky changes.
 void R_InitSkyMap();
 void R_InitSkyDefs();
-void R_LoadSkyDef(const OLumpName& skytex);
+bool R_LoadSkyDef(const OLumpName& skytex);
 
 void R_RenderSkyRange(visplane_t* pl);

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -46,5 +46,6 @@ EXTERN_CVAR (r_stretchsky)
 // Called whenever the sky changes.
 void R_InitSkyMap();
 void R_InitSkyDefs();
+void R_LoadSkyDef(const OLumpName& skytex);
 
 void R_RenderSkyRange(visplane_t* pl);

--- a/common/r_sky.h
+++ b/common/r_sky.h
@@ -47,5 +47,6 @@ EXTERN_CVAR (r_stretchsky)
 void R_InitSkyMap();
 void R_InitSkyDefs();
 bool R_LoadSkyDef(const OLumpName& skytex);
+void R_ClearSkyDefs();
 
 void R_RenderSkyRange(visplane_t* pl);

--- a/server/src/r_sky.cpp
+++ b/server/src/r_sky.cpp
@@ -35,8 +35,14 @@ int 		sky1texture, sky2texture;
 
 fixed_t		sky1scrollxdelta,	sky2scrollxdelta;
 fixed_t		sky1columnoffset,	sky2columnoffset;
+fixed_t		sky1scrollydelta,	sky2scrollydelta;
+fixed_t		sky1rowoffset,	    sky2rowoffset;
 
 char SKYFLATNAME[8] = "F_SKY1";
+
+void R_InitSkyDefs() {}
+bool R_LoadSkyDef(const OLumpName& skytex) { return false; }
+void R_ClearSkyDefs() {}
 
 VERSION_CONTROL (r_sky_cpp, "$Id$")
 

--- a/server/src/r_sky.cpp
+++ b/server/src/r_sky.cpp
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -21,7 +21,7 @@
 //  wall, wrapping around. A 1024 columns equal 360 degrees.
 //  The default sky map is 256 columns and repeats 4 times
 //  on a 320 screen?
-//  
+//
 //-----------------------------------------------------------------------------
 
 
@@ -33,7 +33,7 @@
 int 		skyflatnum;
 int 		sky1texture, sky2texture;
 
-fixed_t		sky1scrolldelta,	sky2scrolldelta;
+fixed_t		sky1scrollxdelta,	sky2scrollxdelta;
 fixed_t		sky1columnoffset,	sky2columnoffset;
 
 char SKYFLATNAME[8] = "F_SKY1";

--- a/server/src/r_sky.cpp
+++ b/server/src/r_sky.cpp
@@ -33,16 +33,16 @@
 int 		skyflatnum;
 int 		sky1texture, sky2texture;
 
-fixed_t		sky1scrollxdelta,	sky2scrollxdelta;
-fixed_t		sky1columnoffset,	sky2columnoffset;
-fixed_t		sky1scrollydelta,	sky2scrollydelta;
-fixed_t		sky1rowoffset,	    sky2rowoffset;
+fixed_t		sky2scrollxdelta;
+fixed_t		sky2columnoffset;
 
 char SKYFLATNAME[8] = "F_SKY1";
 
 void R_InitSkyDefs() {}
-bool R_LoadSkyDef(const OLumpName& skytex) { return false; }
+void R_InitSkiesForLevel() {}
 void R_ClearSkyDefs() {}
+void R_SetDefaultSky(const char* sky) {}
+void R_UpdateSkies() {}
 
 VERSION_CONTROL (r_sky_cpp, "$Id$")
 

--- a/server/src/r_sky.cpp
+++ b/server/src/r_sky.cpp
@@ -38,11 +38,11 @@ fixed_t		sky2columnoffset;
 
 char SKYFLATNAME[8] = "F_SKY1";
 
-void R_InitSkyDefs() {}
-void R_InitSkiesForLevel() {}
-void R_ClearSkyDefs() {}
-void R_SetDefaultSky(const char* sky) {}
-void R_UpdateSkies() {}
+// void R_InitSkyDefs() {}
+// void R_InitSkiesForLevel() {}
+// void R_ClearSkyDefs() {}
+// void R_SetDefaultSky(const char* sky) {}
+// void R_UpdateSkies() {}
 
 VERSION_CONTROL (r_sky_cpp, "$Id$")
 

--- a/server/src/r_sky.cpp
+++ b/server/src/r_sky.cpp
@@ -31,7 +31,7 @@
 
 // [ML] 5/11/06 - Remove sky2
 int 		skyflatnum;
-int 		sky1texture, sky2texture;
+int 		sky2texture;
 
 fixed_t		sky2scrollxdelta;
 fixed_t		sky2columnoffset;

--- a/server/src/r_sky.cpp
+++ b/server/src/r_sky.cpp
@@ -38,11 +38,5 @@ fixed_t		sky2columnoffset;
 
 char SKYFLATNAME[8] = "F_SKY1";
 
-// void R_InitSkyDefs() {}
-// void R_InitSkiesForLevel() {}
-// void R_ClearSkyDefs() {}
-// void R_SetDefaultSky(const char* sky) {}
-// void R_UpdateSkies() {}
-
 VERSION_CONTROL (r_sky_cpp, "$Id$")
 

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -547,7 +547,7 @@ void G_ExitLevel (int position, int drawscores)
 
 	if (drawscores)
         SV_DrawScores();
-	
+
 	gamestate = GS_INTERMISSION;
 	mapchange = TICRATE * sv_intermissionlimit;  // wait n seconds, default 10
 
@@ -566,7 +566,7 @@ void G_SecretExitLevel (int position, int drawscores)
 
     if (drawscores)
         SV_DrawScores();
-        
+
 	gamestate = GS_INTERMISSION;
 	mapchange = TICRATE * sv_intermissionlimit;  // wait n seconds, defaults to 10
 
@@ -720,7 +720,7 @@ void G_DoResetLevel(bool full_reset)
 	P_HordeClearSpawns();
 
 	// Reset the respawned monster count
-	level.respawned_monsters = 0;	
+	level.respawned_monsters = 0;
 
 	// No need to clear the spawn locations because we're not loading a new map.
 	M_StartWDLLog(false);
@@ -783,7 +783,7 @@ void G_DoLoadLevel (int position)
 		wipegamestate = GS_FORCEWIPE;
 
 	gamestate = GS_LEVEL;
-	
+
 	// Reset all keys found
 	for (size_t j = 0; j < NUMCARDS; j++)
 		keysfound[j] = false;
@@ -800,7 +800,6 @@ void G_DoLoadLevel (int position)
 	// [RH] Fetch sky parameters from level_locals_t.
 	// [ML] 5/11/06 - remove sky2 remenants
 	// [SL] 2012-03-19 - Add sky2 back
-	sky1texture = R_TextureNumForName (level.skypic.c_str());
 	if (!level.skypic2.empty())
 		sky2texture = R_TextureNumForName (level.skypic2.c_str());
 	else


### PR DESCRIPTION
This PR adds support for the SKYDEFS lump from the new [ID24](https://www.doomworld.com/forum/topic/146943-id24-a-new-feature-set-standard/) standard.

Included as part of this:
- Support for parsing JSON lumps following the ID24 JSON lump specification
- PSX Doom fire skies
- Mapping skies to flats other than F_SKY1, allowing multiple skies within a level without the use of sky transfers or sky2.
- Vertical and horizontal scaling of skies
- Vertical scrolling of skies
- Vertical offsets for skies

The attached wad showcases all of these features.
[skydef-test.zip](https://github.com/user-attachments/files/17008993/skydef-test.zip)

https://youtu.be/s8FArfOiq8g
