### PR TITLE
[BUGFIX] Render sprites with y offsets less than 1

### DIFF
--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -186,7 +186,7 @@ IWindowSurface* R_GetRenderingSurface()
 // R_PointOnSide
 //
 // Determines which side of a line the point (x, y) is on.
-// Returns side 0 (front) or 1 (back) 
+// Returns side 0 (front) or 1 (back)
 //
 int R_PointOnSide(fixed_t x, fixed_t y, fixed_t xl, fixed_t yl, fixed_t xh, fixed_t yh)
 {
@@ -205,7 +205,7 @@ int R_PointOnSide(fixed_t x, fixed_t y, fixed_t xl, fixed_t yl, fixed_t xh, fixe
 //
 int R_PointOnSide(fixed_t x, fixed_t y, const node_t *node)
 {
-	return R_PointOnSide(x, y, node->x, node->y, node->x + node->dx, node->y + node->dy); 
+	return R_PointOnSide(x, y, node->x, node->y, node->x + node->dx, node->y + node->dy);
 }
 
 //
@@ -317,7 +317,7 @@ fixed_t R_PointToDist2(fixed_t dx, fixed_t dy)
 void R_RotatePoint(fixed_t x, fixed_t y, angle_t ang, fixed_t &tx, fixed_t &ty)
 {
 	int index = ang >> ANGLETOFINESHIFT;
-	
+
 	tx = FixedMul(x, finecosine[index]) - FixedMul(y, finesine[index]);
 	ty = FixedMul(x, finesine[index]) + FixedMul(y, finecosine[index]);
 }
@@ -331,7 +331,7 @@ void R_RotatePoint(fixed_t x, fixed_t y, angle_t ang, fixed_t &tx, fixed_t &ty)
 // right endpoint is rclip percent of the way between the left and right
 // endpoints
 //
-void R_ClipLine(const v2fixed_t* in1, const v2fixed_t* in2, 
+void R_ClipLine(const v2fixed_t* in1, const v2fixed_t* in2,
 				int32_t lclip, int32_t rclip,
 				v2fixed_t* out1, v2fixed_t* out2)
 {
@@ -371,11 +371,11 @@ bool R_ClipLineToFrustum(const v2fixed_t* v1, const v2fixed_t* v2, fixed_t clipd
 	v2fixed_t p1 = *v1, p2 = *v2;
 
 	lclip = 0;
-	rclip = CLIPUNIT; 
+	rclip = CLIPUNIT;
 
 	// Clip portions of the line that are behind the view plane
 	if (p1.y < clipdist)
-	{      
+	{
 		// reject the line entirely if the whole thing is behind the view plane.
 		if (p2.y < clipdist)
 			return false;
@@ -424,7 +424,7 @@ bool R_ClipLineToFrustum(const v2fixed_t* v1, const v2fixed_t* v2, fixed_t clipd
 	if (p2.x > yc2)
 	{
 		// clip line at right edge of the screen
-		fixed_t den = p2.x - p1.x - yc2 + yc1;	
+		fixed_t den = p2.x - p1.x - yc2 + yc1;
 		if (den == 0)
 			return false;
 
@@ -488,7 +488,7 @@ bool R_CheckProjectionY(int &y1, int &y2)
 {
 	y1 = MAX(y1, 0);
 	y2 = MIN(y2, viewheight - 1);
-	return (y1 <= y2);
+	return y1 <= viewheight - 1 || y2 >= 0;
 }
 
 
@@ -576,7 +576,7 @@ void R_DrawLine(const v3fixed_t* inpt1, const v3fixed_t* inpt2, byte color)
 		{
 			R_DrawPixel(x, y, color);
 			if (y == y2)
-				return;		
+				return;
 
 			if (d >= 0)
 			{
@@ -1042,7 +1042,7 @@ void R_RenderPlayerView(player_t* player)
 	{
 		argb_t color = gametic & 8 ? argb_t(0, 0, 0) : argb_t(0, 0, 255);
 		int x1 = viewwindowx, y1 = viewwindowy;
-		int x2 = viewwindowx + viewwidth - 1, y2 = viewwindowy + viewheight - 1; 
+		int x2 = viewwindowx + viewwidth - 1, y2 = viewwindowy + viewheight - 1;
 
 		surface->getDefaultCanvas()->Clear(x1, y1, x2, y2, color);
 	}
@@ -1059,7 +1059,7 @@ void R_RenderPlayerView(player_t* player)
 		int flags2_backup = camera->flags2;
 		camera->flags2 |= MF2_DONTDRAW;
 		R_RenderBSPNode(numnodes - 1);
-		camera->flags2 = flags2_backup; 
+		camera->flags2 = flags2_backup;
 	}
 	else
 		R_RenderBSPNode(numnodes - 1);	// The head node is the last node output.
@@ -1182,14 +1182,14 @@ static void R_InitViewWindow()
 
 	surface->lock();
 
-	// Calculate viewwidth & viewheight based on the amount of window border 
+	// Calculate viewwidth & viewheight based on the amount of window border
 	viewwidth = R_ViewWidth(surface_width, surface_height);
 	viewheight = R_ViewHeight(surface_width, surface_height);
 	viewwindowx = R_ViewWindowX(surface_width, surface_height);
 	viewwindowy = R_ViewWindowY(surface_width, surface_height);
 
 	if (setblocks == 10 || setblocks == 11 || setblocks == 12)
-		freelookviewheight = surface_height; 
+		freelookviewheight = surface_height;
 	else
 		freelookviewheight = ((setblocks * surface_height) / 10) & ~7;
 


### PR DESCRIPTION
Addresses #605

The function R_CheckProjectionY is supposed to return false if the projection defined by its input values is fully outside the bounds of the screen, but instead it was simply returning false when y1 was greater than y2.