### PR TITLE
Fix endianness check for *BSD

### DIFF
--- a/common/crc32.cpp
+++ b/common/crc32.cpp
@@ -50,8 +50,11 @@
   #else
     // defines __BYTE_ORDER as __LITTLE_ENDIAN or __BIG_ENDIAN
     #include <sys/param.h>
-    #if defined(__OpenBSD__) || defined(__NetBSD__) || defined(__FreeBSD__)
-      #include <sys/endian.h>
+    #if defined(__FreeBSD__)
+      #include <endian.h>
+    #elif defined(__OpenBSD__) || defined(__NetBSD__)
+      #include <endian.h>
+      #define __BYTE_ORDER BYTE_ORDER
     #endif
   #endif
 


### PR DESCRIPTION
The macro needs to be defined for Open/NetBSD.
Additionally, the file should be included as `<endian.h>` in userspace https://github.com/openbsd/src/blob/master/sys/sys/endian.h#L29.