### PR TITLE
[FEATURE] More ID24 Linedef Types

### DIFF
--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -39,10 +39,10 @@
 #include "z_zone.h"
 #include "w_wad.h"
 
-
 #include "p_local.h"
 #include "r_local.h"
 #include "r_sky.h"
+#include "p_mapformat.h"
 
 #include "m_alloc.h"
 #include "i_video.h"
@@ -138,12 +138,12 @@ void R_MapSlopedPlane(int y, int x1, int x2)
 	v3float_t s;
 	s.x = x1 - centerx;
 	s.y = y - centery + 1.0f;
-	s.z = xfoc; 
+	s.z = xfoc;
 
 	dspan.iu = M_DotProductVec3f(&s, &a) * flatwidth;
 	dspan.iv = M_DotProductVec3f(&s, &b) * flatheight;
 	dspan.id = M_DotProductVec3f(&s, &c);
-	
+
 	dspan.iustep = a.x * flatwidth;
 	dspan.ivstep = b.x * flatheight;
 	dspan.idstep = c.x;
@@ -176,14 +176,14 @@ void R_MapSlopedPlane(int y, int x1, int x2)
 		{
 			int index = (int)(map >> FRACBITS) + 1;
 			index -= (foggy ? 0 : extralight << 2);
-			
+
 			if (index < 0)
 				dspan.slopelighting[i] = basecolormap;
 			else if (index >= NUMCOLORMAPS)
 				dspan.slopelighting[i] = basecolormap.with((NUMCOLORMAPS - 1));
 			else
 				dspan.slopelighting[i] = basecolormap.with(index);
-			
+
 			map += step;
 		}
 	}
@@ -221,7 +221,7 @@ void R_MapLevelPlane(int y, int x1, int x2)
 	dspan.ystep = FixedMul(pl_ystepscale, slope);
 
 	dspan.xfrac = pl_viewxtrans +
-				FixedMul(FixedMul(pl_viewcos, distance), pl_xscale) + 
+				FixedMul(FixedMul(pl_viewcos, distance), pl_xscale) +
 				(x1 - centerx) * dspan.xstep;
 	dspan.yfrac = pl_viewytrans -
 				FixedMul(FixedMul(pl_viewsin, distance), pl_yscale) +
@@ -413,7 +413,7 @@ void R_MakeSpans(visplane_t *pl, void(*spanfunc)(int, int, int))
 		unsigned int b1 = pl->bottom[x-1];
 		unsigned int t2 = pl->top[x];
 		unsigned int b2 = pl->bottom[x];
-		
+
 		for (; t1 < t2 && t1 <= b1; t1++)
 			spanfunc(t1, spanstart[t1], x-1);
 		for (; b1 > b2 && b1 >= t1; b1--)
@@ -496,11 +496,11 @@ void R_DrawSlopedPlane(visplane_t *pl)
 	M_TranslateVec3f(&p, &viewpos, rotation);
 	M_TranslateVec3f(&t, &viewpos, rotation);
 	M_TranslateVec3f(&s, &viewpos, rotation);
-	
+
 	// Subtract p from t and s, making t and s into direction vectors
 	M_SubVec3f(&t, &t, &p);
 	M_SubVec3f(&s, &s, &p);
-	
+
 	M_CrossProductVec3f(&a, &p, &s);
 	M_CrossProductVec3f(&b, &t, &p);
 	M_CrossProductVec3f(&c, &t, &s);
@@ -511,9 +511,9 @@ void R_DrawSlopedPlane(visplane_t *pl)
 
 	a.y *= ifocratio;
 	b.y *= ifocratio;
-	c.y *= ifocratio;		
-	
-	// (SoM) More help from randy. I was totally lost on this... 
+	c.y *= ifocratio;
+
+	// (SoM) More help from randy. I was totally lost on this...
 	float scalenumer = FIXED2FLOAT(finetangent[FINEANGLES/4+CorrectFieldOfView/2]);
 	float ixscale = scalenumer / flatwidth;
 	float iyscale = scalenumer / flatheight;
@@ -523,12 +523,12 @@ void R_DrawSlopedPlane(visplane_t *pl)
 	angle_t fovang = ANG(consoleplayer().fov / 2.0f);
 	float slopetan = FIXED2FLOAT(finetangent[fovang >> ANGLETOFINESHIFT]);
 	float slopevis = 8.0 * slopetan * 16.0 * 320.0 / float(I_GetSurfaceWidth());
-	
+
 	plight = (slopevis * ixscale * iyscale) / (zat - viewpos.z);
 	shade = 256.0 * 2.0 - (pl->lightlevel + 16.0) * 256.0 / 128.0;
 
 	basecolormap = pl->colormap;	// [RH] set basecolormap
-   
+
 	R_MakeSpans(pl, R_MapSlopedPlane);
 }
 
@@ -550,16 +550,24 @@ void R_DrawLevelPlane(visplane_t *pl)
 	// values for angle 0. This helps the texture to line up correctly.
 	if (pl->angle == 0)
 	{
-		pl_viewx = viewx;
-		pl_viewy = -viewy;
+		pl_viewx = viewx + pl->xoffs;
+		pl_viewy = -viewy + pl->yoffs;
 	}
 	else
 	{
 		const fixed_t pl_cos = finecosine[pl->angle >> ANGLETOFINESHIFT];
 		const fixed_t pl_sin = finesine[pl->angle >> ANGLETOFINESHIFT];
-		
-		pl_viewx = FixedMul(viewx, pl_cos) - FixedMul(viewy, pl_sin);
-		pl_viewy = -(FixedMul(viewx, pl_sin) + FixedMul(viewy, pl_cos));
+
+		if (map_format.getZDoom())
+		{
+			pl_viewx = pl->xoffs + FixedMul(viewx, pl_cos) - FixedMul(viewy, pl_sin);
+			pl_viewy = pl->yoffs - (FixedMul(viewx, pl_sin) + FixedMul(viewy, pl_cos));
+		}
+		else
+		{
+			pl_viewx = FixedMul(viewx + pl->xoffs, pl_cos) - FixedMul(viewy + pl->yoffs, pl_sin);
+			pl_viewy = -(FixedMul(viewx + pl->xoffs, pl_sin) + FixedMul(viewy + pl->yoffs, pl_cos));
+		}
 	}
 
 	// cache a calculation used by R_MapLevelPlane
@@ -567,9 +575,9 @@ void R_DrawLevelPlane(visplane_t *pl)
 	pl_ystepscale = FixedMul(pl_viewcos, pl->yscale) << 10;
 
 	// cache a calculation used by R_MapLevelPlane
-	pl_viewxtrans = FixedMul(pl_viewx + pl->xoffs, pl->xscale) << 10;
-	pl_viewytrans = FixedMul(pl_viewy + pl->yoffs, pl->yscale) << 10;
-	
+	pl_viewxtrans = FixedMul(pl_viewx, pl->xscale) << 10;
+	pl_viewytrans = FixedMul(pl_viewy, pl->yscale) << 10;
+
 	basecolormap = pl->colormap;	// [RH] set basecolormap
 
 	// [SL] 2012-02-05 - Plane's height should be constant for all (x,y)
@@ -596,7 +604,7 @@ void R_DrawPlanes (void)
 	R_ResetDrawFuncs();
 
 	dspan.color = 3;
-	
+
 	for (i = 0; i < MAXVISPLANES; i++)
 	{
 		for (pl = visplanes[i]; pl; pl = pl->next)
@@ -616,7 +624,7 @@ void R_DrawPlanes (void)
 
 				dspan.color += 4;	// [RH] color if r_drawflat is 1
 				dspan.source = (byte *)W_CacheLumpNum (firstflat + useflatnum, PU_STATIC);
-										   
+
 				// [RH] warp a flat if desired
 				if (flatwarp[useflatnum])
 				{
@@ -659,7 +667,7 @@ void R_DrawPlanes (void)
 						dspan.source = warped;
 					}
 				}
-				
+
 				pl->top[pl->maxx+1] = viewheight;
 				pl->top[pl->minx-1] = viewheight;
 
@@ -667,7 +675,7 @@ void R_DrawPlanes (void)
 					R_DrawLevelPlane(pl);
 				else
 					R_DrawSlopedPlane(pl);
-					
+
 				Z_ChangeTag (dspan.source, PU_CACHE);
 			}
 		}

--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -550,8 +550,8 @@ void R_DrawLevelPlane(visplane_t *pl)
 	// values for angle 0. This helps the texture to line up correctly.
 	if (pl->angle == 0)
 	{
-		pl_viewx = viewx + pl->xoffs;
-		pl_viewy = -viewy + pl->yoffs;
+		pl_viewx = pl->xoffs + viewx;
+		pl_viewy = pl->yoffs - viewy;
 	}
 	else
 	{
@@ -565,8 +565,8 @@ void R_DrawLevelPlane(visplane_t *pl)
 		}
 		else
 		{
-			pl_viewx = FixedMul(viewx + pl->xoffs, pl_cos) - FixedMul(viewy + pl->yoffs, pl_sin);
-			pl_viewy = -(FixedMul(viewx + pl->xoffs, pl_sin) + FixedMul(viewy + pl->yoffs, pl_cos));
+			pl_viewx = FixedMul(viewx + pl->xoffs, pl_cos) - FixedMul(viewy - pl->yoffs, pl_sin);
+			pl_viewy = -(FixedMul(viewx + pl->xoffs, pl_sin) + FixedMul(viewy - pl->yoffs, pl_cos));
 		}
 	}
 

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1697,16 +1697,19 @@ void P_SpawnCompatibleScroller(line_t* l, int i)
 		              s, accel);
 		break;
 
-	case 1024: // special 255 with tag control
+	 // special 255 with tag control
 	case 1025:
 	case 1026:
+	case 2085:
+	case 2086:
+		control = sides[*l->sidenum].sector - sectors;
+
+	case 1024:
+	case 2084:
 		if (l->id == 0)
 			Printf(PRINT_HIGH, "Line %d is missing a tag!", i);
 
-		if (special > 1024)
-			control = sides[*l->sidenum].sector - sectors;
-
-		if (special == 1026)
+		if (special == 1026 || special == 2086)
 			accel = 1;
 
 		s = lines[i].sidenum[0];
@@ -1714,14 +1717,27 @@ void P_SpawnCompatibleScroller(line_t* l, int i)
 		dy = sides[s].rowoffset / 8;
 		for (s = -1; (s = P_FindLineFromLineTag(l, s)) >= 0;)
 			if (s != i)
+			{
 				new DScroller(DScroller::sc_side, dx, dy, control, lines[s].sidenum[0],
 				              accel);
+				if (lines[s].sidenum[1] != R_NOSIDE)
+					new DScroller(DScroller::sc_side, -dx, dy, control, lines[s].sidenum[1],
+					              accel);
+			}
 		break;
 
+	case 2082: // scroll both sides left
+		if (lines[i].sidenum[1] != R_NOSIDE)
+			new DScroller(DScroller::sc_side, -FRACUNIT, 0, -1, lines[i].sidenum[1], accel);
+		// [[fallthrough]]
 	case 48: // scroll first side
 		new DScroller(DScroller::sc_side, FRACUNIT, 0, -1, lines[i].sidenum[0], accel);
 		break;
 
+	case 2083: // scroll both sides right
+		if (lines[i].sidenum[1] != R_NOSIDE)
+			new DScroller(DScroller::sc_side, FRACUNIT, 0, -1, lines[i].sidenum[1], accel);
+		// [[fallthrough]]
 	case 85: // jff 1/30/98 2-way scroll
 		new DScroller(DScroller::sc_side, -FRACUNIT, 0, -1, lines[i].sidenum[0], accel);
 		break;

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1458,6 +1458,9 @@ void P_SpawnCompatibleExtra(int i)
 	sector_t* sec;
 	float grav;
 	int damage;
+	fixed_t xoffs;
+	fixed_t yoffs;
+	angle_t angle;
 
 	switch (lines[i].special)
 	{
@@ -1519,8 +1522,8 @@ void P_SpawnCompatibleExtra(int i)
 		break;
 
 	case 2048:
-		fixed_t xoffs = lines[i].dx;
-		fixed_t yoffs = lines[i].dy;
+		xoffs = lines[i].dx;
+		yoffs = lines[i].dy;
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
 			sectors[s].floor_xoffs += xoffs;
@@ -1529,8 +1532,8 @@ void P_SpawnCompatibleExtra(int i)
 		break;
 
 	case 2049:
-		fixed_t xoffs = lines[i].dx;
-		fixed_t yoffs = lines[i].dy;
+		xoffs = lines[i].dx;
+		yoffs = lines[i].dy;
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
 			sectors[s].ceiling_xoffs += xoffs;
@@ -1539,14 +1542,22 @@ void P_SpawnCompatibleExtra(int i)
 		break;
 
 	case 2050:
-		fixed_t xoffs = lines[i].dx;
-		fixed_t yoffs = lines[i].dy;
+		xoffs = lines[i].dx;
+		yoffs = lines[i].dy;
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
 			sectors[s].floor_xoffs += xoffs;
 			sectors[s].floor_yoffs += yoffs;
 			sectors[s].ceiling_xoffs += xoffs;
 			sectors[s].ceiling_yoffs += yoffs;
+		}
+		break;
+
+	case 2051:
+		angle = lines[i].dx;
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].floor_angle += angle;
 		}
 		break;
 	}

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1554,12 +1554,69 @@ void P_SpawnCompatibleExtra(int i)
 		break;
 
 	case 2051:
-		angle = lines[i].dx;
+		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
-			sectors[s].floor_angle += angle;
+			sectors[s].floor_angle -= angle;
 		}
 		break;
+
+	case 2052:
+		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].ceiling_angle -= angle;
+		}
+		break;
+
+	case 2053:
+		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].floor_angle -= angle;
+			sectors[s].ceiling_angle -= angle;
+		}
+		break;
+
+	case 2054:
+		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
+		xoffs = lines[i].dx;
+		yoffs = lines[i].dy;
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].floor_angle -= angle;
+			sectors[s].floor_xoffs += xoffs;
+			sectors[s].floor_yoffs += yoffs;
+		}
+		break;
+
+	case 2055:
+		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
+		xoffs = lines[i].dx;
+		yoffs = lines[i].dy;
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].ceiling_angle -= angle;
+			sectors[s].ceiling_xoffs += xoffs;
+			sectors[s].ceiling_yoffs += yoffs;
+		}
+		break;
+
+	case 2056:
+		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
+		xoffs = lines[i].dx;
+		yoffs = lines[i].dy;
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].floor_angle -= angle;
+			sectors[s].ceiling_angle -= angle;
+			sectors[s].floor_xoffs += xoffs;
+			sectors[s].floor_yoffs += yoffs;
+			sectors[s].ceiling_xoffs += xoffs;
+			sectors[s].ceiling_yoffs += yoffs;
+		}
+		break;
+
 	}
 }
 

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1526,7 +1526,7 @@ void P_SpawnCompatibleExtra(int i)
 		yoffs = lines[i].dy;
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
-			sectors[s].floor_xoffs += xoffs;
+			sectors[s].floor_xoffs -= xoffs;
 			sectors[s].floor_yoffs += yoffs;
 		}
 		break;
@@ -1536,7 +1536,7 @@ void P_SpawnCompatibleExtra(int i)
 		yoffs = lines[i].dy;
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
-			sectors[s].ceiling_xoffs += xoffs;
+			sectors[s].ceiling_xoffs -= xoffs;
 			sectors[s].ceiling_yoffs += yoffs;
 		}
 		break;
@@ -1546,9 +1546,9 @@ void P_SpawnCompatibleExtra(int i)
 		yoffs = lines[i].dy;
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
-			sectors[s].floor_xoffs += xoffs;
+			sectors[s].floor_xoffs -= xoffs;
 			sectors[s].floor_yoffs += yoffs;
-			sectors[s].ceiling_xoffs += xoffs;
+			sectors[s].ceiling_xoffs -= xoffs;
 			sectors[s].ceiling_yoffs += yoffs;
 		}
 		break;
@@ -1585,7 +1585,7 @@ void P_SpawnCompatibleExtra(int i)
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
 			sectors[s].floor_angle -= angle;
-			sectors[s].floor_xoffs += xoffs;
+			sectors[s].floor_xoffs -= xoffs;
 			sectors[s].floor_yoffs += yoffs;
 		}
 		break;
@@ -1597,7 +1597,7 @@ void P_SpawnCompatibleExtra(int i)
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
 		{
 			sectors[s].ceiling_angle -= angle;
-			sectors[s].ceiling_xoffs += xoffs;
+			sectors[s].ceiling_xoffs -= xoffs;
 			sectors[s].ceiling_yoffs += yoffs;
 		}
 		break;
@@ -1610,9 +1610,9 @@ void P_SpawnCompatibleExtra(int i)
 		{
 			sectors[s].floor_angle -= angle;
 			sectors[s].ceiling_angle -= angle;
-			sectors[s].floor_xoffs += xoffs;
+			sectors[s].floor_xoffs -= xoffs;
 			sectors[s].floor_yoffs += yoffs;
-			sectors[s].ceiling_xoffs += xoffs;
+			sectors[s].ceiling_xoffs -= xoffs;
 			sectors[s].ceiling_yoffs += yoffs;
 		}
 		break;

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1521,6 +1521,8 @@ void P_SpawnCompatibleExtra(int i)
 		}
 		break;
 
+	// 2048-2056 ID24 flat offset and rotation
+	// floor offset
 	case 2048:
 		xoffs = lines[i].dx;
 		yoffs = lines[i].dy;
@@ -1530,7 +1532,7 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].floor_yoffs += yoffs;
 		}
 		break;
-
+	// ceiling offset
 	case 2049:
 		xoffs = lines[i].dx;
 		yoffs = lines[i].dy;
@@ -1540,7 +1542,7 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].ceiling_yoffs += yoffs;
 		}
 		break;
-
+	// floor and ceiling offset
 	case 2050:
 		xoffs = lines[i].dx;
 		yoffs = lines[i].dy;
@@ -1552,7 +1554,7 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].ceiling_yoffs += yoffs;
 		}
 		break;
-
+	// floor rotation
 	case 2051:
 		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
@@ -1560,7 +1562,7 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].floor_angle -= angle;
 		}
 		break;
-
+	// ceiling rotation
 	case 2052:
 		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
@@ -1568,7 +1570,7 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].ceiling_angle -= angle;
 		}
 		break;
-
+	// floor and ceiling rotation
 	case 2053:
 		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
 		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
@@ -1577,7 +1579,7 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].ceiling_angle -= angle;
 		}
 		break;
-
+	// floor offset and rotation
 	case 2054:
 		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
 		xoffs = lines[i].dx;
@@ -1589,7 +1591,7 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].floor_yoffs += yoffs;
 		}
 		break;
-
+	// ceiling offset and rotation
 	case 2055:
 		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
 		xoffs = lines[i].dx;
@@ -1601,7 +1603,7 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].ceiling_yoffs += yoffs;
 		}
 		break;
-
+	// floor and ceiling offset and rotation
 	case 2056:
 		angle = P_PointToAngle(lines[i].v1->x, lines[i].v1->y, lines[i].v2->x, lines[i].v2->y);
 		xoffs = lines[i].dx;
@@ -1797,14 +1799,14 @@ void P_SpawnCompatibleScroller(line_t* l, int i)
 		              s, accel);
 		break;
 
-	 // special 255 with tag control
+	// MBF21 scrollers and double sided variants from ID24
 	case 1025:
 	case 1026:
 	case 2085:
 	case 2086:
 		control = sides[*l->sidenum].sector - sectors;
 
-	case 1024:
+	case 1024: // special 255 with tag control
 	case 2084:
 		if (l->id == 0)
 			Printf(PRINT_HIGH, "Line %d is missing a tag!", i);

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -1517,6 +1517,38 @@ void P_SpawnCompatibleExtra(int i)
 			sectors[s].mod = MOD_UNKNOWN;
 		}
 		break;
+
+	case 2048:
+		fixed_t xoffs = lines[i].dx;
+		fixed_t yoffs = lines[i].dy;
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].floor_xoffs += xoffs;
+			sectors[s].floor_yoffs += yoffs;
+		}
+		break;
+
+	case 2049:
+		fixed_t xoffs = lines[i].dx;
+		fixed_t yoffs = lines[i].dy;
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].ceiling_xoffs += xoffs;
+			sectors[s].ceiling_yoffs += yoffs;
+		}
+		break;
+
+	case 2050:
+		fixed_t xoffs = lines[i].dx;
+		fixed_t yoffs = lines[i].dy;
+		for (s = -1; (s = P_FindSectorFromTag(lines[i].id, s)) >= 0;)
+		{
+			sectors[s].floor_xoffs += xoffs;
+			sectors[s].floor_yoffs += yoffs;
+			sectors[s].ceiling_xoffs += xoffs;
+			sectors[s].ceiling_yoffs += yoffs;
+		}
+		break;
 	}
 }
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -774,6 +774,8 @@ bool P_CheckTag(line_t* line)
 
 	case 48: // Scrolling walls
 	case 85:
+	case 2082:
+	case 2083:
 		return true; // zero tag allowed
 
 	default:

--- a/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
+++ b/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
@@ -169,47 +169,47 @@ doom
 		
 		2048
 		{
-			title = "Offset floor by line direction";
+			title = "Offset Floor by Line Delta";
 			prefix = "";
 		}
 		2049
 		{
-			title = "Offset ceiling by line direction";
+			title = "Offset Ceiling by Line Delta";
 			prefix = "";
 		}
 		2050
 		{
-			title = "Offset floor and ceiling by line direction";
+			title = "Offset Floor and Ceiling by Line Delta";
 			prefix = "";
 		}
 		2051
 		{
-			title = "Rotate floor by line angle";
+			title = "Rotate Floor by Line Angle";
 			prefix = "";
 		}
 		2052
 		{
-			title = "Rotate ceiling by line angle";
+			title = "Rotate Ceiling by Line Angle";
 			prefix = "";
 		}
 		2053
 		{
-			title = "Rotate floor and ceiling by line angle";
+			title = "Rotate Floor and Ceiling by Line Angle";
 			prefix = "";
 		}
 		2054
 		{
-			title = "Offset then rotate floor by line direction and angle";
+			title = "Offset and Rotate Floor by Line Delta and Angle";
 			prefix = "";
 		}
 		2055
 		{
-			title = "Offset then rotate ceiling by line direction and angle";
+			title = "Offset and Rotate Ceiling by Line Delta and Angle";
 			prefix = "";
 		}
 		2056
 		{
-			title = "Offset then rotate floor and ceiling by line direction and angle";
+			title = "Offset and Rotate Floor and Ceiling by Line Delta and Angle";
 			prefix = "";
 		}
 	}

--- a/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
+++ b/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
@@ -163,6 +163,56 @@ doom
 			prefix = "";
 		}
 	}
+	flat
+	{
+		title = "Flat";
+		
+		2048
+		{
+			title = "Offset floor by line direction";
+			prefix = "";
+		}
+		2049
+		{
+			title = "Offset ceiling by line direction";
+			prefix = "";
+		}
+		2050
+		{
+			title = "Offset floor and ceiling by line direction";
+			prefix = "";
+		}
+		2051
+		{
+			title = "Rotate floor by line angle";
+			prefix = "";
+		}
+		2052
+		{
+			title = "Rotate ceiling by line angle";
+			prefix = "";
+		}
+		2053
+		{
+			title = "Rotate floor and ceiling by line angle";
+			prefix = "";
+		}
+		2054
+		{
+			title = "Offset then rotate floor by line direction and angle";
+			prefix = "";
+		}
+		2055
+		{
+			title = "Offset then rotate ceiling by line direction and angle";
+			prefix = "";
+		}
+		2056
+		{
+			title = "Offset then rotate floor and ceiling by line direction and angle";
+			prefix = "";
+		}
+	}
 }
 
 zdoom

--- a/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
+++ b/tools/udbconfig/Configurations/Includes/Odamex_linedefs.cfg
@@ -40,7 +40,7 @@ doom
   	}
    	exit
    	{
-    		title = "Exit";
+    	title = "Exit";
       
 		2069
 		{
@@ -133,7 +133,36 @@ doom
 			prefix = "";
 		}
 	}
-	
+	scroll
+	{
+		title = "Scroll";
+		
+		2082
+		{
+			title = "Scroll Texture Left (Double Sided)";
+			prefix = "";
+		}
+		2083
+		{
+			title = "Scroll Texture Right (Double Sided)";
+			prefix = "";
+		}
+		2084
+		{
+			title = "Scroll Wall with Same Tag using Sidedef Offsets (Double Sided)";
+			prefix = "";
+		}
+		2085
+		{
+			title = "Scroll Wall with Same Tag using Sidedef Offsets when Sector Changes Height (Double Sided)";
+			prefix = "";
+		}
+		2086
+		{
+			title = "Scroll Wall with Same Tag using Sidedef Offsets Accelerates when Sector Changes Height (Double Sided)";
+			prefix = "";
+		}
+	}
 }
 
 zdoom


### PR DESCRIPTION
A few more of the new linedef types introduced in ID24.

| Special | Effect | Implemented?
| ------- | ------ | ---------------- |
2048 | Offset target floor texture by line direction. | :white_check_mark:
2049 | Offset target ceiling texture by line direction. | :white_check_mark:
2050 | Offset target floor and ceiling texture by line direction. | :white_check_mark:
2051 | Rotate target floor texture by line angle. | :white_check_mark:
2052 | Rotate target ceiling texture by line angle. | :white_check_mark:
2053 | Rotate target floor and ceiling texture by line angle. | :white_check_mark:
2054 | Offset then rotate target floor texture by line direction and angle. | :white_check_mark:
2055 | Offset then rotate target ceiling texture by line direction and angle. | :white_check_mark:
2056 | Offset then rotate target floor and ceiilng texture by line direction and angle. | :white_check_mark:
2082 |  Scroll Texture Left (Double Sided) | :white_check_mark:
2083 |  Scroll Texture Right (Double Sided) | :white_check_mark:
2084 |  Scroll Wall with Same Tag using Sidedef Offsets (Double Sided) | :white_check_mark:
2085 |  Scroll Wall with Same Tag using Sidedef Offsets when Sector Changes Height (Double Sided) | :white_check_mark:
2086 |  Scroll Wall with Same Tag using Sidedef Offsets Accelerates when Sector Changes Height (Double Sided) | :white_check_mark: