### PR TITLE
Replace remaining links to old wiki with links to the GitHub wiki

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
-For a condensed, easy to read changelog of stable releases, please see 
+For a condensed, easy to read changelog of stable releases 0.8.3 and earlier, please see
 http://odamex.net/wiki/Releases
+
+Newer releases are found at
+https://github.com/odamex/odamex/releases
 
 If you would like to see a more detailed list of changes, we highly recommend
 checking out the repository through one of these methods:

--- a/README
+++ b/README
@@ -92,7 +92,7 @@ to our issues page. You can also submit patches as a Pull Request.
 Before submitting a pull request, please make sure it follows our coding
 standards!
 
-<https://odamex.net/wiki/Coding_standard>
+<https://github.com/odamex/odamex/wiki/Coding-Standard>
 
 For historical purposes, you can also view our bugtracker's archive.
 
@@ -105,7 +105,7 @@ Please visit the following websites for more information about the development
 of the port and our community:
 
 * Odamex Website: <https://odamex.net>
-* Wiki: <https://odamex.net/wiki/Main_Page>
+* Wiki: <https://github.com/odamex/odamex/wiki>
 * Forums: <https://odamex.net/boards/>
 * Discord: <https://discord.gg/aMUzcZE>
 * Twitter: <https://twitter.com/odamex>

--- a/config-samples/coop-doom.cfg
+++ b/config-samples/coop-doom.cfg
@@ -1,6 +1,6 @@
 // Vanilla Doom(2) Cooperative Ruleset (4 Players/Ultraviolence Skill)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/coop-masterlevels.cfg
+++ b/config-samples/coop-masterlevels.cfg
@@ -1,6 +1,6 @@
 // Vanilla Doom(2) Cooperative Ruleset (4 Players/Ultraviolence Skill)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/coop-modern.cfg
+++ b/config-samples/coop-modern.cfg
@@ -1,6 +1,6 @@
 // "Modern" Doom(2) Cooperative Ruleset (No Jump/No Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/coop-zdoom.cfg
+++ b/config-samples/coop-zdoom.cfg
@@ -1,6 +1,6 @@
 // "ZDOOM" Style Cooperative Ruleset (8 Players/Freelook/Jumping)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/ctf-attackdefend.cfg
+++ b/config-samples/ctf-attackdefend.cfg
@@ -1,6 +1,6 @@
 // Attack & Defend CTF with World Doom League (doomleague.org) 3v3/4v4 CTF Ruleset
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/ctf-doom.cfg
+++ b/config-samples/ctf-doom.cfg
@@ -1,6 +1,6 @@
 // Vanilla Doom(2) Settings (8v8) CTF Ruleset
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/ctf-pub.cfg
+++ b/config-samples/ctf-pub.cfg
@@ -1,6 +1,6 @@
 // Commonly Used 8v8 Public CTF Ruleset
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/ctf-wdl.cfg
+++ b/config-samples/ctf-wdl.cfg
@@ -1,6 +1,6 @@
 // World Doom League (doomleague.org) 3v3/4v4 CTF Ruleset
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/dm-doom.cfg
+++ b/config-samples/dm-doom.cfg
@@ -1,6 +1,6 @@
 // Vanilla Doom(2) Style (4 Player) Deathmatch Ruleset (50 Fraglimit/10 Min Timelimit/No Exit)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/dm-modern.cfg
+++ b/config-samples/dm-modern.cfg
@@ -1,6 +1,6 @@
 // "Modern" Doom 2 Style (16 Player) Deathmatch Ruleset (No Jump/No Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/dm-zdoom.cfg
+++ b/config-samples/dm-zdoom.cfg
@@ -1,6 +1,6 @@
 // "ZDOOM" Style (16 Player) Deathmatch Ruleset (Jump/Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/duel-altdeath.cfg
+++ b/config-samples/duel-altdeath.cfg
@@ -1,6 +1,6 @@
 // Vanilla Doom 2 Altdeath (Deathmatch 2.0) 1v1 Ruleset (No Fraglimit and Exiting Enabled)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/duel-ddl.cfg
+++ b/config-samples/duel-ddl.cfg
@@ -1,6 +1,6 @@
 // Doom Duel League (doomleague.org) 1v1 Ruleset
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/duel-doom.cfg
+++ b/config-samples/duel-doom.cfg
@@ -1,6 +1,6 @@
 // Vanilla Doom(2) 1v1 Ruleset (With Standard U.S. Fraglimit & No Exiting)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/duel-zddl.cfg
+++ b/config-samples/duel-zddl.cfg
@@ -1,6 +1,6 @@
 // ZDoom Duel League 2011 1v1 Ruleset
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/duel-zdoom.cfg
+++ b/config-samples/duel-zdoom.cfg
@@ -1,6 +1,6 @@
 // "ZDOOM" Style 1v1 Ruleset
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/horde-doom.cfg
+++ b/config-samples/horde-doom.cfg
@@ -1,6 +1,6 @@
 // Vanilla Doom(2) Horde Ruleset (4 Players/Ultraviolence Skill)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // Skill level matters in hard. Skills 1/2 = Easy. Skill 3 = Normal. Skill 4 = Hard.

--- a/config-samples/horde-modern.cfg
+++ b/config-samples/horde-modern.cfg
@@ -1,6 +1,6 @@
 // "Modern" Doom(2) Horde Ruleset (No Jump/No Freelook/Ultraviolence Skill)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // Skill level matters in hard. Skills 1/2 = Easy. Skill 3 = Normal. Skill 4 = Hard.

--- a/config-samples/horde-zdoom.cfg
+++ b/config-samples/horde-zdoom.cfg
@@ -1,6 +1,6 @@
 // "ZDOOM" Style Horde Ruleset (32 Players/Freelook/Jumping/Ultraviolence Skill)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // Skill level matters in hard. Skills 1/2 = Easy. Skill 3 = Normal. Skill 4 = Hard.

--- a/config-samples/lms-2team.cfg
+++ b/config-samples/lms-2team.cfg
@@ -1,6 +1,6 @@
 // 2-Team Last Man Standing with "Modern" Doom 2 Style (8v8) Team Deathmatch Ruleset (No Jump/No Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/lms-3team.cfg
+++ b/config-samples/lms-3team.cfg
@@ -1,6 +1,6 @@
 // 3-Team Last Man Standing with "Modern" Doom 2 Style (8v8) Team Deathmatch Ruleset (No Jump/No Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/lms-ffa.cfg
+++ b/config-samples/lms-ffa.cfg
@@ -1,6 +1,6 @@
 // Last Man Standing with "Modern" Doom 2 Style (16 Player) Deathmatch Ruleset (No Jump/No Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/survival-modern.cfg
+++ b/config-samples/survival-modern.cfg
@@ -1,6 +1,6 @@
 // "Modern" Doom(2) Survival Cooperative Ruleset (No Jump/No Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/tdm-doom.cfg
+++ b/config-samples/tdm-doom.cfg
@@ -1,6 +1,6 @@
 // Vanilla Doom(2) Style (2v2) Team Deathmatch Ruleset (50 Fraglimit/10 Min Timelimit/No Exit)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/tdm-modern.cfg
+++ b/config-samples/tdm-modern.cfg
@@ -1,6 +1,6 @@
 // "Modern" Doom 2 Style (8v8) Team Deathmatch Ruleset (No Jump/No Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/config-samples/tdm-zdoom.cfg
+++ b/config-samples/tdm-zdoom.cfg
@@ -1,6 +1,6 @@
 // "ZDOOM" Style (8v8) Team Deathmatch Ruleset (Jump/Freelook)
 // Odamex 10.6.0
-// For in-depth information on these variables, visit http://odamex.net/wiki/Category:Server_variables
+// For in-depth information on these variables, visit https://github.com/odamex/odamex/wiki/Console-Variables
 // Note that 1 = on, 0 = off
 
 // --- Network/Broadcast/Administrative Settings ---

--- a/odalaunch/src/dlg_main.cpp
+++ b/odalaunch/src/dlg_main.cpp
@@ -223,7 +223,7 @@ dlgMain::dlgMain(wxWindow* parent, wxWindowID id)
 
 		ConfigInfo.Read(CHECKFORUPDATES, &CheckForUpdates,
 		                ODA_UIAUTOCHECKFORUPDATES);
-		                
+
 		ConfigInfo.Read(ARTENABLE, &m_UseRefreshTimer,
 		                ODA_UIARTENABLE);
 
@@ -349,7 +349,7 @@ void dlgMain::OnClose(wxCloseEvent& event)
     m_TimerNewList = NULL;
     delete m_TimerRefresh;
     m_TimerRefresh = NULL;
-    
+
     /* Threading system shutdown */
     // Wait for the monitor thread to finish
 	if(GetThread() && GetThread()->IsRunning())
@@ -359,7 +359,7 @@ void dlgMain::OnClose(wxCloseEvent& event)
 	// their memory
 	{
         std::vector<QueryThread*>::reverse_iterator it;
-        
+
         for(it = threadVector.rbegin(); it != threadVector.rend(); it++)
         {
             if((*it)->IsRunning())
@@ -374,7 +374,7 @@ void dlgMain::OnClose(wxCloseEvent& event)
         // iterator invalidation.
         threadVector.clear();
 	}
-    
+
 	// Save the UI layout and shut it all down
 	wxFileConfig ConfigInfo;
 
@@ -388,13 +388,13 @@ void dlgMain::OnClose(wxCloseEvent& event)
 
 	delete InfoBar;
 	InfoBar = NULL;
-	
+
     if(config_dlg != NULL)
 		config_dlg->Destroy();
 
 	if(server_dlg != NULL)
 		server_dlg->Destroy();
-	
+
 	Destroy();
 }
 
@@ -426,7 +426,7 @@ void dlgMain::OnCheckVersion(wxCommandEvent &event)
 
     VerMsg = wxString::Format("New! Odamex version %s is available", SiteSrc);
 
-    // Remove version separators 
+    // Remove version separators
     SiteSrc.erase(std::remove(SiteSrc.begin(), SiteSrc.end(), '.'), SiteSrc.end());
 
     // Same or older version
@@ -530,25 +530,25 @@ void dlgMain::GetWebsitePageSource(wxString &SiteSrc)
 // Parses the Odamex websites page source to find the version number, here is
 // hoping that the sites layout doesn't change too much!
 void dlgMain::GetVersionInfoFromWebsite(const wxString &SiteSrc, wxString &ver)
-{  
+{
     wxString VerStr = "Latest version: ";
     int Ch;
-    
+
     // Extract version number from website source
     size_t Pos = SiteSrc.find(VerStr);
-    
+
     if (Pos == wxNOT_FOUND)
         return;
-    
+
     // Skip past the search string
     Pos += VerStr.Length();
-    
+
     // Find the end of the data we need
     size_t EndPos = SiteSrc.find("<", Pos);
-    
+
     if (EndPos == wxNOT_FOUND)
         return;
-    
+
     // Copy only the version number back out
     ver = SiteSrc.Mid(Pos, EndPos - Pos);
 }
@@ -600,7 +600,7 @@ void dlgMain::OnManualConnect(wxCommandEvent& event)
 		case 3:
 		{
 			good = true;
-			
+
 			// Use the servers default port number if none was specified
 			if (!Port)
                 Port = ODA_NETDEFSERVERPORT;
@@ -1046,7 +1046,7 @@ void dlgMain::OnMonitorSignal(wxCommandEvent& event)
 
 		bool cs = MServer.IsCustomServer(ThisServer.GetAddress());
 
-		m_LstCtrlServers->AddServerToList(ThisServer, Result->ServerListIndex, 
+		m_LstCtrlServers->AddServerToList(ThisServer, Result->ServerListIndex,
                                     false, cs);
 
 		m_LstCtrlPlayers->AddPlayersToList(ThisServer);
@@ -1584,7 +1584,7 @@ void dlgMain::OnOpenForum(wxCommandEvent& event)
 
 void dlgMain::OnOpenWiki(wxCommandEvent& event)
 {
-	wxLaunchDefaultBrowser("https://odamex.net/wiki");
+	wxLaunchDefaultBrowser("https://github.com/odamex/odamex/wiki");
 }
 
 void dlgMain::OnOpenChangeLog(wxCommandEvent& event)
@@ -1594,7 +1594,7 @@ void dlgMain::OnOpenChangeLog(wxCommandEvent& event)
 
 void dlgMain::OnOpenReportBug(wxCommandEvent& event)
 {
-	wxLaunchDefaultBrowser("https://odamex.net/bugs/enter_bug.cgi");
+	wxLaunchDefaultBrowser("https://github.com/odamex/odamex/issues/new/choose");
 }
 
 void dlgMain::OnOpenChat(wxCommandEvent& event)


### PR DESCRIPTION
Odalaunch, server configs, and the txt README still contain some links to old pages. Between #1058 and this PR, there should be none left except those kept around intentionally.