### PR TITLE
[BUGFIX] Dim the help screen's transparent sides

### DIFF
--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -999,6 +999,9 @@ void DCanvas::DrawPatchFullScreen(const patch_t* patch, bool clear) const
 	int x = (surface_width - destw) / 2;
 	int y = (surface_height - desth) / 2;
 
+	// Dim everything before drawing the patch.
+	mSurface->getDefaultCanvas()->Dim(0, 0, I_GetVideoWidth(), I_GetVideoHeight());
+
 	DrawPatchStretched(patch, x, y, destw, desth);
 }
 


### PR DESCRIPTION
This is a simple change that I forgot to do when doing widescreen. I made the fullscreen patch drawer not clear whats on the screen, but I forgot to readd the black bars on the help screen. Instead, I added a dim, which I think looks cooler.

![image](https://github.com/user-attachments/assets/98a762d4-3b64-400d-a8cb-96ca38f1ad1f)

More noticeable on transparent help screens:

![image](https://github.com/user-attachments/assets/bc14b06e-6c75-4c00-bebe-3bc03a364bf2)
