### PR TITLE
[FEATURE] ID24 Inventory Reset Exits

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -144,7 +144,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	CL_QuitNetGame(NQ_SILENT);
 	S_StopMusic();
 	currentmusic = gameinfo.titleMusic.c_str();
-	
+
 	S_StartMusic(currentmusic.c_str());
 }
 END_COMMAND (wad)
@@ -157,7 +157,7 @@ EXTERN_CVAR(sv_allowjump)
 
 //
 // G_DoNewGame
-// Is called whenever a new Singleplayer game will be started. 
+// Is called whenever a new Singleplayer game will be started.
 //
 void G_DoNewGame (void)
 {
@@ -291,7 +291,7 @@ void G_InitNew (const char *mapname)
 	viewactive = true;
 
 	D_SetupUserInfo();
-	
+
 	level.mapname = mapname;
 
 	// [AM}] WDL stats (for testing purposes)
@@ -330,8 +330,19 @@ static void goOn(int position)
 	}
 }
 
-void G_ExitLevel (int position, int drawscores)
+void G_ExitLevel (int position, int drawscores, bool resetinv)
 {
+	if (resetinv)
+	{
+		for (Players::iterator it = players.begin();it != players.end();++it)
+		{
+			if (it->ingame())
+			{
+				it->doreborn = true;
+			}
+		}
+	}
+
 	secretexit = false;
 
 	goOn (position);
@@ -340,8 +351,19 @@ void G_ExitLevel (int position, int drawscores)
 }
 
 // Here's for the german edition.
-void G_SecretExitLevel (int position, int drawscores)
+void G_SecretExitLevel (int position, int drawscores, bool resetinv)
 {
+	if (resetinv)
+	{
+		for (Players::iterator it = players.begin();it != players.end();++it)
+		{
+			if (it->ingame())
+			{
+				it->doreborn = true;
+			}
+		}
+	}
+
 	// IF NO WOLF3D LEVELS, NO SECRET EXIT!
 	if ( (gameinfo.flags & GI_MAPxx)
 		 && (W_CheckNumForName("map31")<0))
@@ -687,7 +709,7 @@ void G_WorldDone()
 	// Sort out default options to pass to F_StartFinale
 	finale_options_t options = { 0 };
 	options.music = !level.intermusic.empty() ? level.intermusic.c_str() : thiscluster.messagemusic.c_str();
-	
+
 	if (!level.interbackdrop.empty())
 	{
 		options.flat = level.interbackdrop.c_str();
@@ -700,7 +722,7 @@ void G_WorldDone()
 	{
 		options.flat = &thiscluster.finaleflat[0];
 	}
-	
+
 	if (secretexit)
 	{
 		options.text = (!level.intertextsecret.empty()) ? level.intertextsecret.c_str() : thiscluster.exittext;

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -177,19 +177,19 @@ struct level_pwad_info_t
 
 	fixed_t			sky1ScrollDelta;
 	fixed_t			sky2ScrollDelta;
-	
+
 	std::vector<bossaction_t> bossactions;
 
 	std::string		label;
 	bool			clearlabel;
 	std::string		author;
-	
+
 	level_pwad_info_t()
 	    : mapname(""), levelnum(0), level_name(""), pname(""), nextmap(""), secretmap(""),
 	      partime(0), skypic(""), music(""), flags(0), cluster(0), snapshot(NULL),
 	      defered(NULL), fadetable("COLORMAP"), skypic2(""), gravity(0.0f),
 	      aircontrol(0.0f), exitpic(""), enterpic(""), endpic(""), intertext(""),
-	      intertextsecret(""), interbackdrop(""), intermusic(""), 
+	      intertextsecret(""), interbackdrop(""), intermusic(""),
 	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(),
 	      clearlabel(false), author()
 	{
@@ -327,13 +327,13 @@ struct level_locals_t
 	std::string		intertextsecret;
 	OLumpName		interbackdrop;
 	OLumpName		intermusic;
-	
+
 	std::vector<bossaction_t> bossactions;
 
 	std::string		label;
 	bool			clearlabel;
 	std::string		author;
-	
+
 	// The following is used for automatic gametype detection.
 	float			detected_gametype;
 };
@@ -432,8 +432,8 @@ void G_DeferedInitNew(const char *mapname);
 void G_DeferedFullReset();
 void G_DeferedReset();
 
-void G_ExitLevel(int position, int drawscores);
-void G_SecretExitLevel(int position, int drawscores);
+void G_ExitLevel(int position, int drawscores, bool resetinv = false);
+void G_SecretExitLevel(int position, int drawscores, bool resetinv = false);
 
 void G_DoLoadLevel(int position);
 void G_DoResetLevel(bool full_reset);

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -49,6 +49,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
                                           bool bossaction)
 {
 	int ok;
+	bool resetinv = false;
 
 	//  Things that should never trigger lines
 	//
@@ -435,13 +436,16 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		}
 		break;
 
+	case 2069:
+		resetinv = true;
+		[[fallthrough]]
 	case 52:
 		// EXIT!
 		// killough 10/98: prevent zombies from exiting levels
 		if (bossaction || ((!(thing->player && thing->player->health <= 0)) &&
 		                   CheckIfExitIsGood(thing)))
 		{
-			G_ExitLevel(0, 1);
+			G_ExitLevel(0, 1, resetinv);
 			return true;
 		}
 		break;
@@ -567,6 +571,9 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		}
 		break;
 
+	case 2072:
+		resetinv = true;
+		[[fallthrough]]
 	case 124:
 		// Secret EXIT
 		// killough 10/98: prevent zombies from exiting levels
@@ -574,7 +581,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		if (bossaction || ((!(thing->player && thing->player->health <= 0)) &&
 		                   CheckIfExitIsGood(thing)))
 		{
-			G_SecretExitLevel(0, 1);
+			G_SecretExitLevel(0, 1, resetinv);
 			return true;
 		}
 		break;
@@ -1777,6 +1784,7 @@ void P_SpawnCompatiblePusher(line_t* l)
 bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
                                         bool bossaction)
 {
+	bool resetinv = false; // used for exits
 	bool reuse = false;
 	bool trigger = false; // used for bossactions
 	// e6y
@@ -2075,6 +2083,9 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		}
 		break;
 
+	case 2070:
+		resetinv = true;
+		[[fallthrough]]
 	case 11:
 		/* Exit level
 		 * killough 10/98: prevent zombies from exiting levels
@@ -2088,7 +2099,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		{
 			reuse = false;
 			trigger = true;
-			G_ExitLevel(0, 1);
+			G_ExitLevel(0, 1, resetinv);
 		}
 		break;
 
@@ -2199,6 +2210,9 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		}
 		break;
 
+	case 2073:
+		resetinv = true;
+		[[fallthrough]]
 	case 51:
 		/* Secret EXIT
 		 * killough 10/98: prevent zombies from exiting levels
@@ -2212,7 +2226,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		{
 			reuse = false;
 			trigger = true;
-			G_SecretExitLevel(0, 1);
+			G_SecretExitLevel(0, 1, resetinv);
 		}
 		break;
 
@@ -3239,6 +3253,8 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 
 bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 {
+	bool resetinv = false;
+
 	// pointer to line function is NULL by default, set non-null if
 	// line special is gun triggered generalized linedef type
 	int (*linefunc)(line_t * line) = NULL;
@@ -3379,6 +3395,9 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 	default:
 		switch (line->special)
 		{
+		case 2071:
+			resetinv = true;
+			[[fallthrough]]
 		case 197:
 			// Exit to next level
 			// killough 10/98: prevent zombies from exiting levels
@@ -3386,11 +3405,14 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 				break;
 			if (thing && CheckIfExitIsGood(thing))
 			{
-				G_ExitLevel(0, 1);
+				G_ExitLevel(0, 1, resetinv);
 				return true;
 			}
 			break;
 
+		case 2074:
+			resetinv = true;
+			[[fallthrough]]
 		case 198:
 			// Exit to secret level
 			// killough 10/98: prevent zombies from exiting levels
@@ -3398,7 +3420,7 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 				break;
 			if (thing && CheckIfExitIsGood(thing))
 			{
-				G_SecretExitLevel(0, 1);
+				G_SecretExitLevel(0, 1, resetinv);
 				return true;
 			}
 			break;

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -438,7 +438,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 
 	case 2069:
 		resetinv = true;
-		[[fallthrough]]
+		// TODO: add [[fallthrough]] when C++17 comes
 	case 52:
 		// EXIT!
 		// killough 10/98: prevent zombies from exiting levels
@@ -573,7 +573,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 
 	case 2072:
 		resetinv = true;
-		[[fallthrough]]
+		// TODO: add [[fallthrough]] when C++17 comes
 	case 124:
 		// Secret EXIT
 		// killough 10/98: prevent zombies from exiting levels
@@ -2085,7 +2085,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 
 	case 2070:
 		resetinv = true;
-		[[fallthrough]]
+		// TODO: add [[fallthrough]] when C++17 comes
 	case 11:
 		/* Exit level
 		 * killough 10/98: prevent zombies from exiting levels
@@ -2212,7 +2212,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 
 	case 2073:
 		resetinv = true;
-		[[fallthrough]]
+		// TODO: add [[fallthrough]] when C++17 comes
 	case 51:
 		/* Secret EXIT
 		 * killough 10/98: prevent zombies from exiting levels
@@ -3397,7 +3397,7 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		{
 		case 2071:
 			resetinv = true;
-			[[fallthrough]]
+			// TODO: add [[fallthrough]] when C++17 comes
 		case 197:
 			// Exit to next level
 			// killough 10/98: prevent zombies from exiting levels
@@ -3412,7 +3412,7 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 
 		case 2074:
 			resetinv = true;
-			[[fallthrough]]
+			// TODO: add [[fallthrough]] when C++17 comes
 		case 198:
 			// Exit to secret level
 			// killough 10/98: prevent zombies from exiting levels

--- a/common/p_boomfspec.h
+++ b/common/p_boomfspec.h
@@ -26,7 +26,7 @@
 #pragma once
 
 void OnChangedSwitchTexture(line_t* line, int useAgain);
-void G_SecretExitLevel(int position, int drawscores);
+void G_SecretExitLevel(int position, int drawscores, bool resetinv);
 void P_DamageMobj(AActor* target, AActor* inflictor, AActor* source, int damage, int mod,
                   int flags);
 bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -387,7 +387,7 @@ bool P_IsExitLine(const short special)
 		return special == 74 || special == 75 || special == 244 || special == 243;
 
 	return special == 11 || special == 52 || special == 197 || special == 51 ||
-	       special == 124 || special == 198;
+	       special == 124 || special == 198 || (2069 <= special && special <= 2074);
 }
 
 bool P_IsTeleportLine(const short special)

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -215,10 +215,10 @@ int P_IsUnderDamage(AActor* actor)
 }
 
 /*
-* 
+*
 * P_IsFriendlyThing
 * @brief Helper function to determine if a particular thing is of friendly origin.
-* 
+*
 * @param actor Source actor
 * @param friendshiptest Thing to test friendliness
 */
@@ -580,7 +580,7 @@ static void P_InitAnimDefs ()
 	}
     catch (CRecoverableError &)
     {
-	    
+
     }
 }
 
@@ -764,6 +764,12 @@ bool P_CheckTag(line_t* line)
 	case 51:
 	case 124:
 	case 198:
+	case 2069:
+	case 2070:
+	case 2071:
+	case 2072:
+	case 2073:
+	case 2074:
 
 	case 48: // Scrolling walls
 	case 85:
@@ -1459,7 +1465,7 @@ int P_FindSectorFromTagOrLine(int tag, const line_t* line, int start)
 
 /*
 * @brief checks to see if a ZDoom-style door can be unlocked.
-* 
+*
 * @param player: Player to key check
 * @param lock: ZDoom lock type
 * All ZDoom lock types are supported but Odamex is missing

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -516,13 +516,24 @@ void G_InitNew (const char *mapname)
 // G_DoCompleted
 //
 
-void G_ExitLevel (int position, int drawscores)
+void G_ExitLevel (int position, int drawscores, bool resetinv)
 {
+	if (resetinv)
+	{
+		for (Players::iterator it = players.begin();it != players.end();++it)
+		{
+			if (it->ingame())
+			{
+				it->doreborn = true;
+			}
+		}
+	}
+
 	SV_ExitLevel();
 
 	if (drawscores)
         SV_DrawScores();
-	
+
 	gamestate = GS_INTERMISSION;
 	mapchange = TICRATE * sv_intermissionlimit;  // wait n seconds, default 10
 
@@ -535,13 +546,24 @@ void G_ExitLevel (int position, int drawscores)
 }
 
 // Here's for the german edition.
-void G_SecretExitLevel (int position, int drawscores)
+void G_SecretExitLevel (int position, int drawscores, bool resetinv)
 {
+	if (resetinv)
+	{
+		for (Players::iterator it = players.begin();it != players.end();++it)
+		{
+			if (it->ingame())
+			{
+				it->doreborn = true;
+			}
+		}
+	}
+
 	SV_ExitLevel();
 
     if (drawscores)
         SV_DrawScores();
-        
+
 	gamestate = GS_INTERMISSION;
 	mapchange = TICRATE * sv_intermissionlimit;  // wait n seconds, defaults to 10
 
@@ -695,7 +717,7 @@ void G_DoResetLevel(bool full_reset)
 	P_HordeClearSpawns();
 
 	// Reset the respawned monster count
-	level.respawned_monsters = 0;	
+	level.respawned_monsters = 0;
 
 	// No need to clear the spawn locations because we're not loading a new map.
 	M_StartWDLLog(false);
@@ -758,7 +780,7 @@ void G_DoLoadLevel (int position)
 		wipegamestate = GS_FORCEWIPE;
 
 	gamestate = GS_LEVEL;
-	
+
 	// Reset all keys found
 	for (size_t j = 0; j < NUMCARDS; j++)
 		keysfound[j] = false;

--- a/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
+++ b/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
@@ -37,6 +37,36 @@ doom
 			title = "Line Horizon";
 			prefix = "";
 		}
+				2069
+		{
+			title = "W1 Exit Level & Reset Inventory";
+			prefix = "";
+		}
+		2070
+		{
+			title = "S1 Exit Level & Reset Inventory";
+			prefix = "";
+		}
+		2071
+		{
+			title = "G1 Exit Level & Reset Inventory";
+			prefix = "";
+		}
+		2072
+		{
+			title = "W1 Exit Level & Reset Inventory (goes to secret level)";
+			prefix = "";
+		}
+		2073
+		{
+			title = "S1 Exit Level & Reset Inventory (goes to secret level)";
+			prefix = "";
+		}
+		2074
+		{
+			title = "G1 Exit Level & Reset Inventory (goes to secret level)";
+			prefix = "";
+		}
 	}
 //NOT SUPPORTED YET	
 //	floor

--- a/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
+++ b/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
@@ -3,15 +3,15 @@
 // The ZDoom structure is common to Hexen and UDMF and contains the bulk of the definitions.
 // The Hexen and UDMF structures contain only the little tweaks needed for these formats.
 
-// AS OF JAN 29 2022, ONLY THE DOOM FORMAT ODAMEX SPECIALS HAVE BEEN AUDITED. 
-// PROCEED WITH CAUTION WHEN EDITING THE ZDOOM SECTION. 
+// AS OF JAN 29 2022, ONLY THE DOOM FORMAT ODAMEX SPECIALS HAVE BEEN AUDITED.
+// PROCEED WITH CAUTION WHEN EDITING THE ZDOOM SECTION.
 
 doom
 {
 	init
 	{
 		title = "Static Init";
-	
+
 		333
 		{
 			title = "Init Gravity";
@@ -27,18 +27,48 @@ doom
 			title = "Init Damage";
 			prefix = "";
 		}
-	}	
+	}
 	line
 	{
 		title = "Line";
-		
+
 		337
 		{
 			title = "Line Horizon";
 			prefix = "";
 		}
+		2069
+		{
+			title = "W1 Exit Level & Reset Inventory";
+			prefix = "";
+		}
+		2070
+		{
+			title = "S1 Exit Level & Reset Inventory";
+			prefix = "";
+		}
+		2071
+		{
+			title = "G1 Exit Level & Reset Inventory";
+			prefix = "";
+		}
+		2072
+		{
+			title = "W1 Exit Level & Reset Inventory (goes to secret level)";
+			prefix = "";
+		}
+		2073
+		{
+			title = "S1 Exit Level & Reset Inventory (goes to secret level)";
+			prefix = "";
+		}
+		2074
+		{
+			title = "G1 Exit Level & Reset Inventory (goes to secret level)";
+			prefix = "";
+		}
 	}
-//NOT SUPPORTED YET	
+//NOT SUPPORTED YET
 //	floor
 //	{
 //		338
@@ -52,11 +82,11 @@ doom
 //			prefix = "W1";
 //		}
 //	}
-	
+
 	plane
 	{
 		title = "Plane";
-		
+
 		340
 		{
 			title = "Slope Front Floor";
@@ -98,7 +128,7 @@ doom
 			prefix = "";
 		}
 	}
-	
+
 }
 
 zdoom
@@ -106,7 +136,7 @@ zdoom
 	polyobj
 	{
 		title = "Polyobjects";
-		
+
 		59
 		{
 			title = "Polyobject Move to Spot (override)";
@@ -218,13 +248,13 @@ zdoom
 	line
 	{
 		title = "Line";
-		
+
 		9
 		{
 			title = "Line Horizon";
 			id = "Line_Horizon";
 			requiresactivation = false;
-		}	
+		}
 		121	// Line Identification
 		{
 			arg1
@@ -259,7 +289,7 @@ zdoom
 			title = "Line Set Portal";
 			id = "Line_SetPortal";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Exit Line Tag";
@@ -295,7 +325,7 @@ zdoom
 		{
 			title = "Line Set Portal Target";
 			id = "Line_SetPortalTarget";
-			
+
 			arg0
 			{
 				title = "Source Line Tag";
@@ -307,12 +337,12 @@ zdoom
 				type = 15;
 			}
 		}
-		
+
 		55
 		{
 			title = "Line Set Blocking";
 			id = "Line_SetBlocking";
-			
+
 			arg0
 			{
 				title = "Target Line Tag";
@@ -331,7 +361,7 @@ zdoom
 				enum = "linesetblockingflags";
 			}
 		}
-		
+
 	}
 
 	door
@@ -340,7 +370,7 @@ zdoom
 		{
 			title = "Door Animated";
 			id = "Door_Animated";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -371,7 +401,7 @@ zdoom
 		{
 			title = "Door Generic";
 			id = "Generic_Door";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -415,12 +445,12 @@ zdoom
 				enum = "keys";
 			}
 		}
-		
+
 		249
 		{
 			title = "Door Close Wait Open";
 			id = "Door_CloseWaitOpen";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -451,7 +481,7 @@ zdoom
 	autosave
 	{
 		title = "Autosave";
-		
+
 		15
 		{
 			title = "Autosave";
@@ -474,7 +504,7 @@ zdoom
 		{
 			title = "Floor Move to Value";
 			id = "Floor_MoveToValue";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -498,12 +528,12 @@ zdoom
 				enum = "noyes";
 			}
 		}
-		
+
 		138
 		{
 			title = "Floor Waggle";
 			id = "Floor_Waggle";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -529,12 +559,12 @@ zdoom
 				default = 5;
 			}
 		}
-		
+
 		200
 		{
 			title = "Floor Generic Change";
 			id = "Generic_Floor";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -585,12 +615,12 @@ zdoom
 				}
 			}
 		}
-		
+
 		235
 		{
 			title = "Transfer Floor and Special from Back Side";
 			id = "Floor_TransferTrigger";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -601,7 +631,7 @@ zdoom
 		{
 			title = "Transfer Floor and Special using Numeric Change Model";
 			id = "Floor_TransferNumeric";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -612,7 +642,7 @@ zdoom
 		{
 			title = "Floor Raise to Lowest Ceiling";
 			id = "Floor_RaiseToLowestCeiling";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -630,7 +660,7 @@ zdoom
 		{
 			title = "Floor Raise by TxTy";
 			id = "Floor_RaiseByValueTxTy";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -648,12 +678,12 @@ zdoom
 				title = "Raise by";
 			}
 		}
-		
+
 		240
 		{
 			title = "Floor Raise by Texture";
 			id = "Floor_RaiseByTexture";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -667,12 +697,12 @@ zdoom
 				default = 16;
 			}
 		}
-		
+
 		241
 		{
 			title = "Floor Lower to Lowest TxTy";
 			id = "Floor_LowerToLowestTxTy";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -691,12 +721,12 @@ zdoom
 				floorlowertolowest = true;
 			}
 		}
-		
+
 		242
 		{
 			title = "Floor Lower to Highest Floor";
 			id = "Floor_LowerToHighest";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -729,7 +759,7 @@ zdoom
 		{
 			title = "Floor Donut";
 			id = "Floor_Donut";
-			
+
 			arg0
 			{
 				title = "Center Sector Tag";
@@ -750,12 +780,12 @@ zdoom
 				default = 4;
 			}
 		}
-		
+
 		251
 		{
 			title = "Floor and Ceiling Lower and Raise";
 			id = "FloorAndCeiling_LowerRaise";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -794,7 +824,7 @@ zdoom
 		{
 			title = "Stairs Generic Build";
 			id = "Generic_Stairs";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -828,12 +858,12 @@ zdoom
 				enum = "reset_tics";
 			}
 		}
-		
+
 		217
 		{
 			title = "Stairs Build up (Doom mode)";
 			id = "Stairs_BuildUpDoom";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -889,7 +919,7 @@ zdoom
 	forcefield
 	{
 		title = "Forcefield";
-		
+
 		33
 		{
 			title = "Forcefield Set";
@@ -900,7 +930,7 @@ zdoom
 		{
 			title = "Forcefield Remove";
 			id = "ClearForceField";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -913,12 +943,12 @@ zdoom
 	ceiling
 	{
 		title = "Ceiling";
-		
+
 		38
 		{
 			title = "Ceiling Waggle";
 			id = "Ceiling_Waggle";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -965,40 +995,40 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-			
+
 		}
-		
+
 		97
 		{
 			title = "Ceiling Lower And Crush Dist";
 			id = "Ceiling_LowerAndCrushDist";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
 				type = 13;
 			}
-		
+
 			arg1
 			{
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
 				default = 16;
-				
+
 			}
-		
+
 			arg2
 			{
 				title = "Crush Damage";
 				default = 100;
 			}
-		
+
 			arg3
 			{
 				title = "Lip";
 			}
-		
+
 			arg4
 			{
 				title = "Crush Mode";
@@ -1006,23 +1036,23 @@ zdoom
 				enum = "crush_mode";
 			}
 		}
-		
+
 		104
 		{
 			title = "Ceiling Crush And Raise Dist";
 			id = "Ceiling_CrushAndRaiseSilentDist";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
 				type = 13;
 			}
-		
+
 			arg1
 			{
 				title = "Lip";
 			}
-		
+
 			arg2
 			{
 				title = "Movement Speed";
@@ -1030,13 +1060,13 @@ zdoom
 				enum = "plat_speeds";
 				default = 16;
 			}
-		
+
 			arg3
 			{
 				title = "Crush Damage";
 				default = 100;
 			}
-		
+
 			arg4
 			{
 				title = "Crush Mode";
@@ -1053,13 +1083,13 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-			
+
 		}
 		47
 		{
 			title = "Ceiling Move to Value";
 			id = "Ceiling_MoveToValue";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1087,7 +1117,7 @@ zdoom
 		{
 			title = "Ceiling Generic Crush (Hexen mode)";
 			id = "Generic_Crusher2";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1123,7 +1153,7 @@ zdoom
 		{
 			title = "Ceiling Lower to Highest Floor";
 			id = "Ceiling_LowerToHighestFloor";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1141,7 +1171,7 @@ zdoom
 		{
 			title = "Ceiling Lower Instantly by Value * 8";
 			id = "Ceiling_LowerInstant";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1156,7 +1186,7 @@ zdoom
 		{
 			title = "Ceiling Raise Instantly by Value * 8";
 			id = "Ceiling_RaiseInstant";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1171,7 +1201,7 @@ zdoom
 		{
 			title = "Ceiling Crush Once and Open A";
 			id = "Ceiling_CrushRaiseAndStayA";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1202,13 +1232,13 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-			
+
 		}
 		196
 		{
 			title = "Ceiling Crush Start A";
 			id = "Ceiling_CrushAndRaiseA";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1239,13 +1269,13 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-			
+
 		}
 		197
 		{
 			title = "Ceiling Crush Start A (silent)";
 			id = "Ceiling_CrushAndRaiseSilentA";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1276,13 +1306,13 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-			
+
 		}
 		198
 		{
 			title = "Ceiling Raise by Value * 8";
 			id = "Ceiling_RaiseByValueTimes8";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1304,7 +1334,7 @@ zdoom
 		{
 			title = "Ceiling Lower by Value * 8";
 			id = "Ceiling_LowerByValueTimes8";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1322,12 +1352,12 @@ zdoom
 				title = "Lower by (* 8)";
 			}
 		}
-		
+
 		201
 		{
 			title = "Ceiling Generic Change";
 			id = "Generic_Ceiling";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1382,7 +1412,7 @@ zdoom
 		{
 			title = "Ceiling Generic Crush (Doom mode)";
 			id = "Generic_Crusher";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1418,7 +1448,7 @@ zdoom
 		{
 			title = "Ceiling Raise to Nearest Ceiling";
 			id = "Ceiling_RaiseToNearest";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1436,7 +1466,7 @@ zdoom
 		{
 			title = "Ceiling Lower to Lowest Ceiling";
 			id = "Ceiling_LowerToLowest";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1454,7 +1484,7 @@ zdoom
 		{
 			title = "Ceiling Lower to Floor";
 			id = "Ceiling_LowerToFloor";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1472,7 +1502,7 @@ zdoom
 		{
 			title = "Ceiling Crush Once and Open A (silent)";
 			id = "Ceiling_CrushRaiseAndStaySilA";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1509,12 +1539,12 @@ zdoom
 	breakable
 	{
 		title = "Breakable";
-		
+
 		49
 		{
 			title = "Breakable Glass";
 			id = "GlassBreak";
-			
+
 			arg0
 			{
 				title = "Spawn Glass Shards";
@@ -1527,13 +1557,13 @@ zdoom
 	transfer
 	{
 		title = "Transfer";
-		
+
 		50
 		{
 			title = "Transfer Brightness Level";
 			id = "ExtraFloor_LightOnly";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1556,14 +1586,14 @@ zdoom
 			title = "Transfer Heights";
 			id = "Transfer_Heights";
 			requiresactivation = false;
-			
+
 			errorchecker
 			{
 				ignoreuppertexture = true;
 				ignoremiddletexture = true;
 				ignorelowertexture = true;
 			}
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1585,13 +1615,13 @@ zdoom
 				}
 			}
 		}
-		
+
 		210
 		{
 			title = "Transfer Floor Brightness";
 			id = "Transfer_FloorLight";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1603,7 +1633,7 @@ zdoom
 			title = "Transfer Ceiling Brightness";
 			id = "Transfer_CeilingLight";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1615,7 +1645,7 @@ zdoom
 			title = "Transfer Wall Brightness";
 			id = "Transfer_WallLight";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Line Tag";
@@ -1633,7 +1663,7 @@ zdoom
 				}
 			}
 		}
-		
+
 	}
 
 	platform
@@ -1642,7 +1672,7 @@ zdoom
 		{
 			title = "Platform Raise to Nearest Wait Lower";
 			id = "Plat_UpNearestWaitDownStay";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1667,7 +1697,7 @@ zdoom
 		{
 			title = "Platform Generic Change";
 			id = "Generic_Lift";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1702,7 +1732,7 @@ zdoom
 		{
 			title = "Platform Lower Wait Raise (lip)";
 			id = "Plat_DownWaitUpStayLip";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1737,7 +1767,7 @@ zdoom
 		{
 			title = "Platform Perpetual Move (lip)";
 			id = "Plat_PerpetualRaiseLip";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1766,7 +1796,7 @@ zdoom
 		{
 			title = "Platform Raise Tx0";
 			id = "Plat_RaiseAndStayTx0";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1795,7 +1825,7 @@ zdoom
 		{
 			title = "Platform Raise by Value Tx (* 8)";
 			id = "Plat_UpByValueStayTx";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1817,7 +1847,7 @@ zdoom
 		{
 			title = "Platform Toggle Ceiling";
 			id = "Plat_ToggleCeiling";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1829,12 +1859,12 @@ zdoom
 	teleport
 	{
 		title = "Teleport";
-		
+
 		39
 		{
 			title = "Teleport to Pain State (silent)";
 			id = "Teleport_ZombieChanger";
-			
+
 			arg0
 			{
 				title = "Target Teleport Dest. Tag";
@@ -1890,7 +1920,7 @@ zdoom
 		{
 			title = "Teleport Other";
 			id = "TeleportOther";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -1913,7 +1943,7 @@ zdoom
 		{
 			title = "Teleport Group";
 			id = "TeleportGroup";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -1949,7 +1979,7 @@ zdoom
 		{
 			title = "Teleport in Sector";
 			id = "TeleportInSector";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -1984,7 +2014,7 @@ zdoom
 		{
 			title = "Teleport (no Stop)";
 			id = "Teleport_NoStop";
-			
+
 			arg0
 			{
 				title = "Target Teleport Dest. Tag";
@@ -2007,7 +2037,7 @@ zdoom
 		{
 			title = "Teleport to Line";
 			id = "Teleport_Line";
-			
+
 			arg1
 			{
 				title = "Target Line Tag";
@@ -2028,7 +2058,7 @@ zdoom
 		{
 			title = "Thing Raise";
 			id = "Thing_Raise";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -2039,7 +2069,7 @@ zdoom
 		{
 			title = "Start Conversation";
 			id = "StartConversation";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -2057,7 +2087,7 @@ zdoom
 		{
 			title = "Thing Stop";
 			id = "Thing_Stop";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -2105,7 +2135,7 @@ zdoom
 		{
 			title = "Damage Thing by Tag";
 			id = "Thing_Damage";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -2127,7 +2157,7 @@ zdoom
 		{
 			title = "Move Thing";
 			id = "Thing_Move";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -2149,7 +2179,7 @@ zdoom
 		{
 			title = "Thing Set Special";
 			id = "Thing_SetSpecial";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -2177,7 +2207,7 @@ zdoom
 		{
 			title = "Thing Thrust Z";
 			id = "ThrustThingZ";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -2220,7 +2250,7 @@ zdoom
 		{
 			title = "Spawn Thing Facing";
 			id = "Thing_SpawnFacing";
-			
+
 			arg0
 			{
 				title = "Mapspot Tag";
@@ -2249,7 +2279,7 @@ zdoom
 		{
 			title = "Spawn Projectile (Intercept)";
 			id = "Thing_ProjectileIntercept";
-			
+
 			arg0
 			{
 				title = "Mapspot Tag";
@@ -2281,7 +2311,7 @@ zdoom
 		{
 			title = "Change Thing Tag";
 			id = "Thing_ChangeTID";
-			
+
 			arg0
 			{
 				title = "Old Thing Tag";
@@ -2297,7 +2327,7 @@ zdoom
 		{
 			title = "Thing Hate";
 			id = "Thing_Hate";
-			
+
 			arg0
 			{
 				title = "Hater Tag";
@@ -2328,7 +2358,7 @@ zdoom
 		{
 			title = "Spawn Aimed Projectile";
 			id = "Thing_ProjectileAimed";
-			
+
 			arg0
 			{
 				title = "Mapspot Tag";
@@ -2360,7 +2390,7 @@ zdoom
 		{
 			title = "Set Thing Translation";
 			id = "Thing_SetTranslation";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -2375,7 +2405,7 @@ zdoom
 		{
 			title = "Thing Set Goal";
 			id = "Thing_SetGoal";
-			
+
 			arg0
 			{
 				title = "Monster Thing Tag";
@@ -2390,7 +2420,7 @@ zdoom
 			{
 				title = "Delay";
 				type = 11;
-				enum 
+				enum
 				{
 					0 = "No Delay";
 					1 = "1 Second";
@@ -2416,19 +2446,19 @@ zdoom
 		{
 			title = "Heal Thing";
 			id = "HealThing";
-			
+
 			arg0
 			{
 				title = "Heal Amount";
 			}
 		}
-		
+
 	}
 
 	script
 	{
 		title = "Script";
-		
+
 		83	// Script Locked Execute
 		{
 			arg4	// Key Number
@@ -2441,7 +2471,7 @@ zdoom
 		{
 			title = "Script Execute with Result";
 			id = "ACS_ExecuteWithResult";
-			
+
 			arg0
 			{
 				title = "Script Number";
@@ -2469,29 +2499,29 @@ zdoom
 		{
 			title = "Script Locked Execute (Door message)";
 			id = "ACS_LockedExecuteDoor";
-			
+
 			arg0
 			{
 				title = "Script Number";
 				str = true;
 				titlestr = "Script Name";
 			}
-			
+
 			arg1
 			{
 				title = "Map Number";
 			}
-			
+
 			arg2
 			{
 				title = "Script Argument 1";
 			}
-			
+
 			arg3
 			{
 				title = "Script Argument 2";
 			}
-			
+
 			arg4
 			{
 				title = "Key Number";
@@ -2503,7 +2533,7 @@ zdoom
 		{
 			title = "FraggleScript Execute";
 			id = "FS_Execute";
-			
+
 			arg0
 			{
 				title = "Script Number";
@@ -2539,29 +2569,29 @@ zdoom
 		{
 			title = "Script Execute Always";
 			id = "ACS_ExecuteAlways";
-			
+
 			arg0
 			{
 				title = "Script Number";
 				str = true;
 				titlestr = "Script Name";
 			}
-			
+
 			arg1
 			{
 				title = "Map Number";
 			}
-			
+
 			arg2
 			{
 				title = "Script Argument 1";
 			}
-			
+
 			arg3
 			{
 				title = "Script Argument 2";
 			}
-			
+
 			arg4
 			{
 				title = "Script Argument 3";
@@ -2575,7 +2605,7 @@ zdoom
 		{
 			title = "End Normal";
 			id = "Exit_Normal";
-			
+
 			arg0
 			{
 				title = "Position";
@@ -2585,7 +2615,7 @@ zdoom
 		{
 			title = "End Secret";
 			id = "Exit_Secret";
-			
+
 			arg0
 			{
 				title = "Position";
@@ -2596,13 +2626,13 @@ zdoom
 	scroll
 	{
 		title = "Scroll";
-		
+
 		52
 		{
 			title = "Scroll Wall";
 			id = "Scroll_Wall";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Line Tag";
@@ -2634,7 +2664,7 @@ zdoom
 				}
 			}
 		}
-		
+
 		100 //Scroll_Texture_Left
 		{
 			arg1
@@ -2644,7 +2674,7 @@ zdoom
 				enum = "sidedef_part";
 			}
 		}
-		
+
 		101 //Scroll_Texture_Right
 		{
 			arg1
@@ -2654,7 +2684,7 @@ zdoom
 				enum = "sidedef_part";
 			}
 		}
-		
+
 		102 //Scroll_Texture_Up
 		{
 			arg1
@@ -2664,7 +2694,7 @@ zdoom
 				enum = "sidedef_part";
 			}
 		}
-		
+
 		103 //Scroll_Texture_Down
 		{
 			arg1
@@ -2674,13 +2704,13 @@ zdoom
 				enum = "sidedef_part";
 			}
 		}
-		
+
 		221
 		{
 			title = "Scroll Texture Both";
 			id = "Scroll_Texture_Both";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Line Tag";
@@ -2716,7 +2746,7 @@ zdoom
 			title = "Scroll Texture Model";
 			id = "Scroll_Texture_Model";
 			requiresactivation = false;
-			
+
 			arg1
 			{
 				title = "Options";
@@ -2728,13 +2758,13 @@ zdoom
 				}
 			}
 		}
-		
+
 		223
 		{
 			title = "Scroll Floor";
 			id = "Scroll_Floor";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -2782,7 +2812,7 @@ zdoom
 			title = "Scroll Ceiling";
 			id = "Scroll_Ceiling";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -2819,7 +2849,7 @@ zdoom
 			title = "Scroll Texture by Offsets";
 			id = "Scroll_Texture_Offsets";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sidedef Part";
@@ -2836,7 +2866,7 @@ zdoom
 		{
 			title = "Lightning Control";
 			id = "Light_ForceLightning";
-			
+
 			arg0
 			{
 				title = "Mode";
@@ -2853,7 +2883,7 @@ zdoom
 		{
 			title = "Light Stop";
 			id = "Light_Stop";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -2864,7 +2894,7 @@ zdoom
 		{
 			title = "Light Strobe (Doom mode)";
 			id = "Light_StrobeDoom";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -2889,7 +2919,7 @@ zdoom
 		{
 			title = "Light Change to Darkest Neightbour";
 			id = "Light_MinNeighbor";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -2900,7 +2930,7 @@ zdoom
 		{
 			title = "Light Change to Brightest Neightbour";
 			id = "Light_MaxNeighbor";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -2912,13 +2942,13 @@ zdoom
 	sector
 	{
 		title = "Sector";
-		
+
 		48
 		{
 			title = "Sector Attach 3D Midtex";
 			id = "Sector_Attach3dMidtex";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Line Tag";
@@ -2928,7 +2958,7 @@ zdoom
 			{
 				title = "Sector Tag";
 				type = 13;
-			}		
+			}
 			arg2
 			{
 				title = "Floor / Ceiling";
@@ -2941,7 +2971,7 @@ zdoom
 			title = "Sector Set Link";
 			id = "Sector_SetLink";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Control Sector Tag";
@@ -2972,12 +3002,12 @@ zdoom
 				}
 			}
 		}
-		
+
 		98
 		{
 			title = "Sector Set Translucent";
 			id = "Sector_SetTranslucent";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3009,7 +3039,7 @@ zdoom
 		{
 			title = "Sector Change Flags";
 			id = "Sector_ChangeFlags";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3033,7 +3063,7 @@ zdoom
 			title = "Sector Set Portal";
 			id = "Sector_SetPortal";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3081,7 +3111,7 @@ zdoom
 			title = "Sector Copy Scroller";
 			id = "Sector_CopyScroller";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3097,14 +3127,14 @@ zdoom
 					2 = "Copy floor scroller";
 					4 = "Copy carrying effect";
 				}
-			}		
+			}
 		}
 		160
 		{
 			title = "Sector Set 3D Floor";
 			id = "Sector_Set3dFloor";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3156,7 +3186,7 @@ zdoom
 		{
 			title = "Sector Set Contents (Vavoom compatibility)";
 			id = "Sector_SetContents";
-			
+
 			arg0
 			{
 				title = "Type";
@@ -3196,7 +3226,7 @@ zdoom
 		{
 			title = "Sector Rotate Flat";
 			id = "Sector_SetRotation";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3217,7 +3247,7 @@ zdoom
 		{
 			title = "Sector Ceiling Panning";
 			id = "Sector_SetCeilingPanning";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3244,7 +3274,7 @@ zdoom
 		{
 			title = "Sector Floor Panning";
 			id = "Sector_SetFloorPanning";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3271,7 +3301,7 @@ zdoom
 		{
 			title = "Sector Ceiling Scale";
 			id = "Sector_SetCeilingScale";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3298,7 +3328,7 @@ zdoom
 		{
 			title = "Sector Floor Scale";
 			id = "Sector_SetFloorScale";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3325,7 +3355,7 @@ zdoom
 		{
 			title = "Sector Color";
 			id = "Sector_SetColor";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3352,7 +3382,7 @@ zdoom
 		{
 			title = "Sector Fade";
 			id = "Sector_SetFade";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3375,7 +3405,7 @@ zdoom
 		{
 			title = "Sector Damage";
 			id = "Sector_SetDamage";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3397,7 +3427,7 @@ zdoom
 		{
 			title = "Sector Gravity";
 			id = "Sector_SetGravity";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3412,12 +3442,12 @@ zdoom
 				title = "Gravity Fractional";
 			}
 		}
-		
+
 		218
 		{
 			title = "Sector Wind";
 			id = "Sector_SetWind";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3444,7 +3474,7 @@ zdoom
 			title = "Sector Friction";
 			id = "Sector_SetFriction";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3465,12 +3495,12 @@ zdoom
 				}
 			}
 		}
-		
+
 		220
 		{
 			title = "Sector Current";
 			id = "Sector_SetCurrent";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3497,12 +3527,12 @@ zdoom
 	alert
 	{
 		title = "Alert";
-		
+
 		173
 		{
 			title = "Alert monsters";
 			id = "NoiseAlert";
-			
+
 			arg0
 			{
 				title = "Target Tag";
@@ -3519,12 +3549,12 @@ zdoom
 	communicator
 	{
 		title = "Communicator";
-		
+
 		174
 		{
 			title = "Communicator Message";
 			id = "SendToCommunicator";
-			
+
 			arg0
 			{
 				title = "Message ID";
@@ -3553,12 +3583,12 @@ zdoom
 	change
 	{
 		title = "Change";
-		
+
 		157
 		{
 			title = "Set Global Fog Parameter (GZDoom only)";
 			id = "SetGlobalFogParameter";
-			
+
 			arg0
 			{
 				title = "Property";
@@ -3579,12 +3609,12 @@ zdoom
 		{
 			title = "Change Skill";
 			id = "ChangeSkill";
-			
+
 			arg0
 			{
 				title = "New Skill Level";
 				type = 11;
-				enum 
+				enum
 				{
 					0 = "Very Easy";
 					1 = "Easy";
@@ -3599,13 +3629,13 @@ zdoom
 	plane
 	{
 		title = "Plane";
-		
+
 		118
 		{
 			title = "Plane Copy (slope)";
 			id = "Plane_Copy";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Front Floor Tag";
@@ -3643,7 +3673,7 @@ zdoom
 		{
 			title = "Plane Reflection (OpenGL only)";
 			id = "Sector_SetPlaneReflection";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3663,7 +3693,7 @@ zdoom
 			title = "Plane Align (slope)";
 			id = "Plane_Align";
 			requiresactivation = false;
-			
+
 			arg0
 			{
 				title = "Align Floor";
@@ -3692,12 +3722,12 @@ zdoom
 	static
 	{
 		title = "Static";
-		
+
 		190
 		{
 			title = "Static Init";
 			id = "Static_Init";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3730,12 +3760,12 @@ zdoom
 	player
 	{
 		title = "Player";
-		
+
 		191
 		{
 			title = "Set Player Property";
 			id = "SetPlayerProperty";
-			
+
 			arg0
 			{
 				title = "Target";
@@ -3772,13 +3802,13 @@ zdoom
 	translucent
 	{
 		title = "Translucent";
-		
+
 		208
 		{
 			title = "Translucent Line";
 			id = "TranslucentLine";
 			requiresactivation = false;
-			
+
 			arg1
 			{
 				title = "Opacity";
@@ -3796,12 +3826,12 @@ zdoom
 	point
 	{
 		title = "Point";
-		
+
 		227
 		{
 			title = "Point Pusher/Puller Set Force";
 			id = "PointPush_SetForce";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3828,12 +3858,12 @@ zdoom
 	camera
 	{
 		title = "Camera";
-		
+
 		237
 		{
 			title = "Change Camera";
 			id = "ChangeCamera";
-			
+
 			arg0
 			{
 				title = "Thing Tag";
@@ -3861,12 +3891,12 @@ zdoom
 	elevator
 	{
 		title = "Elevator";
-		
+
 		245
 		{
 			title = "Elevator Raise to Nearest Floor";
 			id = "Elevator_RaiseToNearest";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3889,7 +3919,7 @@ zdoom
 		{
 			title = "Elevator Move to Activated Floor";
 			id = "Elevator_MoveToFloor";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3907,7 +3937,7 @@ zdoom
 		{
 			title = "Elevator Lower to Nearest Floor";
 			id = "Elevator_LowerToNearest";
-			
+
 			arg0
 			{
 				title = "Sector Tag";
@@ -3935,7 +3965,7 @@ hexen
 				title = "This Line Tag";
 				tooltip = "The tag number of the current line";
 				type = 15;
-			}	
+			}
 		}
 	}
 	polyobj

--- a/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
+++ b/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
@@ -3,15 +3,15 @@
 // The ZDoom structure is common to Hexen and UDMF and contains the bulk of the definitions.
 // The Hexen and UDMF structures contain only the little tweaks needed for these formats.
 
-// AS OF JAN 29 2022, ONLY THE DOOM FORMAT ODAMEX SPECIALS HAVE BEEN AUDITED.
-// PROCEED WITH CAUTION WHEN EDITING THE ZDOOM SECTION.
+// AS OF JAN 29 2022, ONLY THE DOOM FORMAT ODAMEX SPECIALS HAVE BEEN AUDITED. 
+// PROCEED WITH CAUTION WHEN EDITING THE ZDOOM SECTION. 
 
 doom
 {
 	init
 	{
 		title = "Static Init";
-
+	
 		333
 		{
 			title = "Init Gravity";
@@ -27,48 +27,18 @@ doom
 			title = "Init Damage";
 			prefix = "";
 		}
-	}
+	}	
 	line
 	{
 		title = "Line";
-
+		
 		337
 		{
 			title = "Line Horizon";
 			prefix = "";
 		}
-		2069
-		{
-			title = "W1 Exit Level & Reset Inventory";
-			prefix = "";
-		}
-		2070
-		{
-			title = "S1 Exit Level & Reset Inventory";
-			prefix = "";
-		}
-		2071
-		{
-			title = "G1 Exit Level & Reset Inventory";
-			prefix = "";
-		}
-		2072
-		{
-			title = "W1 Exit Level & Reset Inventory (goes to secret level)";
-			prefix = "";
-		}
-		2073
-		{
-			title = "S1 Exit Level & Reset Inventory (goes to secret level)";
-			prefix = "";
-		}
-		2074
-		{
-			title = "G1 Exit Level & Reset Inventory (goes to secret level)";
-			prefix = "";
-		}
 	}
-//NOT SUPPORTED YET
+//NOT SUPPORTED YET	
 //	floor
 //	{
 //		338
@@ -82,11 +52,11 @@ doom
 //			prefix = "W1";
 //		}
 //	}
-
+	
 	plane
 	{
 		title = "Plane";
-
+		
 		340
 		{
 			title = "Slope Front Floor";
@@ -128,7 +98,7 @@ doom
 			prefix = "";
 		}
 	}
-
+	
 }
 
 zdoom
@@ -136,7 +106,7 @@ zdoom
 	polyobj
 	{
 		title = "Polyobjects";
-
+		
 		59
 		{
 			title = "Polyobject Move to Spot (override)";
@@ -248,13 +218,13 @@ zdoom
 	line
 	{
 		title = "Line";
-
+		
 		9
 		{
 			title = "Line Horizon";
 			id = "Line_Horizon";
 			requiresactivation = false;
-		}
+		}	
 		121	// Line Identification
 		{
 			arg1
@@ -289,7 +259,7 @@ zdoom
 			title = "Line Set Portal";
 			id = "Line_SetPortal";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Exit Line Tag";
@@ -325,7 +295,7 @@ zdoom
 		{
 			title = "Line Set Portal Target";
 			id = "Line_SetPortalTarget";
-
+			
 			arg0
 			{
 				title = "Source Line Tag";
@@ -337,12 +307,12 @@ zdoom
 				type = 15;
 			}
 		}
-
+		
 		55
 		{
 			title = "Line Set Blocking";
 			id = "Line_SetBlocking";
-
+			
 			arg0
 			{
 				title = "Target Line Tag";
@@ -361,7 +331,7 @@ zdoom
 				enum = "linesetblockingflags";
 			}
 		}
-
+		
 	}
 
 	door
@@ -370,7 +340,7 @@ zdoom
 		{
 			title = "Door Animated";
 			id = "Door_Animated";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -401,7 +371,7 @@ zdoom
 		{
 			title = "Door Generic";
 			id = "Generic_Door";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -445,12 +415,12 @@ zdoom
 				enum = "keys";
 			}
 		}
-
+		
 		249
 		{
 			title = "Door Close Wait Open";
 			id = "Door_CloseWaitOpen";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -481,7 +451,7 @@ zdoom
 	autosave
 	{
 		title = "Autosave";
-
+		
 		15
 		{
 			title = "Autosave";
@@ -504,7 +474,7 @@ zdoom
 		{
 			title = "Floor Move to Value";
 			id = "Floor_MoveToValue";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -528,12 +498,12 @@ zdoom
 				enum = "noyes";
 			}
 		}
-
+		
 		138
 		{
 			title = "Floor Waggle";
 			id = "Floor_Waggle";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -559,12 +529,12 @@ zdoom
 				default = 5;
 			}
 		}
-
+		
 		200
 		{
 			title = "Floor Generic Change";
 			id = "Generic_Floor";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -615,12 +585,12 @@ zdoom
 				}
 			}
 		}
-
+		
 		235
 		{
 			title = "Transfer Floor and Special from Back Side";
 			id = "Floor_TransferTrigger";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -631,7 +601,7 @@ zdoom
 		{
 			title = "Transfer Floor and Special using Numeric Change Model";
 			id = "Floor_TransferNumeric";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -642,7 +612,7 @@ zdoom
 		{
 			title = "Floor Raise to Lowest Ceiling";
 			id = "Floor_RaiseToLowestCeiling";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -660,7 +630,7 @@ zdoom
 		{
 			title = "Floor Raise by TxTy";
 			id = "Floor_RaiseByValueTxTy";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -678,12 +648,12 @@ zdoom
 				title = "Raise by";
 			}
 		}
-
+		
 		240
 		{
 			title = "Floor Raise by Texture";
 			id = "Floor_RaiseByTexture";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -697,12 +667,12 @@ zdoom
 				default = 16;
 			}
 		}
-
+		
 		241
 		{
 			title = "Floor Lower to Lowest TxTy";
 			id = "Floor_LowerToLowestTxTy";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -721,12 +691,12 @@ zdoom
 				floorlowertolowest = true;
 			}
 		}
-
+		
 		242
 		{
 			title = "Floor Lower to Highest Floor";
 			id = "Floor_LowerToHighest";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -759,7 +729,7 @@ zdoom
 		{
 			title = "Floor Donut";
 			id = "Floor_Donut";
-
+			
 			arg0
 			{
 				title = "Center Sector Tag";
@@ -780,12 +750,12 @@ zdoom
 				default = 4;
 			}
 		}
-
+		
 		251
 		{
 			title = "Floor and Ceiling Lower and Raise";
 			id = "FloorAndCeiling_LowerRaise";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -824,7 +794,7 @@ zdoom
 		{
 			title = "Stairs Generic Build";
 			id = "Generic_Stairs";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -858,12 +828,12 @@ zdoom
 				enum = "reset_tics";
 			}
 		}
-
+		
 		217
 		{
 			title = "Stairs Build up (Doom mode)";
 			id = "Stairs_BuildUpDoom";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -919,7 +889,7 @@ zdoom
 	forcefield
 	{
 		title = "Forcefield";
-
+		
 		33
 		{
 			title = "Forcefield Set";
@@ -930,7 +900,7 @@ zdoom
 		{
 			title = "Forcefield Remove";
 			id = "ClearForceField";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -943,12 +913,12 @@ zdoom
 	ceiling
 	{
 		title = "Ceiling";
-
+		
 		38
 		{
 			title = "Ceiling Waggle";
 			id = "Ceiling_Waggle";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -995,40 +965,40 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-
+			
 		}
-
+		
 		97
 		{
 			title = "Ceiling Lower And Crush Dist";
 			id = "Ceiling_LowerAndCrushDist";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
 				type = 13;
 			}
-
+		
 			arg1
 			{
 				title = "Movement Speed";
 				type = 11;
 				enum = "plat_speeds";
 				default = 16;
-
+				
 			}
-
+		
 			arg2
 			{
 				title = "Crush Damage";
 				default = 100;
 			}
-
+		
 			arg3
 			{
 				title = "Lip";
 			}
-
+		
 			arg4
 			{
 				title = "Crush Mode";
@@ -1036,23 +1006,23 @@ zdoom
 				enum = "crush_mode";
 			}
 		}
-
+		
 		104
 		{
 			title = "Ceiling Crush And Raise Dist";
 			id = "Ceiling_CrushAndRaiseSilentDist";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
 				type = 13;
 			}
-
+		
 			arg1
 			{
 				title = "Lip";
 			}
-
+		
 			arg2
 			{
 				title = "Movement Speed";
@@ -1060,13 +1030,13 @@ zdoom
 				enum = "plat_speeds";
 				default = 16;
 			}
-
+		
 			arg3
 			{
 				title = "Crush Damage";
 				default = 100;
 			}
-
+		
 			arg4
 			{
 				title = "Crush Mode";
@@ -1083,13 +1053,13 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-
+			
 		}
 		47
 		{
 			title = "Ceiling Move to Value";
 			id = "Ceiling_MoveToValue";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1117,7 +1087,7 @@ zdoom
 		{
 			title = "Ceiling Generic Crush (Hexen mode)";
 			id = "Generic_Crusher2";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1153,7 +1123,7 @@ zdoom
 		{
 			title = "Ceiling Lower to Highest Floor";
 			id = "Ceiling_LowerToHighestFloor";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1171,7 +1141,7 @@ zdoom
 		{
 			title = "Ceiling Lower Instantly by Value * 8";
 			id = "Ceiling_LowerInstant";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1186,7 +1156,7 @@ zdoom
 		{
 			title = "Ceiling Raise Instantly by Value * 8";
 			id = "Ceiling_RaiseInstant";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1201,7 +1171,7 @@ zdoom
 		{
 			title = "Ceiling Crush Once and Open A";
 			id = "Ceiling_CrushRaiseAndStayA";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1232,13 +1202,13 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-
+			
 		}
 		196
 		{
 			title = "Ceiling Crush Start A";
 			id = "Ceiling_CrushAndRaiseA";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1269,13 +1239,13 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-
+			
 		}
 		197
 		{
 			title = "Ceiling Crush Start A (silent)";
 			id = "Ceiling_CrushAndRaiseSilentA";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1306,13 +1276,13 @@ zdoom
 				type = 11;
 				enum = "crush_mode";
 			}
-
+			
 		}
 		198
 		{
 			title = "Ceiling Raise by Value * 8";
 			id = "Ceiling_RaiseByValueTimes8";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1334,7 +1304,7 @@ zdoom
 		{
 			title = "Ceiling Lower by Value * 8";
 			id = "Ceiling_LowerByValueTimes8";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1352,12 +1322,12 @@ zdoom
 				title = "Lower by (* 8)";
 			}
 		}
-
+		
 		201
 		{
 			title = "Ceiling Generic Change";
 			id = "Generic_Ceiling";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1412,7 +1382,7 @@ zdoom
 		{
 			title = "Ceiling Generic Crush (Doom mode)";
 			id = "Generic_Crusher";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1448,7 +1418,7 @@ zdoom
 		{
 			title = "Ceiling Raise to Nearest Ceiling";
 			id = "Ceiling_RaiseToNearest";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1466,7 +1436,7 @@ zdoom
 		{
 			title = "Ceiling Lower to Lowest Ceiling";
 			id = "Ceiling_LowerToLowest";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1484,7 +1454,7 @@ zdoom
 		{
 			title = "Ceiling Lower to Floor";
 			id = "Ceiling_LowerToFloor";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1502,7 +1472,7 @@ zdoom
 		{
 			title = "Ceiling Crush Once and Open A (silent)";
 			id = "Ceiling_CrushRaiseAndStaySilA";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1539,12 +1509,12 @@ zdoom
 	breakable
 	{
 		title = "Breakable";
-
+		
 		49
 		{
 			title = "Breakable Glass";
 			id = "GlassBreak";
-
+			
 			arg0
 			{
 				title = "Spawn Glass Shards";
@@ -1557,13 +1527,13 @@ zdoom
 	transfer
 	{
 		title = "Transfer";
-
+		
 		50
 		{
 			title = "Transfer Brightness Level";
 			id = "ExtraFloor_LightOnly";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1586,14 +1556,14 @@ zdoom
 			title = "Transfer Heights";
 			id = "Transfer_Heights";
 			requiresactivation = false;
-
+			
 			errorchecker
 			{
 				ignoreuppertexture = true;
 				ignoremiddletexture = true;
 				ignorelowertexture = true;
 			}
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1615,13 +1585,13 @@ zdoom
 				}
 			}
 		}
-
+		
 		210
 		{
 			title = "Transfer Floor Brightness";
 			id = "Transfer_FloorLight";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1633,7 +1603,7 @@ zdoom
 			title = "Transfer Ceiling Brightness";
 			id = "Transfer_CeilingLight";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1645,7 +1615,7 @@ zdoom
 			title = "Transfer Wall Brightness";
 			id = "Transfer_WallLight";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Line Tag";
@@ -1663,7 +1633,7 @@ zdoom
 				}
 			}
 		}
-
+		
 	}
 
 	platform
@@ -1672,7 +1642,7 @@ zdoom
 		{
 			title = "Platform Raise to Nearest Wait Lower";
 			id = "Plat_UpNearestWaitDownStay";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1697,7 +1667,7 @@ zdoom
 		{
 			title = "Platform Generic Change";
 			id = "Generic_Lift";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1732,7 +1702,7 @@ zdoom
 		{
 			title = "Platform Lower Wait Raise (lip)";
 			id = "Plat_DownWaitUpStayLip";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1767,7 +1737,7 @@ zdoom
 		{
 			title = "Platform Perpetual Move (lip)";
 			id = "Plat_PerpetualRaiseLip";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1796,7 +1766,7 @@ zdoom
 		{
 			title = "Platform Raise Tx0";
 			id = "Plat_RaiseAndStayTx0";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1825,7 +1795,7 @@ zdoom
 		{
 			title = "Platform Raise by Value Tx (* 8)";
 			id = "Plat_UpByValueStayTx";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1847,7 +1817,7 @@ zdoom
 		{
 			title = "Platform Toggle Ceiling";
 			id = "Plat_ToggleCeiling";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -1859,12 +1829,12 @@ zdoom
 	teleport
 	{
 		title = "Teleport";
-
+		
 		39
 		{
 			title = "Teleport to Pain State (silent)";
 			id = "Teleport_ZombieChanger";
-
+			
 			arg0
 			{
 				title = "Target Teleport Dest. Tag";
@@ -1920,7 +1890,7 @@ zdoom
 		{
 			title = "Teleport Other";
 			id = "TeleportOther";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -1943,7 +1913,7 @@ zdoom
 		{
 			title = "Teleport Group";
 			id = "TeleportGroup";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -1979,7 +1949,7 @@ zdoom
 		{
 			title = "Teleport in Sector";
 			id = "TeleportInSector";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -2014,7 +1984,7 @@ zdoom
 		{
 			title = "Teleport (no Stop)";
 			id = "Teleport_NoStop";
-
+			
 			arg0
 			{
 				title = "Target Teleport Dest. Tag";
@@ -2037,7 +2007,7 @@ zdoom
 		{
 			title = "Teleport to Line";
 			id = "Teleport_Line";
-
+			
 			arg1
 			{
 				title = "Target Line Tag";
@@ -2058,7 +2028,7 @@ zdoom
 		{
 			title = "Thing Raise";
 			id = "Thing_Raise";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -2069,7 +2039,7 @@ zdoom
 		{
 			title = "Start Conversation";
 			id = "StartConversation";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -2087,7 +2057,7 @@ zdoom
 		{
 			title = "Thing Stop";
 			id = "Thing_Stop";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -2135,7 +2105,7 @@ zdoom
 		{
 			title = "Damage Thing by Tag";
 			id = "Thing_Damage";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -2157,7 +2127,7 @@ zdoom
 		{
 			title = "Move Thing";
 			id = "Thing_Move";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -2179,7 +2149,7 @@ zdoom
 		{
 			title = "Thing Set Special";
 			id = "Thing_SetSpecial";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -2207,7 +2177,7 @@ zdoom
 		{
 			title = "Thing Thrust Z";
 			id = "ThrustThingZ";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -2250,7 +2220,7 @@ zdoom
 		{
 			title = "Spawn Thing Facing";
 			id = "Thing_SpawnFacing";
-
+			
 			arg0
 			{
 				title = "Mapspot Tag";
@@ -2279,7 +2249,7 @@ zdoom
 		{
 			title = "Spawn Projectile (Intercept)";
 			id = "Thing_ProjectileIntercept";
-
+			
 			arg0
 			{
 				title = "Mapspot Tag";
@@ -2311,7 +2281,7 @@ zdoom
 		{
 			title = "Change Thing Tag";
 			id = "Thing_ChangeTID";
-
+			
 			arg0
 			{
 				title = "Old Thing Tag";
@@ -2327,7 +2297,7 @@ zdoom
 		{
 			title = "Thing Hate";
 			id = "Thing_Hate";
-
+			
 			arg0
 			{
 				title = "Hater Tag";
@@ -2358,7 +2328,7 @@ zdoom
 		{
 			title = "Spawn Aimed Projectile";
 			id = "Thing_ProjectileAimed";
-
+			
 			arg0
 			{
 				title = "Mapspot Tag";
@@ -2390,7 +2360,7 @@ zdoom
 		{
 			title = "Set Thing Translation";
 			id = "Thing_SetTranslation";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -2405,7 +2375,7 @@ zdoom
 		{
 			title = "Thing Set Goal";
 			id = "Thing_SetGoal";
-
+			
 			arg0
 			{
 				title = "Monster Thing Tag";
@@ -2420,7 +2390,7 @@ zdoom
 			{
 				title = "Delay";
 				type = 11;
-				enum
+				enum 
 				{
 					0 = "No Delay";
 					1 = "1 Second";
@@ -2446,19 +2416,19 @@ zdoom
 		{
 			title = "Heal Thing";
 			id = "HealThing";
-
+			
 			arg0
 			{
 				title = "Heal Amount";
 			}
 		}
-
+		
 	}
 
 	script
 	{
 		title = "Script";
-
+		
 		83	// Script Locked Execute
 		{
 			arg4	// Key Number
@@ -2471,7 +2441,7 @@ zdoom
 		{
 			title = "Script Execute with Result";
 			id = "ACS_ExecuteWithResult";
-
+			
 			arg0
 			{
 				title = "Script Number";
@@ -2499,29 +2469,29 @@ zdoom
 		{
 			title = "Script Locked Execute (Door message)";
 			id = "ACS_LockedExecuteDoor";
-
+			
 			arg0
 			{
 				title = "Script Number";
 				str = true;
 				titlestr = "Script Name";
 			}
-
+			
 			arg1
 			{
 				title = "Map Number";
 			}
-
+			
 			arg2
 			{
 				title = "Script Argument 1";
 			}
-
+			
 			arg3
 			{
 				title = "Script Argument 2";
 			}
-
+			
 			arg4
 			{
 				title = "Key Number";
@@ -2533,7 +2503,7 @@ zdoom
 		{
 			title = "FraggleScript Execute";
 			id = "FS_Execute";
-
+			
 			arg0
 			{
 				title = "Script Number";
@@ -2569,29 +2539,29 @@ zdoom
 		{
 			title = "Script Execute Always";
 			id = "ACS_ExecuteAlways";
-
+			
 			arg0
 			{
 				title = "Script Number";
 				str = true;
 				titlestr = "Script Name";
 			}
-
+			
 			arg1
 			{
 				title = "Map Number";
 			}
-
+			
 			arg2
 			{
 				title = "Script Argument 1";
 			}
-
+			
 			arg3
 			{
 				title = "Script Argument 2";
 			}
-
+			
 			arg4
 			{
 				title = "Script Argument 3";
@@ -2605,7 +2575,7 @@ zdoom
 		{
 			title = "End Normal";
 			id = "Exit_Normal";
-
+			
 			arg0
 			{
 				title = "Position";
@@ -2615,7 +2585,7 @@ zdoom
 		{
 			title = "End Secret";
 			id = "Exit_Secret";
-
+			
 			arg0
 			{
 				title = "Position";
@@ -2626,13 +2596,13 @@ zdoom
 	scroll
 	{
 		title = "Scroll";
-
+		
 		52
 		{
 			title = "Scroll Wall";
 			id = "Scroll_Wall";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Line Tag";
@@ -2664,7 +2634,7 @@ zdoom
 				}
 			}
 		}
-
+		
 		100 //Scroll_Texture_Left
 		{
 			arg1
@@ -2674,7 +2644,7 @@ zdoom
 				enum = "sidedef_part";
 			}
 		}
-
+		
 		101 //Scroll_Texture_Right
 		{
 			arg1
@@ -2684,7 +2654,7 @@ zdoom
 				enum = "sidedef_part";
 			}
 		}
-
+		
 		102 //Scroll_Texture_Up
 		{
 			arg1
@@ -2694,7 +2664,7 @@ zdoom
 				enum = "sidedef_part";
 			}
 		}
-
+		
 		103 //Scroll_Texture_Down
 		{
 			arg1
@@ -2704,13 +2674,13 @@ zdoom
 				enum = "sidedef_part";
 			}
 		}
-
+		
 		221
 		{
 			title = "Scroll Texture Both";
 			id = "Scroll_Texture_Both";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Line Tag";
@@ -2746,7 +2716,7 @@ zdoom
 			title = "Scroll Texture Model";
 			id = "Scroll_Texture_Model";
 			requiresactivation = false;
-
+			
 			arg1
 			{
 				title = "Options";
@@ -2758,13 +2728,13 @@ zdoom
 				}
 			}
 		}
-
+		
 		223
 		{
 			title = "Scroll Floor";
 			id = "Scroll_Floor";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -2812,7 +2782,7 @@ zdoom
 			title = "Scroll Ceiling";
 			id = "Scroll_Ceiling";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -2849,7 +2819,7 @@ zdoom
 			title = "Scroll Texture by Offsets";
 			id = "Scroll_Texture_Offsets";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sidedef Part";
@@ -2866,7 +2836,7 @@ zdoom
 		{
 			title = "Lightning Control";
 			id = "Light_ForceLightning";
-
+			
 			arg0
 			{
 				title = "Mode";
@@ -2883,7 +2853,7 @@ zdoom
 		{
 			title = "Light Stop";
 			id = "Light_Stop";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -2894,7 +2864,7 @@ zdoom
 		{
 			title = "Light Strobe (Doom mode)";
 			id = "Light_StrobeDoom";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -2919,7 +2889,7 @@ zdoom
 		{
 			title = "Light Change to Darkest Neightbour";
 			id = "Light_MinNeighbor";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -2930,7 +2900,7 @@ zdoom
 		{
 			title = "Light Change to Brightest Neightbour";
 			id = "Light_MaxNeighbor";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -2942,13 +2912,13 @@ zdoom
 	sector
 	{
 		title = "Sector";
-
+		
 		48
 		{
 			title = "Sector Attach 3D Midtex";
 			id = "Sector_Attach3dMidtex";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Line Tag";
@@ -2958,7 +2928,7 @@ zdoom
 			{
 				title = "Sector Tag";
 				type = 13;
-			}
+			}		
 			arg2
 			{
 				title = "Floor / Ceiling";
@@ -2971,7 +2941,7 @@ zdoom
 			title = "Sector Set Link";
 			id = "Sector_SetLink";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Control Sector Tag";
@@ -3002,12 +2972,12 @@ zdoom
 				}
 			}
 		}
-
+		
 		98
 		{
 			title = "Sector Set Translucent";
 			id = "Sector_SetTranslucent";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3039,7 +3009,7 @@ zdoom
 		{
 			title = "Sector Change Flags";
 			id = "Sector_ChangeFlags";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3063,7 +3033,7 @@ zdoom
 			title = "Sector Set Portal";
 			id = "Sector_SetPortal";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3111,7 +3081,7 @@ zdoom
 			title = "Sector Copy Scroller";
 			id = "Sector_CopyScroller";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3127,14 +3097,14 @@ zdoom
 					2 = "Copy floor scroller";
 					4 = "Copy carrying effect";
 				}
-			}
+			}		
 		}
 		160
 		{
 			title = "Sector Set 3D Floor";
 			id = "Sector_Set3dFloor";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3186,7 +3156,7 @@ zdoom
 		{
 			title = "Sector Set Contents (Vavoom compatibility)";
 			id = "Sector_SetContents";
-
+			
 			arg0
 			{
 				title = "Type";
@@ -3226,7 +3196,7 @@ zdoom
 		{
 			title = "Sector Rotate Flat";
 			id = "Sector_SetRotation";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3247,7 +3217,7 @@ zdoom
 		{
 			title = "Sector Ceiling Panning";
 			id = "Sector_SetCeilingPanning";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3274,7 +3244,7 @@ zdoom
 		{
 			title = "Sector Floor Panning";
 			id = "Sector_SetFloorPanning";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3301,7 +3271,7 @@ zdoom
 		{
 			title = "Sector Ceiling Scale";
 			id = "Sector_SetCeilingScale";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3328,7 +3298,7 @@ zdoom
 		{
 			title = "Sector Floor Scale";
 			id = "Sector_SetFloorScale";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3355,7 +3325,7 @@ zdoom
 		{
 			title = "Sector Color";
 			id = "Sector_SetColor";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3382,7 +3352,7 @@ zdoom
 		{
 			title = "Sector Fade";
 			id = "Sector_SetFade";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3405,7 +3375,7 @@ zdoom
 		{
 			title = "Sector Damage";
 			id = "Sector_SetDamage";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3427,7 +3397,7 @@ zdoom
 		{
 			title = "Sector Gravity";
 			id = "Sector_SetGravity";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3442,12 +3412,12 @@ zdoom
 				title = "Gravity Fractional";
 			}
 		}
-
+		
 		218
 		{
 			title = "Sector Wind";
 			id = "Sector_SetWind";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3474,7 +3444,7 @@ zdoom
 			title = "Sector Friction";
 			id = "Sector_SetFriction";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3495,12 +3465,12 @@ zdoom
 				}
 			}
 		}
-
+		
 		220
 		{
 			title = "Sector Current";
 			id = "Sector_SetCurrent";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3527,12 +3497,12 @@ zdoom
 	alert
 	{
 		title = "Alert";
-
+		
 		173
 		{
 			title = "Alert monsters";
 			id = "NoiseAlert";
-
+			
 			arg0
 			{
 				title = "Target Tag";
@@ -3549,12 +3519,12 @@ zdoom
 	communicator
 	{
 		title = "Communicator";
-
+		
 		174
 		{
 			title = "Communicator Message";
 			id = "SendToCommunicator";
-
+			
 			arg0
 			{
 				title = "Message ID";
@@ -3583,12 +3553,12 @@ zdoom
 	change
 	{
 		title = "Change";
-
+		
 		157
 		{
 			title = "Set Global Fog Parameter (GZDoom only)";
 			id = "SetGlobalFogParameter";
-
+			
 			arg0
 			{
 				title = "Property";
@@ -3609,12 +3579,12 @@ zdoom
 		{
 			title = "Change Skill";
 			id = "ChangeSkill";
-
+			
 			arg0
 			{
 				title = "New Skill Level";
 				type = 11;
-				enum
+				enum 
 				{
 					0 = "Very Easy";
 					1 = "Easy";
@@ -3629,13 +3599,13 @@ zdoom
 	plane
 	{
 		title = "Plane";
-
+		
 		118
 		{
 			title = "Plane Copy (slope)";
 			id = "Plane_Copy";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Front Floor Tag";
@@ -3673,7 +3643,7 @@ zdoom
 		{
 			title = "Plane Reflection (OpenGL only)";
 			id = "Sector_SetPlaneReflection";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3693,7 +3663,7 @@ zdoom
 			title = "Plane Align (slope)";
 			id = "Plane_Align";
 			requiresactivation = false;
-
+			
 			arg0
 			{
 				title = "Align Floor";
@@ -3722,12 +3692,12 @@ zdoom
 	static
 	{
 		title = "Static";
-
+		
 		190
 		{
 			title = "Static Init";
 			id = "Static_Init";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3760,12 +3730,12 @@ zdoom
 	player
 	{
 		title = "Player";
-
+		
 		191
 		{
 			title = "Set Player Property";
 			id = "SetPlayerProperty";
-
+			
 			arg0
 			{
 				title = "Target";
@@ -3802,13 +3772,13 @@ zdoom
 	translucent
 	{
 		title = "Translucent";
-
+		
 		208
 		{
 			title = "Translucent Line";
 			id = "TranslucentLine";
 			requiresactivation = false;
-
+			
 			arg1
 			{
 				title = "Opacity";
@@ -3826,12 +3796,12 @@ zdoom
 	point
 	{
 		title = "Point";
-
+		
 		227
 		{
 			title = "Point Pusher/Puller Set Force";
 			id = "PointPush_SetForce";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3858,12 +3828,12 @@ zdoom
 	camera
 	{
 		title = "Camera";
-
+		
 		237
 		{
 			title = "Change Camera";
 			id = "ChangeCamera";
-
+			
 			arg0
 			{
 				title = "Thing Tag";
@@ -3891,12 +3861,12 @@ zdoom
 	elevator
 	{
 		title = "Elevator";
-
+		
 		245
 		{
 			title = "Elevator Raise to Nearest Floor";
 			id = "Elevator_RaiseToNearest";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3919,7 +3889,7 @@ zdoom
 		{
 			title = "Elevator Move to Activated Floor";
 			id = "Elevator_MoveToFloor";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3937,7 +3907,7 @@ zdoom
 		{
 			title = "Elevator Lower to Nearest Floor";
 			id = "Elevator_LowerToNearest";
-
+			
 			arg0
 			{
 				title = "Sector Tag";
@@ -3965,7 +3935,7 @@ hexen
 				title = "This Line Tag";
 				tooltip = "The tag number of the current line";
 				type = 15;
-			}
+			}	
 		}
 	}
 	polyobj


### PR DESCRIPTION
This implements linedef types 2069-2074 as described by ID24.

| Special | Activation Type | Effect |
| ------- | --------------- | ------ |
2069 | W1 | Exit to the next map and reset inventory.
2070 | S1 | Exit to the next map and reset inventory.
2071 | G1 | Exit to the next map and reset inventory.
2072 | W1 | Exit to the secret map and reset inventory.
2073 | S1 | Exit to the secret map and reset inventory.
2074 | G1 | Exit to the secret map and reset inventory.

Test maps:
[resetexittest.zip](https://github.com/user-attachments/files/17022222/resetexittest.zip)