### PR TITLE
[BUGFIX] Fix update to cl_downloadsites when upgrading a config

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -346,7 +346,9 @@ CVAR(cl_downloadsites,
      "https://static.allfearthesentinel.com/wads/ https://doomshack.org/wads/ "
      "http://grandpachuck.org/files/wads/ https://wads.doomleague.org/ "
      "http://files.funcrusher.net/wads/ https://doomshack.org/uploads/ "
-     "https://doom.dogsoft.net/getwad.php?search=",
+     "https://doom.dogsoft.net/getwad.php?search= https://doomshack.org/wadlist.php "
+     "https://wads.firestick.games/ https://euroboros.net/zandronum/wads/ "
+     "https://static.audrealms.org/wads/ https://downloadbox.captainpollutiontv.de/DooM/WADSEEKER/",
      "A list of websites to download WAD files from.  These websites are used if the "
      "server doesn't provide any websites to download files from, or the file can't be "
      "found on any of their sites.  The list of sites is separated by spaces.  These "

--- a/client/src/m_misc.cpp
+++ b/client/src/m_misc.cpp
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -161,7 +161,7 @@ void M_LoadDefaults(void)
 		// dead or so intermittent that it slows down WAD downloading.
 
 		const char* cl_download_old =
-		    "https://static.allfearthesentinel.com/wads/ https://doomshack.org/wads/ "
+		    "https://static.allfearthesentinel.net/wads/ https://doomshack.org/wads/ "
 		    "http://grandpachuck.org/files/wads/ http://ts.chaosunleashed.net/ "
 		    "https://wads.doomleague.org/ http://files.funcrusher.net/wads/";
 
@@ -176,9 +176,25 @@ void M_LoadDefaults(void)
 		// Add new defaults - dogsoft and doomshack's upload dir.
 
 		const char* cl_download_old =
-		    "https://static.allfearthesentinel.com/wads/ https://doomshack.org/wads/ "
+		    "https://static.allfearthesentinel.net/wads/ https://doomshack.org/wads/ "
 		    "http://grandpachuck.org/files/wads/ https://wads.doomleague.org/ "
 		    "http://files.funcrusher.net/wads/";
+
+		if (!strcmp(::cl_downloadsites.cstring(), cl_download_old))
+		{
+			updated = true;
+			::cl_downloadsites.RestoreDefault();
+		}
+	}
+	else if (::configver > 93 && ::configver <= 10060)
+	{
+		// Update the TSPG url from .net to .com.
+
+		const char* cl_download_old =
+		    "https://static.allfearthesentinel.net/wads/ https://doomshack.org/wads/ "
+    	    "http://grandpachuck.org/files/wads/ https://wads.doomleague.org/ "
+		    "http://files.funcrusher.net/wads/ https://doomshack.org/uploads/ "
+		    "https://doom.dogsoft.net/getwad.php?search=";
 
 		if (!strcmp(::cl_downloadsites.cstring(), cl_download_old))
 		{
@@ -199,7 +215,7 @@ void M_LoadDefaults(void)
 	if (updated)
 		Printf("%s: Updating old defaults.\n", __FUNCTION__);
 
-	AddCommandString("alias ? help");	
+	AddCommandString("alias ? help");
 
 	DefaultsLoaded = true;
 }

--- a/client/src/m_misc.cpp
+++ b/client/src/m_misc.cpp
@@ -188,6 +188,7 @@ void M_LoadDefaults(void)
 	}
 	else if (::configver > 93 && ::configver <= 10060)
 	{
+		// Add new defaults - doomshack's wadlist dir, firestick, euroboros, audrealms, and captainpollutiontv.
 		// Update the TSPG url from .net to .com.
 
 		const char* cl_download_old =


### PR DESCRIPTION
#1080 broke the functionality to update the value of `cl_downloadsites` when upgrading to a new Odamex version. This has been fixed, as well as properly added the ability for the TSPG url to be updated.