### PR TITLE
[BUGFIX] Ignore case for file extensions in G_LoadWadString and detect deh files in boot GUI

### DIFF
--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -477,7 +477,7 @@ void D_DoAdvanceDemo (void)
 
             gamestate = GS_DEMOSCREEN;
             pagename = gameinfo.titlePage.c_str();
-            
+
             currentmusic = gameinfo.titleMusic.c_str();
 
             S_StartMusic(currentmusic.c_str());
@@ -508,7 +508,7 @@ void D_DoAdvanceDemo (void)
 					pagetic = 170;
                 pagename = gameinfo.titlePage.c_str();
                 currentmusic = gameinfo.titleMusic.c_str();
-                
+
                 S_StartMusic(currentmusic.c_str());
             }
             else
@@ -704,7 +704,7 @@ void STACK_ARGS D_Shutdown()
 	// stop sound effects and music
 	S_Stop();
 	S_Deinit();
-	
+
 	// shutdown automap
 	AM_Stop();
 
@@ -843,11 +843,23 @@ void D_DoomMain()
 
 	if (!pwads.empty())
 	{
+		const std::vector<std::string>& wad_exts = M_FileTypeExts(OFILE_WAD);
+		const std::vector<std::string>& deh_exts = M_FileTypeExts(OFILE_DEH);
 		for (size_t i = 0; i < pwads.size(); i++)
 		{
 			OWantFile file;
-			OWantFile::make(file, pwads[i], OFILE_WAD);
-			newwadfiles.push_back(file);
+			OWantFile::make(file, pwads[i], OFILE_UNKNOWN);
+			const std::string extension = StdStringToUpper(file.getExt());
+			if (std::find(deh_exts.begin(), deh_exts.end(), extension) != deh_exts.end())
+			{
+				OWantFile::make(file, pwads[i], OFILE_DEH);
+				newpatchfiles.push_back(file);
+			}
+			if (std::find(wad_exts.begin(), wad_exts.end(), extension) != wad_exts.end())
+			{
+				OWantFile::make(file, pwads[i], OFILE_WAD);
+				newwadfiles.push_back(file);
+			}
 		}
 	}
 
@@ -882,7 +894,7 @@ void D_DoomMain()
 
 	if (devparm)
 		Printf(PRINT_HIGH, "%s", GStrings(D_DEVSTR));        // D_DEVSTR
- 
+
 	// set the default value for vid_ticker based on the presence of -devparm
 	if (devparm)
 		vid_ticker.SetDefault("1");
@@ -1025,7 +1037,7 @@ void D_DoomMain()
 		Printf(PRINT_HIGH, "Type connect <address> or use the Odamex Launcher to connect to a game.\n");
     Printf(PRINT_HIGH, "\n");
 
-	// Play a demo, start a map, or show the title screen	
+	// Play a demo, start a map, or show the title screen
 	if (singledemo)
 	{
 		G_DoPlayDemo();

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -422,7 +422,7 @@ bool G_LoadWadString(const std::string& str, const std::string& mapname)
 
 		// Does this look like a DeHackEd patch?
 		bool is_deh =
-		    std::find(deh_exts.begin(), deh_exts.end(), file.getExt()) != deh_exts.end();
+		    std::find(deh_exts.begin(), deh_exts.end(), StdStringToUpper(file.getExt())) != deh_exts.end();
 		if (is_deh)
 		{
 			if (!OWantFile::make(file, ::com_token, OFILE_DEH))
@@ -439,7 +439,7 @@ bool G_LoadWadString(const std::string& str, const std::string& mapname)
 
 		// Does this look like a WAD file?
 		bool is_wad =
-		    std::find(wad_exts.begin(), wad_exts.end(), file.getExt()) != wad_exts.end();
+		    std::find(wad_exts.begin(), wad_exts.end(), StdStringToUpper(file.getExt())) != wad_exts.end();
 		if (is_wad)
 		{
 			if (!OWantFile::make(file, ::com_token, OFILE_WAD))
@@ -794,7 +794,7 @@ void G_InitLevelLocals()
 	::level.info = (level_info_t*)&info;
 	::level.skypic2 = info.skypic2;
 	memcpy(::level.fadeto_color, info.fadeto_color, 4);
-	
+
 	if (::level.fadeto_color[0] || ::level.fadeto_color[1] || ::level.fadeto_color[2] || ::level.fadeto_color[3])
 	{
 		NormalLight.maps = shaderef_t(&V_GetDefaultPalette()->maps, 0);
@@ -823,7 +823,7 @@ void G_InitLevelLocals()
 	ArrayCopy(::level.level_fingerprint, info.level_fingerprint);
 
 	// Only copy the level name if there's a valid level name to be copied.
-	
+
 	if (!info.level_name.empty())
 	{
 		// Get rid of initial lump name or level number.
@@ -844,7 +844,7 @@ void G_InitLevelLocals()
 		{
 			std::string search;
 			StrFormat(search, "%u: ", info.levelnum);
-			
+
 			const std::size_t pos = info.level_name.find(search);
 
 			if (pos != std::string::npos)
@@ -920,12 +920,12 @@ void G_InitLevelLocals()
 	::level.intertextsecret = info.intertextsecret;
 	::level.interbackdrop = info.interbackdrop;
 	::level.intermusic = info.intermusic;
-	
+
 	::level.bossactions = info.bossactions;
 	::level.label = info.label;
 	::level.clearlabel = info.clearlabel;
 	::level.author = info.author;
-	
+
 	::level.detected_gametype = GM_COOP;
 
 	movingsectors.clear();


### PR DESCRIPTION
Addresses #815

When loading wads from the `wad` command or the maplist, the file type is being detected based on the extension. However, this is being done by only comparing to uppercase versions of the file extensions, leading to failures to load files. This has been fixed. I think at some point it would be worth spending some time to try and do a larger cleanup of handling file extensions and case.

Additionally, deh files loaded through the client boot GUI were treated as wad files instead of deh files. This has also been fixed.