### PR TITLE
[BUGFIX] Reset players inventories when using ID24 exits in multiplayer

### DIFF
--- a/server/src/sv_game.cpp
+++ b/server/src/sv_game.cpp
@@ -248,6 +248,7 @@ void G_PlayerReborn (player_t &p) // [Toke - todo] clean this function
 
 	p.usedown = p.attackdown = true;	// don't do anything immediately
 	p.playerstate = PST_LIVE;
+	p.doreborn = false;
 	p.weaponowned[NUMWEAPONS] = true;
 
 	if (!p.spectator)
@@ -387,7 +388,7 @@ bool G_CheckSpot (player_t &player, mapthing2_t *mthing)
 
 // [RH] Returns the distance of the closest player to the given mapthing2_t.
 // denis - todo - should this be used somewhere?
-// [Russell] This code is horrible because it does no position checking, even 
+// [Russell] This code is horrible because it does no position checking, even
 // zdoom 2.x still has it!
 static fixed_t PlayersRangeFromSpot (mapthing2_t *spot)
 {

--- a/server/src/sv_mobj.cpp
+++ b/server/src/sv_mobj.cpp
@@ -74,7 +74,7 @@ void P_SpawnPlayer(player_t& player, mapthing2_t* mthing)
 
 	byte playerstate = player.playerstate; //save playerstate to check enter/respawn script execution later...
 
-	if (player.playerstate == PST_REBORN || player.playerstate == PST_ENTER)
+	if (player.playerstate == PST_REBORN || player.playerstate == PST_ENTER || player.doreborn)
 		G_PlayerReborn(player);
 
 	AActor* mobj;
@@ -154,7 +154,7 @@ void P_SpawnPlayer(player_t& player, mapthing2_t* mthing)
 		}
 
 		team_t team = player.userinfo.team;
-		
+
 		// Log the spawn
 		if (!player.spectator)
 		{


### PR DESCRIPTION
The ID24 exits weren't properly working in multiplayer. Now they do!