### PR TITLE
Account for coop player starts stored out of order

### DIFF
--- a/common/p_mobj.h
+++ b/common/p_mobj.h
@@ -143,6 +143,7 @@ void P_SpawnBlood(fixed_t x, fixed_t y, fixed_t z, angle_t dir, int damage);
 bool P_CheckMissileSpawn(AActor* th);
 AActor* P_SpawnMissile(AActor *source, AActor *dest, mobjtype_t type);
 void P_SpawnPlayerMissile(AActor *source, mobjtype_t type);
+size_t P_GetMapThingPlayerNumber(mapthing2_t* mthing);
 bool P_VisibleToPlayers(AActor *mo);
 void P_SetMobjBaseline(AActor& mo);
 uint32_t P_GetMobjBaselineFlags(AActor& mo);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -142,6 +142,12 @@ std::vector<mapthing2_t> DeathMatchStarts;
 std::vector<mapthing2_t> playerstarts;
 std::vector<mapthing2_t> voodoostarts;
 
+// For sorting player starts
+static bool cmpPlayerNum(mapthing2_t i, mapthing2_t j)
+{
+	return P_GetMapThingPlayerNumber(&i) < P_GetMapThingPlayerNumber(&j);
+}
+
 //
 // P_LoadVertexes
 //
@@ -713,6 +719,9 @@ void P_LoadThings (int lump)
 
 		P_SpawnMapThing (&mt2, 0);
 	}
+
+	// Sort by player number if starts are not in order
+	std::sort(playerstarts.begin(), playerstarts.end(), cmpPlayerNum);
 
 	P_SpawnAvatars();
 


### PR DESCRIPTION
This is a fix for a bug I've run into while playing Memento Mori in coop.

**Steps to reproduce:**

1. Start a 2 player coop game on Memento Mori's MAP28: City of the Unavenged.
2. The second player cannot leave the start area due to a chest-high wall blocking the path, with no way to lower it for either player.

**The root cause:**

Odamex loads player start things in the same order as they are stored in Doom's binary map format. Usually they are stored sequentially `[1, 2, 3, 4]`, but in the case of MM's MAP28 the starts are stored in reverse order `[4, 3, 2, 1]`. This causes player 1 to get player 4 start, player 2 to get player 3 start and so on, and on this map the wall blocking player 3 start is lowered when player 2 crosses a linedef on leaving their start - but no player starts there in this case, resulting in the bug.

**The fix:**

The idea is to sort player starts by player number after they have been loaded. I did not test this in Hexen so I'm not sure if `P_LoadThings2` also needs this change.