### PR TITLE
[FEATURE] Add Redist installer to the installer and zipped output files

### DIFF
--- a/installer/windows/build_release.ps1
+++ b/installer/windows/build_release.ps1
@@ -127,7 +127,7 @@ function CopyFiles {
         -Destination "${X64Dir}\"
 
     # Get VC++ Redist
-		Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "${X64Dir}\redist\vc_redist.x64.exe"
+    Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "${X64Dir}\redist\vc_redist.x64.exe"
 
     ########################################
     ## 32-BIT FILES

--- a/installer/windows/build_release.ps1
+++ b/installer/windows/build_release.ps1
@@ -221,10 +221,10 @@ echo "Checking for Inno Setup Command-Line Compiler..."
 Get-Command ISCC.exe -ErrorAction Stop
 
 echo "Building 64-bit..."
-#BuildX64
+BuildX64
 
 echo "Building 32-bit..."
-#BuildX86
+BuildX86
 
 echo "Copying files..."
 CopyFiles

--- a/installer/windows/build_release.ps1
+++ b/installer/windows/build_release.ps1
@@ -103,6 +103,7 @@ function CopyFiles {
     ########################################
 
     New-Item -Force -ItemType "directory" -Path "${X64Dir}"
+    New-Item -Force -ItemType "directory" -Path "${X64Dir}/redist"
 
     Copy-Item -Force -Path `
         "${PSScriptRoot}\BuildX64\client\RelWithDebInfo\libFLAC-8.dll", `
@@ -125,11 +126,15 @@ function CopyFiles {
         "${PSScriptRoot}\BuildX64\server\RelWithDebInfo\odasrv.exe" `
         -Destination "${X64Dir}\"
 
+    # Get VC++ Redist
+		Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "${X64Dir}\redist\vc_redist.x64.exe"
+
     ########################################
     ## 32-BIT FILES
     ########################################
 
     New-Item -Force -ItemType "directory" -Path "${X86Dir}"
+    New-Item -Force -ItemType "directory" -Path "${X86Dir}/redist"
 
     Copy-Item -Force -Path `
         "${PSScriptRoot}\BuildX86\client\RelWithDebInfo\libFLAC-8.dll", `
@@ -151,6 +156,9 @@ function CopyFiles {
         "${PSScriptRoot}\BuildX86\odalaunch\RelWithDebInfo\wxmsw315u_xrc_vc14x.dll", `
         "${PSScriptRoot}\BuildX86\server\RelWithDebInfo\odasrv.exe" `
         -Destination "${X86Dir}\"
+
+    # Get VC++ Redist
+    Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x86.exe" -OutFile "${X86Dir}\redist\vc_redist.x86.exe"
 }
 
 function Outputs {
@@ -213,10 +221,10 @@ echo "Checking for Inno Setup Command-Line Compiler..."
 Get-Command ISCC.exe -ErrorAction Stop
 
 echo "Building 64-bit..."
-BuildX64
+#BuildX64
 
 echo "Building 32-bit..."
-BuildX86
+#BuildX86
 
 echo "Copying files..."
 CopyFiles


### PR DESCRIPTION
The following change downloads and adds the Visual C++ 2015-2022 Redistributable Installer to the installer, will run it if it doesn't detect if it's installed, and also adds it to the zipped files that are created with `build_release.ps1`.

I also implemented some changes that were supposed to go into #772 but it was approved too quickly for me to make the requested changes.

Solves #400 