### PR TITLE
[BUGFIX] Center view when `centerview` called while the console or menu is open

### DIFF
--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -597,7 +597,7 @@ void G_BuildTiccmd(ticcmd_t *cmd)
 		::localview.skipangle = true;
 	}
 
-	if (sendcenterview)
+	if (sendcenterview && ConsoleState == c_up && !menuactive)
 	{
 		sendcenterview = false;
 		cmd->pitch = CENTERVIEW;


### PR DESCRIPTION
Addresses #763

`centerview` previously had no effect if the menu or console was open, meaning that disabling `cl_mouselook` by any method other than a keybind would not center the screen. Now, if the console or menu is open `sendcenterview` is not set to false and the centering will be attempted again.