### PR TITLE
Implement basic scaling for console font

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -195,6 +195,9 @@ CVAR_RANGE(			con_buffersize, "1024", "Size of console scroll-back buffer",
 CVAR(				con_coloredmessages, "1", "Activates colored messages in printed messages",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
+CVAR_RANGE_FUNC_DECL(con_scaletext, "1", "Scale factor of console text",
+					CVARTYPE_INT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 1.0f, 4.0f)
+
 CVAR(message_showpickups, "1", "Show item pickup messages on the message line.",
      CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -961,6 +961,7 @@ menu_t HUDMenu = {
 EXTERN_CVAR(message_showpickups)
 EXTERN_CVAR(message_showobituaries)
 EXTERN_CVAR (con_coloredmessages)
+EXTERN_CVAR (con_scaletext)
 EXTERN_CVAR (hud_scaletext)
 EXTERN_CVAR (msg0color)
 EXTERN_CVAR (msg1color)
@@ -1010,6 +1011,7 @@ static menuitem_t MessagesItems[] = {
 	{ slider,	"Center Message Timeout",{&con_midtime},		{1.0}, {10.0},	{0.25}, {NULL} },
 	{ slider,	"Scale message text",    {&hud_scaletext},		{1.0}, {4.0}, 	{1.0}, {NULL} },
 	{ discrete,	"Colorize messages",	{&con_coloredmessages},	{2.0}, {0.0},   {0.0},	{OnOff} },
+	{ slider,	"Scale console text",   {&con_scaletext},		{1.0}, {4.0}, 	{1.0}, {NULL} },
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
 	{ yellowtext,"Display settings",		{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
 	{ discrete,	"Show pickup messages",	{&message_showpickups},	{2.0}, {0.0},   {0.0},	{OnOff} },

--- a/common/v_video.h
+++ b/common/v_video.h
@@ -104,7 +104,7 @@ public:
 
 	// Text drawing functions
 	// Output a line of text using the console font
-	void PrintStr(int x, int y, const char *s, int default_color = -1, bool use_color_codes = true) const;
+	void PrintStr(int x, int y, const char *s, int default_color = -1, bool use_color_codes = true, int scale = 1) const;
 
 	// Output some text with wad heads-up font
 	inline void DrawText (int normalcolor, int x, int y, const byte *string) const;


### PR DESCRIPTION
I have poor vision and the default 8x8 console font was giving me headaches trying to read it, so I took a quick pass to make it scalable. The `con_scaletext` CVAR (range 1-4) controls the factor. A menu option was also added in the messages submenu.