### PR TITLE
[BUGFIX] Integer overflow when drawing the automap at high resolutions

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -405,11 +405,11 @@ void AM_findMinMaxBoundaries()
 	const fixed64_t max_w = max.x - min.x;
 	const fixed64_t max_h = max.y - min.y;
 
-	const fixed64_t a = FixedDiv64((I_GetSurfaceWidth()) << FRACBITS64, max_w);
-	const fixed64_t b = FixedDiv64((I_GetSurfaceHeight()) << FRACBITS64, max_h);
+	const fixed64_t a = FixedDiv64(static_cast<int64_t>(I_GetSurfaceWidth()) << FRACBITS64, max_w);
+	const fixed64_t b = FixedDiv64(static_cast<int64_t>(I_GetSurfaceHeight()) << FRACBITS64, max_h);
 
 	min_scale_mtof = a < b ? a : b;
-	max_scale_mtof = FixedDiv64((I_GetSurfaceHeight()) << FRACBITS64, 2 * PLAYERRADIUS64);
+	max_scale_mtof = FixedDiv64(static_cast<int64_t>(I_GetSurfaceHeight()) << FRACBITS64, 2 * PLAYERRADIUS64);
 }
 
 //

--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -161,7 +161,7 @@ EXTERN_CVAR(screenblocks)
 #define M_ZOOMOUT ((int)(FRACUNIT64 / 1.02))
 
 // translates between frame-buffer and map distances
-#define FTOM(x) FixedMul64(((x) << FRACBITS64), scale_ftom)
+#define FTOM(x) FixedMul64((INT2FIXED64((x))), scale_ftom)
 #define MTOF(x) FIXED642INT(FixedMul64((x), scale_mtof))
 
 #define PUTDOTP(xx, yy, cc) fb[(yy)*f_p + (xx)] = (cc)
@@ -364,7 +364,7 @@ void AM_restoreScaleAndLoc()
 	M_AddVec2Fixed64(&m_ur, &m_ll, &m_wh);
 
 	// Change the scaling multipliers
-	scale_mtof = FixedDiv64(f_w << FRACBITS64, m_wh.x);
+	scale_mtof = FixedDiv64(INT2FIXED64(f_w), m_wh.x);
 	scale_ftom = FixedDiv64(FRACUNIT64, scale_mtof);
 }
 

--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -405,11 +405,11 @@ void AM_findMinMaxBoundaries()
 	const fixed64_t max_w = max.x - min.x;
 	const fixed64_t max_h = max.y - min.y;
 
-	const fixed64_t a = FixedDiv64(static_cast<int64_t>(I_GetSurfaceWidth()) << FRACBITS64, max_w);
-	const fixed64_t b = FixedDiv64(static_cast<int64_t>(I_GetSurfaceHeight()) << FRACBITS64, max_h);
+	const fixed64_t a = FixedDiv64(INT2FIXED64(I_GetSurfaceWidth()), max_w);
+	const fixed64_t b = FixedDiv64(INT2FIXED64(I_GetSurfaceHeight()), max_h);
 
 	min_scale_mtof = a < b ? a : b;
-	max_scale_mtof = FixedDiv64(static_cast<int64_t>(I_GetSurfaceHeight()) << FRACBITS64, 2 * PLAYERRADIUS64);
+	max_scale_mtof = FixedDiv64(INT2FIXED64(I_GetSurfaceHeight()), 2 * PLAYERRADIUS64);
 }
 
 //

--- a/common/m_fixed.h
+++ b/common/m_fixed.h
@@ -105,7 +105,7 @@ inline int FIXED642INT(fixed64_t x)
 	return ((int32_t)FRAC64FILL(x >> FRACBITS64, x));
 }
 
-inline fixed_t INT2FIXED64(int x)
+inline fixed64_t INT2FIXED64(int64_t x)
 {
 	return x << FRACBITS64;
 }


### PR DESCRIPTION
The change to 64 bit numbers for the automap resulted in some larger left shifts, which when applied to the screen dimensions, lost some important bits on 32 bit values. Now they are cast to int64_t before shifting. This also fixes a bug with INT2FIXED64, which was returning a 32 bit value.