### PR TITLE
[BUGFIX] Don't draw lives counter in single-player or non-lives games.

### DIFF
--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1017,7 +1017,7 @@ void ST_drawWidgets(bool force_refresh)
 		w_frags.update(force_refresh);
 	}
 
-	w_lives.update(true, G_IsLivesGame()); // Force refreshing to avoid tens
+	w_lives.update(true, !G_IsLivesGame()); // Force refreshing to avoid tens
 	                                       // to be hidden by Doomguy's face
 }
 


### PR DESCRIPTION
Sometimes the lives counter will be shown in the status bar next to doomguy's face when it's not supposed to, such as in single-player or in game modes that don't have lives. This is fixed.