### PR TITLE
[BUGFIX] Draw CWILV graphic from top of screen if its height it 200 (or greater)

### DIFF
--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -601,7 +601,8 @@ void WI_drawEL()
 	screen->DrawPatchClean(ent, (320 - ent->width()) / 2, y);
 
 	// [RH] Changed to adjust by height of entering patch instead of title
-	y += (5 * ent->height()) / 4;
+	if (lnames1->height() < 200)
+		y += (5 * ent->height()) / 4;
 
 	if (!lnames[1].empty())
 	{


### PR DESCRIPTION
Addresses #1067
This is consistent with the behavior of Woof.