### PR TITLE
[BUGFIX] Set texture height for masked segments to 512 instead of 256

### DIFF
--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -676,7 +676,7 @@ void R_RenderMaskedSegRange(drawseg_t* ds, int x1, int x2)
 	mfloorclip = ds->sprbottomclip;
 	mceilingclip = ds->sprtopclip;
 
-	dcol.textureheight = 256*FRACUNIT;
+	dcol.textureheight = texheight;
 
 	// draw the columns
 	// TODO: change negonearray to the actual top/bottom

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -676,7 +676,7 @@ void R_RenderMaskedSegRange(drawseg_t* ds, int x1, int x2)
 	mfloorclip = ds->sprbottomclip;
 	mceilingclip = ds->sprtopclip;
 
-	dcol.textureheight = texheight;
+	dcol.textureheight = 512*FRACUNIT;
 
 	// draw the columns
 	// TODO: change negonearray to the actual top/bottom


### PR DESCRIPTION
This fixes issues with large textures such as the portal at the end of Legacy of Rust map01 and the large banners from OTEX.

Before:

![image](https://github.com/user-attachments/assets/e81ab549-7cad-4586-a623-f9dc99c2c935)
![image](https://github.com/user-attachments/assets/004ea347-2971-404b-ae52-d4dd1df41f12)

After:

![image](https://github.com/user-attachments/assets/0633c23b-2b1b-4ecc-931e-38a37533890d)
![image](https://github.com/user-attachments/assets/41d41444-e64f-4d46-be64-7b113a6a5a75)
