### PR TITLE
[BUGFIX] Add offsets to DrawPatch so intermission screens with offsets can be drawn correctly

### DIFF
--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -568,7 +568,7 @@ void WI_drawLF()
 		// draw <LevelName>
 		patch_t* lnames0 = W_ResolvePatchHandle(lnames[0]);
 		screen->DrawPatchClean(lnames0, (320 - lnames0->width()) / 2, y);
-			y += (5 * lnames0->height()) / 4;
+		y += (5 * lnames0->height()) / 4;
 	}
 	else
 	{

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -568,7 +568,7 @@ void WI_drawLF()
 		// draw <LevelName>
 		patch_t* lnames0 = W_ResolvePatchHandle(lnames[0]);
 		screen->DrawPatchClean(lnames0, (320 - lnames0->width()) / 2, y);
-		y += (5 * lnames0->height()) / 4;
+			y += (5 * lnames0->height()) / 4;
 	}
 	else
 	{
@@ -1394,7 +1394,7 @@ void WI_loadData()
 	const DCanvas* canvas = background_surface->getDefaultCanvas();
 
 	background_surface->lock();
-	canvas->DrawPatch(bg_patch, 0, 0);
+	canvas->DrawPatch(bg_patch, bg_patch->leftoffset(), bg_patch->topoffset());
 	background_surface->unlock();
 
 	for (int i = 0, j; i < 2; i++)


### PR DESCRIPTION
Addresses #1094 
![image](https://github.com/user-attachments/assets/e2c8d225-782e-4afe-8812-8302728beba7)
