### PR TITLE
[BUGFIX] Remove case-sensitivity in UMAPINFO

### DIFF
--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -294,7 +294,7 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 		else
 		{
 			const std::string actor_name = os.getToken();
-			const mobjtype_t i = P_NameToMobj(actor_name);
+			const mobjtype_t i = P_INameToMobj(actor_name);
 			if (i == MT_NULL)
 			{
 				os.error("Unknown thing type %s", os.getToken().c_str());

--- a/common/infomap.cpp
+++ b/common/infomap.cpp
@@ -319,6 +319,26 @@ mobjtype_t P_NameToMobj(const std::string& name)
 	return it->second;
 }
 
+/**
+ * @brief Convert a UMAPINFO/ZDoom class name to a MT Mobj index. Case insensitive for UMAPINFO
+ */
+mobjtype_t P_INameToMobj(const std::string& name)
+{
+	if (::g_MonsterMap.empty())
+	{
+		InitMap();
+	}
+
+	for (MobjMap::iterator it = ::g_MonsterMap.begin(); it != ::g_MonsterMap.end(); ++it)
+	{
+		if (iequals(it->first, name))
+		{
+			return it->second;
+		}
+	}
+	return MT_NULL;
+}
+
 std::string P_MobjToName(const mobjtype_t name)
 {
 	if (::g_MonsterMap.empty())

--- a/common/infomap.h
+++ b/common/infomap.h
@@ -26,5 +26,6 @@
 #include "info.h"
 
 mobjtype_t P_NameToMobj(const std::string& name);
+mobjtype_t P_INameToMobj(const std::string& name);
 weapontype_t P_NameToWeapon(const std::string& name);
 std::string P_MobjToName(const mobjtype_t name);


### PR DESCRIPTION
According to the UMAPINFO spec, values should be case-insensitive. Previously Odamex was failing to parse UMAPINFO with incorrect capitalization of monster classes (e.g. SpiderMasterMind instead of SpiderMastermind)