### PR TITLE
[BUGFIX] Fix 7 second delay after initializing animations with speed of 1

### DIFF
--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -893,8 +893,6 @@ void P_InitPicAnims (void)
 						(anim_p[21] << 16) |
 						(anim_p[22] << 24);
 
-			lastanim->countdown--;
-
 			lastanim++;
 		}
 	Z_Free (animdefs);


### PR DESCRIPTION
Animated textures/flats with a speed of 1 had a 7.3 second delay from the time the wad was loaded. This was due to an overflow from decrementing the countdown to the next frame twice before the first time it's value was checked.