### PR TITLE
[BUGFIX] Don't attempt to parse graphics as intermission scripts

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -498,7 +498,7 @@ void MIType_InterLumpName(OScanner& os, bool newStyleMapInfo, void* data, unsign
 		*static_cast<std::pair<OLumpName*, OLumpName*>*>(data)->second = tok.substr(1);
 		return;
 	}
-	*static_cast<std::pair<OLumpName*, OLumpName*>*>(data)->second = tok;
+	*static_cast<std::pair<OLumpName*, OLumpName*>*>(data)->first = tok;
 }
 
 // Sets the inputted data as an OLumpName, checking LANGUAGE for the actual OLumpName


### PR DESCRIPTION
The fix for debug builds crashing while parsing mapinfo exitpic and enterpic fields accidentally made it so that the lumps specified by these fields would be treated as intermission scripts instead of graphics. This has been fixed.