### PR TITLE
Fix sector types 10 and 14 desync on callvote restart

### DIFF
--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -692,7 +692,8 @@ BOOL EV_DoDoor (DDoor::EVlDoor type, line_t *line, AActor *thing,
 void P_SpawnDoorCloseIn30 (sector_t *sec)
 {
 	DDoor *door = new DDoor (sec);
-	P_AddMovingCeiling(sec);	
+	P_AddMovingCeiling(sec);
+	specialdoors.push_back(sec);
 
 	sec->special = 0;
 
@@ -710,6 +711,7 @@ void P_SpawnDoorRaiseIn5Mins (sector_t *sec)
 {
 	DDoor *door = new DDoor (sec);
 	P_AddMovingCeiling(sec);
+	specialdoors.push_back(sec);
 
 	sec->special = 0;
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -73,6 +73,7 @@ EXTERN_CVAR(sv_allowexit)
 EXTERN_CVAR(sv_fragexitswitch)
 
 std::list<movingsector_t> movingsectors;
+std::list<sector_t*> specialdoors;
 bool s_SpecialFromServer;
 
 int P_FindSectorFromLineTag(int tag, int start);

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -97,6 +97,7 @@ enum ceilingchange_e
 };
 
 extern std::list<movingsector_t> movingsectors;
+extern std::list<sector_t*> specialdoors;
 extern bool s_SpecialFromServer;
 
 #define IgnoreSpecial !serverside && !s_SpecialFromServer

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -740,6 +740,10 @@ void G_DoResetLevel(bool full_reset)
 		G_DoReborn(*it);
 	}
 
+	// Re-add type 10 and 14 sectors
+	for (std::list<sector_t*>::iterator iter = specialdoors.begin(); iter != specialdoors.end(); ++iter)
+		P_AddMovingCeiling(*iter);
+
 	// Send information about the newly reset map, but AFTER the reborns.
 	for (it = players.begin(); it != players.end(); ++it)
 	{
@@ -866,6 +870,8 @@ void G_DoLoadLevel (int position)
 		for (int i = 0; i < NUMTEAMS; i++)
 			GetTeamInfo((team_t)i)->FlagData.flaglocated = false;
 	}
+
+	specialdoors.clear();
 
 	P_SetupLevel (level.mapname.c_str(), position);
 


### PR DESCRIPTION
This bug affects sectors of type 10 (door closes after 30 seconds) and type 14 (door opens and closes after 300 seconds) in multiplayer.

**Steps to reproduce**

1. Start and join a network game.
2. Wait for the sector type 10 and/or 14 to complete the action.
3. Restart the game with `callvote restart`.

The state of those sectors is now desynced.

- For sector type 10, after 30 seconds the door closes on the server side only and stays open for the client, resulting in an invisible wall. The client cannot activate the door linedef either if one is present (for example, to exit a secret area), so the player might get permanently stuck.
- For sector type 14, at the 5 minute mark the client is able to clip through a closed door.

Reloading the level using `map` command fixes the bug.

**The root cause**

Those sectors only get added to `movingsectors` on spawn in `P_SpawnDoorCloseIn30` and `P_SpawnDoorRaiseIn5Mins`. After their actions are completed, they are removed from the list and no longer appear there on level restart. The server still processes them as normal but never sends the information to the client unless the level is reloaded.

**The fix**

The proposed fix is to keep track of those sectors in a separate list as they are spawned, and re-add them to `movingsectors` on level restart. The list is cleared on level reload.