### PR TITLE
Change allfearthesentinel.net to allfearthesentinel.com.

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -340,7 +340,7 @@ CVAR_RANGE (sv_teamsinplay, "2", "Teams that are enabled", CVARTYPE_BYTE, CVAR_S
 // --------------
 
 CVAR(cl_downloadsites,
-     "https://static.allfearthesentinel.net/wads/ https://doomshack.org/wads/ "
+     "https://static.allfearthesentinel.com/wads/ https://doomshack.org/wads/ "
      "http://grandpachuck.org/files/wads/ https://wads.doomleague.org/ "
      "http://files.funcrusher.net/wads/ https://doomshack.org/uploads/ "
      "https://doom.dogsoft.net/getwad.php?search=",

--- a/client/src/m_misc.cpp
+++ b/client/src/m_misc.cpp
@@ -161,7 +161,7 @@ void M_LoadDefaults(void)
 		// dead or so intermittent that it slows down WAD downloading.
 
 		const char* cl_download_old =
-		    "https://static.allfearthesentinel.net/wads/ https://doomshack.org/wads/ "
+		    "https://static.allfearthesentinel.com/wads/ https://doomshack.org/wads/ "
 		    "http://grandpachuck.org/files/wads/ http://ts.chaosunleashed.net/ "
 		    "https://wads.doomleague.org/ http://files.funcrusher.net/wads/";
 
@@ -176,7 +176,7 @@ void M_LoadDefaults(void)
 		// Add new defaults - dogsoft and doomshack's upload dir.
 
 		const char* cl_download_old =
-		    "https://static.allfearthesentinel.net/wads/ https://doomshack.org/wads/ "
+		    "https://static.allfearthesentinel.com/wads/ https://doomshack.org/wads/ "
 		    "http://grandpachuck.org/files/wads/ https://wads.doomleague.org/ "
 		    "http://files.funcrusher.net/wads/";
 


### PR DESCRIPTION
Change all references to TSPG from static.allfearthesentinel.net/wads/ to [static.allfearthesentinel.com/wads/](https://static.allfearthesentinel.com/wads/). allfearthesentinel.net no longer resolves to an existing website, and queries for WADs hosted there will fail.

[TSPG changed domain name](https://zandronum.com/tracker/view.php?id=4099) over a year ago.