### PR TITLE
Explicitly set the size of the Odalaunch search bar + Ubuntu buildgen scripts for 24.04

### DIFF
--- a/ci/ubuntu-buildgen.sh
+++ b/ci/ubuntu-buildgen.sh
@@ -11,10 +11,10 @@ set -x
 sudo apt update
 if [[ -z ${USE_SDL12:-} ]]; then
     sudo apt install ninja-build libsdl2-dev libsdl2-mixer-dev \
-        libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex
+        libcurl4-openssl-dev libwxgtk3.2-dev deutex
 else
     sudo apt install ninja-build libsdl1.2-dev libsdl-mixer1.2-dev \
-        libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex
+        libcurl4-openssl-dev libwxgtk3.2-dev deutex
 fi
 
 # Generate build

--- a/ci/ubuntu-buildgen.sh
+++ b/ci/ubuntu-buildgen.sh
@@ -11,10 +11,10 @@ set -x
 sudo apt update
 if [[ -z ${USE_SDL12:-} ]]; then
     sudo apt install ninja-build libsdl2-dev libsdl2-mixer-dev \
-        libcurl4-openssl-dev libwxgtk3.2-dev deutex
+        libcurl4-openssl-dev libpng-dev libwxgtk3.2-dev deutex
 else
     sudo apt install ninja-build libsdl1.2-dev libsdl-mixer1.2-dev \
-        libcurl4-openssl-dev libwxgtk3.2-dev deutex
+        libcurl4-openssl-dev libpng-dev libwxgtk3.2-dev deutex
 fi
 
 # Generate build

--- a/odalaunch/res/xrc_resource.xrc
+++ b/odalaunch/res/xrc_resource.xrc
@@ -16,7 +16,7 @@
 				<object class="wxMenuItem" name="Id_MnuItmRunOffline">
 					<label>Start Odamex (Single Player)</label>
 					<help>Runs the Odamex Client without connecting to a server</help>
-				</object>				
+				</object>
 				<object class="separator" />
 				<object class="wxMenuItem" name="wxID_PREFERENCES">
 					<label>Settings</label>
@@ -178,6 +178,7 @@
 			<object class="separator" />
 			<object class="wxSearchCtrl" name="Id_SrchCtrlGlobal">
 				<value></value>
+				<size>75,-1d</size>
 			</object>
 		</object>
 		<object class="wxBoxSizer">


### PR DESCRIPTION
Addresses #1078

Over the next month, GitHub Actions runners will be updating to Ubuntu 24.04. Due to this, `libwxgtk3.0-gtk3-dev` is no longer available. This PR changes the build scripts to install the new `libwxgtk3.2-dev` package instead. For reasons I don't understand, automatic sizing of the search bar does not work with wxWidgets 3.2, so it is now set to a width of 50 dialog units.