### PR TITLE
Rework maplist `lastmap`

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -119,15 +119,6 @@ void G_DeferedReset() {
 
 BEGIN_COMMAND (wad) // denis - changes wads
 {
-	std::string lastmap = argv[argc-1];
-	if (lastmap.rfind("lastmap=", 0) == 0)
-	{
-		lastmap = lastmap.substr(8);
-		argc--;
-	}
-	else
-		lastmap = "";
-
 	// [Russell] print out some useful info
 	if (argc == 1)
 	{
@@ -149,7 +140,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	C_HideConsole();
 
 	std::string wadstr = C_EscapeWadList(VectorArgs(argc, argv));
-	G_LoadWadString(wadstr, "", lastmap);
+	G_LoadWadString(wadstr);
 
 	D_StartTitle ();
 	CL_QuitNetGame(NQ_SILENT);

--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -149,7 +149,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	C_HideConsole();
 
 	std::string wadstr = C_EscapeWadList(VectorArgs(argc, argv));
-	G_LoadWadString(wadstr, lastmap);
+	G_LoadWadString(wadstr, "", lastmap);
 
 	D_StartTitle ();
 	CL_QuitNetGame(NQ_SILENT);

--- a/client/src/cl_maplist.cpp
+++ b/client/src/cl_maplist.cpp
@@ -381,21 +381,17 @@ void CMD_MaplistCallback(const maplist_qrows_t &result) {
 	size_t this_index = 0, next_index = 0;
 	bool show_this_map = MaplistCache::instance().get_this_index(this_index);
 	MaplistCache::instance().get_next_index(next_index);
-	for (maplist_qrows_t::const_iterator it = result.begin();it != result.end();++it) {
+	for (const auto& [index, entry] : result) {
+		const auto& [map, lastmap, wads] = *entry;
 		char flag = ' ';
-		if (show_this_map && it->first == this_index) {
+		if (show_this_map && index == this_index) {
 			flag = '*';
-		} else if (it->first == next_index) {
+		} else if (index == next_index) {
 			flag = '+';
 		}
-		if (it->second->lastmap.empty())
-			Printf(PRINT_HIGH, "%c%lu. %s %s\n", flag, it->first + 1,
-				   JoinStrings(it->second->wads, " ").c_str(),
-				   it->second->map.c_str());
-		else
-			Printf(PRINT_HIGH, "%c%lu. %s %s lastmap=%s\n", flag, it->first + 1,
-				   JoinStrings(it->second->wads, " ").c_str(),
-				   it->second->map.c_str(), it->second->lastmap.c_str());
+		Printf(PRINT_HIGH, "%c%lu. %s %s%s\n", flag, index + 1,
+			   JoinStrings(wads, " ").c_str(), map.c_str(),
+			   lastmap.empty() ? "" : fmt::sprintf(" lastmap=%s", lastmap));
 	}
 }
 

--- a/client/src/cl_maplist.cpp
+++ b/client/src/cl_maplist.cpp
@@ -388,9 +388,14 @@ void CMD_MaplistCallback(const maplist_qrows_t &result) {
 		} else if (it->first == next_index) {
 			flag = '+';
 		}
-		Printf(PRINT_HIGH, "%c%lu. %s %s\n", flag, it->first + 1,
-			   JoinStrings(it->second->wads, " ").c_str(),
-			   it->second->map.c_str());
+		if (it->second->lastmap.empty())
+			Printf(PRINT_HIGH, "%c%lu. %s %s\n", flag, it->first + 1,
+				   JoinStrings(it->second->wads, " ").c_str(),
+				   it->second->map.c_str());
+		else
+			Printf(PRINT_HIGH, "%c%lu. %s %s lastmap=%s\n", flag, it->first + 1,
+				   JoinStrings(it->second->wads, " ").c_str(),
+				   it->second->map.c_str(), it->second->lastmap.c_str());
 	}
 }
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1196,7 +1196,7 @@ static void CL_DamagePlayer(const odaproto::svc::DamagePlayer* msg)
 			p->health = 1;
 			p->mo->health = 1;
 		}
-		else 
+		else
 			p->health = 0;
 	}
 
@@ -2260,7 +2260,7 @@ static void CL_ResetMap(const odaproto::svc::ResetMap* msg)
 	P_DestroyScrollerThinkers();
 
 	P_DestroyLightThinkers();
-	
+
 	// You don't get to keep cards.  This isn't communicated anywhere else.
 	if (sv_gametype == GM_COOP)
 		P_ClearPlayerCards(consoleplayer());
@@ -2733,9 +2733,11 @@ static void CL_MaplistUpdate(const odaproto::svc::MaplistUpdate* msg)
 	{
 		const odaproto::svc::MaplistUpdate::Row& row = msg->maplist().Get(i);
 		const std::string& map = indexer.getString(row.map());
+		const std::string& lastmap = indexer.getString(row.lastmap());
 
 		maplist_entry_t maplist_entry;
 		maplist_entry.map = map;
+		maplist_entry.lastmap = lastmap;
 		for (int j = 0; j < row.wads_size(); j++)
 		{
 			const std::string& wad = indexer.getString(row.wads().Get(j));

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1044,7 +1044,7 @@ void M_DrawEpisode()
 	{
 		y -= (LINEHEIGHT * (episodenum - 4));
 	}
-
+		
 	screen->DrawPatchClean(W_CachePatch("M_EPISOD"), 54, y);
 }
 
@@ -1875,7 +1875,7 @@ bool M_Responder (event_t* ev)
 	if (ch == -1 || HU_ChatMode() != CHAT_INACTIVE)
 		return false;
 
-	// Transfer any action to the Options Menu Responder
+	// Transfer any action to the Options Menu Responder 
 	// if we're not on the main menu.
 	if (menuactive && OptionsActive) {
 		M_OptResponder (ev);
@@ -1909,7 +1909,7 @@ bool M_Responder (event_t* ev)
 				saveCharIndex--;
 				savegamestrings[saveSlot][saveCharIndex] = 0;
 			}
-		}
+		} 
 		else if (Key_IsCancelKey(ch))
 		{
 			genStringEnter = 0;
@@ -1923,8 +1923,8 @@ bool M_Responder (event_t* ev)
 			if (savegamestrings[saveSlot][0])
 				genStringEnd(saveSlot);	// [RH] Function to call when enter is pressed
 		}
-		else
-		{
+		else 
+		{ 
 			ch = ev->data3;	// [RH] Use user keymap
 			if (ch >= 32 && ch <= 127 &&
 				saveCharIndex < genStringLen &&
@@ -1943,8 +1943,8 @@ bool M_Responder (event_t* ev)
 	if (messageToPrint)
 	{
 		if (messageNeedsInput &&
-		    (!(ch2 == ' ' || Key_IsMenuKey(ch) || Key_IsYesKey(ch) || Key_IsNoKey(ch) ||
-			(isascii(ch2) && (toupper(ch2) == 'N' || toupper(ch2) == 'Y')))))
+		    (!(ch2 == ' ' || Key_IsMenuKey(ch) || Key_IsYesKey(ch) || Key_IsNoKey(ch) || 
+			(isascii(ch2) && (toupper(ch2) == 'N' || toupper(ch2) == 'Y'))))) 
 			return true;
 
 		menuactive = messageLastMenuActive;

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1044,7 +1044,7 @@ void M_DrawEpisode()
 	{
 		y -= (LINEHEIGHT * (episodenum - 4));
 	}
-		
+
 	screen->DrawPatchClean(W_CachePatch("M_EPISOD"), 54, y);
 }
 
@@ -1074,7 +1074,7 @@ void M_StartGame(int choice)
         {
             // Load No Rest for The Living Externally
             epi = 0;
-            G_LoadWadString(str, "");
+            G_LoadWadString(str);
         }
         else
         {
@@ -1083,7 +1083,7 @@ void M_StartGame(int choice)
             {
                 if (iequals(str, wadfiles[i].getBasename()))
                 {
-                    G_LoadWadString(wadfiles[1].getFullpath(), "");
+                    G_LoadWadString(wadfiles[1].getFullpath());
                 }
             }
 
@@ -1875,7 +1875,7 @@ bool M_Responder (event_t* ev)
 	if (ch == -1 || HU_ChatMode() != CHAT_INACTIVE)
 		return false;
 
-	// Transfer any action to the Options Menu Responder 
+	// Transfer any action to the Options Menu Responder
 	// if we're not on the main menu.
 	if (menuactive && OptionsActive) {
 		M_OptResponder (ev);
@@ -1909,7 +1909,7 @@ bool M_Responder (event_t* ev)
 				saveCharIndex--;
 				savegamestrings[saveSlot][saveCharIndex] = 0;
 			}
-		} 
+		}
 		else if (Key_IsCancelKey(ch))
 		{
 			genStringEnter = 0;
@@ -1923,8 +1923,8 @@ bool M_Responder (event_t* ev)
 			if (savegamestrings[saveSlot][0])
 				genStringEnd(saveSlot);	// [RH] Function to call when enter is pressed
 		}
-		else 
-		{ 
+		else
+		{
 			ch = ev->data3;	// [RH] Use user keymap
 			if (ch >= 32 && ch <= 127 &&
 				saveCharIndex < genStringLen &&
@@ -1943,8 +1943,8 @@ bool M_Responder (event_t* ev)
 	if (messageToPrint)
 	{
 		if (messageNeedsInput &&
-		    (!(ch2 == ' ' || Key_IsMenuKey(ch) || Key_IsYesKey(ch) || Key_IsNoKey(ch) || 
-			(isascii(ch2) && (toupper(ch2) == 'N' || toupper(ch2) == 'Y'))))) 
+		    (!(ch2 == ' ' || Key_IsMenuKey(ch) || Key_IsYesKey(ch) || Key_IsNoKey(ch) ||
+			(isascii(ch2) && (toupper(ch2) == 'N' || toupper(ch2) == 'Y')))))
 			return true;
 
 		menuactive = messageLastMenuActive;

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -402,7 +402,7 @@ const char *ParseString2(const char *data);
 // Takes a string of random wads and patches, which is sorted through and
 // trampolined to the implementation of G_LoadWad.
 //
-bool G_LoadWadString(const std::string& str, const std::string& lastmap, const std::string& mapname)
+bool G_LoadWadString(const std::string& str, const std::string& mapname, const std::string& lastmap)
 {
 	const std::vector<std::string>& wad_exts = M_FileTypeExts(OFILE_WAD);
 	const std::vector<std::string>& deh_exts = M_FileTypeExts(OFILE_DEH);

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -465,7 +465,7 @@ void P_RemoveDefereds();
 
 bool G_LoadWad(const OWantFiles& newwadfiles, const OWantFiles& newpatchfiles,
                const std::string& mapname = "");
-bool G_LoadWadString(const std::string& str, const std::string& lastmap, const std::string& mapname = "");
+bool G_LoadWadString(const std::string& str, const std::string& mapname = "", const std::string& lastmap = "");
 
 LevelInfos& getLevelInfos();
 ClusterInfos& getClusterInfos();

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1511,6 +1511,10 @@ odaproto::svc::MaplistUpdate SVC_MaplistUpdate(const maplist_status_t status,
 			const uint32_t mapidx = indexer.getIndex(map);
 			row->set_map(mapidx);
 
+			const std::string& lastmap = it->second->lastmap;
+			const uint32_t lastmapidx = indexer.getIndex(lastmap);
+			row->set_lastmap(lastmapidx);
+
 			for (std::vector<std::string>::iterator itr = it->second->wads.begin();
 			     itr != it->second->wads.end(); ++itr)
 			{

--- a/config-samples/coop-doom.cfg
+++ b/config-samples/coop-doom.cfg
@@ -61,7 +61,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/coop-masterlevels.cfg
+++ b/config-samples/coop-masterlevels.cfg
@@ -66,7 +66,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/coop-modern.cfg
+++ b/config-samples/coop-modern.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/coop-zdoom.cfg
+++ b/config-samples/coop-zdoom.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/ctf-attackdefend.cfg
+++ b/config-samples/ctf-attackdefend.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/ctf-doom.cfg
+++ b/config-samples/ctf-doom.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/ctf-pub.cfg
+++ b/config-samples/ctf-pub.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/ctf-wdl.cfg
+++ b/config-samples/ctf-wdl.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/dm-doom.cfg
+++ b/config-samples/dm-doom.cfg
@@ -57,7 +57,6 @@ set sv_weaponstay "1"
 // --- Single Player/Coop ---
 
 set sv_fastmonsters "0"
-set sv_loopepisode "0"
 set sv_monstersrespawn "0"
 set sv_nomonsters "1"
 set sv_sharekeys "0"

--- a/config-samples/dm-modern.cfg
+++ b/config-samples/dm-modern.cfg
@@ -57,7 +57,6 @@ set sv_weaponstay "1"
 // --- Single Player/Coop ---
 
 set sv_fastmonsters "0"
-set sv_loopepisode "0"
 set sv_monstersrespawn "0"
 set sv_nomonsters "1"
 set sv_sharekeys "0"

--- a/config-samples/dm-zdoom.cfg
+++ b/config-samples/dm-zdoom.cfg
@@ -57,7 +57,6 @@ set sv_weaponstay "1"
 // --- Single Player/Coop ---
 
 set sv_fastmonsters "0"
-set sv_loopepisode "0"
 set sv_monstersrespawn "0"
 set sv_nomonsters "1"
 set sv_sharekeys "0"

--- a/config-samples/duel-altdeath.cfg
+++ b/config-samples/duel-altdeath.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "0"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/duel-ddl.cfg
+++ b/config-samples/duel-ddl.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/duel-doom.cfg
+++ b/config-samples/duel-doom.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/duel-zddl.cfg
+++ b/config-samples/duel-zddl.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/duel-zdoom.cfg
+++ b/config-samples/duel-zdoom.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/horde-doom.cfg
+++ b/config-samples/horde-doom.cfg
@@ -64,7 +64,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/horde-modern.cfg
+++ b/config-samples/horde-modern.cfg
@@ -62,7 +62,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/horde-zdoom.cfg
+++ b/config-samples/horde-zdoom.cfg
@@ -63,7 +63,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/lms-2team.cfg
+++ b/config-samples/lms-2team.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/lms-3team.cfg
+++ b/config-samples/lms-3team.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/lms-ffa.cfg
+++ b/config-samples/lms-ffa.cfg
@@ -57,7 +57,6 @@ set sv_weaponstay "1"
 // --- Single Player/Coop ---
 
 set sv_fastmonsters "0"
-set sv_loopepisode "0"
 set sv_monstersrespawn "0"
 set sv_nomonsters "1"
 set sv_sharekeys "0"

--- a/config-samples/survival-modern.cfg
+++ b/config-samples/survival-modern.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/tdm-doom.cfg
+++ b/config-samples/tdm-doom.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/tdm-modern.cfg
+++ b/config-samples/tdm-modern.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/config-samples/tdm-zdoom.cfg
+++ b/config-samples/tdm-zdoom.cfg
@@ -59,7 +59,6 @@ set sv_weaponstay "1"
 
 set sv_fastmonsters "0"
 set sv_keepkeys "0"
-set sv_loopepisode "0"
 set sv_monsterdamage "1.0"
 set sv_monstershealth "1.0"
 set sv_monstersrespawn "0"

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -92,12 +92,12 @@ message LoadMap
 	{
 		string name = 1;
 		string hash = 2;
-	}	
+	}
 
 	repeated Resource wadnames = 1;
 	repeated Resource patchnames = 2;
 	string mapname = 3;
-	int32 time = 4;	
+	int32 time = 4;
 }
 
 // svc_consoleplayer
@@ -349,7 +349,7 @@ message Say
 {
 	bool visibility = 1;
 	int32 pid = 2;
-	string message = 3;	
+	string message = 3;
 }
 
 // svc_ctfrefresh
@@ -455,7 +455,7 @@ message ResetMap
 message PlayerQueuePos
 {
 	int32 pid = 1;
-	int32 queuepos = 2;	
+	int32 queuepos = 2;
 }
 
 // svc_fullupdatestart
@@ -551,14 +551,14 @@ message ThinkerUpdate
 	{
 		int32 sector = 1;
 		int32 min_light = 2;
-		int32 max_light = 3;	
+		int32 max_light = 3;
 	}
 
 	message LightFlash
 	{
 		int32 sector = 1;
 		int32 min_light = 2;
-		int32 max_light = 3;	
+		int32 max_light = 3;
 	}
 
 	message Strobe
@@ -630,7 +630,8 @@ message MaplistUpdate
 	message Row
 	{
 		uint32 map = 1;
-		repeated uint32 wads = 2;
+		uint32 lastmap = 2;
+		repeated uint32 wads = 3;
 	}
 
 	int32 status = 1;

--- a/server/src/sv_cvarlist.cpp
+++ b/server/src/sv_cvarlist.cpp
@@ -101,9 +101,6 @@ CVAR(			sv_loopepisode, "0", "Determines whether Doom 1 episodes carry over",
 CVAR_FUNC_DECL(	sv_shufflemaplist, "0", "Randomly shuffle the maplist",
 				CVARTYPE_BOOL, CVAR_SERVERARCHIVE)
 
-CVAR(			sv_mapliststayonwad, "0", "Stay on the current wad when changing maps, proceed to next maplist entry when the wad is finished",
-				CVARTYPE_BOOL, CVAR_SERVERARCHIVE)
-
 // Network settings
 // ----------------
 

--- a/server/src/sv_cvarlist.cpp
+++ b/server/src/sv_cvarlist.cpp
@@ -95,9 +95,6 @@ CVAR(			sv_curmap, "", "Set to the last played map",
 CVAR(			sv_nextmap, "", "Set to the next map to be played",
 				CVARTYPE_STRING, CVAR_NOSET | CVAR_NOENABLEDISABLE)
 
-CVAR(			sv_loopepisode, "0", "Determines whether Doom 1 episodes carry over",
-				CVARTYPE_BOOL, CVAR_SERVERARCHIVE)
-
 CVAR_FUNC_DECL(	sv_shufflemaplist, "0", "Randomly shuffle the maplist",
 				CVARTYPE_BOOL, CVAR_SERVERARCHIVE)
 

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -204,9 +204,9 @@ std::string G_NextMap()
 {
 	std::string next = level.nextmap.c_str();
 
-	if (gamestate == GS_STARTUP || sv_gametype != GM_COOP || next.empty())
+	if (gamestate == GS_STARTUP || (sv_gametype != GM_COOP && forcedlastmap.empty()) || next.empty())
 	{
-		// if not coop, stay on same level
+		// if not coop, and lastmap is not specified, stay on same level
 		// [ML] 1/25/10: OR if next is empty
 		next = level.mapname.c_str();
 	}

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -204,9 +204,10 @@ std::string G_NextMap()
 {
 	std::string next = level.nextmap.c_str();
 
-	if (gamestate == GS_STARTUP || next.empty())
+	if (gamestate == GS_STARTUP || sv_gametype != GM_COOP || next.empty())
 	{
-		// [ML] 1/25/10: if next is empty, stay on same level
+		// if not coop, stay on same level
+		// [ML] 1/25/10: OR if next is empty
 		next = level.mapname.c_str();
 	}
 	else if (secretexit && W_CheckNumForName(level.secretmap.c_str()) != -1)

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -70,7 +70,6 @@ EXTERN_CVAR (sv_endmapscript)
 EXTERN_CVAR (sv_startmapscript)
 EXTERN_CVAR (sv_curmap)
 EXTERN_CVAR (sv_nextmap)
-EXTERN_CVAR (sv_loopepisode)
 EXTERN_CVAR (sv_intermissionlimit)
 EXTERN_CVAR (sv_warmup)
 EXTERN_CVAR (sv_timelimit)
@@ -203,7 +202,7 @@ bool isLastMap()
 	if (iequals(next.substr(0, 7), "EndGame") ||
 			(gamemode == retail_chex && iequals(level.nextmap.c_str(), "E1M6")))
 	{
-		if (sv_loopepisode || gameinfo.flags & GI_MAPxx || gamemode == shareware ||
+		if (gameinfo.flags & GI_MAPxx || gamemode == shareware ||
 				((gamemode == registered && level.cluster == 3) ||
 				 ((gameinfo.flags & GI_MENUHACK_RETAIL) && level.cluster == 4)))
 			return true;
@@ -235,15 +234,11 @@ std::string G_NextMap()
 			(gamemode == retail_chex && iequals(level.nextmap.c_str(), "E1M6")))
 	{
 		if (gameinfo.flags & GI_MAPxx || gamemode == shareware ||
-			(!sv_loopepisode && (level.nextmap == "" || level.mapname == forcedlastmap)) ||
-			(!sv_loopepisode && ((gamemode == registered && level.cluster == 3) ||
+			((level.nextmap == "" || level.mapname == forcedlastmap)) ||
+			(((gamemode == registered && level.cluster == 3) ||
 			((gameinfo.flags & GI_MENUHACK_RETAIL) && level.cluster == 4))))
 		{
 			next = CalcMapName(1, 1);
-		}
-		else if (sv_loopepisode)
-		{
-			next = CalcMapName(level.cluster, 1);
 		}
 		else
 		{
@@ -275,7 +270,7 @@ void G_ChangeMap()
 		else
 		{
 			size_t next_index;
-			if (!isLastMap() || !Maplist::instance().get_next_index(next_index))
+			if ((!forcedlastmap.empty() && !isLastMap()) || !Maplist::instance().get_next_index(next_index))
 			{
 				// We don't have a maplist, so grab the next 'natural' map lump.
 				std::string next = G_NextMap();

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -196,20 +196,7 @@ EXTERN_CVAR(sv_shufflemaplist)
 
 bool isLastMap()
 {
-	if (level.nextmap == "" || level.mapname == forcedlastmap)
-		return true;
-
-	std::string next = level.nextmap.c_str();
-	if (iequals(next.substr(0, 7), "EndGame") ||
-			(gamemode == retail_chex && iequals(level.nextmap.c_str(), "E1M6")))
-	{
-		if (gameinfo.flags & GI_MAPxx || gamemode == shareware ||
-				((gamemode == registered && level.cluster == 3) ||
-				 ((gameinfo.flags & GI_MENUHACK_RETAIL) && level.cluster == 4)))
-			return true;
-	}
-
-	return false;
+	return level.nextmap == "" || level.mapname == forcedlastmap;
 }
 
 // Returns the next map, assuming there is no maplist.
@@ -230,12 +217,10 @@ std::string G_NextMap()
 
 	// NES - exiting a Doom 1 episode moves to the next episode,
 	// rather than always going back to E1M1
-	if (level.nextmap == "" || level.mapname == forcedlastmap ||
-			iequals(next.substr(0, 7), "EndGame") ||
-			(gamemode == retail_chex && iequals(level.nextmap.c_str(), "E1M6")))
+	if (iequals(next.substr(0, 7), "EndGame") ||
+	    (gamemode == retail_chex && iequals(level.nextmap.c_str(), "E1M6")))
 	{
 		if (gameinfo.flags & GI_MAPxx || gamemode == shareware ||
-			((level.nextmap == "" || level.mapname == forcedlastmap)) ||
 			(((gamemode == registered && level.cluster == 3) ||
 			((gameinfo.flags & GI_MENUHACK_RETAIL) && level.cluster == 4))))
 		{

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -76,7 +76,6 @@ EXTERN_CVAR (sv_warmup)
 EXTERN_CVAR (sv_timelimit)
 EXTERN_CVAR (sv_teamsinplay)
 EXTERN_CVAR(g_resetinvonexit)
-EXTERN_CVAR(sv_mapliststayonwad)
 
 extern int mapchange;
 extern std::string forcedlastmap;
@@ -187,7 +186,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	}
 
 	std::string wadstr = C_EscapeWadList(VectorArgs(argc, argv));
-	G_LoadWadString(wadstr, lastmap);
+	G_LoadWadString(wadstr, "", lastmap);
 }
 END_COMMAND (wad)
 
@@ -271,12 +270,12 @@ void G_ChangeMap()
 		if (!Maplist::instance().lobbyempty())
 		{
 			std::string wadstr = C_EscapeWadList(lobby_entry.wads);
-			G_LoadWadString(wadstr, "", lobby_entry.map);
+			G_LoadWadString(wadstr, lobby_entry.map);
 		}
 		else
 		{
 			size_t next_index;
-			if ((sv_mapliststayonwad && !isLastMap()) || !Maplist::instance().get_next_index(next_index))
+			if (!isLastMap() || !Maplist::instance().get_next_index(next_index))
 			{
 				// We don't have a maplist, so grab the next 'natural' map lump.
 				std::string next = G_NextMap();
@@ -288,7 +287,7 @@ void G_ChangeMap()
 				Maplist::instance().get_map_by_index(next_index, maplist_entry);
 
 				std::string wadstr = C_EscapeWadList(maplist_entry.wads);
-				G_LoadWadString(wadstr, maplist_entry.lastmap, maplist_entry.map);
+				G_LoadWadString(wadstr, maplist_entry.map, maplist_entry.lastmap);
 
 				// Set the new map as the current map
 				Maplist::instance().set_index(next_index);
@@ -314,7 +313,7 @@ void G_ChangeMap(size_t index) {
 	}
 
 	std::string wadstr = C_EscapeWadList(maplist_entry.wads);
-	G_LoadWadString(wadstr, maplist_entry.lastmap, maplist_entry.map);
+	G_LoadWadString(wadstr, maplist_entry.map, maplist_entry.lastmap);
 
 	// Set the new map as the current map
 	Maplist::instance().set_index(index);

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4239,7 +4239,7 @@ void SV_RunTics()
 		if (!Maplist::instance().lobbyempty())
 		{
 			std::string wadstr = C_EscapeWadList(lobby_entry.wads);
-			G_LoadWadString(wadstr, "", lobby_entry.map);
+			G_LoadWadString(wadstr, lobby_entry.map);
 		}
 		else
 		{

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -130,6 +130,7 @@ bool Maplist::insert(const size_t &position, maplist_entry_t &maplist_entry) {
 
 	// capitalize the map names
 	maplist_entry.map = StdStringToUpper(maplist_entry.map);
+	maplist_entry.lastmap = StdStringToUpper(maplist_entry.lastmap);
 
 	// Puts the map into its proper place
 	this->maplist.insert(this->maplist.begin() + position, maplist_entry);
@@ -661,9 +662,14 @@ BEGIN_COMMAND (maplist) {
 		} else if (it->first == next_index) {
 			flag = '+';
 		}
-		Printf(PRINT_HIGH, "%c%lu. %s %s\n", flag, it->first + 1,
-			   JoinStrings(it->second->wads, " ").c_str(),
-			   it->second->map.c_str());
+		if (it->second->lastmap.empty())
+			Printf(PRINT_HIGH, "%c%lu. %s %s\n", flag, it->first + 1,
+				   JoinStrings(it->second->wads, " ").c_str(),
+				   it->second->map.c_str());
+		else
+			Printf(PRINT_HIGH, "%c%lu. %s %s lastmap=%s\n", flag, it->first + 1,
+				   JoinStrings(it->second->wads, " ").c_str(),
+				   it->second->map.c_str(), it->second->lastmap.c_str());
 	}
 } END_COMMAND (maplist)
 

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -655,22 +655,17 @@ BEGIN_COMMAND (maplist) {
 	size_t this_index, next_index;
 	bool show_this_map = Maplist::instance().get_this_index(this_index);
 	Maplist::instance().get_next_index(next_index);
-	for (std::vector<std::pair<size_t, maplist_entry_t*> >::iterator it = result.begin();
-		 it != result.end();++it) {
+	for (const auto& [index, entry] : result) {
+		const auto& [map, lastmap, wads] = *entry;
 		char flag = ' ';
-		if (show_this_map && it->first == this_index) {
+		if (show_this_map && index == this_index) {
 			flag = '*';
-		} else if (it->first == next_index) {
+		} else if (index == next_index) {
 			flag = '+';
 		}
-		if (it->second->lastmap.empty())
-			Printf(PRINT_HIGH, "%c%lu. %s %s\n", flag, it->first + 1,
-				   JoinStrings(it->second->wads, " ").c_str(),
-				   it->second->map.c_str());
-		else
-			Printf(PRINT_HIGH, "%c%lu. %s %s lastmap=%s\n", flag, it->first + 1,
-				   JoinStrings(it->second->wads, " ").c_str(),
-				   it->second->map.c_str(), it->second->lastmap.c_str());
+		Printf(PRINT_HIGH, "%c%lu. %s %s%s\n", flag, index + 1,
+			   JoinStrings(wads, " ").c_str(), map.c_str(),
+			   lastmap.empty() ? "" : fmt::sprintf(" lastmap=%s", lastmap));
 	}
 } END_COMMAND (maplist)
 


### PR DESCRIPTION
This is based on @loopfz's work in #899. `sv_mapliststayonwad` has been removed. Instead, it's behavior is triggered by the presence of the `lastmap` argument to the `wad`, `addmap`, and `insertmap` commands. This means that explicitly setting the lastmap is required when that behavior is desired. Additionally, `sv_loopepisode` has been removed, as it is incompatible with UMAPINFO's implementation of episodes, and this allows for more flexibility.