### PR TITLE
[BUGFIX] Throw error when attempting to spawn object in MBF21 codepointers

### DIFF
--- a/common/d_dehacked.h
+++ b/common/d_dehacked.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -139,10 +139,10 @@ static const char* SoundMap[] = { NULL,
                             "misc/chat",
 
                             // MBF SOUNDS
-                            "dog/sight", 
-                            "dog/attack", 
-                            "dog/active", 
-                            "dog/death", 
+                            "dog/sight",
+                            "dog/attack",
+                            "dog/active",
+                            "dog/death",
                             "dog/pain",
 
                             // Padding -- DEHEXTRA's new sound range
@@ -167,7 +167,7 @@ static const char* SoundMap[] = { NULL,
                             "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
                             "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
                             "", "", "", "", "", "", "", "",
-                            
+
                             // Crispy/Retro (DEHEXTRA)
                             "dehextra/sound000", "dehextra/sound001", "dehextra/sound002", "dehextra/sound003",
                             "dehextra/sound004", "dehextra/sound005", "dehextra/sound006", "dehextra/sound007",
@@ -226,3 +226,4 @@ static const char* SoundMap[] = { NULL,
 void D_UndoDehPatch();
 void D_PostProcessDeh();
 bool D_DoDehPatch(const OResFile* patchfile, const int lump);
+bool CheckIfDehActorDefined(const mobjtype_t mobjtype);

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -899,7 +899,7 @@ void A_Look (AActor *actor)
 
 		if (!co_zdoomsound && (actor->flags2 & MF2_BOSS || actor->flags3 & MF3_FULLVOLSOUNDS))
 			S_Sound(CHAN_VOICE, sound, 1, ATTN_NORM);
-		else 
+		else
 			S_Sound (actor, CHAN_VOICE, sound, 1, ATTN_NORM);
 	}
 
@@ -1894,6 +1894,11 @@ void A_SpawnObject(AActor* actor)
 	vel_y = actor->state->args[6];
 	vel_z = actor->state->args[7];
 
+	if (!CheckIfDehActorDefined((mobjtype_t)type))
+	{
+		I_Error("A_SpawnObject: Attempted to spawn undefined object type.");
+	}
+
 	// calculate position offsets
 	an = actor->angle + (unsigned int)(((int64_t)angle << 16) / 360);
 	fan = an >> ANGLETOFINESHIFT;
@@ -1956,6 +1961,11 @@ void A_MonsterProjectile(AActor* actor)
 	pitch = actor->state->args[2];
 	spawnofs_xy = actor->state->args[3];
 	spawnofs_z = actor->state->args[4];
+
+	if (!CheckIfDehActorDefined((mobjtype_t)type))
+	{
+		I_Error("A_MonsterProjectile: Attempted to spawn undefined projectile type.");
+	}
 
 	A_FaceTarget(actor);
 	mo = P_SpawnMissile(actor, actor->target, (mobjtype_t)type);
@@ -2099,14 +2109,14 @@ void A_HealChase(AActor* actor)
 	state = actor->state->args[0];
 	sound = actor->state->args[1];
 
-	if (!P_HealCorpse(actor, actor->info->radius, state, sound))	
+	if (!P_HealCorpse(actor, actor->info->radius, state, sound))
 		A_Chase(actor);
 }
 
 //
 // P_HealCorpse
 // A generic corpse resurrection codepointer.
-// 
+//
 bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 {
 	// don't attempt to resurrect clientside
@@ -2602,7 +2612,7 @@ void A_Scream (AActor *actor)
 
 	if (!co_zdoomsound && (actor->flags2 & MF2_BOSS || actor->flags3 & MF3_FULLVOLSOUNDS))
 		S_Sound(CHAN_VOICE, sound, 1, ATTN_NORM);
-	else 
+	else
 	    S_Sound (actor, CHAN_VOICE, sound, 1, ATTN_NORM);
 }
 
@@ -2710,7 +2720,7 @@ void A_BossDeath(AActor *actor)
 	if (!level.bossactions.empty())
 	{
 		std::vector<bossaction_t>::iterator ba = level.bossactions.begin();
-		
+
 		// see if the BossAction applies to this type
 		for (; ba != level.bossactions.end(); ++ba)
 		{
@@ -2740,7 +2750,7 @@ void A_BossDeath(AActor *actor)
 			if (ba->type == actor->type)
 			{
 				line_t ld;
-				
+
 				if (map_format.getZDoom())
 				{
 					maplinedef_t mld;

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -37,6 +37,7 @@
 
 #include "g_gametype.h"
 #include "svc_message.h"
+#include "i_system.h"
 
 // State.
 #include "p_pspr.h"
@@ -1007,6 +1008,11 @@ void A_WeaponProjectile(AActor* mo)
 	pitch = psp->state->args[2];
 	spawnofs_xy = psp->state->args[3];
 	spawnofs_z = psp->state->args[4];
+
+	if (!CheckIfDehActorDefined((mobjtype_t)type))
+	{
+		I_Error("A_WeaponProjectile: Attempted to spawn undefined projectile type.");
+	}
 
 	if (serverside)
 		P_SpawnMBF21PlayerMissile(player->mo, (mobjtype_t)type, angle, pitch, spawnofs_xy, spawnofs_z);


### PR DESCRIPTION
Addresses #621

Now instead of crashing if the type is undefined, an error such as the following is shown.
![image](https://github.com/user-attachments/assets/97ea2f14-f3a8-4426-9820-ac9533c6c579)
