### PR TITLE
[BUGFIX] Search for chex.deh when chex.wad is selected as IWAD in GUI

### DIFF
--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -175,7 +175,7 @@ class BootWindow : public Fl_Window
 				m_tabPWADs->end();
 			} // Fl_Group* tabPWADs
 			{
-				Fl_Group* tabGameOptions = 
+				Fl_Group* tabGameOptions =
 					new Fl_Group(0, 25, 425, 175, "Game Options");
 				{
 					Fl_Box* o = new Fl_Box(
@@ -517,7 +517,11 @@ class BootWindow : public Fl_Window
 	{
 		// IWADs
 		const size_t value = static_cast<size_t>(m_IWADBrowser->value());
-		g_SelectedWADs.iwad = m_IWADs[value - 1].path;
+		scannedIWAD_t iwad = m_IWADs[value - 1];
+		g_SelectedWADs.iwad = iwad.path;
+
+		if (iwad.id != NULL && iwad.id->mIdName == "CHEX QUEST")
+			g_SelectedWADs.options.insert(g_SelectedWADs.options.end(), { "-deh", "chex.deh" });
 
 		// PWADs
 		for (scannedPWADPtrs_t::iterator it = m_selectedPWADs.begin();

--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -521,7 +521,10 @@ class BootWindow : public Fl_Window
 		g_SelectedWADs.iwad = iwad.path;
 
 		if (iwad.id != NULL && iwad.id->mIdName == "CHEX QUEST")
-			g_SelectedWADs.options.insert(g_SelectedWADs.options.end(), { "-deh", "chex.deh" });
+		{
+			g_SelectedWADs.options.push_back("-deh");
+			g_SelectedWADs.options.push_back("chex.deh");
+		}
 
 		// PWADs
 		for (scannedPWADPtrs_t::iterator it = m_selectedPWADs.begin();

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -179,7 +179,7 @@ static const char* steam_install_subdirs[] =
 	"steamapps\\common\\ultimate doom\\base\\plutonia",
 	"steamapps\\common\\ultimate doom\\base\\tnt",
 	"steamapps\\common\\ultimate doom\\rerelease",
-	
+
 };
 
 
@@ -334,7 +334,7 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 
 				const char* csubpath = subpath;
 				D_AddSearchDir(dirs, csubpath, separator);
-				
+
 				free(subpath);
 			}
 
@@ -355,7 +355,7 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 
 	const char separator = ':';
 
-	#if defined(INSTALL_PREFIX) && defined(INSTALL_DATADIR) 
+	#if defined(INSTALL_PREFIX) && defined(INSTALL_DATADIR)
 	D_AddSearchDir(dirs, INSTALL_PREFIX "/" INSTALL_DATADIR "/odamex", separator);
 	D_AddSearchDir(dirs, INSTALL_PREFIX "/" INSTALL_DATADIR "/games/odamex", separator);
 	#endif
@@ -412,8 +412,8 @@ static void D_PrintIWADIdentity()
 	{
 		if (gamemode == undetermined)
 			Printf(PRINT_HIGH, "Game mode indeterminate, no standard wad found.\n");
-		else 
-			Printf(PRINT_HIGH, "%s\n", D_GetTitleString().c_str()); 
+		else
+			Printf(PRINT_HIGH, "%s\n", D_GetTitleString().c_str());
 	}
 }
 
@@ -428,7 +428,7 @@ void D_LoadResolvedPatches()
 	for (OResFiles::const_iterator it = ::patchfiles.begin(); it != ::patchfiles.end();
 	     ++it)
 	{
-		if (it->getBasename() == "CHEX.DEH")
+		if (StdStringToUpper(it->getBasename()) == "CHEX.DEH")
 		{
 			chexLoaded = true;
 		}
@@ -513,7 +513,7 @@ static bool FindIWAD(OResFile& out)
 /**
  * @brief Load files that are assumed to be resolved, in the correct order,
  *        and complete.
- * 
+ *
  * @param newwadfiles New set of WAD files.
  * @param newpatchfiles New set of patch files.
 */
@@ -560,7 +560,7 @@ static void LoadResolvedFiles(const OResFiles& newwadfiles,
 /**
  * @brief Print a warning that occurrs when the user has an IWAD that's a
  *        different version than the one we want.
- * 
+ *
  * @param wanted The IWAD that we wanted.
  * @return True if we emitted an commercial IWAD warning.
  */
@@ -763,11 +763,11 @@ void D_LoadResourceFiles(const OWantFiles& newwadfiles, const OWantFiles& newpat
 /**
  * @brief Check to see if the list of WAD files and patches matches the
  *        currently loaded files.
- * 
+ *
  * @detail Note that this relies on the hashes being equal, so if you want
  *         resources to not be reloaded, ensure the hashes are equal by the
  *         time they reach this spot.
- * 
+ *
  * @param newwadfiles WAD files to check.
  * @param newpatchfiles Patch files to check.
  * @return True if everything checks out.
@@ -1115,7 +1115,7 @@ void D_RunTics(void (*sim_func)(), void(*display_func)())
 #ifdef CLIENT_APP
 	// Use linear interpolation for rendering entities if the display
 	// framerate is not synced with the simulation frequency.
-	// Ch0wW : if you experience a spinning effect while trying to pause the frame, 
+	// Ch0wW : if you experience a spinning effect while trying to pause the frame,
 	// don't forget to add your condition here.
 	if ((maxfps == TICRATE && capfps)
 		|| timingdemo || paused || step_mode


### PR DESCRIPTION
Addresses #616

When Chex Quest is selected in the client IWAD select GUI, `-deh chex.deh` is automatically added as an argument.

This also fixes a bug where the warning that chex.deh was not loaded would be displayed if the loaded chex.deh did not have an uppercase filename.