### PR TITLE
[BUGFIX] Weapons using MBF21 A_ConsumeAmmo still consume ammo when sv_infiniteammo is enabled

### DIFF
--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -916,6 +916,9 @@ void A_ConsumeAmmo(AActor* mo)
 	player_t* player = mo->player;
 	struct pspdef_s* psp = &player->psprites[player->psprnum];
 
+	if (sv_infiniteammo)
+		return;
+
 	// don't do dumb things, kids
 	type = weaponinfo[player->readyweapon].ammotype;
 	if (!psp->state || type == am_noammo)


### PR DESCRIPTION
Fixes Legacy of Rust Incinerator and Calamity Blade consuming ammo with `sv_infiniteammo`.