### PR TITLE
[BUGFIX] Fix UMAPINFO par times being 35x too high

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1113,7 +1113,6 @@ struct MapInfoDataSetter<level_pwad_info_t>
 		ENTRY3("fade", &MIType_Color, &ref.fadeto_color)
 		ENTRY3("outsidefog", &MIType_Color, &ref.outsidefog_color)
 		ENTRY3("titlepatch", &MIType_LumpName, &ref.pname)
-		ENTRY3("par", &MIType_Int, &ref.partime)
 		ENTRY3("music", &MIType_MusicLumpName, &ref.music)
 		ENTRY4("nointermission", &MIType_SetFlag, &ref.flags, LEVEL_NOINTERMISSION)
 		ENTRY4("doublesky", &MIType_SetFlag, &ref.flags, LEVEL_DOUBLESKY)

--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -222,7 +222,7 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 	else if (!stricmp(pname.c_str(), "partime"))
 	{
 		os.mustScanInt();
-		mape->partime = TICRATE * os.getTokenInt();
+		mape->partime = os.getTokenInt();
 	}
 	else if (!stricmp(pname.c_str(), "intertext"))
 	{


### PR DESCRIPTION
Yet another small MAPINFO fix. Par times in UMAPINFO were being multiplied by the tic rate unnecessarily, resulting in incorrect par times that often would just be SUCKS.