### PR TITLE
Implement new options for horde mode

### DIFF
--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -273,6 +273,12 @@ CVAR(g_horde_maxtotalhp, "10.0", "Multiplier for maximum spawned health at a tim
 CVAR(g_horde_goalhp, "8.0", "Goal health multiplier for a given round", CVARTYPE_FLOAT,
      CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
 
+CVAR(g_horde_relaxhp, "0", "Multiplier for limit of spawnable health per wave", CVARTYPE_FLOAT,
+     CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
+CVAR(g_horde_bosspace, "1", "Only waves that are a multiple of this value will have a boss", CVARTYPE_INT,
+     CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
 CVAR_RANGE(g_horde_spawnempty_min, "1",
            "Minimum number of seconds it takes to spawn a monster in an empty horde map",
            CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE, 1,

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -279,6 +279,12 @@ CVAR(g_horde_relaxhp, "0", "Multiplier for limit of spawnable health per wave", 
 CVAR(g_horde_bosspace, "1", "Only waves that are a multiple of this value will have a boss", CVARTYPE_INT,
      CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
 
+CVAR(g_horde_bossrelax, "0", "Starting a boss fight resets the relaxhp limit", CVARTYPE_BOOL,
+     CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
+CVAR(g_horde_bosswipe, "0", "Winning a boss fight will kill all remaining enemies", CVARTYPE_BOOL,
+     CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)
+
 CVAR_RANGE(g_horde_spawnempty_min, "1",
            "Minimum number of seconds it takes to spawn a monster in an empty horde map",
            CVARTYPE_INT, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE, 1,

--- a/common/p_horde.cpp
+++ b/common/p_horde.cpp
@@ -45,6 +45,7 @@
 #endif
 
 EXTERN_CVAR(g_horde_waves)
+EXTERN_CVAR(g_horde_bosspace)
 EXTERN_CVAR(g_lives)
 EXTERN_CVAR(g_horde_spawnempty_min)
 EXTERN_CVAR(g_horde_spawnempty_max)
@@ -482,6 +483,8 @@ class HordeState
 	}
 
 	int getAliveHealth() const { return m_spawnedHealth - m_killedHealth; }
+	bool getIsBossWave() const { return ::g_horde_bosspace < 1 ? false : m_wave % static_cast<int>(::g_horde_bosspace) == 0; }
+
 	void changeState();
 	void getNextSpawnTime(int& min, int& max);
 	void tick();
@@ -495,6 +498,7 @@ void HordeState::changeState()
 	const hordeDefine_t& define = G_HordeDefine(m_defineID);
 
 	const int goalHealth = define.goalHealth() + m_waveStartHealth;
+	const int relaxHealth = define.relaxHealth() == 0 ? INT_MAX : define.relaxHealth() + m_waveStartHealth;
 
 	switch (m_state)
 	{
@@ -507,20 +511,25 @@ void HordeState::changeState()
 		return;
 	}
 	case HS_PRESSURE: {
-		if (m_killedHealth > goalHealth && m_bosses.empty())
+		if (getIsBossWave() && m_killedHealth > goalHealth && m_bosses.empty())
 		{
-			// We reached the goal, spawn the boss.
+			// We reached the goal and this wave needs a boss, spawn it.
 			setState(HS_WANTBOSS);
+		}
+		else if (m_spawnedHealth > relaxHealth)
+		{
+			// Spawn quota has been reached, relax.
+			setState(HS_RELAX);
 		}
 		return;
 	}
 	case HS_RELAX: {
-		if (m_killedHealth > goalHealth && m_bosses.empty())
+		if (getIsBossWave() && m_killedHealth > goalHealth && m_bosses.empty())
 		{
-			// We reached the goal, spawn the boss.
+			// We reached the goal and this wave needs a boss, spawn it.
 			setState(HS_WANTBOSS);
 		}
-		else
+		else if (m_spawnedHealth <= relaxHealth)
 		{
 			// There's not enough monsters in the level, add more.
 			setState(HS_PRESSURE);
@@ -529,9 +538,16 @@ void HordeState::changeState()
 	case HS_WANTBOSS: {
 		if (m_bossRecipe.isValid() && static_cast<int>(m_bosses.size()) >= m_bossRecipe.count)
 		{
-			// Doesn't matter which state we enter, but we're more likely
-			// to be in the relax state after spawning a big hunk of HP.
-			setState(HS_PRESSURE);
+			if (m_spawnedHealth > relaxHealth)
+			{
+				// Spawn quota has been reached, relax.
+				setState(HS_RELAX);
+			}
+			else
+			{
+				// There's not enough monsters in the level, add more.
+				setState(HS_PRESSURE);
+			}
 		}
 		return;
 	}
@@ -609,6 +625,17 @@ void HordeState::tick()
 		if (!alive)
 		{
 			// Start the next wave.
+			nextWave();
+			return;
+		}
+	}
+	else if (m_bosses.empty() && !getIsBossWave())
+	{
+		const hordeDefine_t& define = G_HordeDefine(m_defineID);
+		const int goalHealth = define.goalHealth() + m_waveStartHealth;
+
+		if (m_killedHealth > goalHealth)
+		{
 			nextWave();
 			return;
 		}
@@ -996,6 +1023,7 @@ END_COMMAND(hordeboss)
 EXTERN_CVAR(g_horde_mintotalhp)
 EXTERN_CVAR(g_horde_maxtotalhp)
 EXTERN_CVAR(g_horde_goalhp)
+EXTERN_CVAR(g_horde_relaxhp)
 
 BEGIN_COMMAND(hordeinfo)
 {
@@ -1029,6 +1057,19 @@ BEGIN_COMMAND(hordeinfo)
 	Printf("Goal Health: %d = waveMaxGroup:%d * g_horde_goalhp:%s * skillLevel:%0.2f\n",
 	       define.goalHealth(), define.maxGroupHealth, ::g_horde_goalhp.cstring(),
 	       skillScaler);
+
+	if (define.relaxHealth() == 0)
+		Printf("Relax Health: Unlimited (g_horde_relaxhp:%s < g_horde_goalhp:%s)\n",
+	        ::g_horde_relaxhp.cstring(), ::g_horde_goalhp.cstring());
+	else
+	    Printf("Relax Health: %d = waveMaxGroup:%d * g_horde_relaxhp:%s * skillLevel:%0.2f\n",
+	        define.relaxHealth(), define.maxGroupHealth, ::g_horde_relaxhp.cstring(),
+	        skillScaler);
+
+	if (::g_horde_bosspace < 1)
+		Printf("Boss Pace: Never (g_horde_bosspace:%s < 1)\n", ::g_horde_bosspace.cstring());
+	else
+		Printf("Boss Pace: Every %d wave(s) (g_horde_bosspace:%s)\n", static_cast<int>(::g_horde_bosspace), ::g_horde_bosspace.cstring());
 
 	const char* stateStr = NULL;
 	switch (::g_HordeDirector.serialize().state)
@@ -1066,6 +1107,7 @@ BEGIN_COMMAND(hordeinfo)
 	       g_horde_spawnfull_max.asInt());
 	Printf("Alive Health: %d\n", ::g_HordeDirector.serialize().alive());
 	Printf("Killed Health: %d\n", ::g_HordeDirector.serialize().killed());
+	Printf("Boss Wave: %s\n", g_HordeDirector.getIsBossWave() ? "yes" : "no");
 	Printf("Boss Health: %d\n", ::g_HordeDirector.serialize().bossHealth);
 	Printf("Boss Damage: %d\n", ::g_HordeDirector.serialize().bossDamage);
 }

--- a/common/p_horde.cpp
+++ b/common/p_horde.cpp
@@ -45,7 +45,11 @@
 #endif
 
 EXTERN_CVAR(g_horde_waves)
+EXTERN_CVAR(g_horde_goalhp)
+EXTERN_CVAR(g_horde_relaxhp)
 EXTERN_CVAR(g_horde_bosspace)
+EXTERN_CVAR(g_horde_bossrelax)
+EXTERN_CVAR(g_horde_bosswipe)
 EXTERN_CVAR(g_lives)
 EXTERN_CVAR(g_horde_spawnempty_min)
 EXTERN_CVAR(g_horde_spawnempty_max)
@@ -309,8 +313,7 @@ class HordeState
 		#endif
 		}
 
-
-		if (::g_horde_waves && m_wave >= ::g_horde_waves)
+		if ((::g_horde_waves && m_wave >= ::g_horde_waves) || (!m_bosses.empty() && ::g_horde_bosswipe))
 		{
 			// All monsters explode!  Woo!
 			AActor* actor;
@@ -331,7 +334,10 @@ class HordeState
 					}
 				}
 			}
+		}
 
+		if (::g_horde_waves && m_wave >= ::g_horde_waves)
+		{
 			G_EndGame();
 			return;
 		}
@@ -498,7 +504,10 @@ void HordeState::changeState()
 	const hordeDefine_t& define = G_HordeDefine(m_defineID);
 
 	const int goalHealth = define.goalHealth() + m_waveStartHealth;
-	const int relaxHealth = define.relaxHealth() == 0 ? INT_MAX : define.relaxHealth() + m_waveStartHealth;
+	const int relaxHealth = g_horde_relaxhp <= 0 ? INT_MAX // disable relax if 0
+		: g_horde_bossrelax && !m_bosses.empty() ? goalHealth + define.relaxHealth() // if bossrelax is on and bosses exist, add goal health
+		: g_horde_relaxhp < g_horde_goalhp ? goalHealth // otherwise, if relax is less than goal, set it to goal
+		: define.relaxHealth() + m_waveStartHealth;
 
 	switch (m_state)
 	{
@@ -1022,8 +1031,6 @@ END_COMMAND(hordeboss)
 
 EXTERN_CVAR(g_horde_mintotalhp)
 EXTERN_CVAR(g_horde_maxtotalhp)
-EXTERN_CVAR(g_horde_goalhp)
-EXTERN_CVAR(g_horde_relaxhp)
 
 BEGIN_COMMAND(hordeinfo)
 {
@@ -1058,18 +1065,31 @@ BEGIN_COMMAND(hordeinfo)
 	       define.goalHealth(), define.maxGroupHealth, ::g_horde_goalhp.cstring(),
 	       skillScaler);
 
-	if (define.relaxHealth() == 0)
-		Printf("Relax Health: Unlimited (g_horde_relaxhp:%s < g_horde_goalhp:%s)\n",
-	        ::g_horde_relaxhp.cstring(), ::g_horde_goalhp.cstring());
+	if (g_horde_relaxhp <= 0)
+		Printf("Relax Health: Unlimited (g_horde_relaxhp <= 0)\n");
 	else
-	    Printf("Relax Health: %d = waveMaxGroup:%d * g_horde_relaxhp:%s * skillLevel:%0.2f\n",
-	        define.relaxHealth(), define.maxGroupHealth, ::g_horde_relaxhp.cstring(),
-	        skillScaler);
+	{
+		if (::g_horde_relaxhp < ::g_horde_goalhp)
+			Printf("Relax Health: Goal (g_horde_relaxhp:%s < g_horde_goalhp:%s)\n",
+				::g_horde_relaxhp.cstring(), ::g_horde_goalhp.cstring());
+		else
+			Printf("Relax Health: %d = waveMaxGroup:%d * g_horde_relaxhp:%s * skillLevel:%0.2f\n",
+				define.relaxHealth(), define.maxGroupHealth, ::g_horde_relaxhp.cstring(),
+				skillScaler);
+
+		if (!::g_horde_bossrelax)
+			Printf("Boss Relax Health: N/A (g_horde_bossrelax:0)\n");
+		else
+			Printf("Boss Relax Health: %d = goalHealth:%d + relaxHealth:%d (g_horde_bossrelax:1)\n",
+				define.goalHealth() + define.relaxHealth(), define.goalHealth(), define.relaxHealth());
+	}
 
 	if (::g_horde_bosspace < 1)
 		Printf("Boss Pace: Never (g_horde_bosspace:%s < 1)\n", ::g_horde_bosspace.cstring());
 	else
 		Printf("Boss Pace: Every %d wave(s) (g_horde_bosspace:%s)\n", static_cast<int>(::g_horde_bosspace), ::g_horde_bosspace.cstring());
+
+	Printf("Boss Wipe: %s (g_horde_bosswipe:%s)\n", g_horde_bosswipe ? "Yes" : "No", ::g_horde_bosswipe.cstring());
 
 	const char* stateStr = NULL;
 	switch (::g_HordeDirector.serialize().state)
@@ -1105,6 +1125,7 @@ BEGIN_COMMAND(hordeinfo)
 	Printf("Empty/Full Spawn Rate: %d-%dsec, %d-%dsec\n", g_horde_spawnempty_min.asInt(),
 	       g_horde_spawnempty_max.asInt(), g_horde_spawnfull_min.asInt(),
 	       g_horde_spawnfull_max.asInt());
+	Printf("Spawned Health: %d\n", ::g_HordeDirector.serialize().spawnedHealth - g_HordeDirector.serialize().waveStartHealth);
 	Printf("Alive Health: %d\n", ::g_HordeDirector.serialize().alive());
 	Printf("Killed Health: %d\n", ::g_HordeDirector.serialize().killed());
 	Printf("Boss Wave: %s\n", g_HordeDirector.getIsBossWave() ? "yes" : "no");

--- a/common/p_hordedefine.cpp
+++ b/common/p_hordedefine.cpp
@@ -99,9 +99,7 @@ int hordeDefine_t::goalHealth() const
 
 int hordeDefine_t::relaxHealth() const
 {
-	return ::g_horde_relaxhp < ::g_horde_goalhp
-		? 0
-		: static_cast<float>(maxGroupHealth) * ::g_horde_relaxhp * SkillScaler();
+	return static_cast<float>(maxGroupHealth) * ::g_horde_relaxhp * SkillScaler();
 }
 
 const char* hordeDefine_t::difficulty(const bool colored) const

--- a/common/p_hordedefine.cpp
+++ b/common/p_hordedefine.cpp
@@ -38,6 +38,7 @@
 EXTERN_CVAR(g_horde_mintotalhp)
 EXTERN_CVAR(g_horde_maxtotalhp)
 EXTERN_CVAR(g_horde_goalhp)
+EXTERN_CVAR(g_horde_relaxhp)
 EXTERN_CVAR(g_horde_waves)
 
 std::vector<hordeDefine_t> WAVE_DEFINES;
@@ -94,6 +95,13 @@ int hordeDefine_t::maxTotalHealth() const
 int hordeDefine_t::goalHealth() const
 {
 	return static_cast<float>(maxGroupHealth) * ::g_horde_goalhp * SkillScaler();
+}
+
+int hordeDefine_t::relaxHealth() const
+{
+	return ::g_horde_relaxhp < ::g_horde_goalhp
+		? 0
+		: static_cast<float>(maxGroupHealth) * ::g_horde_relaxhp * SkillScaler();
 }
 
 const char* hordeDefine_t::difficulty(const bool colored) const

--- a/common/p_hordedefine.h
+++ b/common/p_hordedefine.h
@@ -126,6 +126,7 @@ struct hordeDefine_t
 	int minTotalHealth() const;
 	int maxTotalHealth() const;
 	int goalHealth() const;
+	int relaxHealth() const;
 	const char* difficulty(const bool colored) const;
 	StringTokens weaponStrings(player_t* player) const;
 };


### PR DESCRIPTION
I'm a big fan of invasion style game modes, so I thought I'd add a few options to Odamex's horde mode to allow different style and pacing options. By default, the new options are set such that the behavior is identical to current horde mode.

New CVAR options:

g_horde_relaxhp (default 0):
Places a hard limit on the spawnable health of each wave. This is calculated the same way as goal HP. If this value is less than goal HP, then there is no limit and monsters will spawn continuously (the default horde behavior). Setting this value equal to goal HP achieves a more traditional invasion-like play style where a wave is fully cleared before a new wave begins.

g_horde_bosspace (default 1):
Allows for changing the pace of boss fights. Only waves that are a multiple of this value will have a boss, otherwise the wave ends immediately when the goal HP is reached and the next wave begins. A value of 0 means there are no bosses at all. The default value of 1 means every wave has a boss. Setting this equal to the total number of waves means only the final wave will have a boss.

These options are especially helpful for solo play or small groups to make things more manageable, but also allow for a different kind of difficulty by increasing the spawn rate, allowing for shorter but very intense waves with periods of calm in between. I'm new to this codebase so let me know if I've missed anything.