### PR TITLE
[BUGFIX] Floor lowering to lowest adjacent floor for line special 40

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -417,11 +417,9 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		break;
 
 	case 40:
-		// RaiseCeilingLowerFloor
+		// RaiseCeilingLowerFloor -- only raises ceiling
 		EV_DoCeiling(DCeiling::ceilRaiseToHighest, line, line->id, SPEED(C_SLOW), 0, 0, 0,
 		             0, 0);
-		EV_DoFloor(DFloor::floorLowerToLowest, line, line->id, SPEED(F_SLOW), 0, 0,
-		           0); // jff 02/12/98 doesn't work
 		return true;
 		//line->special = 0;
 		break;


### PR DESCRIPTION
Addresses #1096

When handling linedef type 40, there is a call to EV_DoFloor, which in vanilla Doom is non-functional and which other source ports have either removed or left non-functional. In Odamex, it actually does lower the floor, which is not the standard behavior for this linedef type.