### PR TITLE
[CHANGE] Improve missing spawns warning for horde mode

### DIFF
--- a/common/p_horde.cpp
+++ b/common/p_horde.cpp
@@ -610,7 +610,7 @@ void HordeState::tick()
 				alive += 1;
 		}
 		if (!alive)
-		{			
+		{
 			// Start the next wave.
 			nextWave();
 			return;
@@ -816,16 +816,16 @@ void P_RunHordeTics()
 	if (!P_HordeHasSpawns())
 	{
 		P_HordeAddSpawns();
-		if (!P_HordeHasSpawns())
+		if (!P_HordeHasSpawns() || !P_HordeHasRequiredMonsterSpawns())
 		{
 			if (::level.time == 0)
 			{
 				Printf(
 				    PRINT_WARNING,
-				    "WARNING: This map is missing Horde Monster, Horde Supply Cache, "
+				    "WARNING: This map is missing Horde Monster, Horde Boss, Horde Supply Cache, "
 				    "or Horde Powerup spawns.  At least one of each must be present.\n");
 			}
-			
+
 			// This map has no horde things in it - probably inside a
 			// non-horde map.
 			return;

--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -223,14 +223,15 @@ bool P_HordeHasRequiredMonsterSpawns()
 {
 	bool bossspawnfound = false;
 	bool monsterspawnfound = false;
-	hordeSpawns_t::iterator it;
-	for (it = monsterSpawns.begin(); it != monsterSpawns.end(); it++)
+
+	for (hordeSpawns_t::iterator it = monsterSpawns.begin(); it != monsterSpawns.end(); it++)
 	{
 		if (it->type == TTYPE_HORDE_BOSS)
 			bossspawnfound = true;
 		if (it->type == TTYPE_HORDE_MONSTER)
 			monsterspawnfound = true;
 	}
+
 	return bossspawnfound && monsterspawnfound;
 }
 

--- a/common/p_hordespawn.cpp
+++ b/common/p_hordespawn.cpp
@@ -217,6 +217,24 @@ bool P_HordeHasSpawns()
 }
 
 /**
+ * @brief Return true if there is both at least one large boss spawner and one large monster spawner in the map.
+ */
+bool P_HordeHasRequiredMonsterSpawns()
+{
+	bool bossspawnfound = false;
+	bool monsterspawnfound = false;
+	hordeSpawns_t::iterator it;
+	for (it = monsterSpawns.begin(); it != monsterSpawns.end(); it++)
+	{
+		if (it->type == TTYPE_HORDE_BOSS)
+			bossspawnfound = true;
+		if (it->type == TTYPE_HORDE_MONSTER)
+			monsterspawnfound = true;
+	}
+	return bossspawnfound && monsterspawnfound;
+}
+
+/**
  * @brief Clear all tracked spawn points.
  */
 void P_HordeClearSpawns()
@@ -228,7 +246,7 @@ void P_HordeClearSpawns()
 
 /**
  * @brief True if passed radius and height fits in the passed mobjinfo.
- * 
+ *
  * @param info Info to check against.
  * @param rad Radius to check in whole units (not fixed).
  * @param height Height to check in whole units (not fixed).

--- a/common/p_hordespawn.h
+++ b/common/p_hordespawn.h
@@ -72,6 +72,7 @@ typedef std::vector<hordeSpawn_t> hordeSpawns_t;
 
 void P_HordeAddSpawns();
 bool P_HordeHasSpawns();
+bool P_HordeHasRequiredMonsterSpawns();
 void P_HordeClearSpawns();
 hordeSpawn_t* P_HordeSpawnPoint(const hordeRecipe_t& recipe);
 AActors P_HordeSpawn(hordeSpawn_t& spawn, const hordeRecipe_t& recipe);


### PR DESCRIPTION
Addresses #712

The warning for missing spawners is now displayed if there is no large boss spawner or regular monster spawner, and it now reads:

> WARNING: This map is missing Horde Monster, Horde Boss, Horde Supply Cache, or Horde Powerup spawns. At least one of each must be present.

As an alternative to this, we could instead restrict the waves that can be selected on a map by the spawner types present. e.g. Only waves with no ground monsters other than bosses in a map containing only flying spawners (and a boss spawner). Or only waves with thin bosses in a map with only thin boss spawners.