### PR TITLE
[BUGFIX] Point readme link to up to date documentation

### DIFF
--- a/README
+++ b/README
@@ -79,7 +79,7 @@ On Windows, all libraries are automatically downloaded if not found.  On
 Please check this page for further instructions on how to compile Odamex
 for your platform.
 
-<https://odamex.net/wiki/How_to_build_from_source>
+<https://github.com/odamex/odamex/wiki/Compiling-Odamex>
 
 Contributing to the project
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ On Windows, all libraries are automatically downloaded if not found.  On \*nix/M
 
 Please check [this page][1] for further instructions on how to compile Odamex for your platform.
 
-[1]: https://odamex.net/wiki/How_to_build_from_source
+[1]: https://github.com/odamex/odamex/wiki/Compiling-Odamex
 
 Contributing to the project
 ---------------------------


### PR DESCRIPTION
The current README.md points to the odamex.net wiki, which is extremely old and outdated. This changes the link to the documentation for compiling Odamex that is up to date.

Addresses #756 