### PR TITLE
A few minor fixes and changes

### DIFF
--- a/client/sdl/i_main.cpp
+++ b/client/sdl/i_main.cpp
@@ -49,7 +49,7 @@
 #include <stack>
 #include <iostream>
 
-#include "i_sdl.h" 
+#include "i_sdl.h"
 #include "i_crash.h"
 // [Russell] - Don't need SDLmain library
 #ifdef _WIN32
@@ -107,7 +107,7 @@ void STACK_ARGS nx_early_deinit (void)
 #endif
 
 
-#if defined GCONSOLE && !defined __SWITCH__ 
+#if defined GCONSOLE && !defined __SWITCH__
 int I_Main(int argc, char *argv[])
 #else
 int main(int argc, char *argv[])
@@ -219,16 +219,6 @@ int main(int argc, char *argv[])
         	putenv((char*)"SDL_VIDEODRIVER=directx");
 	#endif	// SDL12
 
-	
-	#if defined(SDL20)
-        // FIXME: Remove this when SDL gets it shit together, see 
-        // https://bugzilla.libsdl.org/show_bug.cgi?id=2089
-        // ...
-        // Disable thread naming on windows, with SDL 2.0.5 and GDB > 7.8.1
-        // RaiseException will be thrown and will crash under the debugger with symbols
-        // loaded or not
-        SDL_SetHint(SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING, "1");
-	#endif // SDL20
 
         // Set the process affinity mask to 1 on Windows, so that all threads
         // run on the same processor.  This is a workaround for a bug in

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -26,7 +26,7 @@
 
 #include "odamex.h"
 
-#include "i_sdl.h" 
+#include "i_sdl.h"
 #include <SDL_mixer.h>
 #include <stdlib.h>
 
@@ -67,13 +67,13 @@ CVAR_FUNC_IMPL(snd_samplerate)
 
 /**
  * @brief Write out a WAV file containing sound data.
- * 
+ *
  * @detail This is an internal debugging function that should be ifdef'ed out
  *         when not in use.
- * 
+ *
  * @param filename Output filename.
  * @param data Data to write.
- * @param length Total length of data to write. 
+ * @param length Total length of data to write.
  * @param samplerate Samplerate to put in the header.
  */
 static void WriteWAV(char* filename, byte* data, uint32_t length, int samplerate)
@@ -175,9 +175,8 @@ static void ExpandSoundData(byte* data, int samplerate, int bits, int length,
 	for (size_t i = 0; i < expanded_length; ++i)
 	{
 		Sint16 sample;
-		int src;
 
-		src = (i * expand_ratio) >> 8;
+		const size_t src = (i * expand_ratio) >> 8;
 
 		// [crispy] Handle 16 bit audio data
 		if (bits == 16)
@@ -313,7 +312,7 @@ static void getsfx(sfxinfo_struct *sfx)
     // Double up twice: 8 -> 16 bit and mono -> stereo
 
     expanded_length *= 4;
-	
+
 	chunk = (Mix_Chunk *)Z_Malloc(sizeof(Mix_Chunk), PU_STATIC, NULL);
     chunk->allocated = 1;
     chunk->alen = expanded_length;
@@ -322,7 +321,7 @@ static void getsfx(sfxinfo_struct *sfx)
 
     ExpandSoundData((byte*)data + 8, samplerate, 8, length, chunk);
     sfx->data = chunk;
-    
+
     Z_ChangeTag(data, PU_CACHE);
 }
 
@@ -356,7 +355,7 @@ int I_StartSound(int id, float vol, int sep, int pitch, bool loop)
 		return -1;
 
 	Mix_Chunk *chunk = (Mix_Chunk *)S_sfx[id].data;
-	
+
 	// find a free channel, starting from the first after
 	// the last channel we used
 	int channel = nextchannel;
@@ -433,7 +432,7 @@ void I_LoadSound (sfxinfo_struct *sfx)
 {
 	if (!sound_initialized)
 		return;
-	
+
 	if (!sfx->data)
 	{
 		DPrintf ("loading sound \"%s\" (%d)\n", sfx->name, sfx->lumpnum);
@@ -445,13 +444,13 @@ void I_InitSound()
 {
 	if (I_IsHeadless() || Args.CheckParm("-nosound"))
 		return;
-		
+
     #if defined(SDL12)
     const char *driver = getenv("SDL_AUDIODRIVER");
 
 	if(!driver)
 		driver = "default";
-		
+
     Printf(PRINT_HIGH, "I_InitSound: Initializing SDL's sound subsystem (%s)\n", driver);
     #elif defined(SDL20)
     Printf("I_InitSound: Initializing SDL's sound subsystem\n");
@@ -460,16 +459,16 @@ void I_InitSound()
 	if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
 	{
 		Printf(PRINT_ERROR,
-               "I_InitSound: Unable to set up sound: %s\n", 
+               "I_InitSound: Unable to set up sound: %s\n",
                SDL_GetError());
-               
+
 		return;
 	}
 
     #if defined(SDL20)
 	Printf("I_InitSound: Using SDL's audio driver (%s)\n", SDL_GetCurrentAudioDriver());
 	#endif
-	
+
 	const SDL_version *ver = Mix_Linked_Version();
 
 	if(ver->major != MIX_MAJOR_VERSION
@@ -503,7 +502,7 @@ void I_InitSound()
 #endif
 	{
 		Printf(PRINT_ERROR,
-               "I_InitSound: Error initializing SDL_mixer: %s\n", 
+               "I_InitSound: Error initializing SDL_mixer: %s\n",
                Mix_GetError());
 		return;
 	}
@@ -511,11 +510,11 @@ void I_InitSound()
     if(!Mix_QuerySpec(&mixer_freq, &mixer_format, &mixer_channels))
 	{
 		Printf(PRINT_ERROR,
-               "I_InitSound: Error initializing SDL_mixer: %s\n", 
+               "I_InitSound: Error initializing SDL_mixer: %s\n",
                Mix_GetError());
 		return;
 	}
-	
+
 	Printf("I_InitSound: Using %d channels (freq:%d, fmt:%d, chan:%d)\n",
            Mix_AllocateChannels(NUM_CHANNELS),
 		   mixer_freq, mixer_format, mixer_channels);

--- a/client/sdl/i_system.cpp
+++ b/client/sdl/i_system.cpp
@@ -29,7 +29,7 @@
 
 #include "nonstd/scope.hpp"
 
-#include "i_sdl.h" 
+#include "i_sdl.h"
 #include <stdlib.h>
 
 #ifdef OSX
@@ -553,7 +553,7 @@ void I_BaseError(const std::string& errortext)
 	abort();
 }
 
-NORETURN void I_BaseFatalError(const std::string& errortext)
+[[noreturn]] void I_BaseFatalError(const std::string& errortext)
 {
 	std::string messagetext;
 

--- a/client/sdl/i_system.h
+++ b/client/sdl/i_system.h
@@ -92,7 +92,7 @@ void STACK_ARGS I_Quit (void);
 
 void I_BaseWarning(const std::string& errortext);
 void I_BaseError(const std::string& errortext);
-NORETURN void I_BaseFatalError(const std::string& errortext);
+[[noreturn]] void I_BaseFatalError(const std::string& errortext);
 
 template <typename... ARGS>
 void I_Warning(const fmt::string_view format, const ARGS&... args)

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -37,7 +37,7 @@
 #include "i_video_sdl12.h"
 #elif defined(SDL20)
 #include "i_video_sdl20.h"
-#else 
+#else
 #error "no video subsystem selected"
 #endif
 
@@ -426,8 +426,8 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		    (palindex_t*)source_surface->getBuffer() + srcy * srcpitchpixels + srcx;
 		palindex_t* dest = (palindex_t*)getBuffer() + buffery * destpitchpixels + bufferx;
 
-		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
-			destw, desth, 
+		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels,
+			destw, desth,
 			off_top, off_bottom, off_left, off_right,
 			xstep, ystep, palette);
 	}
@@ -440,7 +440,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		    (palindex_t*)source_surface->getBuffer() + srcy * srcpitchpixels + srcx;
 		argb_t* dest = (argb_t*)getBuffer() + buffery * destpitchpixels + bufferx;
 
-		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
+		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels,
 				destw, desth,
 				off_top, off_bottom, off_left, off_right,
 				xstep, ystep, palette);
@@ -456,7 +456,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 		    (argb_t*)source_surface->getBuffer() + srcy * srcpitchpixels + srcx;
 		argb_t* dest = (argb_t*)getBuffer() + buffery * destpitchpixels + bufferx;
 
-		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels, 
+		BlitLoopCrop(dest, source, destpitchpixels, srcpitchpixels,
 			destw, desth,
 			off_top, off_bottom, off_left, off_right,
 			xstep, ystep, palette);
@@ -469,7 +469,7 @@ void IWindowSurface::blitcrop(const IWindowSurface* source_surface, int srcx, in
 //
 // Blits a surface into this surface, automatically scaling the source image
 // to fit the destination dimensions.
-// 
+//
 void IWindowSurface::blit(const IWindowSurface* source_surface, int srcx, int srcy, int srcw, int srch,
 			int destx, int desty, int destw, int desth)
 {
@@ -522,7 +522,7 @@ void IWindowSurface::blit(const IWindowSurface* source_surface, int srcx, int sr
 	int destbits = getBitsPerPixel();
 	int srcpitchpixels = source_surface->getPitchInPixels();
 	int destpitchpixels = getPitchInPixels();
-	
+
 	const argb_t* palette = source_surface->getPalette();
 
 	if (srcbits == 8 && destbits == 8)
@@ -666,9 +666,7 @@ std::string I_GetVideoModeString(const IVideoMode& mode)
 		"full screen window"
 	};
 
-	std::string str;
-	StrFormat(str, "%dx%d %dbpp (%s)", mode.width, mode.height, mode.bpp, window_strs[I_GetWindow()->getWindowMode()]);
-	return str;
+	return fmt::sprintf("%dx%d %dbpp (%s)", mode.width, mode.height, mode.bpp, window_strs[I_GetWindow()->getWindowMode()]);
 }
 
 
@@ -720,7 +718,7 @@ static IVideoMode I_ValidateVideoMode(const IVideoMode& mode)
 	// check if the given bit-depth is supported
 	if (!I_IsModeSupported(desired_mode.bpp, desired_mode.window_mode))
 	{
-		// mode is not supported -- check a different bit depth 
+		// mode is not supported -- check a different bit depth
 		desired_mode.bpp = desired_mode.bpp ^ (32 | 8);
 		if (!I_IsModeSupported(desired_mode.bpp, desired_mode.window_mode))
 			return invalid_mode;
@@ -781,7 +779,7 @@ void I_SetVideoMode(const IVideoMode& requested_mode)
 
 	// [SL] 2011-11-30 - Prevent the player's view angle from moving
 	I_FlushInput();
-		
+
 	// Set up the primary and emulated surfaces
 	primary_surface = window->getPrimarySurface();
 	int surface_width = primary_surface->getWidth(), surface_height = primary_surface->getHeight();
@@ -860,7 +858,7 @@ void I_SetVideoMode(const IVideoMode& requested_mode)
 	// Ensure matted surface dimensions are sane and sanitized.
 	surface_width = clamp<uint16_t>(surface_width, 320, MAXWIDTH);
 	surface_height = clamp<uint16_t>(surface_height, 200, MAXHEIGHT);
-	
+
 	// Is matting being used? Create matted_surface based on the primary_surface.
 	if (surface_width != primary_surface->getWidth() ||
 		surface_height != primary_surface->getHeight())

--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -1951,12 +1951,12 @@ void AM_Drawer()
 			{
 				if (G_IsHordeMode())
 				{
-					StrFormat(line, TEXTCOLOR_RED "MONSTERS:" TEXTCOLOR_NORMAL " %d",
+					line = fmt::sprintf(TEXTCOLOR_RED "MONSTERS:" TEXTCOLOR_NORMAL " %d",
 				        level.killed_monsters);
 				}
 				else
 				{
-					StrFormat(line, TEXTCOLOR_RED "MONSTERS:" TEXTCOLOR_NORMAL " %d / %d",
+					line = fmt::sprintf(TEXTCOLOR_RED "MONSTERS:" TEXTCOLOR_NORMAL " %d / %d",
 				        level.killed_monsters,
 				        (level.total_monsters + level.respawned_monsters));
 				}
@@ -1984,9 +1984,9 @@ void AM_Drawer()
 
 			if (am_showitems && !G_IsHordeMode())
 			{
-				StrFormat(line, TEXTCOLOR_RED "ITEMS:" TEXTCOLOR_NORMAL " %d / %d",
-				        level.found_items,
-				        level.total_items);
+				line = fmt::sprintf(TEXTCOLOR_RED "ITEMS:" TEXTCOLOR_NORMAL " %d / %d",
+				                    level.found_items,
+				                    level.total_items);
 
 				int x, y;
 				const int text_width = V_StringWidth(line.c_str()) * CleanXfac;
@@ -2007,8 +2007,8 @@ void AM_Drawer()
 
 			if (am_showsecrets && !G_IsHordeMode())
 			{
-				StrFormat(line, TEXTCOLOR_RED "SECRETS:" TEXTCOLOR_NORMAL " %d / %d",
-				        level.found_secrets, level.total_secrets);
+				line = fmt::sprintf(TEXTCOLOR_RED "SECRETS:" TEXTCOLOR_NORMAL " %d / %d",
+				                    level.found_secrets, level.total_secrets);
 				int x, y;
 				const int text_width = V_StringWidth(line.c_str()) * CleanXfac;
 
@@ -2120,8 +2120,7 @@ void AM_Drawer()
 
 		if (am_showtime)
 		{
-			StrFormat(line, " %02d:%02d:%02d", time / 3600, (time % 3600) / 60,
-			        time % 60); // Time
+			line = fmt::sprintf(" %02d:%02d:%02d", time / 3600, (time % 3600) / 60, time % 60); // Time
 
 			int x, y;
 			const int text_width = V_StringWidth(line.c_str()) * CleanXfac;

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1150,7 +1150,7 @@ void C_AddNotifyString(int printlevel, const char* color_code, const char* sourc
 	char work[MAX_LINE_LENGTH];
 	brokenlines_t *lines;
 
-	size_t len = strlen(source);
+	const size_t len = strlen(source);
 
 	if ((printlevel != 128 && !show_messages) || len == 0 ||
 		(gamestate != GS_LEVEL && gamestate != GS_INTERMISSION) )
@@ -1693,7 +1693,7 @@ void C_DrawConsole()
 	int primary_surface_height = primary_surface->getHeight();
 
 	int left = CONPX(8);
-	size_t lines = (ConBottom - CONPX(12)) / CONPX(8);
+	int lines = (ConBottom - CONPX(12)) / CONPX(8);
 
 	int offset;
 	if (lines * CONPX(8) > ConBottom - CONPX(16))

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1746,8 +1746,8 @@ void C_DrawConsole()
 			StrFormatBytes(dlnow, progress.dlnow);
 			std::string dltotal;
 			StrFormatBytes(dltotal, progress.dltotal);
-			StrFormat(download, "%s: %s/%s", filename.c_str(), dlnow.c_str(),
-			          dltotal.c_str());
+			download = fmt::sprintf("%s: %s/%s", filename.c_str(), dlnow.c_str(),
+			                        dltotal.c_str());
 
 			// Avoid divide by zero.
 			if (progress.dltotal == 0)

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -56,12 +56,6 @@
 #include "nx_io.h"
 #endif
 
-// These functions are standardized in C++11, POSIX standard otherwise
-#if defined(_WIN32) && (__cplusplus <= 199711L)
-#	define vsnprintf _vsnprintf
-#	define snprintf  _snprintf
-#endif
-
 static const int MAX_LINE_LENGTH = 8192;
 
 static bool ShouldTabCycle = false;

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -538,14 +538,14 @@ bool NetDemo::startPlaying(const std::string &filename)
 		{
 			int maj, min, patch;
 			BREAKVER(latestVersion, maj, min, patch);
-			StrFormat(buffer,
+			buffer = fmt::sprintf(
 			          "This demo is too old to play in this version of Odamex.  Please "
 			          "visit https://odamex.net/ to obtain Odamex %d.%d.%d or older.",
 			          maj, min, patch);
 		}
 		else
 		{
-			StrFormat(buffer,
+			buffer = fmt::sprintf(
 			          "This demo is too new to play in this version of Odamex.  Please "
 			          "visit https://odamex.net/ to obtain a newer version of Odamex.");
 		}

--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -1692,7 +1692,7 @@ void G_BuildSaveName(std::string &name, int slot)
 #else
 	std::string path = M_GetUserFileName(name.c_str());
 #endif
-	StrFormat(name, "%s" PATHSEP "odasv%d.ods", path.c_str(), slot);
+	name = fmt::sprintf("%s" PATHSEP "odasv%d.ods", path.c_str(), slot);
 }
 
 void G_DoSaveGame()

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1990,7 +1990,7 @@ static std::string SVCName(byte header)
 	std::string svc = ::svc_info[header].getName();
 	if (svc.empty())
 	{
-		StrFormat(svc, "svc_%u", header);
+		svc = fmt::sprintf("svc_%u", header);
 	}
 	return svc;
 }

--- a/client/src/cl_maplist.cpp
+++ b/client/src/cl_maplist.cpp
@@ -279,11 +279,13 @@ void MaplistCache::status_handler(maplist_status_t status) {
 		// If our cache is out-of-date and we are able to request
 		// an updated maplist, request one.
 		MSG_WriteMarker(&net_buffer, clc_maplist_update);
+		[[fallthrough]];
 	case MAPLIST_EMPTY:
 	case MAPLIST_THROTTLED:
 		// If our cache is out-of-date or the maplist on the other end
 		// is empty, invalidate the local cache.
 		this->invalidate();
+		[[fallthrough]];
 	case MAPLIST_OK:
 		// No matter what, we ought to set the correct status.
 		this->status = status;

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -193,11 +193,11 @@ static void CL_Disconnect(const odaproto::svc::Disconnect* msg)
 	std::string buffer;
 	if (!msg->message().empty())
 	{
-		StrFormat(buffer, "Disconnected from server: %s", msg->message().c_str());
+		buffer = fmt::sprintf("Disconnected from server: %s", msg->message().c_str());
 	}
 	else
 	{
-		StrFormat(buffer, "Disconnected from server\n");
+		buffer = fmt::sprintf("Disconnected from server\n");
 	}
 
 	Printf("%s", msg->message().c_str());
@@ -2002,8 +2002,8 @@ static void CL_SecretEvent(const odaproto::svc::SecretEvent* msg)
 		return;
 
 	std::string buf;
-	StrFormat(buf, "%s%s %sfound a secret!\n", TEXTCOLOR_YELLOW,
-	          player.userinfo.netname.c_str(), TEXTCOLOR_NORMAL);
+	buf = fmt::sprintf("%s%s %sfound a secret!\n", TEXTCOLOR_YELLOW,
+	                   player.userinfo.netname.c_str(), TEXTCOLOR_NORMAL);
 	Printf("%s", buf.c_str());
 
 	if (::hud_revealsecrets == 1)

--- a/client/src/hu_elements.cpp
+++ b/client/src/hu_elements.cpp
@@ -254,7 +254,6 @@ static const char *ordinal(int n)
  */
 std::string HelpText()
 {
-	std::string str;
 	int queuePos = consoleplayer().QueuePosition;
 
 	std::string joinmsg;
@@ -278,29 +277,25 @@ std::string HelpText()
 	{
 		if (queuePos > 0)
 		{
-			StrFormat(str, "%s - " TEXTCOLOR_GREEN "%d%s" TEXTCOLOR_NORMAL " in line",
-			          joinmsg.c_str(), queuePos, ordinal(queuePos));
-			return str;
+			return fmt::sprintf("%s - " TEXTCOLOR_GREEN "%d%s" TEXTCOLOR_NORMAL " in line",
+			                    joinmsg.c_str(), queuePos, ordinal(queuePos));
 		}
 
-		StrFormat(str, "%s - Press " TEXTCOLOR_GOLD "%s" TEXTCOLOR_NORMAL " to queue",
-		          joinmsg.c_str(), ::Bindings.GetKeynameFromCommand("+use").c_str());
-		return str;
+		return fmt::sprintf("%s - Press " TEXTCOLOR_GOLD "%s" TEXTCOLOR_NORMAL " to queue",
+		                    joinmsg.c_str(), ::Bindings.GetKeynameFromCommand("+use").c_str());
 	}
 
 	if (G_CanShowJoinTimer())
 	{
-		StrFormat(str,
+		return fmt::sprintf(
 		          "Press " TEXTCOLOR_GOLD "%s" TEXTCOLOR_NORMAL
 		          " to join - " TEXTCOLOR_GREEN "%d" TEXTCOLOR_NORMAL " secs left",
 		          ::Bindings.GetKeynameFromCommand("+use").c_str(),
 		          ::levelstate.getJoinTimeLeft());
-		return str;
 	}
 
-	StrFormat(str, "Press " TEXTCOLOR_GOLD "%s" TEXTCOLOR_NORMAL " to join",
-	          ::Bindings.GetKeynameFromCommand("+use").c_str());
-	return str;
+	return fmt::sprintf("Press " TEXTCOLOR_GOLD "%s" TEXTCOLOR_NORMAL " to join",
+	                    ::Bindings.GetKeynameFromCommand("+use").c_str());
 }
 
 /**
@@ -321,9 +316,7 @@ std::string SpyPlayerName()
 		color = GetTeamInfo(plyr.userinfo.team)->TextColor.c_str();
 	}
 
-	std::string str;
-	StrFormat(str, "%s%s", color, plyr.userinfo.netname.c_str());
-	return str;
+	return fmt::sprintf("%s%s", color, plyr.userinfo.netname.c_str());
 }
 
 /**
@@ -350,7 +343,7 @@ std::string Timer()
 
 
 	OTimespan tspan;
-	if (::levelstate.getState() == LevelState::WARMUP || 
+	if (::levelstate.getState() == LevelState::WARMUP ||
 		::levelstate.getState() == LevelState::WARMUP_COUNTDOWN ||
 		::levelstate.getState() == LevelState::WARMUP_FORCED_COUNTDOWN )
 	{
@@ -382,12 +375,11 @@ std::string Timer()
 	std::string str;
 	if (tspan.hours)
 	{
-		StrFormat(str, "%s%02d:%02d:%02d", color, tspan.hours, tspan.minutes,
-		          tspan.seconds);
+		str = fmt::sprintf("%s%02d:%02d:%02d", color, tspan.hours, tspan.minutes, tspan.seconds);
 	}
 	else
 	{
-		StrFormat(str, "%s%02d:%02d", color, tspan.minutes, tspan.seconds);
+		str = fmt::sprintf("%s%02d:%02d", color, tspan.minutes, tspan.seconds);
 	}
 	return str;
 }
@@ -410,11 +402,11 @@ std::string IntermissionTimer()
 	std::string str;
 	if (tspan.hours)
 	{
-		StrFormat(str, "%02d:%02d:%02d", tspan.hours, tspan.minutes, tspan.seconds);
+		str = fmt::sprintf("%02d:%02d:%02d", tspan.hours, tspan.minutes, tspan.seconds);
 	}
 	else
 	{
-		StrFormat(str, "%02d:%02d", tspan.minutes, tspan.seconds);
+		str = fmt::sprintf("%02d:%02d", tspan.minutes, tspan.seconds);
 	}
 	return str;
 }
@@ -422,12 +414,11 @@ std::string IntermissionTimer()
 /**
  * @brief Return a "spread" of personal frags or team points that the current
  *        player or team is ahead or behind by.
- * 
+ *
  * @return Colored string to render in the HUD.
  */
 std::string PersonalSpread()
 {
-	std::string str;
 	player_t& plyr = displayplayer();
 
 	if (G_IsFFAGame())
@@ -484,14 +475,12 @@ std::string PersonalSpread()
 
 			// Player is on top.
 			int diff = plyr_number - next_number;
-			StrFormat(str, TEXTCOLOR_GREEN "+%d", diff);
-			return str;
+			return fmt::sprintf(TEXTCOLOR_GREEN "+%d", diff);
 		}
 
 		// Player is behind.
 		int diff = top_number - plyr_number;
-		StrFormat(str, TEXTCOLOR_BRICK "-%d", diff);
-		return str;
+		return fmt::sprintf(TEXTCOLOR_BRICK "-%d", diff);
 	}
 	else if (G_IsTeamGame())
 	{
@@ -542,14 +531,12 @@ std::string PersonalSpread()
 
 			// Player team is on top.
 			int diff = plyr_number - next_number;
-			StrFormat(str, TEXTCOLOR_GREEN "+%d", diff);
-			return str;
+			return fmt::sprintf(TEXTCOLOR_GREEN "+%d", diff);
 		}
 
 		// Player team is behind.
 		int diff = top_number - plyr_number;
-		StrFormat(str, TEXTCOLOR_BRICK "-%d", diff);
-		return str;
+		return fmt::sprintf(TEXTCOLOR_BRICK "-%d", diff);
 	}
 
 	// We're not in an appropriate gamemode.
@@ -560,7 +547,7 @@ std::string PersonalSpread()
  * @brief Return a string that contains the current team score or personal
  *        frags of the individual player.  Optionally returns the "limit"
  *        as well.
- * 
+ *
  * @return Colorized string to render to the HUD.
  */
 std::string PersonalScore()
@@ -575,29 +562,29 @@ std::string PersonalScore()
 		{
 			if (g_winlimit)
 			{
-				StrFormat(str, "%s%d/%d", plyr_team.TextColor.c_str(),
-				          plyr_team.RoundWins, g_winlimit.asInt());
+				str = fmt::sprintf("%s%d/%d", plyr_team.TextColor.c_str(),
+				                   plyr_team.RoundWins, g_winlimit.asInt());
 			}
 			else
 			{
-				StrFormat(str, "%s%d", plyr_team.TextColor.c_str(), plyr.roundwins);
+				str = fmt::sprintf("%s%d", plyr_team.TextColor.c_str(), plyr.roundwins);
 			}
 		}
 		else
 		{
 			if (G_UsesFraglimit() && sv_fraglimit > 0)
 			{
-				StrFormat(str, "%s%d/%d", plyr_team.TextColor.c_str(), plyr_team.Points,
-				          sv_fraglimit.asInt());
+				str = fmt::sprintf("%s%d/%d", plyr_team.TextColor.c_str(), plyr_team.Points,
+				                   sv_fraglimit.asInt());
 			}
 			else if (!G_UsesFraglimit() && sv_scorelimit > 0)
 			{
-				StrFormat(str, "%s%d/%d", plyr_team.TextColor.c_str(), plyr_team.Points,
-				          sv_scorelimit.asInt());
+				str = fmt::sprintf("%s%d/%d", plyr_team.TextColor.c_str(), plyr_team.Points,
+				                   sv_scorelimit.asInt());
 			}
 			else
 			{
-				StrFormat(str, "%s%d", plyr_team.TextColor.c_str(), plyr.fragcount);
+				str = fmt::sprintf("%s%d", plyr_team.TextColor.c_str(), plyr.fragcount);
 			}
 		}
 	}
@@ -607,24 +594,24 @@ std::string PersonalScore()
 		{
 			if (g_winlimit)
 			{
-				StrFormat(str, TEXTCOLOR_GREY "%d/%d", plyr.roundwins,
-				          g_winlimit.asInt());
+				str = fmt::sprintf(TEXTCOLOR_GREY "%d/%d", plyr.roundwins,
+				                   g_winlimit.asInt());
 			}
 			else
 			{
-				StrFormat(str, TEXTCOLOR_GREY "%d", plyr.roundwins);
+				str = fmt::sprintf(TEXTCOLOR_GREY "%d", plyr.roundwins);
 			}
 		}
 		else
 		{
 			if (sv_fraglimit)
 			{
-				StrFormat(str, TEXTCOLOR_GREY "%d/%d", plyr.fragcount,
-				          sv_fraglimit.asInt());
+				str = fmt::sprintf(TEXTCOLOR_GREY "%d/%d", plyr.fragcount,
+				                   sv_fraglimit.asInt());
 			}
 			else
 			{
-				StrFormat(str, TEXTCOLOR_GREY "%d", plyr.fragcount);
+				str = fmt::sprintf(TEXTCOLOR_GREY "%d", plyr.fragcount);
 			}
 		}
 	}
@@ -645,12 +632,12 @@ std::string PersonalMatchDuelPlacement()
 
 	if (g_winlimit)
 	{
-		StrFormat(str, TEXTCOLOR_GREY "%d/%d W", plyr.roundwins,
-				    g_winlimit.asInt());
+		str = fmt::sprintf(TEXTCOLOR_GREY "%d/%d W", plyr.roundwins,
+				           g_winlimit.asInt());
 	}
 	else
 	{
-		StrFormat(str, TEXTCOLOR_GREY "%d W", plyr.roundwins);
+		str = fmt::sprintf(TEXTCOLOR_GREY "%d W", plyr.roundwins);
 	}
 
 	return str;
@@ -801,7 +788,7 @@ std::string TeamPoints(int& color, byte team) {
 
 /**
  * @brief Calculate the number of team lives for the HUD.
- * 
+ *
  * @param str Output string buffer.
  * @param color Output color.
  * @param team Team to construct for.
@@ -824,7 +811,7 @@ void TeamLives(std::string& str, int& color, byte team)
 	for (; it != results.players.end(); ++it)
 		lives += (*it)->lives;
 
-	StrFormat(str, "%d", lives);
+	str = fmt::sprintf("%d", lives);
 }
 
 std::string TeamKD(int& color, byte team) {
@@ -947,7 +934,7 @@ void EleBar(const int x, const int y, const int w, const float scale,
 			// i0 is short-circuited, so remove it.
 			const int idx = i - 1;
 
-			// Each unit 
+			// Each unit
 			const float scaled = pct * (UNITS - 2);
 
 			if (scaled < static_cast<float>(idx) + 0.5f)
@@ -1126,8 +1113,8 @@ void EATeamPlayerNames(int x, int y, const float scale,
 			{
 				color = GetTeamPlayerColor(player);
 			}
-			else if(player->id == displayplayer().id) 
-			{	
+			else if(player->id == displayplayer().id)
+			{
 				color = CR_GOLD;
 			}
 			hud::DrawText(x, y, scale, x_align, y_align, x_origin, y_origin,
@@ -1207,8 +1194,7 @@ void EAPlayerRoundWins(int x, int y, const float scale, const x_align_t x_align,
 		player_t* player = sortedPlayers()[i];
 		if (ingamePlayer(player))
 		{
-			std::string buffer;
-			StrFormat(buffer, "%d", player->roundwins);
+			std::string buffer = fmt::sprintf("%d", player->roundwins);
 
 			hud::DrawText(x, y, scale, x_align, y_align, x_origin, y_origin,
 			              buffer.c_str(), CR_GREY, force_opaque);
@@ -1236,8 +1222,7 @@ void EAPlayerLives(int x, int y, const float scale, const x_align_t x_align,
 		player_t* player = sortedPlayers()[i];
 		if (ingamePlayer(player))
 		{
-			std::string buffer;
-			StrFormat(buffer, "%d", player->lives);
+			std::string buffer = fmt::sprintf("%d", player->lives);
 
 			hud::DrawText(x, y, scale, x_align, y_align, x_origin, y_origin,
 			              buffer.c_str(), CR_GREY, force_opaque);
@@ -1265,8 +1250,7 @@ void EATeamPlayerLives(int x, int y, const float scale, const x_align_t x_align,
 		player_t* player = sortedPlayers()[i];
 		if (inTeamPlayer(player, team))
 		{
-			std::string buffer;
-			StrFormat(buffer, "%d", player->lives);
+			std::string buffer = fmt::sprintf("%d", player->lives);
 
 			hud::DrawText(x, y, scale, x_align, y_align, x_origin, y_origin,
 			              buffer.c_str(), CR_GREY, force_opaque);
@@ -1809,7 +1793,7 @@ void EATargets(int x, int y, const float scale,
 				else
 					color = TEXTCOLOR_LIGHTBLUE;
 
-				StrFormat(nameplate, "%s %s%d",
+				nameplate = fmt::sprintf("%s %s%d",
 				          Targets[i].PlayPtr->userinfo.netname.c_str(), color, health);
 			}
 			else

--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -278,7 +278,7 @@ BOOL HU_Responder(event_t *ev)
 	}
 	else
 	{
-		altdown = false;	
+		altdown = false;
 	}
 
 	if ((gamestate != GS_LEVEL && gamestate != GS_INTERMISSION) || ev->type != ev_keydown)
@@ -753,10 +753,10 @@ void drawHeader(player_t *player, int y)
 	              hud::ClientsSplit().c_str(), CR_GREEN, true);
 
 	int yOffset = 0;
-	if (G_IsTeamGame()) 
+	if (G_IsTeamGame())
 	{
 		int xOffset = GetLongestTeamWidth();
-		
+
 		for (int i = 0; i < sv_teamsinplay; i++)
 		{
 			// Display wins for round-based gamemodes, otherwise points.
@@ -776,18 +776,18 @@ void drawHeader(player_t *player, int y)
 			std::string points;
 			if (g_rounds)
 			{
-				StrFormat(points, "%d", GetTeamInfo((team_t)i)->RoundWins);
+				points = fmt::sprintf("%d", GetTeamInfo((team_t)i)->RoundWins);
 			}
 			else
 			{
-				StrFormat(points, "%d", GetTeamInfo((team_t)i)->Points);
+				points = fmt::sprintf("%d", GetTeamInfo((team_t)i)->Points);
 			}
 
 			hud::DrawText(-236 + xOffset, y + yOffset, hud_scalescoreboard, hud::X_CENTER,
 			              hud::Y_MIDDLE, hud::X_LEFT, hud::Y_TOP, points.c_str(),
 			              CR_GREEN, true);
 		}
-	} 
+	}
 	else
 	{
 		hud::DrawText(-236, y + 8, hud_scalescoreboard,
@@ -826,7 +826,7 @@ void drawHeader(player_t *player, int y)
 	// Winlimit.
 	if (g_winlimit > 0.0 && G_UsesWinlimit())
 	{
-		StrFormat(str, "%d", g_winlimit.asInt());
+		str = fmt::sprintf("%d", g_winlimit.asInt());
 		names.push_back("WIN LIMIT: ");
 		values.push_back(str);
 	}
@@ -834,7 +834,7 @@ void drawHeader(player_t *player, int y)
 	// Roundlimit.
 	if (g_roundlimit > 0.0 && G_UsesRoundlimit())
 	{
-		StrFormat(str, "%d", g_roundlimit.asInt());
+		str = fmt::sprintf("%d", g_roundlimit.asInt());
 		names.push_back("ROUND LIMIT: ");
 		values.push_back(str);
 	}
@@ -842,7 +842,7 @@ void drawHeader(player_t *player, int y)
 	// Scorelimit.
 	if (sv_scorelimit > 0.0 && G_UsesScorelimit())
 	{
-		StrFormat(str, "%d", sv_scorelimit.asInt());
+		str = fmt::sprintf("%d", sv_scorelimit.asInt());
 		names.push_back("SCORE LIMIT: ");
 		values.push_back(str);
 	}
@@ -850,7 +850,7 @@ void drawHeader(player_t *player, int y)
 	// Fraglimit
 	if (sv_fraglimit > 0.0 && G_UsesFraglimit())
 	{
-		StrFormat(str, "%d", sv_fraglimit.asInt());
+		str = fmt::sprintf("%d", sv_fraglimit.asInt());
 		names.push_back("FRAG LIMIT: ");
 		values.push_back(str);
 	}
@@ -1360,7 +1360,7 @@ void Scoreboard(player_t *player)
 			height += extraQuadRows / 2 * DefaultTeamHeight;
 			height += extraQuadRows * 16;
 		}
-	} 
+	}
 	else
 	{
 		height = 92;
@@ -1401,7 +1401,7 @@ void Scoreboard(player_t *player)
 			teams++;
 		y += 31 + (teams * 8);
 		hud::drawTeamScores(player, y, extra_player_rows);
-	} 
+	}
 	else
 	{
 		y += 31;
@@ -1834,8 +1834,8 @@ void LowScoreboard(player_t *player)
 void HU_DrawScores(player_t *player)
 {
 	if (hud::XSize(hud_scalescoreboard) >= HiResolutionWidth)
-		hud::Scoreboard(player); 
-	else 
+		hud::Scoreboard(player);
+	else
 		hud::LowScoreboard(player);
 }
 
@@ -1915,7 +1915,7 @@ static float HU_CalculateFragDeathRatio(const player_t* player)
 	int deaths = 0;
 
 	if (G_IsRoundsGame() && !G_IsDuelGame())
-	{	
+	{
 		frags = player->totalpoints;
 		deaths = player->totaldeaths;
 	}

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1044,7 +1044,7 @@ void M_DrawEpisode()
 	{
 		y -= (LINEHEIGHT * (episodenum - 4));
 	}
-		
+
 	screen->DrawPatchClean(W_CachePatch("M_EPISOD"), 54, y);
 }
 
@@ -1257,13 +1257,12 @@ void M_QuitResponse(int ch)
 
 void M_QuitDOOM(int choice)
 {
-	static std::string endstring;
-
 	// We pick index 0 which is language sensitive,
 	//  or one at random, between 1 and maximum number.
-	StrFormat(endstring, "%s\n\n%s",
-	          GStrings.getIndex(GStrings.toIndex(QUITMSG) + (gametic % NUM_QUITMESSAGES)),
-	          GStrings(DOSY));
+	static std::string endstring =
+		fmt::sprintf("%s\n\n%s",
+		             GStrings.getIndex(GStrings.toIndex(QUITMSG) + (gametic % NUM_QUITMESSAGES)),
+		             GStrings(DOSY));
 
 	M_StartMessage(endstring.c_str(), M_QuitResponse, true);
 }
@@ -1709,16 +1708,12 @@ static void M_PlayerTeamChanged (int choice)
 
 static void SendNewColor(int red, int green, int blue)
 {
-	std::string colorcommand;
-	std::string customcolorcommand;
 	int colorpreset = D_ColorPreset(cl_colorpreset.cstring());
 
-	StrFormat(colorcommand, "cl_color \"%02x %02x %02x\"", red, green, blue);
-	AddCommandString(colorcommand);
+	AddCommandString(fmt::sprintf("cl_color \"%02x %02x %02x\"", red, green, blue));
 	if (colorpreset == COLOR_CUSTOM)
 	{
-		StrFormat(customcolorcommand, "cl_customcolor \"%02x %02x %02x\"", red, green, blue);
-		AddCommandString(customcolorcommand);
+		AddCommandString(fmt::sprintf("cl_customcolor \"%02x %02x %02x\"", red, green, blue));
 	}
 
 	// [SL] not connected to a server so we don't have to wait for the server
@@ -1875,7 +1870,7 @@ bool M_Responder (event_t* ev)
 	if (ch == -1 || HU_ChatMode() != CHAT_INACTIVE)
 		return false;
 
-	// Transfer any action to the Options Menu Responder 
+	// Transfer any action to the Options Menu Responder
 	// if we're not on the main menu.
 	if (menuactive && OptionsActive) {
 		M_OptResponder (ev);
@@ -1909,7 +1904,7 @@ bool M_Responder (event_t* ev)
 				saveCharIndex--;
 				savegamestrings[saveSlot][saveCharIndex] = 0;
 			}
-		} 
+		}
 		else if (Key_IsCancelKey(ch))
 		{
 			genStringEnter = 0;
@@ -1923,8 +1918,8 @@ bool M_Responder (event_t* ev)
 			if (savegamestrings[saveSlot][0])
 				genStringEnd(saveSlot);	// [RH] Function to call when enter is pressed
 		}
-		else 
-		{ 
+		else
+		{
 			ch = ev->data3;	// [RH] Use user keymap
 			if (ch >= 32 && ch <= 127 &&
 				saveCharIndex < genStringLen &&
@@ -1943,8 +1938,8 @@ bool M_Responder (event_t* ev)
 	if (messageToPrint)
 	{
 		if (messageNeedsInput &&
-		    (!(ch2 == ' ' || Key_IsMenuKey(ch) || Key_IsYesKey(ch) || Key_IsNoKey(ch) || 
-			(isascii(ch2) && (toupper(ch2) == 'N' || toupper(ch2) == 'Y'))))) 
+		    (!(ch2 == ' ' || Key_IsMenuKey(ch) || Key_IsYesKey(ch) || Key_IsNoKey(ch) ||
+			(isascii(ch2) && (toupper(ch2) == 'N' || toupper(ch2) == 'Y')))))
 			return true;
 
 		menuactive = messageLastMenuActive;

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1521,11 +1521,11 @@ void M_DrawSlider (int x, int y, float leftval, float rightval, float cur, float
 	if (step == 0.0f)
 		return;
 	else if (step >= 1.0f)
-		StrFormat(buf, "%.0f", cur);
+		buf = fmt::sprintf("%.0f", cur);
 	else if (step >= 0.1f)
-		StrFormat(buf, "%.1f", cur);
+		buf = fmt::sprintf("%.1f", cur);
 	else
-		StrFormat(buf, "%.2f", cur);
+		buf = fmt::sprintf("%.2f", cur);
 	screen->DrawTextCleanMove(CR_GREEN, x + 96, y, buf.c_str());
 }
 

--- a/client/src/otransfer.cpp
+++ b/client/src/otransfer.cpp
@@ -452,8 +452,8 @@ bool OTransfer::tick()
 		{
 			ext = std::string(".") + ext;
 		}
-		StrFormat(fallback, "%s%s%s.%s%s", path.c_str(), PATHSEP, base.c_str(),
-		          actualHash.getHexStr().substr(0, 6).c_str(), ext.c_str());
+		fallback = fmt::sprintf("%s%s%s.%s%s", path.c_str(), PATHSEP, base.c_str(),
+		                        actualHash.getHexStr().substr(0, 6).c_str(), ext.c_str());
 
 		// Try one more time.
 		ok = rename(m_filePart.c_str(), fallback.c_str());
@@ -462,9 +462,8 @@ bool OTransfer::tick()
 			// Something is seriously wrong with our writable directory.
 			m_shouldCheckAgain = false;
 
-			std::string buf;
-			StrFormat(buf, "File %s could not be renamed to %s - %s", m_filePart.c_str(),
-			          m_filename.c_str(), strerror(errno));
+			std::string buf = fmt::sprintf("File %s could not be renamed to %s - %s", m_filePart.c_str(),
+			                               m_filename.c_str(), strerror(errno));
 			m_errorProc(buf.c_str());
 			return false;
 		}

--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -438,7 +438,7 @@ void R_InitTranslationTables()
 	}
 
 	// Create powerup tints by grabbing each players rgb translation table
-	for (size_t i = 0; i < MAXPLAYERS + 1; i++)
+	for (int i = 0; i < MAXPLAYERS + 1; i++)
 	{
 		R_RebuildPlayerGreenTintTables(i);
 		R_RebuildPlayerRedTintTables(i);

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -400,7 +400,7 @@ void ST_voteDraw (int y) {
 		return;
 	}
 
-	size_t x1, x2;
+	int x1, x2;
 	x1 = (I_GetSurfaceWidth() - V_StringWidth(result_string.c_str()) * xscale) >> 1;
 	if (hud_scale) {
 		screen->DrawTextClean(result_color, x1, y, result_string.c_str());

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -88,8 +88,6 @@ static lumpHandle_t FlagIconDropped[NUMTEAMS];
 static lumpHandle_t LivesIcon[NUMTEAMS];
 static lumpHandle_t ToastIcon[NUMMODS];
 
-static int		NameUp = -1;
-
 extern lumpHandle_t negminus;
 extern lumpHandle_t tallnum[10];
 extern lumpHandle_t faces[];
@@ -174,10 +172,6 @@ void ST_initNew()
 
 	::widest_num = widest;
 	::num_height = W_ResolvePatchHandle(::tallnum[0])->height();
-
-	// [AM] FIXME: What does this do, exactly?
-	if (multiplayer && (sv_gametype == GM_COOP || demoplayback) && level.time)
-		NameUp = level.time + 2 * TICRATE;
 
 	::flagiconteam = W_CachePatchHandle("FLAGIT", PU_STATIC);
 	::flagiconteamoffense = W_CachePatchHandle("FLAGITO", PU_STATIC);

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -192,11 +192,9 @@ void ST_initNew()
 	::line_rightempty = W_CachePatchHandle("ODABARRE", PU_STATIC);
 	::line_rightfull = W_CachePatchHandle("ODABARRF", PU_STATIC);
 
-	std::string buffer;
 	for (size_t i = 0; i < NUMMODS; i++)
 	{
-		StrFormat(buffer, "ODAMOD%lu", i);
-		::ToastIcon[i] = W_CachePatchHandle(buffer.c_str(), PU_STATIC);
+		::ToastIcon[i] = W_CachePatchHandle(fmt::sprintf("ODAMOD%lu", i).c_str(), PU_STATIC);
 	}
 }
 
@@ -499,7 +497,6 @@ static void drawTeamGametype()
 	const int FLAG_ICON_HEIGHT = 18;
 	const int LIVES_HEIGHT = 12;
 
-	std::string buffer;
 	player_t* plyr = &consoleplayer();
 	int xscale = hud_scale ? CleanXfac : 1;
 	int yscale = hud_scale ? CleanYfac : 1;
@@ -590,7 +587,7 @@ static void drawTeamGametype()
 			               hud::Y_BOTTOM, hud::X_RIGHT, hud::Y_BOTTOM,
 			               W_ResolvePatchHandle(::LivesIcon[i]));
 
-			StrFormat(buffer, "%d", teamInfo->LivesPool());
+			std::string buffer = fmt::sprintf("%d", teamInfo->LivesPool());
 			int color = (i % 2) ? CR_GOLD : CR_GREY;
 			hud::DrawText(SCREEN_BORDER + 12, patchPosY + 3, hud_scale, hud::X_RIGHT,
 			              hud::Y_BOTTOM, hud::X_RIGHT, hud::Y_BOTTOM, buffer.c_str(),
@@ -612,11 +609,11 @@ static void drawHordeGametype()
 	std::string waverow, killrow;
 	if (::g_horde_waves.asInt() != 0)
 	{
-		StrFormat(waverow, "WAVE:%d/%d", info.wave, ::g_horde_waves.asInt());
+		waverow = fmt::sprintf("WAVE:%d/%d", info.wave, ::g_horde_waves.asInt());
 	}
 	else
 	{
-		StrFormat(waverow, "WAVE:%d", info.wave);
+		waverow = fmt::sprintf("WAVE:%d", info.wave);
 	}
 
 	float killPct = 0.0f;
@@ -657,11 +654,11 @@ static void drawHordeGametype()
 		}
 		else
 		{
-			StrFormat(buf2, "%d-%d sec", min, max);
+			buf2 = fmt::sprintf("%d-%d sec", min, max);
 		}
-		StrFormat(buf, "Min HP: %d\nAlive HP: %d\nMax HP: %d\nSpawn: %s",
-		          define.minTotalHealth(), info.alive(), define.maxTotalHealth(),
-		          buf2.c_str());
+		buf = fmt::sprintf("Min HP: %d\nAlive HP: %d\nMax HP: %d\nSpawn: %s",
+		                   define.minTotalHealth(), info.alive(), define.maxTotalHealth(),
+		                   buf2.c_str());
 		hud::DrawText(SCREEN_BORDER, 64, ::hud_scale, hud::X_LEFT, hud::Y_BOTTOM,
 		              hud::X_LEFT, hud::Y_BOTTOM, buf.c_str(), CR_GREY);
 
@@ -824,8 +821,8 @@ static void drawLevelStats()
 
 	if (G_IsHordeMode())
 	{
-		StrFormat(line, TEXTCOLOR_RED "K" TEXTCOLOR_NORMAL " %d",
-	        level.killed_monsters);
+		line = fmt::sprintf(TEXTCOLOR_RED "K" TEXTCOLOR_NORMAL " %d",
+	                        level.killed_monsters);
 
 		hud::DrawText(x, y, ::hud_scale, hud::X_LEFT,
 	                  hud::Y_BOTTOM, hud::X_LEFT, hud::Y_BOTTOM, line.c_str(), CR_GREY);
@@ -843,16 +840,16 @@ static void drawLevelStats()
 		hud::DrawText(x, y + LINE_SPACING * 2, ::hud_scale, hud::X_LEFT,
 	                  hud::Y_BOTTOM, hud::X_LEFT, hud::Y_BOTTOM, TEXTCOLOR_RED "K", CR_GREY);
 
-		StrFormat(killrow, "%s" " %d/%d",
-		          (level.killed_monsters >= (level.total_monsters + level.respawned_monsters) ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
-		   	      level.killed_monsters,
-		   	      (level.total_monsters + level.respawned_monsters));
-		StrFormat(itemrow, "%s" " %d/%d",
-		          (level.found_items >= level.total_items ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
-		          level.found_items, level.total_items);
-		StrFormat(secretrow, "%s" " %d/%d",
-		          (level.found_secrets >= level.total_secrets ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
-		          level.found_secrets, level.total_secrets);
+		killrow = fmt::sprintf("%s %d/%d",
+		                       (level.killed_monsters >= (level.total_monsters + level.respawned_monsters) ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
+		   	                   level.killed_monsters,
+		   	                   (level.total_monsters + level.respawned_monsters));
+		itemrow = fmt::sprintf("%s %d/%d",
+		                       (level.found_items >= level.total_items ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
+		                       level.found_items, level.total_items);
+		secretrow = fmt::sprintf("%s %d/%d",
+		                         (level.found_secrets >= level.total_secrets ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
+		                         level.found_secrets, level.total_secrets);
 
 		x += 9 - font_offset * 4;
 
@@ -866,16 +863,16 @@ static void drawLevelStats()
 	}
 	else
 	{
-		StrFormat(line, TEXTCOLOR_RED "K" "%s" " %d/%d "
-					    TEXTCOLOR_RED "I" "%s" " %d/%d "
-					    TEXTCOLOR_RED "S" "%s" " %d/%d",
-		                (level.killed_monsters >= (level.total_monsters + level.respawned_monsters) ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
-		                level.killed_monsters,
-		                (level.total_monsters + level.respawned_monsters),
-		                (level.found_items >= level.total_items ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
-		                level.found_items, level.total_items,
-		                (level.found_secrets >= level.total_secrets ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
-		                level.found_secrets, level.total_secrets);
+		line = fmt::sprintf(TEXTCOLOR_RED "K" "%s %d/%d "
+					        TEXTCOLOR_RED "I" "%s %d/%d "
+					        TEXTCOLOR_RED "S" "%s %d/%d",
+		                    (level.killed_monsters >= (level.total_monsters + level.respawned_monsters) ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
+		                    level.killed_monsters,
+		                    (level.total_monsters + level.respawned_monsters),
+		                    (level.found_items >= level.total_items ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
+		                    level.found_items, level.total_items,
+		                    (level.found_secrets >= level.total_secrets ? TEXTCOLOR_YELLOW : TEXTCOLOR_NORMAL),
+		                    level.found_secrets, level.total_secrets);
 
 		hud::DrawText(x, y, ::hud_scale, hud::X_LEFT,
 		    hud::Y_BOTTOM, hud::X_LEFT, hud::Y_BOTTOM, line.c_str(), CR_GREY);
@@ -937,7 +934,7 @@ void OdamexHUD() {
 		if (plyr->lives <= 0)
 			lives_color = CR_DARKGREY;
 
-		StrFormat(buf, "x%d", plyr->lives);
+		buf = fmt::sprintf("x%d", plyr->lives);
 		hud::DrawText(text_ax + 48 + 2 + 20 + 2, 10 + 2, hud_scale, hud::X_LEFT, hud::Y_BOTTOM,
 		              hud::X_LEFT, hud::Y_MIDDLE, buf.c_str(), lives_color, false);
 	}
@@ -993,7 +990,7 @@ void OdamexHUD() {
 		if (::hud_bigfont)
 			V_SetFont("BIGFONT");
 
-		StrFormat(buf, "%d" TEXTCOLOR_DARKGREY "ups",
+		buf = fmt::sprintf("%d" TEXTCOLOR_DARKGREY "ups",
 		          static_cast<int>(HU_GetPlayerSpeed()));
 		hud::DrawText(0, iy, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
 		              hud::Y_BOTTOM, buf.c_str(), CR_GREY);
@@ -1242,12 +1239,12 @@ static std::string WinToColorString(const WinInfo& win)
 		const player_t& pl = idplayer(win.id);
 		if (pl.userinfo.netname.empty())
 		{
-			StrFormat(buf, TEXTCOLOR_GREEN "???" TEXTCOLOR_NORMAL);
+			buf = fmt::sprintf(TEXTCOLOR_GREEN "???" TEXTCOLOR_NORMAL);
 		}
 		else
 		{
-			StrFormat(buf, TEXTCOLOR_GREEN "%s" TEXTCOLOR_NORMAL,
-			          pl.userinfo.netname.c_str());
+			buf = fmt::sprintf(TEXTCOLOR_GREEN "%s" TEXTCOLOR_NORMAL,
+			                   pl.userinfo.netname.c_str());
 		}
 		return buf;
 	}
@@ -1256,17 +1253,17 @@ static std::string WinToColorString(const WinInfo& win)
 		const TeamInfo& tm = *GetTeamInfo((team_t)win.id);
 		if (tm.Team == TEAM_NONE)
 		{
-			StrFormat(buf, TEXTCOLOR_GREEN "???" TEXTCOLOR_NORMAL);
+			buf = fmt::sprintf(TEXTCOLOR_GREEN "???" TEXTCOLOR_NORMAL);
 		}
 		else
 		{
-			StrFormat(buf, "%s%s" TEXTCOLOR_NORMAL, tm.TextColor.c_str(),
-			          tm.ColorString.c_str());
+			buf = fmt::sprintf("%s%s" TEXTCOLOR_NORMAL, tm.TextColor.c_str(),
+			                   tm.ColorString.c_str());
 		}
 		return buf;
 	}
 
-	StrFormat(buf, TEXTCOLOR_GREEN "???" TEXTCOLOR_NORMAL);
+	buf = fmt::sprintf(TEXTCOLOR_GREEN "???" TEXTCOLOR_NORMAL);
 	return buf;
 }
 
@@ -1319,20 +1316,20 @@ static void LevelStateHorde(levelStateLines_t& lines)
 	{
 		if (::g_horde_waves.asInt() != 0)
 		{
-			StrFormat(lines.title,
+			lines.title = fmt::sprintf(
 			          "Wave " TEXTCOLOR_YELLOW "%d " TEXTCOLOR_GREY "of " TEXTCOLOR_YELLOW
 			          "%d",
 			          info.wave, ::g_horde_waves.asInt());
 		}
 		else
 		{
-			StrFormat(lines.title, "Wave " TEXTCOLOR_YELLOW "%d", info.wave);
+			lines.title = fmt::sprintf("Wave " TEXTCOLOR_YELLOW "%d", info.wave);
 		}
 
-		StrFormat(lines.subtitle[0], "\"" TEXTCOLOR_YELLOW "%s" TEXTCOLOR_GREY "\"",
-		          define.name.c_str());
+		lines.subtitle[0] = fmt::sprintf("\"" TEXTCOLOR_YELLOW "%s" TEXTCOLOR_GREY "\"",
+		                                 define.name.c_str());
 
-		StrFormat(lines.subtitle[1], "Difficulty: %s", define.difficulty(true));
+		lines.subtitle[1] = fmt::sprintf("Difficulty: %s", define.difficulty(true));
 
 		// Detect when there are new weapons to pick up.
 		StringTokens weapList;
@@ -1348,7 +1345,7 @@ static void LevelStateHorde(levelStateLines_t& lines)
 
 		if (!weapList.empty())
 		{
-			StrFormat(lines.subtitle[3], TEXTCOLOR_GREY "Weapons: " TEXTCOLOR_GREEN "%s",
+			lines.subtitle[3] = fmt::sprintf(TEXTCOLOR_GREY "Weapons: " TEXTCOLOR_GREEN "%s",
 			          JoinStrings(weapList, " ").c_str());
 		}
 
@@ -1386,7 +1383,7 @@ void LevelStateHUD()
 			}
 			else
 			{
-				StrFormat(lines.subtitle[0],
+				lines.subtitle[0] = fmt::sprintf(
 				          "Press " TEXTCOLOR_GOLD "%s" TEXTCOLOR_NORMAL
 				          " when ready to play",
 				          ::Bindings.GetKeynameFromCommand("ready").c_str());
@@ -1401,22 +1398,22 @@ void LevelStateHUD()
 	}
 	case LevelState::WARMUP_COUNTDOWN:
 	case LevelState::WARMUP_FORCED_COUNTDOWN: {
-		StrFormat(lines.title, "%s", G_GametypeName().c_str());
-		StrFormat(lines.subtitle[0], "Match begins in " TEXTCOLOR_GREEN "%d",
-		          ::levelstate.getCountdown());
+		lines.title = fmt::sprintf("%s", G_GametypeName().c_str());
+		lines.subtitle[0] = fmt::sprintf("Match begins in " TEXTCOLOR_GREEN "%d",
+		                                 ::levelstate.getCountdown());
 		break;
 	}
 	case LevelState::PREROUND_COUNTDOWN: {
-		StrFormat(lines.title, "Round " TEXTCOLOR_YELLOW " %d", ::levelstate.getRound());
+		lines.title = fmt::sprintf("Round " TEXTCOLOR_YELLOW " %d", ::levelstate.getRound());
 		if (g_preroundreset)
 		{
-			StrFormat(lines.subtitle[0], "Round begins in " TEXTCOLOR_GREEN "%d",
-			          ::levelstate.getCountdown());
+			lines.subtitle[0] = fmt::sprintf("Round begins in " TEXTCOLOR_GREEN "%d",
+			                                 ::levelstate.getCountdown());
 		}
 		else
 		{
-			StrFormat(lines.subtitle[0], "Weapons unlocked in " TEXTCOLOR_GREEN "%d",
-			          ::levelstate.getCountdown());
+			lines.subtitle[0] = fmt::sprintf("Weapons unlocked in " TEXTCOLOR_GREEN "%d",
+			                                 ::levelstate.getCountdown());
 		}
 		break;
 	}
@@ -1449,7 +1446,7 @@ void LevelStateHUD()
 				lines.title = "GO!\n";
 				if (G_IsRoundsGame() && g_roundlimit)
 				{
-					StrFormat(lines.subtitle[0],
+					lines.subtitle[0] = fmt::sprintf(
 					          TEXTCOLOR_GREEN "%d" TEXTCOLOR_GREY " attempts left",
 					          g_roundlimit.asInt() - ::levelstate.getRound() + 1);
 				}
@@ -1467,29 +1464,29 @@ void LevelStateHUD()
 	}
 	case LevelState::ENDROUND_COUNTDOWN: {
 		if (G_IsCoopGame() || G_IsHordeMode())
-			StrFormat(lines.title,
+			lines.title = fmt::sprintf(
 				"Attempt " TEXTCOLOR_YELLOW "%d " TEXTCOLOR_GREY "complete\n",
 				::levelstate.getRound());
 		else
-			StrFormat(lines.title,
+			lines.title = fmt::sprintf(
 				"Round " TEXTCOLOR_YELLOW "%d " TEXTCOLOR_GREY "complete\n",
 				::levelstate.getRound());
 
 		WinInfo win = ::levelstate.getWinInfo();
 		if (win.type == WinInfo::WIN_DRAW)
-			StrFormat(lines.subtitle[0], "Tied at the end of the round");
+			lines.subtitle[0] = fmt::sprintf("Tied at the end of the round");
 		else if (win.type == WinInfo::WIN_PLAYER)
-			StrFormat(lines.subtitle[0], "%s wins the round",
-			          WinToColorString(win).c_str());
+			lines.subtitle[0] = fmt::sprintf("%s wins the round",
+			                                 WinToColorString(win).c_str());
 		else if (win.type == WinInfo::WIN_TEAM)
-			StrFormat(lines.subtitle[0], "%s team wins the round",
-			          WinToColorString(win).c_str());
+			lines.subtitle[0] = fmt::sprintf("%s team wins the round",
+			                                 WinToColorString(win).c_str());
 		else if (G_IsCoopGame() || G_IsHordeMode())
-			StrFormat(lines.subtitle[0], "Next attempt in " TEXTCOLOR_GREEN "%d",
-			          ::levelstate.getCountdown());
+			lines.subtitle[0] = fmt::sprintf("Next attempt in " TEXTCOLOR_GREEN "%d",
+			                                 ::levelstate.getCountdown());
 		else
-			StrFormat(lines.subtitle[0], "Next round in " TEXTCOLOR_GREEN "%d",
-			          ::levelstate.getCountdown());
+			lines.subtitle[0] = fmt::sprintf("Next round in " TEXTCOLOR_GREEN "%d",
+			                                 ::levelstate.getCountdown());
 		break;
 	}
 	case LevelState::ENDGAME_COUNTDOWN: {
@@ -1497,23 +1494,23 @@ void LevelStateHUD()
 		//Upper Text
 		if
 			(win.type == WinInfo::WIN_EVERYBODY)
-			StrFormat(lines.title, TEXTCOLOR_YELLOW "Mission Success!");
+			lines.title = fmt::sprintf(TEXTCOLOR_YELLOW "Mission Success!");
 		else if
 			(win.type == WinInfo::WIN_NOBODY)
-			StrFormat(lines.title, TEXTCOLOR_RED "Mission Failed!");
+			lines.title = fmt::sprintf(TEXTCOLOR_RED "Mission Failed!");
 		else
-			StrFormat(lines.title, "Match complete");
+			lines.title = fmt::sprintf("Match complete");
 
 		// Lower Text
 		if (win.type == WinInfo::WIN_DRAW)
-			StrFormat(lines.subtitle[0], "The game ends in a tie");
+			lines.subtitle[0] = fmt::sprintf("The game ends in a tie");
 		else if (win.type == WinInfo::WIN_PLAYER)
-			StrFormat(lines.subtitle[0], "%s wins!", WinToColorString(win).c_str());
+			lines.subtitle[0] = fmt::sprintf("%s wins!", WinToColorString(win).c_str());
 		else if (win.type == WinInfo::WIN_TEAM)
-			StrFormat(lines.subtitle[0], "%s team wins!", WinToColorString(win).c_str());
+			lines.subtitle[0] = fmt::sprintf("%s team wins!", WinToColorString(win).c_str());
 		else
-			StrFormat(lines.subtitle[0], "Intermission in " TEXTCOLOR_GREEN "%d",
-			          ::levelstate.getCountdown());
+			lines.subtitle[0] = fmt::sprintf("Intermission in " TEXTCOLOR_GREEN "%d",
+			                                 ::levelstate.getCountdown());
 		break;
 	}
 	default:
@@ -1606,8 +1603,8 @@ void DoomHUD()
 	if (::hud_speedometer && ::consoleplayer_id == ::displayplayer_id)
 	{
 		std::string buf;
-		StrFormat(buf, "%d" TEXTCOLOR_DARKGREY "ups",
-		          static_cast<int>(HU_GetPlayerSpeed()));
+		buf = fmt::sprintf("%d" TEXTCOLOR_DARKGREY "ups",
+		                   static_cast<int>(HU_GetPlayerSpeed()));
 		hud::DrawText(0, st_y, hud_scale, hud::X_CENTER, hud::Y_BOTTOM, hud::X_CENTER,
 		              hud::Y_BOTTOM, buf.c_str(), CR_GREY);
 		st_y += V_LineHeight() + 1;

--- a/client/src/v_palette.cpp
+++ b/client/src/v_palette.cpp
@@ -211,17 +211,17 @@ public:
 class DoomGammaStrategy : public GammaStrategy
 {
 public:
-	float min() const
+	float min() const override
 	{
 		return 0.0f;
 	}
 
-	float max() const
+	float max() const override
 	{
 		return 7.0f;
 	}
 
-	float increment(float level) const
+	float increment(float level) const override
 	{
 		level += 1.0f;
 		if (level > max())
@@ -229,7 +229,7 @@ public:
 		return level;
 	}
 
-	void generateGammaTable(byte* table, float level) const
+	void generateGammaTable(byte* table, float level) const override
 	{
 		// [SL] Use vanilla Doom's gamma table
 		//
@@ -250,17 +250,17 @@ public:
 class ZDoomGammaStrategy : public GammaStrategy
 {
 public:
-	float min() const
+	float min() const override
 	{
 		return 0.5f;
 	}
 
-	float max() const
+	float max() const override
 	{
 		return 3.0f;
 	}
 
-	float increment(float level) const
+	float increment(float level) const override
 	{
 		level += 0.1f;
 		if (level > max())
@@ -268,7 +268,7 @@ public:
 		return level;
 	}
 
-	void generateGammaTable(byte* table, float level) const
+	void generateGammaTable(byte* table, float level) const override
 	{
 		// [SL] Use ZDoom 1.22 gamma correction
 
@@ -711,7 +711,7 @@ void BuildDefaultColorAndShademap(const palette_t* pal, shademap_t& maps)
 
 	const argb_t* palette = pal->basecolors;
 	argb_t fadecolor(level.fadeto_color[0], level.fadeto_color[1], level.fadeto_color[2], level.fadeto_color[3]);
-	
+
 	palindex_t* colormap = maps.colormap;
 	argb_t* shademap = maps.shademap;
 
@@ -740,9 +740,9 @@ void BuildDefaultColorAndShademap(const palette_t* pal, shademap_t& maps)
 						 palette[c].getg() * 0.00229296875f +
 			 			 palette[c].getb() * 0.0005625f), 0.0f, 1.0f));
 
-		argb_t color(255, grayint, grayint, grayint); 
+		argb_t color(255, grayint, grayint, grayint);
 		colormap[c] = V_BestColor(palette, color);
-		shademap[c] = V_GammaCorrect(color); 
+		shademap[c] = V_GammaCorrect(color);
 	}
 }
 
@@ -755,7 +755,7 @@ void BuildDefaultShademap(const palette_t* pal, shademap_t& maps)
 
 	const argb_t* palette = pal->basecolors;
 	argb_t fadecolor(level.fadeto_color[0], level.fadeto_color[1], level.fadeto_color[2], level.fadeto_color[3]);
-	
+
 	argb_t* shademap = maps.shademap;
 
 	for (int i = 0; i < NUMCOLORMAPS; i++, shademap += 256)
@@ -782,8 +782,8 @@ void BuildDefaultShademap(const palette_t* pal, shademap_t& maps)
 						 palette[c].getg() * 0.00229296875f +
 			 			 palette[c].getb() * 0.0005625f), 0.0f, 1.0f));
 
-		argb_t color(255, grayint, grayint, grayint); 
-		shademap[c] = V_GammaCorrect(color); 
+		argb_t color(255, grayint, grayint, grayint);
+		shademap[c] = V_GammaCorrect(color);
 	}
 }
 
@@ -940,7 +940,7 @@ fahsv_t V_RGBtoHSV(const fargb_t &color)
 	float largest = std::max(std::max(r, g), b);
 	float delta = largest - smallest;
 
-	if (delta == 0.0f)	
+	if (delta == 0.0f)
 		return fahsv_t(a, 0, 0, largest);
 
 	float hue;
@@ -1212,7 +1212,7 @@ void V_DoPaletteEffects()
 			if (bonus_amount > 0.0f)
 			{
 				bonus_amount = MIN(bonus_amount, 24.0f);
-				float alpha = (bonus_amount + 8.0f) / 64.0f;				
+				float alpha = (bonus_amount + 8.0f) / 64.0f;
 
 				static const float red = 215.0f / 255.0f;
 				static const float green = 186.0f / 255.0f;

--- a/client/src/v_screenshot.cpp
+++ b/client/src/v_screenshot.cpp
@@ -147,7 +147,6 @@ static void SetPNGComments(PNGStrings& out, png_struct* png_ptr, png_info* info_
 	return;
 #endif
 
-	std::string strbuf;
 	const int PNG_TEXT_LINES = 6;
 	png_text pngtext[PNG_TEXT_LINES];
 	int text_line = 0;
@@ -183,8 +182,7 @@ static void SetPNGComments(PNGStrings& out, png_struct* png_ptr, png_info* info_
 	                              : (png_charp) "32bpp";
 	text_line++;
 
-	StrFormat(strbuf, "%#.3f", gammalevel.value());
-	out.at(text_line) = strbuf;
+	out.at(text_line) = fmt::sprintf("%#.3f", gammalevel.value());
 	pngtext[text_line].key = (png_charp) "In-game Gamma Correction Level";
 	pngtext[text_line].text = (png_charp)out.at(text_line).c_str();
 	text_line++;
@@ -234,7 +232,7 @@ static int V_SavePNG(const std::string& filename, IWindowSurface* surface)
 		Printf(PRINT_HIGH, "I_SavePNG: png_create_info_struct failed\n");
 		return -1;
 	}
-	
+
 	// libpng instances compiled without PNG_NO_SETJMP expect this;
 	// PNG_ABORT() is invoked instead if PNG_SETJMP_SUPPORTED was not defined
 	// see include/pnglibconf.h for libpng feature support macros
@@ -270,11 +268,11 @@ static int V_SavePNG(const std::string& filename, IWindowSurface* surface)
 	int png_bpp = (surface->getBitsPerPixel() == 8) ? 1 : 3;
 	png_byte** row_ptrs = (png_byte**)png_malloc(png_ptr, (png_alloc_size_t)(height * sizeof(png_byte*)));
 	png_byte* row;
-	
+
 	for (unsigned int rownum = 0; rownum < height; rownum++)
 	{
 		row = (png_byte*)png_malloc(png_ptr, (png_alloc_size_t)(sizeof(uint8_t) * width * png_bpp));
-		
+
 		if (row != NULL)
 		{
 			row_ptrs[rownum] = row;
@@ -287,17 +285,17 @@ static int V_SavePNG(const std::string& filename, IWindowSurface* surface)
 			png_free(png_ptr, row_ptrs);
 			png_destroy_write_struct(&png_ptr, &info_ptr);
 			fclose(fp);
-			
+
 			Printf(PRINT_WARNING, "I_SavePNG: Not enough RAM to create PNG file\n");
 			return -1;
 		}
 	}
-	
+
 	// write PNG in either paletted or RGB form, according to the current screen mode
 	if (surface->getBitsPerPixel() == 8)
 	{
 		V_SetPNGPalette(png_ptr, info_ptr, surface->getPalette());
-		
+
 		const palindex_t* source = (palindex_t*)surface->getBuffer();
 		const int pitch_remainder = surface->getPitchInPixels() - width;
 
@@ -325,7 +323,7 @@ static int V_SavePNG(const std::string& filename, IWindowSurface* surface)
 		for (unsigned int y = 0; y < height; y++)
 		{
 			row = row_ptrs[y];
-			
+
 			for (unsigned int x = 0; x < width; x++)
 			{
 				// gather color components from current pixel of SDL surface
@@ -342,7 +340,7 @@ static int V_SavePNG(const std::string& filename, IWindowSurface* surface)
 			source += pitch_remainder;
 		}
 	}
-	
+
 	// commit PNG image data to file
 	surface->unlock();
 	png_init_io(png_ptr, fp);
@@ -359,17 +357,17 @@ static int V_SavePNG(const std::string& filename, IWindowSurface* surface)
 	#else
 	Printf(PRINT_HIGH, "I_SavePNG: Skipping PNG tIME chunk\n");
 	#endif // PNG_tIME_SUPPORTED
-	
+
 	png_set_rows(png_ptr, info_ptr, row_ptrs);
 	png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
-	
+
 	// free allocated PNG image data
 	for (unsigned int y = 0; y < height; y++)
 		png_free(png_ptr, row_ptrs[y]);
 
 	png_free(png_ptr, row_ptrs);
 	png_destroy_write_struct(&png_ptr, &info_ptr);
-	
+
 	fclose(fp);
 	return 0;
 }

--- a/client/src/v_text.cpp
+++ b/client/src/v_text.cpp
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -73,7 +73,7 @@ void V_TextInit()
 	sub = 0;
 	for (int i = 0; i < HU_FONTSIZE; i++)
 	{
-		StrFormat(buffer, bigfont, j++ - sub);
+		buffer = fmt::sprintf(bigfont, j++ - sub);
 
 		// Some letters of this font are missing.
 		int num = W_CheckNumForName(buffer.c_str());
@@ -88,7 +88,7 @@ void V_TextInit()
 	sub = 0;
 	for (int i = 0; i < HU_FONTSIZE; i++)
 	{
-		StrFormat(buffer, smallfont, j++ - sub);
+		buffer = fmt::sprintf(smallfont, j++ - sub);
 		::hu_smallfont[i] = W_CachePatchHandle(buffer.c_str(), PU_STATIC);
 	}
 
@@ -102,11 +102,11 @@ void V_TextInit()
 	{
 		if ((j >= '0' && j <= '9') || (j >= 'A' && j <= 'Z'))
 		{
-			StrFormat(buffer, digfont_literal, j++);
+			buffer = fmt::sprintf(digfont_literal, j++);
 		}
 		else
 		{
-			StrFormat(buffer, digfont, j++);
+			buffer = fmt::sprintf(digfont, j++);
 		}
 
 		// Some letters of this font might be missing.
@@ -148,7 +148,7 @@ void V_TextShutdown()
 
 /**
  * @brief Set the current font.
- * 
+ *
  * @param fontname Font name, can be one of "BIGFONT" or "SMALLFONT".
  */
 void V_SetFont(const char* fontname)
@@ -361,7 +361,7 @@ void DCanvas::TextSWrapper (EWrapperCode drawer, int normalcolor, int x, int y, 
 	TextSWrapper(drawer, normalcolor, x, y, string, CleanXfac, CleanYfac);
 }
 
-void DCanvas::TextSWrapper (EWrapperCode drawer, int normalcolor, int x, int y, 
+void DCanvas::TextSWrapper (EWrapperCode drawer, int normalcolor, int x, int y,
 							const byte *string, int scalex, int scaley) const
 {
 	if (::hu_font[0].empty())
@@ -386,7 +386,7 @@ void DCanvas::TextSWrapper (EWrapperCode drawer, int normalcolor, int x, int y,
 		{
 			int new_color = V_GetTextColor(str);
 			V_ColorMap = translationref_t(Ranges + new_color * 256);
-			str += 2;	
+			str += 2;
 			continue;
 		}
 
@@ -429,7 +429,7 @@ int V_StringWidth(const byte* str)
 		return 8;
 
 	int width = 0;
-	
+
 	while (*str)
 	{
 		// skip over color markup escape codes

--- a/client/src/v_text.cpp
+++ b/client/src/v_text.cpp
@@ -485,7 +485,7 @@ static void breakit(brokenlines_t* line, const byte* start, const byte* string, 
 	while (string > start && isspace(*(string - 1)))
 		string--;
 
-	int prefix_len = prefix ? strlen(prefix) : 0;
+	size_t prefix_len = prefix ? strlen(prefix) : 0;
 
 	line->string = new char[string - start + 1 + prefix_len];
 

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -719,15 +719,15 @@ void V_DrawFPSWidget()
 		             argb_t(0x13, 0x13, 0x13));
 
 		// Min
-		StrFormat(buffer, "%4.1f", ::g_GraphData.minimum);
+		buffer = fmt::sprintf("%4.1f", ::g_GraphData.minimum);
 		screen->PrintStr(graphBox.max.x, graphBox.max.y - 3, buffer.c_str());
 
 		// Max
-		StrFormat(buffer, "%4.1f", ::g_GraphData.maximum);
+		buffer = fmt::sprintf("%4.1f", ::g_GraphData.maximum);
 		screen->PrintStr(graphBox.max.x, graphBox.min.y - 3, buffer.c_str());
 
 		// Actual
-		StrFormat(buffer, "%4.1f", delta_time_ms);
+		buffer = fmt::sprintf("%4.1f", delta_time_ms);
 		screen->PrintStr(graphBox.max.x, graphBox.min.y + (::GRAPH_HEIGHT / 2) - 3,
 		                 buffer.c_str());
 
@@ -748,7 +748,7 @@ void V_DrawFPSWidget()
 		}
 
 		// FPS counter
-		StrFormat(buffer, "FPS %5.1f", last_fps);
+		buffer = fmt::sprintf("FPS %5.1f", last_fps);
 		screen->PrintStr(graphBox.min.x, graphBox.max.y + 1, buffer.c_str());
 	}
 	else if (vid_displayfps.asInt() == FPS_COUNTER)
@@ -769,7 +769,7 @@ void V_DrawFPSWidget()
 
 		// FPS counter
 		std::string buffer;
-		StrFormat(buffer, "FPS %5.1f", last_fps);
+		buffer = fmt::sprintf("FPS %5.1f", last_fps);
 		screen->PrintStr(botleft.x, botleft.y + 1, buffer.c_str());
 	}
 }

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -149,8 +149,8 @@ bool V_CheckModeAdjustment()
 	if (V_GetRequestedVideoMode() != window->getVideoMode())
 		return true;
 
-	bool using_widescreen = I_IsWideResolution();
-	if (vid_widescreen.asInt() > 0 && sv_allowwidescreen != using_widescreen)
+	bool allow_widescreen = sv_allowwidescreen != 0.0f;
+	if (vid_widescreen.asInt() > 0 && allow_widescreen != I_IsWideResolution())
 		return true;
 
 	if (vid_widescreen.asInt() != vid_widescreen_old)
@@ -268,7 +268,8 @@ CVAR_FUNC_IMPL(vid_pillarbox)
 static bool CheckWideModeAdjustment()
 {
 	bool using_widescreen = I_IsWideResolution();
-	if (vid_widescreen.asInt() > 0 && sv_allowwidescreen != using_widescreen)
+	bool allow_widescreen = sv_allowwidescreen != 0.0f;
+	if (vid_widescreen.asInt() > 0 && allow_widescreen != using_widescreen)
 		return true;
 
 	if (vid_widescreen.asInt() > 0 != using_widescreen)

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -674,7 +674,7 @@ void V_DrawFPSWidget()
 		                         v2int_t(::GRAPH_WIDTH, ::GRAPH_HEIGHT));
 
 		// Data
-		for (size_t count = 1; count < ::GRAPH_WIDTH - 2; count++)
+		for (int count = 1; count < ::GRAPH_WIDTH - 2; count++)
 		{
 			const double start = ::g_GraphData.getTail(count - 1);
 			const double end = ::g_GraphData.getTail(count);

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1039,8 +1039,7 @@ void WI_drawNetgameStats()
 		// Display player names online!
 		if (!demoplayback)
 		{
-			std::string str;
-			StrFormat(str, "%s", it->userinfo.netname.c_str());
+			std::string str = fmt::sprintf("%s", it->userinfo.netname.c_str());
 			WI_DrawSmallName(str.c_str(), x+10, y+24);
 		}
 

--- a/common/actor.h
+++ b/common/actor.h
@@ -111,12 +111,12 @@
 
 //
 // [SL] 2012-04-30 - A bit field to store a bool value for every player.
-// 
+//
 class PlayerBitField
 {
 public:
 	PlayerBitField() { clear(); }
-	
+
 	void clear()
 	{
 		memset(bitfield, 0, sizeof(bitfield));
@@ -126,33 +126,33 @@ public:
 	{
 		int bytenum = id >> 3;
 		int bitnum = id & bytemask;
-	
+
 		bitfield[bytenum] |= (1 << bitnum);
 	}
-	
+
 	void unset(byte id)
 	{
 		int bytenum = id >> 3;
 		int bitnum = id & bytemask;
-	
+
 		bitfield[bytenum] &= ~(1 << bitnum);
 	}
-	
+
 	bool get(byte id) const
 	{
 		int bytenum = id >> 3;
-		int bitnum = id & bytemask;	
-	
+		int bitnum = id & bytemask;
+
 		return ((bitfield[bytenum] & (1 << bitnum)) != 0);
 	}
-	
+
 private:
 	static const int bytesize = 8*sizeof(byte);
 	static const int bytemask = bytesize - 1;
-	
+
 	// Hacky way of getting ceil() at compile-time
 	static const size_t fieldsize = (MAXPLAYERS + bytemask) / bytesize;
-	
+
 	byte	bitfield[fieldsize];
 };
 
@@ -432,7 +432,7 @@ public:
 	void Destroy ();
 	~AActor ();
 
-	virtual void RunThink ();
+	void RunThink () override;
 
     // Info for drawing: position.
     fixed_t		x;
@@ -481,7 +481,7 @@ public:
     mobjinfo_t*		info;	// &mobjinfo[mobj->type]
     int				tics;	// state tic counter
 	state_t			*state;
-	int				damage;			// For missiles	
+	int				damage;			// For missiles
 	int				flags;
 	int				flags2;	// Heretic flags
 	int				flags3;	// MBF21 flags
@@ -575,7 +575,7 @@ public:
 	void SetOrigin (fixed_t x, fixed_t y, fixed_t z);
 
 	AActorPtr ptr(){ return self; }
-	
+
 	//
 	// ActorBlockMapListNode
 	//
@@ -595,12 +595,12 @@ public:
 	private:
 		void clear();
 		size_t getIndex(int bmx, int bmy);
-		
+
 		static const size_t BLOCKSX = 3;
 		static const size_t BLOCKSY = 3;
 
 		AActor		*actor;
-			
+
 		// the top-left blockmap the actor is in
 		int			originx;
 		int			originy;
@@ -613,7 +613,7 @@ public:
 		AActor		*next[BLOCKSX * BLOCKSY];
 		AActor		**prev[BLOCKSX * BLOCKSY];
 	};
-	
+
 	ActorBlockMapListNode bmapnode;
 };
 

--- a/common/c_cvars.cpp
+++ b/common/c_cvars.cpp
@@ -153,7 +153,7 @@ void cvar_t::ForceSet(const char* valstr)
 	// [SL] 2013-04-16 - Latched CVARs do not change values until the next map.
 	// Servers and single-player games should abide by this behavior but
 	// multiplayer clients should just do what the server tells them.
-	if (m_Flags & CVAR_LATCH && serverside && 
+	if (m_Flags & CVAR_LATCH && serverside &&
 		(gamestate == GS_LEVEL || gamestate == GS_INTERMISSION))
 	{
 		m_Flags |= CVAR_MODIFIED;
@@ -331,12 +331,10 @@ void cvar_t::FilterCompactCVars (TArray<cvar_t *> &cvars, DWORD filter)
 	}
 }
 
-// Uses sprintf's return value (number of chars written) to advance
+// Uses snprintf's return value (number of chars written) to advance
 // a pointer of an array of chars to write out a packed byte array
-// of cvars.
-// 
-// To rewrite it for snprintf, we need the base array size
-// which we'll subtract from the total every advancement
+// of cvars, subtracting the base array size from the total after
+// each advancement.
 void cvar_t::C_WriteCVars (byte **demo_p, DWORD filter, size_t array_size, bool compact)
 {
 	if (array_size <= 0)
@@ -633,7 +631,7 @@ static std::string C_GetValueString(const cvar_t* var)
 	if (atof(var->cstring()) == 0.0f)
 		return "disabled";
 	else
-		return "enabled";	
+		return "enabled";
 }
 
 static std::string C_GetLatchedValueString(const cvar_t* var)

--- a/common/c_cvars.cpp
+++ b/common/c_cvars.cpp
@@ -644,9 +644,7 @@ static std::string C_GetLatchedValueString(const cvar_t* var)
 
 	if (var->flags() & CVAR_NOENABLEDISABLE)
 	{
-		std::string str = "";
-		StrFormat(str, "\"%s\"", var->latched());
-		return str;
+		return fmt::sprintf("\"%s\"", var->latched());
 	}
 
 	if (atof(var->latched()) == 0.0f)

--- a/common/c_dispatch.h
+++ b/common/c_dispatch.h
@@ -50,7 +50,7 @@ class DConsoleCommand : public DObject
 	DECLARE_CLASS (DConsoleCommand, DObject)
 public:
 	DConsoleCommand (const char *name);
-	virtual ~DConsoleCommand ();
+	~DConsoleCommand () override;
 	virtual void Run (uint32_t key = 0) = 0;
 	virtual bool IsAlias () { return false; }
 	void PrintCommand () { Printf (PRINT_HIGH, "%s\n", m_Name.c_str()); }
@@ -84,9 +84,9 @@ class DConsoleAlias : public DConsoleCommand
 	bool state_lock;
 public:
 	DConsoleAlias (const char *name, const char *command);
-	virtual ~DConsoleAlias ();
-	virtual void Run (uint32_t key = 0);
-	virtual bool IsAlias () { return true; }
+	~DConsoleAlias () override;
+	void Run (uint32_t key = 0) override;
+	bool IsAlias () override { return true; }
 	void PrintAlias () { Printf (PRINT_HIGH, "%s : %s\n", m_Name.c_str(), m_Command.c_str()); }
 	void Archive (FILE *f);
 

--- a/common/c_doc.cpp
+++ b/common/c_doc.cpp
@@ -67,7 +67,7 @@ static void HTMLHeader(std::string& out, const char* title)
 	    "</style>"
 	    "</head>"
 	    "<body>";
-	StrFormat(out, HEADER, title);
+	out = fmt::sprintf(HEADER, title);
 }
 
 /**
@@ -119,18 +119,18 @@ static void HTMLCvarRow(std::string& out, const cvar_t& cvar)
 	case CVARTYPE_INT: {
 		std::string buffer;
 		int val = atoi(cvar.getDefault().c_str());
-		StrFormat(buffer, "Default: %d", val);
+		buffer = fmt::sprintf("Default: %d", val);
 		info.push_back(buffer);
 
 		if (cvar.getMinValue() != -FLT_MAX)
 		{
-			StrFormat(buffer, "Min: %d", static_cast<int>(cvar.getMinValue()));
+			buffer = fmt::sprintf("Min: %d", static_cast<int>(cvar.getMinValue()));
 			info.push_back(buffer);
 		}
 
 		if (cvar.getMaxValue() != FLT_MAX)
 		{
-			StrFormat(buffer, "Max: %d", static_cast<int>(cvar.getMaxValue()));
+			buffer = fmt::sprintf("Max: %d", static_cast<int>(cvar.getMaxValue()));
 			info.push_back(buffer);
 		}
 
@@ -139,18 +139,18 @@ static void HTMLCvarRow(std::string& out, const cvar_t& cvar)
 	case CVARTYPE_FLOAT: {
 		std::string buffer;
 		float val = atof(cvar.getDefault().c_str());
-		StrFormat(buffer, "Default: %f", val);
+		buffer = fmt::sprintf("Default: %f", val);
 		info.push_back(buffer);
 
 		if (cvar.getMinValue() != -FLT_MAX)
 		{
-			StrFormat(buffer, "Min: %f", cvar.getMinValue());
+			buffer = fmt::sprintf("Min: %f", cvar.getMinValue());
 			info.push_back(buffer);
 		}
 
 		if (cvar.getMaxValue() != FLT_MAX)
 		{
-			StrFormat(buffer, "Max: %f", cvar.getMaxValue());
+			buffer = fmt::sprintf("Max: %f", cvar.getMaxValue());
 			info.push_back(buffer);
 		}
 
@@ -160,7 +160,7 @@ static void HTMLCvarRow(std::string& out, const cvar_t& cvar)
 		if (!cvar.getDefault().empty())
 		{
 			std::string buf;
-			StrFormat(buf, "Default: \"%s\"", cvar.getDefault().c_str());
+			buf = fmt::sprintf("Default: \"%s\"", cvar.getDefault().c_str());
 			info.push_back(buf);
 		}
 		break;
@@ -194,7 +194,7 @@ static void HTMLCvarRow(std::string& out, const cvar_t& cvar)
 	                  "<p><small><em>%s</em></small></p>"
 	                  "<p>%s</p>"
 	                  "</dd>";
-	StrFormat(out, ROW, cvar.name(), flagstr.c_str(), cvar.helptext());
+	out = fmt::sprintf(ROW, cvar.name(), flagstr.c_str(), cvar.helptext());
 }
 
 /**
@@ -256,7 +256,7 @@ BEGIN_COMMAND(cvardoc)
 
 	// First the header.
 	std::string title;
-	StrFormat(title, "%s %s Console Variables", CS_STRING, DOTVERSIONSTR);
+	title = fmt::sprintf("%s %s Console Variables", CS_STRING, DOTVERSIONSTR);
 	HTMLHeader(buffer, title.c_str());
 	fwrite(buffer.data(), sizeof(char), buffer.size(), fh);
 
@@ -272,7 +272,7 @@ BEGIN_COMMAND(cvardoc)
 	    "number with a decimal point in it, like 3.14."
 	    "</p>";
 
-	StrFormat(buffer, PREAMBLE, title.c_str(), NiceVersion());
+	buffer = fmt::sprintf(PREAMBLE, title.c_str(), NiceVersion());
 	fwrite(buffer.data(), sizeof(char), buffer.size(), fh);
 
 	// Initial tag for cvars.

--- a/common/cmdlib.cpp
+++ b/common/cmdlib.cpp
@@ -354,17 +354,6 @@ StringTokens TokenizeString(const std::string& str, const std::string& delim) {
 //
 // A quick and dirty std::string formatting that uses snprintf under the covers.
 //
-FORMAT_PRINTF(2, 3) void STACK_ARGS StrFormat(std::string& out, const char* fmt, ...)
-{
-	va_list va;
-	va_start(va, fmt);
-	VStrFormat(out, fmt, va);
-	va_end(va);
-}
-
-//
-// A quick and dirty std::string formatting that uses snprintf under the covers.
-//
 void STACK_ARGS VStrFormat(std::string& out, const char* fmt, va_list va)
 {
 	va_list va2;
@@ -420,9 +409,9 @@ void StrFormatBytes(std::string& out, size_t bytes)
 	}
 
 	if (magnitude)
-		StrFormat(out, "%.2f %s", checkbytes, BYTE_MAGS[magnitude]);
+		out = fmt::sprintf("%.2f %s", checkbytes, BYTE_MAGS[magnitude]);
 	else
-		StrFormat(out, "%.0f %s", checkbytes, BYTE_MAGS[magnitude]);
+		out = fmt::sprintf("%.0f %s", checkbytes, BYTE_MAGS[magnitude]);
 }
 
 // [AM] Format a tm struct as an ISO8601-compliant extended format string.

--- a/common/cmdlib.cpp
+++ b/common/cmdlib.cpp
@@ -39,6 +39,8 @@
 #include "i_system.h"
 #include "cmdlib.h"
 
+#include "fmt/ranges.h"
+
 #ifdef GEKKO
 #include "i_wii.h"
 #endif
@@ -327,15 +329,7 @@ std::vector<std::string> VectorArgs(size_t argc, char **argv) {
 
 // [AM] Return a joined string based on a vector of strings
 std::string JoinStrings(const std::vector<std::string> &pieces, const std::string &glue) {
-	std::ostringstream result;
-	for (std::vector<std::string>::const_iterator it = pieces.begin();
-		 it != pieces.end();++it) {
-		result << *it;
-		if (it != (pieces.end() - 1)) {
-			result << glue;
-		}
-	}
-	return result.str();
+	return fmt::format("{}", fmt::join(pieces, glue));
 }
 
 // Tokenize a string

--- a/common/cmdlib.h
+++ b/common/cmdlib.h
@@ -91,7 +91,6 @@ std::string JoinStrings(const std::vector<std::string> &pieces, const std::strin
 typedef std::vector<std::string> StringTokens;
 StringTokens TokenizeString(const std::string& str, const std::string& delim);
 
-FORMAT_PRINTF(2, 3) void STACK_ARGS StrFormat(std::string& out, const char* fmt, ...);
 void STACK_ARGS VStrFormat(std::string& out, const char* fmt, va_list va);
 
 void StrFormatBytes(std::string& out, size_t bytes);
@@ -113,7 +112,7 @@ float NextAfter(const float from, const float to);
 
 /**
  * @brief Initialize an array with a specific value.
- * 
+ *
  * @tparam A Array type to initialize.
  * @tparam T Value type to initialize with.
  * @param dst Array to initialize.
@@ -128,10 +127,10 @@ static void ArrayInit(A& dst, const T& val)
 
 /**
  * @brief Copy the complete contents of an array from one to the other.
- * 
+ *
  * @detail Both params are templated in case the destination's type doesn't
  *         line up 100% with the source.
- * 
+ *
  * @tparam A1 Destination array type.
  * @tparam A2 Source array type.
  * @param dst Destination array to write to.

--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -987,7 +987,7 @@ static int PatchThing(int thingy)
 		}
 
 		size_t val = atoi(Line2);
-		int linelen = strlen(Line1);
+		size_t linelen = strlen(Line1);
 
 		if (stricmp(Line1 + linelen - 6, " frame") == 0)
 		{
@@ -1510,7 +1510,7 @@ static int PatchFrame(int frameNum)
 	while ((result = GetLine()) == 1)
 	{
 		size_t val = atoi(Line2);
-		int linelen = strlen(Line1);
+		size_t linelen = strlen(Line1);
 
 		if (HandleKey(keys, info, Line1, val, sizeof(*info)))
 		{
@@ -1698,7 +1698,7 @@ static int PatchWeapon(int weapNum)
 	while ((result = GetLine()) == 1)
 	{
 		size_t val = atoi(Line2);
-		int linelen = strlen(Line1);
+		size_t linelen = strlen(Line1);
 
 		if (HandleKey(keys, info, Line1, val, sizeof(*info)))
 		{
@@ -2198,7 +2198,7 @@ static int PatchStrings(int dummy)
 			    (i >= GStrings.toIndex(OB_FRIENDLY1) &&
 			     i <= GStrings.toIndex(OB_FRIENDLY4) && strstr(holdstring, "%k") == NULL))
 			{
-				int len = strlen(holdstring);
+				size_t len = strlen(holdstring);
 				memmove(holdstring + 3, holdstring, len);
 				holdstring[0] = '%';
 				holdstring[1] = i <= GStrings.toIndex(OB_DEFAULT) ? 'o' : 'k';

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -971,19 +971,19 @@ public:
 		mTask(task)
 	{ }
 
-	virtual ~UncappedTaskScheduler() { }
+	~UncappedTaskScheduler() override { }
 
-	virtual void run()
+	void run() override
 	{
 		mTask();
 	}
 
-	virtual dtime_t getNextTime() const
+	dtime_t getNextTime() const override
 	{
 		return I_GetTime();
 	}
 
-	virtual float getRemainder() const
+	float getRemainder() const override
 	{
 		return 0.0f;
 	}
@@ -1003,9 +1003,9 @@ public:
 	{
 	}
 
-	virtual ~CappedTaskScheduler() { }
+	~CappedTaskScheduler() override { }
 
-	virtual void run()
+	void run() override
 	{
 		mFrameStartTime = I_GetTime();
 		mAccumulator += mFrameStartTime - mPreviousFrameStartTime;
@@ -1020,12 +1020,12 @@ public:
 		}
 	}
 
-	virtual dtime_t getNextTime() const
+	dtime_t getNextTime() const override
 	{
 		return mFrameStartTime + mFrameDuration - mAccumulator;
 	}
 
-	virtual float getRemainder() const
+	float getRemainder() const override
 	{
 		// mAccumulator can be greater than mFrameDuration so only get the
 		// time remaining until the next frame

--- a/common/dobject.cpp
+++ b/common/dobject.cpp
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -90,9 +90,7 @@ DObject::~DObject ()
 			// object is queued for deletion, but is not being deleted
 			// by the destruction process, so remove it from the
 			// ToDestroy array and do other necessary stuff.
-			int i;
-
-			for (i = ToDestroy.Size() - 1; i >= 0; i--)
+			for (size_t i = ToDestroy.Size() - 1; i >= 0; i--)
 			{
 				if (ToDestroy[i] == this)
 				{
@@ -148,7 +146,7 @@ void DObject::RemoveFromArray ()
 	// so there's really no telling which is destroyed first, better to bail
 	if(Inactive)
 		return;
-	
+
 	if (Objects.Size () == Index + 1)
 	{
 		DObject *dummy;

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -51,12 +51,6 @@
 	#define FORMAT_PRINTF(index, first_arg) __attribute__ ((format(printf, index, first_arg)))
 #endif
 
-#ifdef _MSC_VER
-	#define NORETURN __declspec(noreturn)
-#else
-	#define NORETURN __attribute__ ((noreturn))
-#endif
-
 // [RH] Some windows includes already define this
 #if !defined(_WINDEF_) && !defined(__wtypes_h__) && !defined(GEKKO)
 typedef int BOOL;
@@ -185,9 +179,9 @@ typedef uint64_t			dtime_t;
 
 /**
  * @brief Returns a bitfield with a range of bits set from a to b, inclusive.
- * 
+ *
  * @param a Low bit in the mask.
- * @param b High bit in the mask. 
+ * @param b High bit in the mask.
  */
 static inline uint32_t BIT_MASK(uint32_t a, uint32_t b)
 {
@@ -235,7 +229,7 @@ typedef enum {
 
 	PRINT_NORCON,		// Do NOT send the message to any rcon client.
 
-	PRINT_FILTERCHAT,	// Filter the message to not be displayed ingame, but only in the console (ugly hack)		
+	PRINT_FILTERCHAT,	// Filter the message to not be displayed ingame, but only in the console (ugly hack)
 
 	PRINT_MAXPRINT
 } printlevel_t;
@@ -289,7 +283,7 @@ forceinline T clamp (const T in, const T min, const T max)
 // ARRAY_LENGTH
 //
 // Safely counts the number of items in an C array.
-// 
+//
 // https://www.drdobbs.com/cpp/counting-array-elements-at-compile-time/197800525?pgno=1
 //
 #define ARRAY_LENGTH(arr) ( \

--- a/common/dsectoreffect.h
+++ b/common/dsectoreffect.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -47,7 +47,7 @@ public:
 	DSectorEffect (sector_t *sector);
 	~DSectorEffect ();
 	virtual DSectorEffect* Clone(sector_t *sector) const;
-	virtual void Destroy();
+	void Destroy() override;
 	sector_t* GetSector() const { return m_Sector; }
 protected:
 	DSectorEffect ();

--- a/common/dthinker.h
+++ b/common/dthinker.h
@@ -59,8 +59,8 @@ class DThinker : public DObject
 public:
 	DThinker ();
 	void Orphan();
-	virtual void Destroy ();
-	virtual ~DThinker ();
+	void Destroy () override;
+	~DThinker () override;
 	virtual void RunThink () {}
 
 	void *operator new (size_t size);

--- a/common/farchive.h
+++ b/common/farchive.h
@@ -71,19 +71,19 @@ public:
 	FLZOFile();
 	FLZOFile(const char* name, EOpenMode mode, bool dontcompress = false);
 	FLZOFile(FILE* file, EOpenMode mode, bool dontcompress = false);
-	virtual ~FLZOFile();
+	~FLZOFile();
 
-	virtual bool Open(const char* name, EOpenMode mode);
-	virtual void Close();
-	virtual void Flush();
-	virtual EOpenMode Mode() const;
-	virtual bool IsPersistent() const { return true; }
-	virtual bool IsOpen() const;
+	bool Open(const char* name, EOpenMode mode) override;
+	void Close() override;
+	void Flush() override;
+	EOpenMode Mode() const override;
+	bool IsPersistent() const override { return true; }
+	bool IsOpen() const override;
 
-	virtual FFile& Write(const void*, unsigned int);
-	virtual FFile& Read(void*, unsigned int);
-	virtual unsigned int Tell() const;
-	virtual FFile& Seek(int, ESeekPos);
+	FFile& Write(const void*, unsigned int) override;
+	FFile& Read(void*, unsigned int) override;
+	unsigned int Tell() const override;
+	FFile& Seek(int, ESeekPos) override;
 
 protected:
 	unsigned int m_Pos;
@@ -108,14 +108,14 @@ class FLZOMemFile : public FLZOFile
 public:
 	FLZOMemFile();
 
-	virtual ~FLZOMemFile();
+	~FLZOMemFile() override;
 
-	virtual bool Open(const char* name, EOpenMode mode);	// Works for reading only
+	bool Open(const char* name, EOpenMode mode) override;	// Works for reading only
 	virtual bool Open(void* memblock);	// Open for reading only
 	virtual bool Open();	// Open for writing only
 	virtual bool Reopen();	// Re-opens imploded file for reading only
-	virtual void Close();
-	virtual bool IsOpen() const;
+	void Close() override;
+	bool IsOpen() const override;
 
 	void Serialize(FArchive &arc);
 
@@ -123,7 +123,7 @@ public:
 	void WriteToBuffer(void* buf, size_t length) const;
 
 protected:
-	virtual bool FreeOnExplode() { return !m_SourceFromMem; }
+	bool FreeOnExplode() override { return !m_SourceFromMem; }
 
 private:
 	bool m_SourceFromMem;

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -277,7 +277,7 @@ bool G_IsLevelState(LevelState::States state)
  */
 bool G_IsDefendingTeam(team_t team)
 {
-	return g_sides == false || ::levelstate.getDefendingTeam() == team;
+	return !g_sides || ::levelstate.getDefendingTeam() == team;
 }
 
 /**
@@ -343,7 +343,7 @@ bool G_IsTeamGame()
  */
 bool G_IsRoundsGame()
 {
-	if (g_rounds == false)
+	if (!g_rounds)
 	{
 		// Not turned on.
 		return false;

--- a/common/g_gametypecmd.cpp
+++ b/common/g_gametypecmd.cpp
@@ -130,7 +130,7 @@ static StringList GametypeArgs(const GametypeParam (&params)[SIZE], size_t argc,
 	std::string buffer;
 	for (CvarTable::const_iterator it = cvars.begin(); it != cvars.end(); ++it)
 	{
-		StrFormat(buffer, "%s %d", it->first.c_str(), it->second);
+		buffer = fmt::sprintf("%s %d", it->first.c_str(), it->second);
 		ret.push_back(buffer);
 	}
 

--- a/common/g_horde.cpp
+++ b/common/g_horde.cpp
@@ -73,8 +73,7 @@ static void ParsePowerupConfig(OScanner& os, hordeDefine_t::powConfig_t& outConf
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer;
-			StrFormat(buffer, "Unknown Powerup Token \"%s\".", os.getToken().c_str());
+			std::string buffer = fmt::sprintf("Unknown Powerup Token \"%s\".", os.getToken().c_str());
 			os.error(buffer.c_str());
 		}
 	}
@@ -111,8 +110,7 @@ static void ParseMonsterConfig(OScanner& os, hordeDefine_t::monConfig_t& outConf
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer;
-			StrFormat(buffer, "Unknown Monster/Boss Token \"%s\".", os.getToken().c_str());
+			std::string buffer = fmt::sprintf("Unknown Monster/Boss Token \"%s\".", os.getToken().c_str());
 			os.error(buffer.c_str());
 		}
 	}
@@ -176,9 +174,8 @@ static void ParseDefine(OScanner& os)
 					}
 					else
 					{
-						std::string buffer;
-						StrFormat(buffer, "Unknown weapon \"%s\".",
-						          os.getToken().c_str());
+						std::string buffer = fmt::sprintf("Unknown weapon \"%s\".",
+						                                  os.getToken().c_str());
 						os.error(buffer.c_str());
 					}
 				}
@@ -199,8 +196,7 @@ static void ParseDefine(OScanner& os)
 			const mobjtype_t type = NameOrAliasToMobj(os.getToken());
 			if (type == MT_NULL)
 			{
-				std::string buffer;
-				StrFormat(buffer, "Unknown powerup \"%s\".", os.getToken().c_str());
+				std::string buffer = fmt::sprintf("Unknown powerup \"%s\".", os.getToken().c_str());
 				os.error(buffer.c_str());
 			}
 
@@ -226,8 +222,7 @@ static void ParseDefine(OScanner& os)
 			const mobjtype_t type = NameOrAliasToMobj(os.getToken());
 			if (type == MT_NULL)
 			{
-				std::string buffer;
-				StrFormat(buffer, "Unknown monster \"%s\".", os.getToken().c_str());
+				std::string buffer = fmt::sprintf("Unknown monster \"%s\".", os.getToken().c_str());
 				os.error(buffer.c_str());
 			}
 
@@ -253,8 +248,7 @@ static void ParseDefine(OScanner& os)
 			const mobjtype_t type = NameOrAliasToMobj(os.getToken());
 			if (type == MT_NULL)
 			{
-				std::string buffer;
-				StrFormat(buffer, "Unknown boss \"%s\".", os.getToken().c_str());
+				std::string buffer = fmt::sprintf("Unknown boss \"%s\".", os.getToken().c_str());
 				os.error(buffer.c_str());
 			}
 
@@ -276,8 +270,7 @@ static void ParseDefine(OScanner& os)
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer;
-			StrFormat(buffer, "Unknown Token \"%s\".", os.getToken().c_str());
+			std::string buffer = fmt::sprintf("Unknown Token \"%s\".", os.getToken().c_str());
 			os.error(buffer.c_str());
 		}
 	}
@@ -317,53 +310,53 @@ static void ParseDefine(OScanner& os)
 	}
 	if (define.weapons.empty())
 	{
-		StrFormat(buf, "No weapon pickups found for define \"%s\".", define.name.c_str());
+		buf = fmt::sprintf("No weapon pickups found for define \"%s\".", define.name.c_str());
 		os.warning(buf.c_str());
 	}
 	if (define.monsters.empty())
 	{
-		StrFormat(buf, "No monsters found for define \"%s\".", define.name.c_str());
+		buf = fmt::sprintf("No monsters found for define \"%s\".", define.name.c_str());
 		os.error(buf.c_str());
 	}
 	if (define.powerups.empty())
 	{
-		StrFormat(buf, "No powerups found for define \"%s\".", define.name.c_str());
+		buf = fmt::sprintf("No powerups found for define \"%s\".", define.name.c_str());
 		os.error(buf.c_str());
 	}
 	if (define.minGroupHealth < 0)
 	{
-		StrFormat(buf, "Minimum group health for define \"%s\" was not set.",
-		          define.name.c_str());
+		buf = fmt::sprintf("Minimum group health for define \"%s\" was not set.",
+		                   define.name.c_str());
 		os.error(buf.c_str());
 	}
 	if (define.maxGroupHealth <= 0)
 	{
-		StrFormat(buf, "Maximum group health for define \"%s\" was not set.",
-		          define.name.c_str());
+		buf = fmt::sprintf("Maximum group health for define \"%s\" was not set.",
+		                   define.name.c_str());
 		os.error(buf.c_str());
 	}
 	if (define.minGroupHealth > define.maxGroupHealth)
 	{
-		StrFormat(buf, "Maximum group health for define \"%s\" is less than minimum.",
-		          define.name.c_str());
+		buf = fmt::sprintf("Maximum group health for define \"%s\" is less than minimum.",
+		                   define.name.c_str());
 		os.error(buf.c_str());
 	}
 	if (define.minBossHealth < 0)
 	{
-		StrFormat(buf, "Minimum boss health for define \"%s\" was not set.",
-		          define.name.c_str());
+		buf = fmt::sprintf("Minimum boss health for define \"%s\" was not set.",
+		                   define.name.c_str());
 		os.error(buf.c_str());
 	}
 	if (define.maxBossHealth <= 0)
 	{
-		StrFormat(buf, "Maximum boss health for define \"%s\" was not set.",
-		          define.name.c_str());
+		buf = fmt::sprintf("Maximum boss health for define \"%s\" was not set.",
+		                   define.name.c_str());
 		os.error(buf.c_str());
 	}
 	if (define.minBossHealth > define.maxBossHealth)
 	{
-		StrFormat(buf, "Maximum boss health for define \"%s\" is less than minimum.",
-		          define.name.c_str());
+		buf = fmt::sprintf("Maximum boss health for define \"%s\" is less than minimum.",
+		                   define.name.c_str());
 		os.error(buf.c_str());
 	}
 
@@ -382,16 +375,14 @@ static void ParseAlias(OScanner& os)
 	if (otype == MT_NULL)
 	{
 		// We don't know what this token is.
-		std::string buffer;
-		StrFormat(buffer, "Can't alias unknown thing \"%s\".", original.c_str());
+		std::string buffer = fmt::sprintf("Can't alias unknown thing \"%s\".", original.c_str());
 		os.error(buffer.c_str());
 	}
 
 	if (!CheckIfDehActorDefined(otype))
 	{
 		// [Blair] DEHEXTRA monster not defined
-		std::string buffer;
-		StrFormat(buffer, "The following actor is undefined: \"%s\".", original.c_str());
+		std::string buffer = fmt::sprintf("The following actor is undefined: \"%s\".", original.c_str());
 		os.error(buffer.c_str());
 	}
 
@@ -427,8 +418,7 @@ static void ParseHordeDef(const int lump, const char* name)
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer;
-			StrFormat(buffer, "Unknown Token \"%s\".", os.getToken().c_str());
+			std::string buffer = fmt::sprintf("Unknown Token \"%s\".", os.getToken().c_str());
 			os.error(buffer.c_str());
 		}
 	}

--- a/common/g_horde.cpp
+++ b/common/g_horde.cpp
@@ -465,15 +465,7 @@ static void ParseHordeDefs()
 	// Must be stable for wave ID's to be the same on client and server.
 	std::stable_sort(::WAVE_DEFINES.begin(), ::WAVE_DEFINES.end(), CmpHordeDefs);
 
-	// Dedupe wave defines.  Note that this has a gigantic hack for 10.0 that keeps
-	// track of the original wave ID so it can be sent to 10.0 clients.  This hack
-	// should be removed in 11.0 at the soonest.
-
-	for (size_t i = 0; i < ::WAVE_DEFINES.size(); i++)
-	{
-		::WAVE_DEFINES[i].legacyID = i;
-	}
-
+	// Dedupe wave defines.
 	for (std::vector<hordeDefine_t>::iterator it = ::WAVE_DEFINES.begin();
 	     it != ::WAVE_DEFINES.end(); ++it)
 	{

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -833,7 +833,7 @@ void G_InitLevelLocals()
 		if (info.mapname[0] == 'E' && info.mapname[2] == 'M')
 		{
 			std::string search;
-			StrFormat(search, "E%cM%c: ", info.mapname[1], info.mapname[3]);
+			search = fmt::sprintf("E%cM%c: ", info.mapname[1], info.mapname[3]);
 
 			const std::size_t pos = info.level_name.find(search);
 
@@ -845,7 +845,7 @@ void G_InitLevelLocals()
 		else if (strstr(info.mapname.c_str(), "MAP") == &info.mapname[0])
 		{
 			std::string search;
-			StrFormat(search, "%u: ", info.levelnum);
+			search = fmt::sprintf("%u: ", info.levelnum);
 
 			const std::size_t pos = info.level_name.find(search);
 

--- a/common/g_levelstate.cpp
+++ b/common/g_levelstate.cpp
@@ -599,23 +599,23 @@ void LevelState::printRoundStart() const
 	std::string left, right;
 	if (g_roundlimit > 0)
 	{
-		StrFormat(left, "Round %d of %d has started", m_roundNumber,
-		          g_roundlimit.asInt());
+		left = fmt::sprintf("Round %d of %d has started", m_roundNumber,
+		                    g_roundlimit.asInt());
 	}
 	else
 	{
-		StrFormat(left, "Round %d has started", m_roundNumber);
+		left = fmt::sprintf("Round %d has started", m_roundNumber);
 	}
 
 	team_t def = getDefendingTeam();
 	if (G_IsCoopGame() && g_roundlimit)
 	{
-		StrFormat(right, "%d attempts left", g_roundlimit.asInt() - m_roundNumber + 1);
+		right = fmt::sprintf("%d attempts left", g_roundlimit.asInt() - m_roundNumber + 1);
 	}
 	else if (def != TEAM_NONE)
 	{
 		TeamInfo& teaminfo = *GetTeamInfo(def);
-		StrFormat(right, "%s is on defense", teaminfo.ColorizedTeamName().c_str());
+		right = fmt::sprintf("%s is on defense", teaminfo.ColorizedTeamName().c_str());
 	}
 
 	if (!right.empty())

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1148,8 +1148,8 @@ struct MapInfoDataSetter<level_pwad_info_t>
 			{ "sucktime", &MIType_EatNext },
 			{ "enterpic", &MIType_InterLumpName, &enterpicscript },
 			{ "exitpic", &MIType_InterLumpName, &exitpicscript },
-			{ "enteranim", &MIType_LumpName, &ref.enteranim }, // nonstandard, from ID24 UMAPINFO, only present here for _D1NFO in odamex.wad
-			{ "exitanim", &MIType_LumpName, &ref.exitanim }, // nonstandard, from ID24 UMAPINFO, only present here for _D1NFO in odamex.wad
+			{ "enteranim", &MIType_LumpName, &ref.enteranim },
+			{ "exitanim", &MIType_LumpName, &ref.exitanim },
 			{ "interpic", &MIType_EatNext },
 			{ "translator", &MIType_EatNext },
 			{ "compat_shorttex", &MIType_CompatFlag, &ref.flags }, // todo: not implemented

--- a/common/g_spawninv.cpp
+++ b/common/g_spawninv.cpp
@@ -145,9 +145,7 @@ static int WeaponTypeFromChar(const char ch)
  */
 static std::string InvHealthStr(const spawnInventory_t& inv)
 {
-	std::string rvo;
-	StrFormat(rvo, "%d", inv.health);
-	return rvo;
+	return fmt::sprintf("%d", inv.health);
 }
 
 /**
@@ -155,9 +153,7 @@ static std::string InvHealthStr(const spawnInventory_t& inv)
  */
 static std::string InvArmorPointsStr(const spawnInventory_t& inv)
 {
-	std::string rvo;
-	StrFormat(rvo, "%d", inv.armorpoints);
-	return rvo;
+	return fmt::sprintf("%d", inv.armorpoints);
 }
 
 /**
@@ -165,9 +161,7 @@ static std::string InvArmorPointsStr(const spawnInventory_t& inv)
  */
 static std::string InvReadyWeaponStr(const spawnInventory_t& inv)
 {
-	std::string rvo;
-	StrFormat(rvo, "%c", WeaponTypeToChar(inv.readyweapon));
-	return rvo;
+	return fmt::sprintf("%c", WeaponTypeToChar(inv.readyweapon));
 }
 
 /**
@@ -196,9 +190,7 @@ static std::string InvAmmoStr(const spawnInventory_t& inv, const ammotype_t type
 	{
 		return "";
 	}
-	std::string rvo;
-	StrFormat(rvo, "%d", inv.ammo[type]);
-	return rvo;
+	return fmt::sprintf("%d", inv.ammo[type]);
 }
 // unused
 /**
@@ -222,9 +214,7 @@ static std::string InvAmmoStr(const spawnInventory_t& inv, const ammotype_t type
  */
 static std::string InvInvulStr(const spawnInventory_t& inv)
 {
-	std::string rvo;
-	StrFormat(rvo, "%d", inv.invul);
-	return rvo;
+	return fmt::sprintf("%d", inv.invul);
 }
 
 /**
@@ -342,52 +332,52 @@ static std::string SpawnInvSerialize(const spawnInventory_t& inv)
 	StringTokens params;
 	std::string buf;
 
-	StrFormat(buf, "health:%s", InvHealthStr(inv).c_str());
+	buf = fmt::sprintf("health:%s", InvHealthStr(inv).c_str());
 	params.push_back(buf);
 
 	if (inv.armortype > 0 && inv.armortype <= 2 && inv.armorpoints > 0)
 	{
 		if (inv.armortype == 1)
-			StrFormat(buf, "armor1:%s", InvArmorPointsStr(inv).c_str());
+			buf = fmt::sprintf("armor1:%s", InvArmorPointsStr(inv).c_str());
 		else if (inv.armortype == 2)
-			StrFormat(buf, "armor2:%s", InvArmorPointsStr(inv).c_str());
+			buf = fmt::sprintf("armor2:%s", InvArmorPointsStr(inv).c_str());
 
 		params.push_back(buf);
 	}
 
 	if (inv.readyweapon != NUMWEAPONS)
 	{
-		StrFormat(buf, "rweapon:%s", InvReadyWeaponStr(inv).c_str());
+		buf = fmt::sprintf("rweapon:%s", InvReadyWeaponStr(inv).c_str());
 		params.push_back(buf);
 	}
 
 	if (!InvWeaponsStr(inv).empty())
 	{
-		StrFormat(buf, "weapons:%s", InvWeaponsStr(inv).c_str());
+		buf = fmt::sprintf("weapons:%s", InvWeaponsStr(inv).c_str());
 		params.push_back(buf);
 	}
 
 	if (inv.ammo[am_clip] > 0)
 	{
-		StrFormat(buf, "bullets:%s", InvAmmoStr(inv, am_clip).c_str());
+		buf = fmt::sprintf("bullets:%s", InvAmmoStr(inv, am_clip).c_str());
 		params.push_back(buf);
 	}
 
 	if (inv.ammo[am_shell] > 0)
 	{
-		StrFormat(buf, "shells:%s", InvAmmoStr(inv, am_shell).c_str());
+		buf = fmt::sprintf("shells:%s", InvAmmoStr(inv, am_shell).c_str());
 		params.push_back(buf);
 	}
 
 	if (inv.ammo[am_misl] > 0)
 	{
-		StrFormat(buf, "rockets:%s", InvAmmoStr(inv, am_misl).c_str());
+		buf = fmt::sprintf("rockets:%s", InvAmmoStr(inv, am_misl).c_str());
 		params.push_back(buf);
 	}
 
 	if (inv.ammo[am_cell] > 0)
 	{
-		StrFormat(buf, "cells:%s", InvAmmoStr(inv, am_cell).c_str());
+		buf = fmt::sprintf("cells:%s", InvAmmoStr(inv, am_cell).c_str());
 		params.push_back(buf);
 	}
 
@@ -398,7 +388,7 @@ static std::string SpawnInvSerialize(const spawnInventory_t& inv)
 
 	if (inv.invul > 0)
 	{
-		StrFormat(buf, "invul:%s", InvInvulStr(inv).c_str());
+		buf = fmt::sprintf("invul:%s", InvInvulStr(inv).c_str());
 		params.push_back(buf);
 	}
 
@@ -789,8 +779,7 @@ BEGIN_COMMAND(spawninv)
 		}
 		if (::gSpawnInv.invul)
 		{
-			std::string buf;
-			StrFormat(buf, "Invul (%ds)", ::gSpawnInv.invul);
+			std::string buf = fmt::sprintf("Invul (%ds)", ::gSpawnInv.invul);
 			other.push_back(buf);
 		}
 		if (!other.empty())

--- a/common/hashtable.h
+++ b/common/hashtable.h
@@ -177,7 +177,7 @@ static inline unsigned int __hash_cstring(const char* str)
 	unsigned int val = 0;
 	while (*str != 0)
 		val = val * 101 + *str++;
-	return val;	
+	return val;
 }
 
 template <> struct hashfunc<char*>
@@ -230,7 +230,7 @@ public:
 	typedef generic_iterator<const HashPairType, const HashTableType> const_iterator;
 
 	template <typename IVT, typename IHTT>
-	class generic_iterator : public std::iterator<std::forward_iterator_tag, OHashTable>
+	class generic_iterator
 	{
 	private:
 		// typedef for easier-to-read code
@@ -238,6 +238,12 @@ public:
 		typedef generic_iterator<const IVT, const IHTT> ConstThisClass;
 
 	public:
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = OHashTable;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type*;
+		using reference = value_type&;
+
 		generic_iterator() :
 			mBucketNum(IHTT::NOT_FOUND), mHashTable(NULL)
 		{ }
@@ -273,7 +279,7 @@ public:
 			do {
 				mBucketNum++;
 			} while (mBucketNum < mHashTable->mSize && mHashTable->emptyBucket(mBucketNum));
-			
+
 			if (mBucketNum >= mHashTable->mSize)
 				mBucketNum = IHTT::NOT_FOUND;
 			return *this;
@@ -379,7 +385,7 @@ public:
 	inline const_iterator end() const
 	{
 		return const_iterator(NOT_FOUND, this);
-	}	
+	}
 
 	inline iterator find(const KT& key)
 	{
@@ -407,7 +413,7 @@ public:
 
 	std::pair<iterator, bool> insert(const HashPairType& hp)
 	{
-		unsigned int oldused = mUsed;	
+		unsigned int oldused = mUsed;
 		IndexType bucketnum = insertElement(hp.first, hp.second);
 		return std::pair<iterator, bool>(iterator(bucketnum, this), mUsed > oldused);
 	}
@@ -424,7 +430,7 @@ public:
 
 	void erase(iterator it)
 	{
-		eraseBucket(it.mBucketNum);	
+		eraseBucket(it.mBucketNum);
 	}
 
 	unsigned int erase(const KT& key)
@@ -507,7 +513,7 @@ private:
 
 	inline IndexType findBucket(const KT& key) const
 	{
-		IndexType bucketnum = (mHashFunc(key) * 2654435761u) & mSizeMask; 
+		IndexType bucketnum = (mHashFunc(key) * 2654435761u) & mSizeMask;
 
 		// [SL] NOTE: this can loop infinitely if there is no match and the table is full!
 		while (!emptyBucket(bucketnum) && mElements[bucketnum].pair.first != key)
@@ -560,7 +566,7 @@ private:
 			if (new_bucketnum != bucketnum)
 			{
 				mElements[new_bucketnum].pair = mElements[bucketnum].pair;
-				mElements[bucketnum].pair = HashPairType();	
+				mElements[bucketnum].pair = HashPairType();
 			}
 
 			bucketnum = (bucketnum + 1) & mSizeMask;

--- a/common/m_cheat.cpp
+++ b/common/m_cheat.cpp
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -83,7 +83,7 @@ bool CHEAT_ChangeLevel(cheatseq_t* cheat)
 		snprintf(buf, sizeof(buf), "map 1%c", cheat->Args[1]);
 	else
 		snprintf(buf, sizeof(buf), "map %c%c\n", cheat->Args[0], cheat->Args[1]);
-	
+
 	AddCommandString(buf);
 	return true;
 }
@@ -255,6 +255,7 @@ void CHEAT_DoCheat(player_t* player, int cheat, bool silentmsg)
 
 				player->health = deh.GodHealth;
 			}
+			[[fallthrough]];
 		case CHT_GOD:
 
 			if (player->spectator)
@@ -286,7 +287,7 @@ void CHEAT_DoCheat(player_t* player, int cheat, bool silentmsg)
 			    return;
 
 			player->cheats ^= CF_NOTARGET;
-		    msg = (player->cheats & CF_NOTARGET) ? "notarget ON" 
+		    msg = (player->cheats & CF_NOTARGET) ? "notarget ON"
 				                                 : "notarget OFF";
 			break;
 
@@ -296,7 +297,7 @@ void CHEAT_DoCheat(player_t* player, int cheat, bool silentmsg)
 			    return;
 
 			player->cheats ^= CF_CHASECAM;
-			msg = (player->cheats & CF_CHASECAM) ? "chasecam ON" 
+			msg = (player->cheats & CF_CHASECAM) ? "chasecam ON"
 				                                 : "chasecam OFF";
 			break;
 
@@ -396,7 +397,7 @@ void CHEAT_DoCheat(player_t* player, int cheat, bool silentmsg)
 			}
 			break;
 
-		case CHT_MDK: 
+		case CHT_MDK:
 		{
 			if (multiplayer && !player->client.allow_rcon)
 				return;
@@ -421,7 +422,7 @@ void CHEAT_DoCheat(player_t* player, int cheat, bool silentmsg)
 		}
 	    break;
 
-		case CHT_BUDDHA: 
+		case CHT_BUDDHA:
 		{
 		        player->cheats ^= CF_BUDDHA;
 		        msg = (player->cheats & CF_BUDDHA) ? GStrings(TXT_BUDDHAON)
@@ -436,8 +437,8 @@ void CHEAT_DoCheat(player_t* player, int cheat, bool silentmsg)
 			if (msg != NULL)
 				Printf("%s\n", msg);
 		}
-				
-			
+
+
 #ifdef SERVER_APP
 			SV_BroadcastPrintfButPlayer(PRINT_HIGH, player->id, "%s is a cheater: %s\n",
 			                            player->userinfo.netname.c_str(), msg);
@@ -472,7 +473,7 @@ void CHEAT_GiveTo(player_t* player, const char* name)
 		} else {
 			if (player->mo)
 				player->mo->health = deh.GodHealth;
-	  
+
 			player->health = deh.GodHealth;
 		}
 

--- a/common/m_fileio_posix.cpp
+++ b/common/m_fileio_posix.cpp
@@ -340,9 +340,7 @@ bool M_GetAbsPath(const std::string& path, std::string& out)
 {
 
 #ifdef __SWITCH__
-	std::string res;
-	StrFormat(res, "%s", path.c_str());
-	out = res;
+	out = fmt::sprintf("%s", path.c_str());
 	return true;
 #else
 	char buffer[PATH_MAX];

--- a/common/m_fileio_win32.cpp
+++ b/common/m_fileio_win32.cpp
@@ -72,8 +72,7 @@ std::string M_GetHomeDir(const std::string& user)
 	}
 
 	// Now that we have the Documents folder, just go up one.
-	std::string path;
-	StrFormat(path, "%s\\..", folderPath);
+	std::string path = fmt::sprintf("%s\\..", folderPath);
 	return M_CleanPath(path);
 }
 
@@ -90,9 +89,7 @@ std::string M_GetUserDir()
 		I_FatalError("Could not get user's personal folder.\n");
 	}
 
-	std::string path;
-	StrFormat(path, "%s\\My Games\\Odamex", folderPath);
-	return path;
+	return fmt::sprintf("%s\\My Games\\Odamex", folderPath);
 #endif
 }
 

--- a/common/m_mempool.h
+++ b/common/m_mempool.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -22,7 +22,7 @@
 //	the intial memory pool is exhausted, additional pools are allocated. These
 //	are consolodated into one large pool the next time clear() is called.
 //
-//    
+//
 //-----------------------------------------------------------------------------
 
 
@@ -72,7 +72,7 @@ public:
 private:
 	void resize(size_t new_max_count)
 	{
-		uint32_t new_size = new_max_count * sizeof(T);
+		size_t new_size = new_max_count * sizeof(T);
 
 		if (new_size == 0)
 			return;
@@ -103,7 +103,7 @@ private:
 	void free_data()
 	{
 		for (size_t i = 0; i < num_blocks; i++)
-			delete [] data_block[i];	
+			delete [] data_block[i];
 
 		delete [] block_size;
 		delete [] data_block;

--- a/common/m_strindex.cpp
+++ b/common/m_strindex.cpp
@@ -49,7 +49,7 @@ OStringIndexer OStringIndexer::maplistFactory()
 	{
 		for (int m = 1; m <= 9; m++)
 		{
-			StrFormat(buf, "E%dM%d", e, m);
+			buf = fmt::sprintf("E%dM%d", e, m);
 			stridx.getIndex(buf);
 		}
 	}
@@ -57,7 +57,7 @@ OStringIndexer OStringIndexer::maplistFactory()
 	// 32 for DOOM II/Final Doom.
 	for (int i = 1; i <= 32; i++)
 	{
-		StrFormat(buf, "MAP%02d", i);
+		buf = fmt::sprintf("MAP%02d", i);
 		stridx.getIndex(buf);
 	}
 

--- a/common/ohash.h
+++ b/common/ohash.h
@@ -42,7 +42,7 @@ class OHash
 class OMD5Hash : public OHash
 {
   protected:
-	void concrete() { }
+	void concrete() override { }
 
   public:
 	static bool makeFromHexStr(OMD5Hash& out, const std::string& hash);
@@ -51,7 +51,7 @@ class OMD5Hash : public OHash
 class OCRC32Sum : public OHash
 {
   protected:
-	void concrete() { }
+	void concrete() override { }
 
   public:
 	static bool makeFromHexStr(OCRC32Sum& out, const std::string& hash);

--- a/common/olumpname.cpp
+++ b/common/olumpname.cpp
@@ -104,7 +104,7 @@ size_t OLumpName::size() const
 			break;
 		}
 	}
-	
+
 	return i;
 }
 
@@ -132,15 +132,10 @@ bool OLumpName::empty() const
 char& OLumpName::at(const size_t pos)
 {
 	const size_t s = size();
-	
+
 	if (pos > 7 || pos > s)
 	{
-		char buffer[80];
-		snprintf(buffer, 80,
-				"Attempted to access OLumpName at position %lu when the size was %lu",
-				pos, s);
-		
-		throw std::out_of_range(buffer);
+		throw std::out_of_range(fmt::format("Attempted to access OLumpName at position {} when the size was {}", pos, s));
 	}
 
 	return m_data[pos];
@@ -152,12 +147,7 @@ const char& OLumpName::at(const size_t pos) const
 
 	if (pos > 7 || pos > s)
 	{
-		char buffer[80];
-		snprintf(buffer, 80,
-		        "Attempted to access OLumpName at position %lu when the size was %lu",
-		        pos, s);
-
-		throw std::out_of_range(buffer);
+		throw std::out_of_range(fmt::format("Attempted to access OLumpName at position {} when the size was {}", pos, s));
 	}
 
 	return m_data[pos];

--- a/common/oscanner.cpp
+++ b/common/oscanner.cpp
@@ -307,8 +307,7 @@ void OScanner::mustScanInt()
 	std::string str = m_token;
 	if (IsNum(str.c_str()) == false && str != "MAXINT")
 	{
-		std::string err;
-		StrFormat(err, "Expected integer, got \"%s\".", m_token.c_str());
+		std::string err = fmt::sprintf("Expected integer, got \"%s\".", m_token.c_str());
 		error(err.c_str());
 	}
 }
@@ -326,8 +325,7 @@ void OScanner::mustScanFloat()
 	std::string str = m_token;
 	if (IsRealNum(str.c_str()) == false)
 	{
-		std::string err;
-		StrFormat(err, "Expected float, got \"%s\".", m_token.c_str());
+		std::string err = fmt::sprintf("Expected float, got \"%s\".", m_token.c_str());
 		error(err.c_str());
 	}
 }
@@ -344,8 +342,7 @@ void OScanner::mustScanBool()
 
 	if (!iequals(m_token, "true") && !iequals(m_token, "false"))
 	{
-		std::string err;
-		StrFormat(err, "Expected boolean, got \"%s\".", m_token.c_str());
+		std::string err = fmt::sprintf("Expected boolean, got \"%s\".", m_token.c_str());
 		error(err.c_str());
 	}
 }
@@ -391,8 +388,7 @@ int OScanner::getTokenInt() const
 
 	if (*stopper != 0)
 	{
-		std::string err;
-		StrFormat(err, "Bad integer constant \"%s\".", m_token.c_str());
+		std::string err = fmt::sprintf("Bad integer constant \"%s\".", m_token.c_str());
 		error(err.c_str());
 	}
 
@@ -411,8 +407,7 @@ float OScanner::getTokenFloat() const
 
 	if (*stopper != 0)
 	{
-		std::string err;
-		StrFormat(err, "Bad float constant \"%s\".", m_token.c_str());
+		std::string err = fmt::sprintf("Bad float constant \"%s\".", m_token.c_str());
 		error(err.c_str());
 	}
 

--- a/common/oscanner.h
+++ b/common/oscanner.h
@@ -87,14 +87,14 @@ class OScanner
 	template <typename... ARGS>
 	void warning(const fmt::string_view format, const ARGS&... args) const
 	{
-		Printf(PRINT_WARNING, "Script Warning: %s:%d: %s\n", m_config.lumpName,
+		Printf(PRINT_WARNING, "Parse Warning: %s:%d: %s\n", m_config.lumpName,
 		       m_lineNumber, fmt::sprintf(format, args...));
 	}
 
 	template <typename... ARGS>
 	void error(const fmt::string_view format, const ARGS&... args) const
 	{
-		I_Error("Script Error: %s:%d: %s", m_config.lumpName, m_lineNumber,
+		I_Error("Parse Error: %s:%d: %s", m_config.lumpName, m_lineNumber,
 		        fmt::sprintf(format, args...));
 	}
 };

--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -1105,7 +1105,7 @@ public:
 				 float r2, float g2, float b2, float a2,
 				 float time, AActor *who);
 	~DFlashFader ();
-	virtual void RunThink ();
+	void RunThink () override;
 	virtual void DestroyedPointer(DObject *obj);
 	AActor *WhoFor() { return ForWho; }
 	void Cancel ();
@@ -1215,7 +1215,7 @@ public:
 	DPlaneWatcher (AActor *it, line_t *line, int lineSide, bool ceiling,
 		int tag, int height, int special,
 		int arg0, int arg1, int arg2, int arg3, int arg4);
-	virtual void RunThink ();
+	void RunThink () override;
 	virtual void DestroyedPointer(DObject *obj);
 private:
 	sector_t *Sector;

--- a/common/p_acs.h
+++ b/common/p_acs.h
@@ -530,7 +530,7 @@ public:
 	DACSThinker ();
 	~DACSThinker ();
 
-	void RunThink ();
+	void RunThink () override;
 
 	DLevelScript *RunningScripts[1000];	// Array of all synchronous scripts
 	static DACSThinker *ActiveThinker;

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -200,7 +200,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		case 269:
 			if (bossaction)
 				return false;
-
+			[[fallthrough]];
 		case 4:  // raise door
 		case 10: // plat down-wait-up-stay trigger
 		case 88: // plat down-wait-up-stay retrigger
@@ -1803,7 +1803,7 @@ void P_SpawnCompatibleScroller(line_t* l, int i)
 	case 2085:
 	case 2086:
 		control = sides[*l->sidenum].sector - sectors;
-
+		[[fallthrough]];
 	case 1024: // special 255 with tag control
 	case 2084:
 		if (l->id == 0)

--- a/common/p_ceiling.cpp
+++ b/common/p_ceiling.cpp
@@ -159,6 +159,7 @@ void DCeiling::RunThink ()
 				m_Sector->damageinterval = m_NewDmgInterval;
 				m_Sector->leakrate = m_NewLeakRate;
 				m_Sector->flags = m_NewFlags;
+				[[fallthrough]];
 			case genCeilingChg:
 				m_Sector->ceilingpic = m_Texture;
 				Destroy();
@@ -227,6 +228,7 @@ void DCeiling::RunThink ()
 				m_Sector->damageinterval = m_NewDmgInterval;
 				m_Sector->leakrate = m_NewLeakRate;
 				m_Sector->flags = m_NewFlags;
+				[[fallthrough]];
 			case genCeilingChg:
 				m_Sector->ceilingpic = m_Texture;
 				Destroy();
@@ -648,6 +650,7 @@ BOOL P_SpawnZDoomCeiling(DCeiling::ECeiling type, line_t* line, int tag, fixed_t
 		case DCeiling::ceilCrushAndRaise:
 		case DCeiling::ceilCrushRaiseAndStay:
 			ceiling->m_TopHeight = ceilingheight;
+			[[fallthrough]];
 		case DCeiling::ceilLowerAndCrush:
 			targheight = ceiling->m_BottomHeight = floorheight + height;
 			ceiling->m_Direction = -1;
@@ -909,6 +912,7 @@ manual_ceiling:
 		case DCeiling::silentCrushAndRaise:
 		case DCeiling::ceilCrushRaiseAndStay:
 			ceiling->m_TopHeight = ceilingheight;
+			[[fallthrough]];
 		case DCeiling::lowerAndCrush:
 			ceiling->m_Crush = crush ? DOOM_CRUSH : NO_CRUSH;
 			targheight = ceiling->m_BottomHeight = floorheight + 8*FRACUNIT;

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -302,6 +302,7 @@ DFloor::DFloor(sector_t* sec, DFloor::EFloor floortype, line_t* line, fixed_t sp
 
 	case DFloor::floorLowerInstant:
 		m_Speed = height;
+		[[fallthrough]];
 	case DFloor::floorLowerByValue:
 		m_Direction = -1;
 		m_FloorDestHeight = floorheight - height;
@@ -309,6 +310,7 @@ DFloor::DFloor(sector_t* sec, DFloor::EFloor floortype, line_t* line, fixed_t sp
 
 	case DFloor::floorRaiseInstant:
 		m_Speed = height;
+		[[fallthrough]];
 	case DFloor::floorRaiseByValue:
 		m_Direction = 1;
 		m_FloorDestHeight = floorheight + height;
@@ -321,6 +323,7 @@ DFloor::DFloor(sector_t* sec, DFloor::EFloor floortype, line_t* line, fixed_t sp
 
 	case DFloor::floorRaiseAndCrushDoom:
 		height = 8 * FRACUNIT;
+		[[fallthrough]];
 	case DFloor::floorRaiseToLowestCeiling:
 		m_Direction = 1;
 		m_FloorDestHeight = P_FindLowestCeilingSurrounding(sec);
@@ -345,6 +348,7 @@ DFloor::DFloor(sector_t* sec, DFloor::EFloor floortype, line_t* line, fixed_t sp
 
 	case DFloor::floorRaiseAndCrush:
 		height = 8 * FRACUNIT;
+		[[fallthrough]];
 	case DFloor::floorRaiseToCeiling:
 		m_Direction = 1;
 		m_FloorDestHeight = ceilingheight - height;
@@ -721,6 +725,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 
 	case DFloor::floorLowerInstant:
 		m_Speed = height;
+		[[fallthrough]];
 	case DFloor::floorLowerByValue:
 		m_Direction = -1;
 		m_FloorDestHeight = floorheight - height;
@@ -728,6 +733,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 
 	case DFloor::floorRaiseInstant:
 		m_Speed = height;
+		[[fallthrough]];
 	case DFloor::floorRaiseByValue:
 		m_Direction = 1;
 		m_FloorDestHeight = floorheight + height;
@@ -740,6 +746,7 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 
 	case DFloor::floorRaiseAndCrush:
 		m_Crush = crush;
+		[[fallthrough]];
 	case DFloor::floorRaiseToLowestCeiling:
 		m_Direction = 1;
 		m_FloorDestHeight =
@@ -2060,7 +2067,7 @@ void DWaggle::RunThink()
 
 	m_Accumulator += m_AccDelta;
 	fixed_t changeamount = m_OriginalHeight + FixedMul(FloatBobOffsets[(m_Accumulator >> FRACBITS) & 63], m_Scale);
-	
+
 	if (m_Ceiling)
 	{
 		P_SetCeilingHeight(m_Sector, changeamount);

--- a/common/p_horde.cpp
+++ b/common/p_horde.cpp
@@ -405,7 +405,6 @@ class HordeState
 		info.waveTime = m_waveTime;
 		info.bossTime = m_bossTime;
 		info.defineID = m_defineID;
-		info.legacyID = G_HordeDefine(m_defineID).legacyID;
 		info.spawnedHealth = m_spawnedHealth;
 		info.killedHealth = m_killedHealth;
 		info.bossHealth = m_bossHealth;

--- a/common/p_horde.h
+++ b/common/p_horde.h
@@ -43,7 +43,6 @@ struct hordeInfo_t
 	int waveTime;
 	int bossTime;
 	uint64_t defineID;
-	uint64_t legacyID;
 	int spawnedHealth;
 	int killedHealth;
 	int bossHealth;

--- a/common/p_hordedefine.h
+++ b/common/p_hordedefine.h
@@ -102,7 +102,6 @@ struct hordeDefine_t
 	typedef std::vector<powerup_t> powerups_t;
 	typedef std::vector<monster_t> monsters_t;
 
-	uint32_t legacyID;	 // ID of wave assuming no deduplication.  Remove me.
 	std::string name;    // Name of the wave.
 	weapons_t weapons;   // Weapons we can spawn this wave.
 	ammos_t ammos;       // Ammos we can replenish this wave.
@@ -114,7 +113,7 @@ struct hordeDefine_t
 	int maxBossHealth;  // Maximum health of a group of bosses to spawn.
 
 	hordeDefine_t()
-	    : legacyID(0), minGroupHealth(-1), maxGroupHealth(-1), minBossHealth(-1),
+	    : minGroupHealth(-1), maxGroupHealth(-1), minBossHealth(-1),
 	      maxBossHealth(-1)
 	{
 	}

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -518,7 +518,7 @@ ItemEquipVal P_GiveCard(player_t *player, card_t card)
 	{
 #ifdef SERVER_APP
 		// Register the key
-		SV_ShareKeys(card, *player);	
+		SV_ShareKeys(card, *player);
 #endif
 
 
@@ -578,7 +578,7 @@ ItemEquipVal P_GivePower(player_t *player, int /*powertype_t*/ power)
 
 /**
  * @brief Give the player a care package.
- * 
+ *
  * @detail A care package gives you a small collection of items based on what
  *         you're already holding.  TODO: These messages should be LANGUAGE'ed.
  */
@@ -709,7 +709,7 @@ static void P_GiveCarePack(player_t* player)
 				case NUMWEAPONS:
 					break;
 				}
-				
+
 				break;
 			}
 		}
@@ -1372,7 +1372,7 @@ void SexMessage (const char *from, char *to, int gender, const char *victim, con
 			}
 			if (subst != NULL)
 			{
-				int len = strlen (subst);
+				size_t len = strlen (subst);
 				memcpy (to, subst, len);
 				to += len;
 				from++;
@@ -2100,8 +2100,8 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 	// inflict thrust and push the victim out of reach,
 	// thus kick away unless using the chainsaw.
 
-	if (inflictor && 
-		!(target->flags & MF_NOCLIP) && 
+	if (inflictor &&
+		!(target->flags & MF_NOCLIP) &&
 	    (!source || !source->player || !(weaponinfo[source->player->readyweapon].flags & WPF_NOTHRUST)) &&
 	    !(inflictor->flags2 & MF2_NODMGTHRUST))
 	{
@@ -2156,7 +2156,7 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 		if (!sv_friendlyfire && source && source->player && target != source &&
 			mod != MOD_TELEFRAG)
 		{
-			if (G_IsCoopGame() || 
+			if (G_IsCoopGame() ||
 				(G_IsTeamGame() && player->userinfo.team == source->player->userinfo.team))
 			{
 				damage = 0;
@@ -2254,7 +2254,7 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 			else
 			{
 				player->health = 0;
-			} 
+			}
 		}
 
 		player->attacker = source ? source->ptr() : AActor::AActorPtr();

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -2158,13 +2158,13 @@ void AdjustPusher (int tag, int magnitude, int angle, DPusher::EPusher type)
 		}
 	}
 
-	int numcollected = Collection.Size ();
+	size_t numcollected = Collection.Size ();
 	int secnum = -1;
 
 	// Now create pushers for any sectors that don't already have them.
 	while ((secnum = P_FindSectorFromTag (tag, secnum)) >= 0)
 	{
-		int i;
+		size_t i;
 		for (i = 0; i < numcollected; i++)
 		{
 			if (Collection[i].RefNum == sectors[secnum].tag)
@@ -2264,13 +2264,13 @@ FUNC(LS_Scroll_Texture_Both)
 			}
 		}
 
-		int numcollected = Collection.Size ();
+		size_t numcollected = Collection.Size ();
 		int linenum = -1;
 
 		// Now create scrollers for any walls that don't already have them.
 		while ((linenum = P_FindLineFromID (arg0, linenum)) >= 0)
 		{
-			int i;
+			size_t i;
 			for (i = 0; i < numcollected; i++)
 			{
 				if (Collection[i].RefNum == lines[linenum].sidenum[sidechoice])

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -604,7 +604,7 @@ FUNC(LS_Thing_Stop)
 			target->momx = target->momy = target->momz = 0;
 			if (target->player != NULL)
 				target->momx = target->momy = 0;
-			
+
 			return true;
 		}
 	}
@@ -2938,7 +2938,7 @@ BOOL CheckIfExitIsGood (AActor *self)
 
 	// Bypass the exit restrictions if we're on a lobby.
 	if (level.flags & LEVEL_LOBBYSPECIAL)
-		return true;	
+		return true;
 
 	// [Toke - dmflags] Old location of DF_NO_EXIT
 	if (sv_gametype != GM_COOP && self)
@@ -2960,12 +2960,12 @@ BOOL CheckIfExitIsGood (AActor *self)
 		std::string tstr;
 		if (tspan.hours)
 		{
-			StrFormat(tstr, "%02d:%02d:%02d.%02d", tspan.hours, tspan.minutes,
-			          tspan.seconds, tspan.csecs);
+			tstr = fmt::sprintf("%02d:%02d:%02d.%02d", tspan.hours, tspan.minutes,
+			                    tspan.seconds, tspan.csecs);
 		}
 		else
 		{
-			StrFormat(tstr, "%02d:%02d.%02d", tspan.minutes, tspan.seconds, tspan.csecs);
+			tstr = fmt::sprintf("%02d:%02d.%02d", tspan.minutes, tspan.seconds, tspan.csecs);
 		}
 
 		SV_BroadcastPrintf("%s exited the level in %s.\n",

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -414,7 +414,7 @@ class DRotatePoly : public DPolyAction
 	DECLARE_SERIAL (DRotatePoly, DPolyAction)
 public:
 	DRotatePoly (int polyNum);
-	void RunThink ();
+	void RunThink () override;
 protected:
 	friend BOOL EV_RotatePoly (line_t *line, int polyNum, int speed, int byteAngle, int direction, BOOL overRide);
 private:
@@ -426,7 +426,7 @@ class DMovePoly : public DPolyAction
 	DECLARE_SERIAL (DMovePoly, DPolyAction)
 public:
 	DMovePoly (int polyNum);
-	void RunThink ();
+	void RunThink () override;
 protected:
 	DMovePoly ();
 	int m_Angle;
@@ -441,7 +441,7 @@ class DPolyDoor : public DMovePoly
 	DECLARE_SERIAL (DPolyDoor, DMovePoly)
 public:
 	DPolyDoor (int polyNum, podoortype_t type);
-	void RunThink ();
+	void RunThink () override;
 protected:
 	int m_Direction;
 	int m_TotalDist;

--- a/common/p_plats.cpp
+++ b/common/p_plats.cpp
@@ -513,6 +513,7 @@ BOOL EV_DoPlat (int tag, line_t *line, DPlat::EPlatType type, fixed_t height,
 	{
 	case DPlat::platToggle:
 		rtn = true;
+		[[fallthrough]];
 	case DPlat::platPerpetualRaise:
 		P_ActivateInStasis (tag);
 		break;

--- a/common/p_quake.cpp
+++ b/common/p_quake.cpp
@@ -35,7 +35,7 @@ class DEarthquake : public DThinker
 	DECLARE_SERIAL (DEarthquake, DThinker);
 public:
 	DEarthquake (AActor *center, int intensity, int duration, int damrad, int tremrad);
-	virtual void RunThink ();
+	void RunThink () override;
 	virtual void DestroyedPointer(DObject *obj);
 
 	AActor *m_Spot;
@@ -77,7 +77,7 @@ void DEarthquake::RunThink ()
 {
 	if (level.time % 48 == 0)
 		S_Sound (m_Spot, CHAN_BODY, "world/quake", 1, ATTN_NORM);
-		
+
 	if (serverside)
 	{
 		for (Players::iterator it = players.begin();it != players.end();++it)
@@ -148,6 +148,6 @@ BOOL P_StartQuake (int tid, int intensity, int duration, int damrad, int tremrad
 		res = true;
 		new DEarthquake (center, intensity, duration, damrad, tremrad);
 	}
-	
+
 	return res;
 }

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1045,8 +1045,6 @@ void P_LoadLineDefs (const int lump)
 	// We'll fix this for now by just checking for the E2M7 FarmHash
 	const std::string e2m7hash = "43ffa244f5ae923b7df59dbf511c0468";
 
-	std::string levelHash;
-
 	// [Blair] Serialize the hashes before reading.
 	uint64_t reconsthash1 = (uint64_t)(::level.level_fingerprint[0]) |
 	                        (uint64_t)(::level.level_fingerprint[1]) << 8 |
@@ -1066,7 +1064,7 @@ void P_LoadLineDefs (const int lump)
 	                        (uint64_t)(::level.level_fingerprint[14]) << 48 |
 	                        (uint64_t)(::level.level_fingerprint[15]) << 56;
 
-	StrFormat(levelHash, "%16llx%16llx", reconsthash1, reconsthash2);
+	std:: string levelHash = fmt::sprintf("%16llx%16llx", reconsthash1, reconsthash2);
 
 	bool isE2M7 = (levelHash == e2m7hash);
 

--- a/common/p_snapshot.h
+++ b/common/p_snapshot.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -54,32 +54,32 @@ extern int gametic;
 class Snapshot
 {
 public:
-	Snapshot(int time = -1);	
+	Snapshot(int time = -1);
 	virtual ~Snapshot() {};
 
 	bool operator==(const Snapshot &other) const;
-	
+
 	bool isValid() const { return mValid; }
 	bool isAuthoritative() const { return mAuthoritative; }
 	bool isContinuous() const { return mContinuous; }
 	bool isInterpolated() const { return mInterpolated; }
 	bool isExtrapolated() const { return mExtrapolated; }
-	
+
 	virtual void setAuthoritative(bool val) { mAuthoritative = val; }
 	virtual void setContinuous(bool val) { mContinuous = val; }
 	virtual void setInterpolated(bool val) { mInterpolated = val; }
 	virtual void setExtrapolated(bool val) { mExtrapolated = val; }
-	
+
 	int getTime() const { return mTime; }
 	void setTime(int time) { mTime = time; }
 
 private:
 	int			mTime;
-	bool		mValid;	
+	bool		mValid;
 
 	bool		mAuthoritative;
 	bool		mContinuous;
-	
+
 	bool		mInterpolated;
 	bool		mExtrapolated;
 };
@@ -94,24 +94,24 @@ private:
 class ActorSnapshot : public Snapshot
 {
 public:
-	ActorSnapshot(int time = -1);	
+	ActorSnapshot(int time = -1);
 	ActorSnapshot(int time, const AActor *mo);
-	virtual ~ActorSnapshot() {};
+	~ActorSnapshot() override {};
 
 	bool operator==(const ActorSnapshot &other) const;
-	
+
 	void merge(const ActorSnapshot& other);
 
 	void toActor(AActor *mo) const;
-	
+
 	fixed_t getX() const			{ return mX; }
 	fixed_t getY() const			{ return mY; }
 	fixed_t getZ() const			{ return mZ; }
 	fixed_t getMomX() const			{ return mMomX; }
 	fixed_t getMomY() const			{ return mMomY; }
 	fixed_t getMomZ() const			{ return mMomZ; }
-	angle_t getAngle() const		{ return mAngle; }	
-	angle_t getPitch() const		{ return mPitch; }	
+	angle_t getAngle() const		{ return mAngle; }
+	angle_t getPitch() const		{ return mPitch; }
 	bool	getOnGround() const		{ return mOnGround; }
 	fixed_t getCeilingZ() const		{ return mCeilingZ; }
 	fixed_t getFloorZ() const		{ return mFloorZ; }
@@ -139,7 +139,7 @@ public:
 		mZ = val;
 		mFields |= ACT_POSITIONZ;
 	}
-	
+
 	void setMomX(fixed_t val)
 	{
 		mMomX = val;
@@ -151,31 +151,31 @@ public:
 		mMomY = val;
 		mFields |= ACT_MOMENTUMY;
 	}
-	
+
 	void setMomZ(fixed_t val)
 	{
 		mMomZ = val;
 		mFields |= ACT_MOMENTUMZ;
 	}
-			
+
 	void setAngle(angle_t val)
 	{
 		mAngle = val;
 		mFields |= ACT_ANGLE;
 	}
-	
+
 	void setPitch(angle_t val)
 	{
 		mPitch = val;
 		mFields |= ACT_PITCH;
 	}
-	
+
 	void setOnGround(bool val)
 	{
 		mOnGround = val;
 		mFields |= ACT_ONGROUND;
 	}
-	
+
 	void setCeilingZ(fixed_t val)
 	{
 		mCeilingZ = val;
@@ -193,24 +193,24 @@ public:
 		mReactionTime = val;
 		mFields |= ACT_REACTIONTIME;
 	}
-	
+
 	void setWaterLevel(int val)
 	{
 		mWaterLevel = val;
 		mFields |= ACT_WATERLEVEL;
 	}
-	
+
 	void setFlags(int val)
 	{
 		mFlags = val;
 		mFields |= ACT_FLAGS;
 	}
-	
+
 	void setFlags2(int val)
 	{
 		mFlags2 = val;
 		mFields |= ACT_FLAGS2;
-	}	
+	}
 
 	void setFlags3(int val)
 	{
@@ -228,7 +228,7 @@ private:
 	enum ActorFields {
 		ACT_POSITIONX			= BIT(0),
 		ACT_POSITIONY			= BIT(1),
-		ACT_POSITIONZ			= BIT(2),	
+		ACT_POSITIONZ			= BIT(2),
 		ACT_MOMENTUMX			= BIT(3),
 		ACT_MOMENTUMY			= BIT(4),
 		ACT_MOMENTUMZ			= BIT(5),
@@ -244,9 +244,9 @@ private:
 		ACT_WATERLEVEL			= BIT(15),
 		ACT_FRAME				= BIT(16)
 	};
-	
+
 	unsigned int	mFields;
-	
+
 	fixed_t			mX;
 	fixed_t			mY;
 	fixed_t			mZ;
@@ -257,12 +257,12 @@ private:
 	angle_t			mPitch;
 
 	bool			mOnGround;
-	fixed_t			mCeilingZ;	
+	fixed_t			mCeilingZ;
 	fixed_t			mFloorZ;
-	
+
 	int				mReactionTime;
 	int				mWaterLevel;
-	
+
 	int				mFlags;
 	int				mFlags2;
 	int				mFlags3;
@@ -281,10 +281,10 @@ class PlayerSnapshot : public Snapshot
 public:
 	PlayerSnapshot(int time = -1);
 	PlayerSnapshot(int time, player_t *player);
-	virtual ~PlayerSnapshot() {};
+	~PlayerSnapshot() override {};
 
 	bool operator==(const PlayerSnapshot &other) const;
-	
+
 	void merge(const PlayerSnapshot& other);
 
 	void toPlayer(player_t *player) const;
@@ -299,8 +299,8 @@ public:
 	fixed_t getMomX() const				{ return mActorSnap.getMomX(); }
 	fixed_t getMomY() const				{ return mActorSnap.getMomY(); }
 	fixed_t getMomZ() const				{ return mActorSnap.getMomZ(); }
-	angle_t getAngle() const			{ return mActorSnap.getAngle(); }	
-	angle_t getPitch() const			{ return mActorSnap.getPitch(); }	
+	angle_t getAngle() const			{ return mActorSnap.getAngle(); }
+	angle_t getPitch() const			{ return mActorSnap.getPitch(); }
 	bool	getOnGround() const			{ return mActorSnap.getOnGround(); }
 	fixed_t getCeilingZ() const			{ return mActorSnap.getCeilingZ(); }
 	fixed_t getFloorZ() const			{ return mActorSnap.getFloorZ(); }
@@ -311,48 +311,48 @@ public:
 	int		getFlags3() const			{ return mActorSnap.getFlags3(); }
 	int		getFrame() const			{ return mActorSnap.getFrame(); }
 
-	virtual void setAuthoritative(bool val)
+	void setAuthoritative(bool val) override
 	{
 		Snapshot::setAuthoritative(val);
 		mActorSnap.setAuthoritative(val);
 	}
-	
-	virtual void setContinuous(bool val)
+
+	void setContinuous(bool val) override
 	{
 		Snapshot::setContinuous(val);
 		mActorSnap.setContinuous(val);
 	}
-	
-	virtual void setInterpolated(bool val)
+
+	void setInterpolated(bool val) override
 	{
 		Snapshot::setInterpolated(val);
 		mActorSnap.setInterpolated(val);
 	}
-	
-	virtual void setExtrapolated(bool val)
+
+	void setExtrapolated(bool val) override
 	{
 		Snapshot::setExtrapolated(val);
 		mActorSnap.setExtrapolated(val);
 	}
-	
+
 	void setX(fixed_t val)
 	{
 		mActorSnap.setX(val);
 		mFields |= PLY_POSITIONX;
 	}
-	
+
 	void setY(fixed_t val)
 	{
 		mActorSnap.setY(val);
-		mFields |= PLY_POSITIONY;		
-	}	
-	
+		mFields |= PLY_POSITIONY;
+	}
+
 	void setZ(fixed_t val)
 	{
 		mActorSnap.setZ(val);
 		mFields |= PLY_POSITIONZ;
 	}
-	
+
 	void setMomX(fixed_t val)
 	{
 		mActorSnap.setMomX(val);
@@ -364,13 +364,13 @@ public:
 		mActorSnap.setMomY(val);
 		mFields |= PLY_MOMENTUMY;
 	}
-	
+
 	void setMomZ(fixed_t val)
 	{
 		mActorSnap.setMomZ(val);
 		mFields |= PLY_MOMENTUMZ;
 	}
-			
+
 	void setAngle(angle_t val)
 	{
 		mActorSnap.setAngle(val);
@@ -382,7 +382,7 @@ public:
 		mActorSnap.setPitch(val);
 		mFields |= PLY_PITCH;
 	}
-	
+
 	void setCeilingZ(fixed_t val)
 	{
 		mActorSnap.setCeilingZ(val);
@@ -400,7 +400,7 @@ public:
 		mActorSnap.setOnGround(val != 0);
 		mFields |= PLY_ONGROUND;
 	}
-	
+
 	void setReactionTime(int val)
 	{
 		mActorSnap.setReactionTime(val);
@@ -411,44 +411,44 @@ public:
 	{
 		mActorSnap.setFlags(val);
 		mFields |= PLY_FLAGS;
-	}	
+	}
 
 	void setFlags2(int val)
 	{
 		mActorSnap.setFlags2(val);
 		mFields |= PLY_FLAGS2;
-	}	
+	}
 
 	void setFlags3(int val)
 	{
 		mActorSnap.setFlags3(val);
 		mFields |= PLY_FLAGS3;
-	}	
+	}
 
 	void setFrame(int val)
 	{
 		mActorSnap.setFrame(val);
 		mFields |= PLY_FRAME;
 	}
-			
+
 	void setWaterLevel(int val)
 	{
 		mActorSnap.setWaterLevel(val);
 		mFields |= PLY_WATERLEVEL;
 	}
-	
+
 	void setViewHeight(fixed_t val)
 	{
 		mViewHeight = val;
 		mFields |= PLY_VIEWHEIGHT;
 	}
-	
+
 	void setDeltaViewHeight(fixed_t val)
 	{
 		mDeltaViewHeight = val;
 		mFields |= PLY_DELTAVIEWHEIGHT;
 	}
-	
+
 	void setJumpTime(int val)
 	{
 		mJumpTime = val;
@@ -456,13 +456,13 @@ public:
 	}
 
 	friend PlayerSnapshot P_LerpPlayerPosition(const PlayerSnapshot&, const PlayerSnapshot&, float);
-	friend PlayerSnapshot P_ExtrapolatePlayerPosition(const PlayerSnapshot&, float);	
-	
+	friend PlayerSnapshot P_ExtrapolatePlayerPosition(const PlayerSnapshot&, float);
+
 private:
 	enum PlayerFields {
 		PLY_POSITIONX			= 0x00000001,
 		PLY_POSITIONY			= 0x00000002,
-		PLY_POSITIONZ			= 0x00000004,	
+		PLY_POSITIONZ			= 0x00000004,
 		PLY_MOMENTUMX			= 0x00000008,
 		PLY_MOMENTUMY			= 0x00000010,
 		PLY_MOMENTUMZ			= 0x00000020,
@@ -481,7 +481,7 @@ private:
 		PLY_DELTAVIEWHEIGHT		= 0x00040000,
 		PLY_JUMPTIME			= 0x00080000
 	};
-	
+
 	unsigned int	mFields;		// bitfield of data present in snapshot
 	ActorSnapshot	mActorSnap;
 
@@ -500,12 +500,12 @@ private:
 class PlayerSnapshotManager
 {
 public:
-	PlayerSnapshotManager();	
-	
+	PlayerSnapshotManager();
+
 	void clearSnapshots();
-	
+
 	int getMostRecentTime() const { return mMostRecent; }
-	
+
 	void addSnapshot(const PlayerSnapshot &snap);
 	PlayerSnapshot getSnapshot(int time) const;
 
@@ -514,7 +514,7 @@ private:
 	int mFindValidSnapshot(int starttime, int endtime) const;
 	PlayerSnapshot mInterpolateSnapshots(int from, int to, int time) const;
 	PlayerSnapshot mExtrapolateSnapshot(int from, int time) const;
-	
+
 	PlayerSnapshot	mSnaps[NUM_SNAPSHOTS];
 	int				mMostRecent;
 };
@@ -531,7 +531,7 @@ class SectorSnapshot : public Snapshot
 public:
 	SectorSnapshot(int time = -1);
 	SectorSnapshot(int time, sector_t *sector);
-	virtual ~SectorSnapshot() {};
+	~SectorSnapshot() override {};
 
 	void clear();
 	void toSector(sector_t *sector) const;
@@ -540,14 +540,14 @@ public:
 	void setFloorMoverType(movertype_t val)	{ mFloorMoverType = val; }
 	void setSector(sector_t *val)			{ mSector = val; }
 	void setCeilingType(int val)			{ mCeilingType = val; }
-	void setFloorType(int val)				{ mFloorType = val; }	
+	void setFloorType(int val)				{ mFloorType = val; }
 	void setCeilingTag(int val)				{ mCeilingTag = val; }
-	void setFloorTag(int val)				{ mFloorTag = val; }	
+	void setFloorTag(int val)				{ mFloorTag = val; }
 	void setCeilingLine(line_t *val)		{ mCeilingLine = val; }
-	void setFloorLine(line_t *val)			{ mFloorLine = val; }	
+	void setFloorLine(line_t *val)			{ mFloorLine = val; }
 	void setCeilingHeight(fixed_t val)		{ mCeilingHeight = val; }
 	void setFloorHeight(fixed_t val)		{ mFloorHeight = val; }
-	void setCeilingSpeed(fixed_t val)		{ mCeilingSpeed = val; }	
+	void setCeilingSpeed(fixed_t val)		{ mCeilingSpeed = val; }
 	void setFloorSpeed(fixed_t val)			{ mFloorSpeed = val; }
 	void setCeilingDestination(fixed_t val)	{ mCeilingDestination = val; }
 	void setFloorDestination(fixed_t val)	{ mFloorDestination = val; }
@@ -564,15 +564,15 @@ public:
 	void setFloorLow(fixed_t val)			{ mFloorLow = val; }
 	void setFloorHigh(fixed_t val)			{ mFloorHigh = val; }
 	void setCeilingCrush(bool val)			{ mCeilingCrush = val; }
-	void setFloorCrush(bool val)			{ mFloorCrush = val; }	
+	void setFloorCrush(bool val)			{ mFloorCrush = val; }
 	void setSilent(bool val)				{ mSilent = val; }
 	void setCeilingWait(int val)			{ mCeilingWait = val; }
-	void setFloorWait(int val)				{ mFloorWait = val; }	
+	void setFloorWait(int val)				{ mFloorWait = val; }
 	void setCeilingCounter(int val)			{ mCeilingCounter = val; }
-	void setFloorCounter(int val)			{ mFloorCounter = val; }	
+	void setFloorCounter(int val)			{ mFloorCounter = val; }
 	void setResetCounter(int val)			{ mResetCounter = val; }
 	void setCeilingStatus(int val)			{ mCeilingStatus = val; }
-	void setFloorStatus(int val)			{ mFloorStatus = val; }	
+	void setFloorStatus(int val)			{ mFloorStatus = val; }
 	void setOldFloorStatus(int val)			{ mOldFloorStatus = val; }
 	void setCrusherSpeed1(fixed_t val)		{ mCrusherSpeed1 = val; }
 	void setCrusherSpeed2(fixed_t val)		{ mCrusherSpeed2 = val; }
@@ -585,20 +585,20 @@ public:
 	void setFloorOffset(fixed_t val)		{ mFloorOffset = val; }
 	void setCeilingChange(int val)			{ mCeilingChange = val; }
 	void setFloorChange(int val)			{ mFloorChange = val; }
-		
+
 	movertype_t	getCeilingMoverType() const	{ return mCeilingMoverType; }
-	movertype_t	getFloorMoverType() const	{ return mFloorMoverType; }	
+	movertype_t	getFloorMoverType() const	{ return mFloorMoverType; }
 	sector_t* getSector() const				{ return mSector; }
 	int		getCeilingType() const			{ return mCeilingType; }
-	int		getFloorType() const			{ return mFloorType; }	
+	int		getFloorType() const			{ return mFloorType; }
 	int		getCeilingTag() const			{ return mCeilingTag; }
-	int		getFloorTag() const				{ return mFloorTag; }	
+	int		getFloorTag() const				{ return mFloorTag; }
 	line_t*	getCeilingLine() const			{ return mCeilingLine; }
-	line_t*	getFloorLine() const			{ return mFloorLine; }			
+	line_t*	getFloorLine() const			{ return mFloorLine; }
 	fixed_t	getCeilingHeight() const		{ return mCeilingHeight; }
 	fixed_t	getFloorHeight() const			{ return mFloorHeight; }
 	fixed_t getCeilingSpeed() const			{ return mCeilingSpeed; }
-	fixed_t getFloorSpeed() const			{ return mFloorSpeed; }	
+	fixed_t getFloorSpeed() const			{ return mFloorSpeed; }
 	fixed_t getCeilingDestination() const	{ return mCeilingDestination; }
 	fixed_t getFloorDestination() const		{ return mFloorDestination; }
 	int		getCeilingDirection() const		{ return mCeilingDirection; }
@@ -610,19 +610,19 @@ public:
 	short	getCeilingSpecial() const		{ return mNewCeilingSpecial; }
 	short	getFloorSpecial() const			{ return mNewFloorSpecial; }
 	fixed_t	getCeilingLow() const			{ return mCeilingLow; }
-	fixed_t	getCeilingHigh() const			{ return mCeilingHigh; }	
+	fixed_t	getCeilingHigh() const			{ return mCeilingHigh; }
 	fixed_t	getFloorLow() const				{ return mFloorLow; }
 	fixed_t	getFloorHigh() const			{ return mFloorHigh; }
 	bool	getCeilingCrush() const			{ return mCeilingCrush; }
-	bool	getFloorCrush() const			{ return mFloorCrush; }	
+	bool	getFloorCrush() const			{ return mFloorCrush; }
 	bool	getSilent() const				{ return mSilent; }
 	int		getCeilingWait() const			{ return mCeilingWait; }
-	int		getFloorWait() const			{ return mFloorWait; }	
+	int		getFloorWait() const			{ return mFloorWait; }
 	int		getCeilingCounter() const		{ return mCeilingCounter; }
-	int		getFloorCounter() const			{ return mFloorCounter; }	
+	int		getFloorCounter() const			{ return mFloorCounter; }
 	int		getResetCounter() const			{ return mResetCounter; }
 	int		getCeilingStatus() const		{ return mCeilingStatus; }
-	int		getFloorStatus() const			{ return mFloorStatus; }	
+	int		getFloorStatus() const			{ return mFloorStatus; }
 	int		getOldFloorStatus() const		{ return mOldFloorStatus; }
 	fixed_t	getCrusherSpeed1() const		{ return mCrusherSpeed1; }
 	fixed_t	getCrusherSpeed2() const		{ return mCrusherSpeed1; }
@@ -641,65 +641,65 @@ private:
 	movertype_t		mFloorMoverType;
 
 	sector_t*		mSector;
-	
+
 	int				mCeilingType;
 	int				mFloorType;
 	int				mCeilingTag;
 	int				mFloorTag;
 	line_t*			mCeilingLine;
 	line_t*			mFloorLine;
-		
+
 	fixed_t			mCeilingHeight;
 	fixed_t			mFloorHeight;
-		
+
 	fixed_t			mCeilingSpeed;
 	fixed_t			mFloorSpeed;
-	
+
 	fixed_t			mCeilingDestination;
 	fixed_t			mFloorDestination;
-	
+
 	int				mCeilingDirection;
 	int				mFloorDirection;
-	
+
 	int				mCeilingOldDirection;
 	int				mFloorOldDirection;
-	
+
 	short			mCeilingTexture;
 	short			mFloorTexture;
-	
+
 	short			mNewCeilingSpecial;
 	short			mNewFloorSpecial;
 
 	fixed_t			mCeilingLow;
 	fixed_t			mCeilingHigh;
-	
+
 	fixed_t			mFloorLow;
 	fixed_t			mFloorHigh;
-	
+
 	bool			mCeilingCrush;
 	bool			mFloorCrush;
 	bool			mSilent;
 	int				mCeilingWait;
-	int				mFloorWait;	
+	int				mFloorWait;
 	int				mCeilingCounter;
 	int				mFloorCounter;
 	int				mResetCounter;
 	int				mCeilingStatus;
 	int				mFloorStatus;
 	int				mOldFloorStatus;
-	
+
 	fixed_t			mCrusherSpeed1;
 	fixed_t			mCrusherSpeed2;
-	
+
 	int				mStepTime;
 	int				mPerStepTime;
 	int				mPauseTime;
 	int				mOrgHeight;
 	int				mDelay;
-	
+
 	fixed_t			mFloorLip;
 	fixed_t			mFloorOffset;
-	
+
 	int				mCeilingChange;
 	int				mFloorChange;
 };
@@ -718,15 +718,15 @@ public:
 
 	bool empty();
 	void clearSnapshots();
-	
+
 	int getMostRecentTime() const { return mMostRecent; }
-	
+
 	void addSnapshot(const SectorSnapshot &snap);
 	SectorSnapshot getSnapshot(int time) const;
-	
+
 private:
 	bool mValidSnapshot(int time) const;
-	
+
 	SectorSnapshot	mSnaps[NUM_SNAPSHOTS];
 	int				mMostRecent;
 };

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -34,7 +34,7 @@ typedef struct movingsector_s
 	movingsector_s() :
 		sector(NULL), moving_ceiling(false), moving_floor(false)
 	{}
-	
+
 	sector_t	*sector;
 	bool		moving_ceiling;
 	bool		moving_floor;
@@ -220,7 +220,7 @@ public:
 	DScroller (EScrollType type, fixed_t dx, fixed_t dy, int control, int affectee, int accel);
 	DScroller (fixed_t dx, fixed_t dy, const line_t *l, int control, int accel);
 
-	void RunThink ();
+	void RunThink () override;
 
 	bool AffectsWall (int wallnum) { return m_Type == sc_side && m_Affectee == wallnum; }
 	int GetWallNum () { return m_Type == sc_side ? m_Affectee : -1; }
@@ -317,7 +317,7 @@ public:
 		m_Magnitude = magnitude;
 	}
 
-	virtual void RunThink ();
+	void RunThink () override;
 
 protected:
 	EPusher m_Type;
@@ -661,7 +661,7 @@ public:
 		platRaiseAndStayLockout
 	};
 
-	void RunThink ();
+	void RunThink () override;
 
 	void SetState(byte state, int count) { m_Status = (EPlatState)state; m_Count = count; }
 	void GetState(byte &state, int &count) { state = (byte)m_Status; count = m_Count; }
@@ -671,7 +671,7 @@ public:
 	DPlat(sector_t* sector, int target, int delay, int speed, int trigger); // [Blair] Boom Generic Plat type
 	DPlat* Clone(sector_t* sec) const;
 	friend void P_SetPlatDestroy(DPlat *plat);
-	
+
 	void PlayPlatSound ();
 
 	fixed_t 	m_Speed;
@@ -735,7 +735,7 @@ public:
 		destroy,
 		state_size
 	};
-	
+
 	enum EPillar
 	{
 		pillarBuild,
@@ -747,12 +747,12 @@ public:
 	DPillar(sector_t* sector, EPillar type, fixed_t speed, fixed_t height,
 	        fixed_t height2, int crush, bool hexencrush);
 	DPillar* Clone(sector_t* sec) const;
-	friend void P_SetPillarDestroy(DPillar *pillar);	
+	friend void P_SetPillarDestroy(DPillar *pillar);
 	friend bool EV_DoZDoomPillar(DPillar::EPillar type, line_t* line, int tag,
 	                             fixed_t speed, fixed_t floordist, fixed_t ceilingdist,
 	                             int crush, bool hexencrush);
-	
-	void RunThink ();
+
+	void RunThink () override;
 	void PlayPillarSound();
 
 	EPillar		m_Type;
@@ -762,7 +762,7 @@ public:
 	fixed_t		m_CeilingTarget;
 	int			m_Crush;
 	bool		m_HexenCrush;
-	
+
 	EPillarState m_Status;
 
 };
@@ -847,11 +847,8 @@ public:
 	DDoor* Clone(sector_t* sec) const;
 
 	friend void P_SetDoorDestroy(DDoor *door);
-	
-	void RunThink ();
-	void PlayDoorSound();	
 
-	EVlDoor		m_Type;
+	void RunThink () override;
 	fixed_t 	m_TopHeight;
 	fixed_t 	m_Speed;
 
@@ -917,7 +914,7 @@ public:
 		destroy,
 		state_size
 	};
-	
+
 	enum ECeiling
 	{
 		lowerToFloor,
@@ -968,10 +965,10 @@ public:
 	DCeiling(sector_t* sec, line_t* line, int silent, int speed);
 	DCeiling* Clone(sector_t* sec) const;
 	friend void P_SetCeilingDestroy(DCeiling *ceiling);
-	
-	void RunThink ();
-	void PlayCeilingSound();	
-	
+
+	void RunThink () override;
+	void PlayCeilingSound();
+
 	ECeiling	m_Type;
 	crushmode_e m_CrushMode;
 	fixed_t 	m_BottomHeight;
@@ -994,9 +991,9 @@ public:
 	// ID
 	int 		m_Tag;
 	int 		m_OldDirection;
-	
+
 	ECeilingState m_Status;
-	
+
 protected:
 
 
@@ -1047,7 +1044,7 @@ public:
 		destroy,
 		state_size
 	};
-	
+
 	enum EFloor
 	{
 		floorLowerToLowest,
@@ -1108,9 +1105,9 @@ public:
 	friend void P_SetFloorDestroy(DFloor *floor);
 	friend BOOL EV_DoGenFloor(line_t* line);
 	friend BOOL EV_DoGenStairs(line_t* line);
-		
-	void RunThink ();
-	void PlayFloorSound();	
+
+	void RunThink () override;
+	void PlayFloorSound();
 
 	EFloor	 	m_Type;
 	EFloorState	m_Status;
@@ -1133,7 +1130,7 @@ public:
 	int			m_PauseTime;
 	int			m_StepTime;
 	int			m_PerStepTime;
-	
+
 	fixed_t		m_Height;
 	line_t		*m_Line;
 	int			m_Change;
@@ -1197,9 +1194,9 @@ public:
 
 	DElevator (sector_t *sec);
 	DElevator* Clone(sector_t* sec) const;
-	friend void P_SetElevatorDestroy(DElevator *elevator);	
+	friend void P_SetElevatorDestroy(DElevator *elevator);
 
-	void RunThink ();
+	void RunThink () override;
 	void PlayElevatorSound();
 
 	EElevator	m_Type;
@@ -1207,9 +1204,9 @@ public:
 	fixed_t		m_FloorDestHeight;
 	fixed_t		m_CeilingDestHeight;
 	fixed_t		m_Speed;
-	
+
 	EElevatorState m_Status;
-	
+
 protected:
 	friend BOOL EV_DoElevator (line_t *line, DElevator::EElevator type, fixed_t speed,
 		fixed_t height, int tag);
@@ -1259,7 +1256,7 @@ class DWaggle : public DMover
 	DWaggle* Clone(sector_t* sec) const;
 	friend void P_SetWaggleDestroy(DWaggle* waggle);
 
-	void RunThink();
+	void RunThink() override;
 
 	fixed_t m_OriginalHeight;
 	fixed_t m_Accumulator;

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -669,7 +669,7 @@ public:
 	DPlat(sector_t *sector);
 	DPlat(sector_t *sector, DPlat::EPlatType type, fixed_t height, int speed, int delay, fixed_t lip);
 	DPlat(sector_t* sector, int target, int delay, int speed, int trigger); // [Blair] Boom Generic Plat type
-	DPlat* Clone(sector_t* sec) const;
+	DPlat* Clone(sector_t* sec) const override;
 	friend void P_SetPlatDestroy(DPlat *plat);
 
 	void PlayPlatSound ();
@@ -746,7 +746,7 @@ public:
 	DPillar ();
 	DPillar(sector_t* sector, EPillar type, fixed_t speed, fixed_t height,
 	        fixed_t height2, int crush, bool hexencrush);
-	DPillar* Clone(sector_t* sec) const;
+	DPillar* Clone(sector_t* sec) const override;
 	friend void P_SetPillarDestroy(DPillar *pillar);
 	friend bool EV_DoZDoomPillar(DPillar::EPillar type, line_t* line, int tag,
 	                             fixed_t speed, fixed_t floordist, fixed_t ceilingdist,
@@ -844,11 +844,14 @@ public:
 	// ZDoom Compatible DDoor
 	DDoor(sector_t* sec, line_t* ln, EVlDoor type, fixed_t speed, int topwait,
 	      byte lighttag, int topcountdown);
-	DDoor* Clone(sector_t* sec) const;
+	DDoor* Clone(sector_t* sec) const override;
 
 	friend void P_SetDoorDestroy(DDoor *door);
 
 	void RunThink () override;
+	void PlayDoorSound();
+
+	EVlDoor		m_Type;
 	fixed_t 	m_TopHeight;
 	fixed_t 	m_Speed;
 
@@ -963,7 +966,7 @@ public:
 	DCeiling (sector_t* sec, line_t* line, int speed,
 	         int target, int crush, int change, int direction, int model);
 	DCeiling(sector_t* sec, line_t* line, int silent, int speed);
-	DCeiling* Clone(sector_t* sec) const;
+	DCeiling* Clone(sector_t* sec) const override;
 	friend void P_SetCeilingDestroy(DCeiling *ceiling);
 
 	void RunThink () override;
@@ -1101,7 +1104,7 @@ public:
 	DFloor(sector_t* sec, DFloor::EFloor floortype, line_t* line, fixed_t speed,
 	               fixed_t height, int crush, int change, bool hexencrush,
 	               bool hereticlower);
-	DFloor* Clone(sector_t* sec) const;
+	DFloor* Clone(sector_t* sec) const override;
 	friend void P_SetFloorDestroy(DFloor *floor);
 	friend BOOL EV_DoGenFloor(line_t* line);
 	friend BOOL EV_DoGenStairs(line_t* line);
@@ -1193,7 +1196,7 @@ public:
 	};
 
 	DElevator (sector_t *sec);
-	DElevator* Clone(sector_t* sec) const;
+	DElevator* Clone(sector_t* sec) const override;
 	friend void P_SetElevatorDestroy(DElevator *elevator);
 
 	void RunThink () override;
@@ -1253,7 +1256,7 @@ class DWaggle : public DMover
 	DWaggle(sector_t* sec);
 	DWaggle(sector_t* sector, int height, int speed, int offset, int timer,
 	                 bool ceiling);
-	DWaggle* Clone(sector_t* sec) const;
+	DWaggle* Clone(sector_t* sec) const override;
 	friend void P_SetWaggleDestroy(DWaggle* waggle);
 
 	void RunThink() override;

--- a/common/p_switch.cpp
+++ b/common/p_switch.cpp
@@ -58,7 +58,7 @@ public:
 	DActiveButton ();
 	DActiveButton (line_t *, EWhere, SWORD tex, SDWORD time, fixed_t x, fixed_t y);
 
-	void RunThink ();
+	void RunThink () override;
 
 	line_t	*m_Line;
 	EWhere	m_Where;

--- a/common/p_xlat.cpp
+++ b/common/p_xlat.cpp
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -317,7 +317,7 @@ void P_TranslateLineDef (line_t *ld, maplinedef_t *mld)
 	unsigned int flags = (unsigned short)mld->flags;
 	bool passthrough = (flags & ML_PASSUSE);
 	int i;
-	
+
 	flags &= 0x01ff;	// Ignore flags unknown to DOOM
 
 	if (special <= NUM_SPECIALS)
@@ -325,7 +325,7 @@ void P_TranslateLineDef (line_t *ld, maplinedef_t *mld)
 		// This is a regular special; translate thru LUT
 		flags = flags | (SpecialTranslation[special].flags);
 		if (passthrough)
-		{	
+		{
 			if (GET_SPAC(flags) == ML_SPAC_USE)
 			{
 				flags &= ~ML_SPAC_MASK;
@@ -336,7 +336,7 @@ void P_TranslateLineDef (line_t *ld, maplinedef_t *mld)
 				flags &= ~ML_SPAC_MASK;
 				flags |= ML_SPAC_CROSSTHROUGH;
 			}
-			
+
 			// TODO: what to do with gun-activated lines with passthrough?
 		}
 		ld->special = SpecialTranslation[special].newspecial;
@@ -359,7 +359,7 @@ void P_TranslateLineDef (line_t *ld, maplinedef_t *mld)
 		ld->flags = flags;
 		ld->id = tag;
 		memset(ld->args, 0, sizeof(ld->args));
-		
+
 		switch (special)
 		{
 		case 340:		// Slope the Floor in front of the line
@@ -418,6 +418,7 @@ void P_TranslateLineDef (line_t *ld, maplinedef_t *mld)
 		{
 		case WalkMany:
 			flags |= ML_REPEATSPECIAL;
+			[[fallthrough]];
 		case WalkOnce:
             if (passthrough)
 				flags |= ML_SPAC_CROSSTHROUGH;
@@ -428,6 +429,7 @@ void P_TranslateLineDef (line_t *ld, maplinedef_t *mld)
 		case SwitchMany:
 		case PushMany:
 			flags |= ML_REPEATSPECIAL;
+			[[fallthrough]];
 		case SwitchOnce:
 		case PushOnce:
 			if (passthrough)
@@ -438,6 +440,7 @@ void P_TranslateLineDef (line_t *ld, maplinedef_t *mld)
 
 		case GunMany:
 			flags |= ML_REPEATSPECIAL;
+			[[fallthrough]];
 		case GunOnce:
 			flags |= ML_SPAC_IMPACT;
 			break;

--- a/common/p_zdoomhexspec.cpp
+++ b/common/p_zdoomhexspec.cpp
@@ -182,6 +182,7 @@ bool P_TestActivateZDoomLine(line_t* line, AActor* mo, int side,
 				case Door_Raise:
 					if (line->args[1] >= 64)
 						break;
+					[[fallthrough]];
 				case Teleport:
 				case Teleport_NoFog:
 				case Teleport_Line:

--- a/common/s_sndseq.cpp
+++ b/common/s_sndseq.cpp
@@ -95,11 +95,11 @@ class DSeqActorNode : public DSeqNode
 	DECLARE_SERIAL (DSeqActorNode, DSeqNode)
 public:
 	DSeqActorNode (AActor *actor, int sequence);
-	~DSeqActorNode ();
-	void MakeSound () { S_SoundID (m_Actor, CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
-	void MakeLoopedSound () { S_LoopedSoundID (m_Actor, CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
-	bool IsPlaying () { return S_GetSoundPlayingInfo (m_Actor, m_CurrentSoundID); }
-	void *Source () { return m_Actor; }
+	~DSeqActorNode () override;
+	void MakeSound () override { S_SoundID (m_Actor, CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
+	void MakeLoopedSound () override { S_LoopedSoundID (m_Actor, CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
+	bool IsPlaying () override { return S_GetSoundPlayingInfo (m_Actor, m_CurrentSoundID); }
+	void *Source () override { return m_Actor; }
 	virtual void DestroyedPointer(DObject *obj);
 private:
 	DSeqActorNode () {}
@@ -111,11 +111,11 @@ class DSeqPolyNode : public DSeqNode
 	DECLARE_SERIAL (DSeqPolyNode, DSeqNode)
 public:
 	DSeqPolyNode (polyobj_t *poly, int sequence);
-	~DSeqPolyNode ();
-	void MakeSound () { S_SoundID (&m_Poly->startSpot[0], CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
-	void MakeLoopedSound () { S_LoopedSoundID (&m_Poly->startSpot[0], CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
-	bool IsPlaying () { return S_GetSoundPlayingInfo (&m_Poly->startSpot[0], m_CurrentSoundID); }
-	void *Source () { return m_Poly; }
+	~DSeqPolyNode () override;
+	void MakeSound () override { S_SoundID (&m_Poly->startSpot[0], CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
+	void MakeLoopedSound () override { S_LoopedSoundID (&m_Poly->startSpot[0], CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
+	bool IsPlaying () override { return S_GetSoundPlayingInfo (&m_Poly->startSpot[0], m_CurrentSoundID); }
+	void *Source () override { return m_Poly; }
 private:
 	DSeqPolyNode () {}
 	polyobj_t *m_Poly;
@@ -126,11 +126,11 @@ class DSeqSectorNode : public DSeqNode
 	DECLARE_SERIAL (DSeqSectorNode, DSeqNode)
 public:
 	DSeqSectorNode (sector_t *sec, int sequence);
-	~DSeqSectorNode ();
-	void MakeSound () { S_SoundID (&m_Sector->soundorg[0], CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
-	void MakeLoopedSound () { S_LoopedSoundID (&m_Sector->soundorg[0], CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
-	bool IsPlaying () { return S_GetSoundPlayingInfo (m_Sector->soundorg, m_CurrentSoundID); }
-	void *Source () { return m_Sector; }
+	~DSeqSectorNode () override;
+	void MakeSound () override { S_SoundID (&m_Sector->soundorg[0], CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
+	void MakeLoopedSound () override { S_LoopedSoundID (&m_Sector->soundorg[0], CHAN_BODY, m_CurrentSoundID, m_Volume, m_Atten); }
+	bool IsPlaying () override { return S_GetSoundPlayingInfo (m_Sector->soundorg, m_CurrentSoundID); }
+	void *Source () override { return m_Sector; }
 private:
 	DSeqSectorNode() {}
 	sector_t *m_Sector;
@@ -440,7 +440,7 @@ void S_ParseSndSeq()
 		    true,     // cComments
 		};
 		OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));
-		
+
 		while (os.scan())
 		{
 			std::string str = os.getToken();
@@ -886,7 +886,7 @@ void DSeqNode::RunThink ()
 		Destroy ();
 		break;
 
-	default:	
+	default:
 		break;
 	}
 }
@@ -923,7 +923,7 @@ void SN_StopAllSequences (void)
 		node = next;
 	}
 }
-	
+
 //==========================================================================
 //
 //  SN_GetSequenceOffset

--- a/common/sarray.h
+++ b/common/sarray.h
@@ -17,7 +17,7 @@
 //
 // DESCRIPTION:
 //
-// A static array implementation utilizing unique IDs for access. 
+// A static array implementation utilizing unique IDs for access.
 //
 //-----------------------------------------------------------------------------
 
@@ -32,7 +32,7 @@
 
 // ============================================================================
 //
-// SArray 
+// SArray
 //
 // Lightweight fixed-size array implementation with iterator.
 // The class provides many desirable characteristics:
@@ -43,7 +43,7 @@
 //		Iterators that are STL conformant for use with <algorithm>
 //
 // ------------------------------------------------------------------------
-// 
+//
 // Notes:
 //
 // There are a fixed number of slots for the array, between 1 and MAX_SIZE.
@@ -96,7 +96,7 @@ public:
 	typedef generic_iterator<const VT, const SArrayType> const_iterator;
 
 	template <typename IVT, typename ISAT>
-	class generic_iterator : public std::iterator<std::forward_iterator_tag, SArray>
+	class generic_iterator
 	{
 	private:
 		// typedef for easier-to-read code
@@ -104,6 +104,12 @@ public:
 		typedef generic_iterator<const IVT, const ISAT> ConstThisClass;
 
 	public:
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = SArray;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type*;
+		using reference = value_type&;
+
 		generic_iterator(ISAT& sarray) :
 			mSArray(sarray), mSlot(NOT_FOUND)
 		{ }
@@ -365,7 +371,7 @@ public:
 	inline const_iterator end() const
 	{
 		return const_iterator(*this, NOT_FOUND);
-	}	
+	}
 
 	//
 	// SArray::validate
@@ -418,7 +424,7 @@ public:
 		assert(slot != NOT_FOUND);
 		return mItemRecords[slot].mItem;
 	}
-		
+
 	//
 	// SArray::operator[]
 	//
@@ -549,7 +555,7 @@ private:
 		}
 		for (SlotNumber i = mNextUnused; i < newsize; i++)
 			newitemrecords[i].mId = NOT_FOUND;
-		
+
 		delete [] mItemRecords;
 		mSize = newsize;
 		mItemRecords = newitemrecords;
@@ -665,7 +671,7 @@ private:
 			mFreeHead = mItemRecords[slot].mId;
 		else
 			slot = mNextUnused++;
-		
+
 		assert(slot < mSize);
 		mItemRecords[slot].mId = generateId(slot);
 		mUsed++;
@@ -710,7 +716,7 @@ private:
 		mIdKey = other.mIdKey;
 	}
 
-	static const unsigned int SLOT_BITS = N; 
+	static const unsigned int SLOT_BITS = N;
 	static const unsigned int KEY_BITS = 32 - SLOT_BITS;
 	static const unsigned int MAX_SIZE = 1 << SLOT_BITS;
 
@@ -718,7 +724,7 @@ private:
 	static const unsigned int MAX_KEY = (1 << KEY_BITS) - 1;
 
 	static const unsigned int MIN_SLOT = 0;
-	static const unsigned int MAX_SLOT = (1 << SLOT_BITS) - 1; 
+	static const unsigned int MAX_SLOT = (1 << SLOT_BITS) - 1;
 	static const unsigned int SLOT_MASK = (1 << SLOT_BITS) - 1;
 
 	static const unsigned int NOT_FOUND = (1 << SLOT_BITS) | MAX_SLOT;

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1584,7 +1584,6 @@ odaproto::svc::HordeInfo SVC_HordeInfo(const hordeInfo_t& horde)
 	msg.set_wave_time(horde.waveTime);
 	msg.set_boss_time(horde.bossTime);
 	msg.set_define_id(horde.defineID);
-	msg.set_legacy_id(horde.legacyID);
 	msg.set_spawned_health(horde.spawnedHealth);
 	msg.set_killed_health(horde.killedHealth);
 	msg.set_boss_health(horde.bossHealth);

--- a/common/teaminfo.cpp
+++ b/common/teaminfo.cpp
@@ -247,27 +247,21 @@ TeamsView TeamQuery::execute()
 
 std::string V_GetTeamColor(team_t ateam)
 {
-	std::string buf;
 	TeamInfo* team = GetTeamInfo(ateam);
-	StrFormat(buf, "%s%s%s", team->TextColor.c_str(), team->ColorStringUpper.c_str(),
-	          TEXTCOLOR_NORMAL);
-	return buf;
+	return fmt::sprintf("%s%s%s", team->TextColor.c_str(), team->ColorStringUpper.c_str(),
+	                    TEXTCOLOR_NORMAL);
 }
 
 std::string V_GetTeamColor(UserInfo userinfo)
 {
-	std::string buf;
 	TeamInfo* team = GetTeamInfo(userinfo.team);
-	StrFormat(buf, "%s%s%s", team->TextColor.c_str(), team->ColorStringUpper.c_str(), TEXTCOLOR_NORMAL);
-	return buf;
+	return fmt::sprintf("%s%s%s", team->TextColor.c_str(), team->ColorStringUpper.c_str(), TEXTCOLOR_NORMAL);
 }
 
 const std::string TeamInfo::ColorizedTeamName()
 {
-	std::string buf;
-	StrFormat(buf, "%s%s%s", TextColor.c_str(), ColorStringUpper.c_str(),
-	          TEXTCOLOR_NORMAL);
-	return buf;
+	return fmt::sprintf("%s%s%s", TextColor.c_str(), ColorStringUpper.c_str(),
+	                    TEXTCOLOR_NORMAL);
 }
 
 int TeamInfo::LivesPool()

--- a/common/version.cpp
+++ b/common/version.cpp
@@ -39,7 +39,7 @@
 /**
  * @brief Compare two "packed" versions of Odamex to see if they are expected
  *        to be protocol-compatible.
- * 
+ *
  * @param server Packed version of the server.
  * @param client Packed version of the client.
  * @return 0 if they are compatible, -1 if the server is on the older verison
@@ -96,7 +96,7 @@ int VersionCompat(const int server, const int client)
 
 /**
  * @brief Generate a version mismatch message.
- * 
+ *
  * @param server Packed version of the server.
  * @param client Packed version of the client.
  * @param email E-mail address of server host.
@@ -104,7 +104,7 @@ int VersionCompat(const int server, const int client)
 */
 std::string VersionMessage(const int server, const int client, const char* email)
 {
-	std::string rvo, buf;
+	std::string rvo;
 
 	int cmp = VersionCompat(server, client);
 	if (!cmp)
@@ -115,32 +115,27 @@ std::string VersionMessage(const int server, const int client, const char* email
 	int cl_maj, cl_min, cl_pat;
 	BREAKVER(client, cl_maj, cl_min, cl_pat);
 
-	StrFormat(
-	    buf,
+	rvo += fmt::sprintf(
 	    "Your version of Odamex %d.%d.%d does not match the server version %d.%d.%d.\n",
 	    cl_maj, cl_min, cl_pat, sv_maj, sv_min, sv_pat);
-	rvo += buf;
 
 	if (cmp > 0)
 	{
-		StrFormat(buf,
+		rvo += fmt::sprintf(
 		          "Please visit https://odamex.net/ to obtain Odamex %d.%d.%d or "
 		          "newer.\nIf you do not see this version available for download, "
 		          "you are likely attempting to connect to a server running a "
 		          "development version of Odamex.\n",
 		          sv_maj, sv_min, sv_pat);
-		rvo += buf;
 	}
 	else
 	{
-		StrFormat(buf, "Please allow the server admin some time to upgrade.");
-		rvo += buf;
+		rvo += fmt::sprintf("Please allow the server admin some time to upgrade.");
 
 		if (email != NULL)
 		{
-			StrFormat(buf, "  If the problem persists, you can contact them at %s.\n",
+			rvo += fmt::sprintf("  If the problem persists, you can contact them at %s.\n",
 			          email);
-			rvo += buf;
 		}
 		else
 		{
@@ -210,7 +205,7 @@ const char* GitBranch()
 
 /**
  * @brief Return the number of commits since the first commit.
- * 
+ *
  * @detail Two branches that are the same distance from the first commit
  *         can have the same number.
  */
@@ -272,12 +267,12 @@ const char* NiceVersionDetails()
 	else if (!strncmp(GitBranch(), "release", ARRAY_LENGTH(RELEASE_PREFIX) - 1))
 	{
 		// "Release" branch is omitted.
-		StrFormat(version, "g%s-%s%s", GitShortHash(), GitRevCount(), debug);
+		version = fmt::sprintf("g%s-%s%s", GitShortHash(), GitRevCount(), debug);
 	}
 	else
 	{
 		// Other branches are written in.
-		StrFormat(version, "%s, g%s-%s%s", GitBranch(), GitShortHash(), GitRevCount(),
+		version = fmt::sprintf("%s, g%s-%s%s", GitBranch(), GitShortHash(), GitRevCount(),
 		          debug);
 	}
 
@@ -309,7 +304,7 @@ const char* NiceVersion()
 	else
 	{
 		// Put details in parens.
-		StrFormat(version, "%s (%s)", DOTVERSIONSTR, details);
+		version = fmt::sprintf("%s (%s)", DOTVERSIONSTR, details);
 	}
 
 	return version.c_str();

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -158,7 +158,7 @@ OCRC32Sum W_CRC32(const std::string& filename)
 	if (!fp)
 		return rvo;
 
-	unsigned n = 0;
+	size_t n = 0;
 	unsigned char buf[file_chunk_size];
 	uint32_t crc = 0;
 
@@ -189,7 +189,7 @@ OMD5Hash W_MD5(const std::string& filename)
 	md5_state_t state;
 	md5_init(&state);
 
-	unsigned n = 0;
+	size_t n = 0;
 	unsigned char buf[file_chunk_size];
 
 	while((n = fread(buf, 1, sizeof(buf), fp)))

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -169,7 +169,7 @@ OCRC32Sum W_CRC32(const std::string& filename)
 
 	std::string hashStr;
 
-	StrFormat(hashStr, "%08X", crc);
+	hashStr = fmt::sprintf("%08X", crc);
 
 	OCRC32Sum::makeFromHexStr(rvo, hashStr);
 	return rvo; // bubble up failure

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -665,13 +665,12 @@ message HordeInfo
 	int32 wave = 2;
 	int32 wave_time = 3;
 	int32 boss_time = 4;
-	uint64 legacy_id = 5; // [AM] Remove me after 10.x.
-	int32 spawned_health = 6;
-	int32 killed_health = 7;
-	int32 boss_health = 8;
-	int32 boss_damage = 9;
-	int32 wave_start_health = 10;
-	uint64 define_id = 11;
+	int32 spawned_health = 5;
+	int32 killed_health = 6;
+	int32 boss_health = 7;
+	int32 boss_damage = 8;
+	int32 wave_start_health = 9;
+	uint64 define_id = 10;
 }
 
 // svc_netdemocap

--- a/server/src/i_system.cpp
+++ b/server/src/i_system.cpp
@@ -365,7 +365,7 @@ void I_BaseError(const std::string& errortext)
 	throw CRecoverableError(errortext);
 }
 
-NORETURN void I_BaseFatalError(const std::string& errortext)
+[[noreturn]] void I_BaseFatalError(const std::string& errortext)
 {
 	static BOOL alreadyThrown = false;
 	gameisdead = true;
@@ -489,7 +489,7 @@ std::string I_ConsoleInput (void)
             // Accept return but not unusual characters as input (eg Ctrl-B)
             if ((ch != '\n' && ch != '\r') && (ch < 32 || ch > 126))
                 continue;
-			
+
 			buffer[len++] = ch;
 		}
 

--- a/server/src/i_system.h
+++ b/server/src/i_system.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -79,7 +79,7 @@ ticcmd_t *I_BaseTiccmd (void);
 void STACK_ARGS I_Quit (void);
 
 void I_BaseError(const std::string& errortext);
-NORETURN void I_BaseFatalError(const std::string& errortext);
+[[noreturn]] void I_BaseFatalError(const std::string& errortext);
 
 template <typename... ARGS>
 void I_Error(const fmt::string_view format, const ARGS&... args)

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1585,7 +1585,7 @@ bool SV_CheckClientVersion(client_t *cl, Players::iterator it)
 		GameVer = MSG_ReadLong();
 		BREAKVER(GameVer, cl_major, cl_minor, cl_patch);
 
-		StrFormat(VersionStr, "%d.%d.%d", cl_major, cl_minor, cl_patch);
+		VersionStr = fmt::sprintf("%d.%d.%d", cl_major, cl_minor, cl_patch);
 
 		cl->packedversion = GameVer;
 
@@ -1621,8 +1621,7 @@ bool SV_CheckClientVersion(client_t *cl, Players::iterator it)
 		if (msg.empty())
 		{
 			// Failsafe.
-			StrFormat(
-			    msg,
+			msg = fmt::sprintf(
 			    "Your version of Odamex does not match the server %s.\nFor updates, "
 			    "visit https://odamex.net/\n",
 			    DOTVERSIONSTR);
@@ -1672,7 +1671,7 @@ static void SV_DisconnectOldClient()
 	if (msg.empty())
 	{
 		// Failsafe.
-		StrFormat(msg,
+		msg = fmt::sprintf(
 		          "Your version of Odamex does not match the server %s.\nFor updates, "
 		          "visit https://odamex.net/\n",
 		          DOTVERSIONSTR);
@@ -4362,22 +4361,21 @@ BEGIN_COMMAND(playerlist)
 		}
 
 		std::string strMain, strScore;
-		StrFormat(strMain, "(%02d): %s %s - %s - time:%d - ping:%d", it->id,
-		          it->userinfo.netname.c_str(), it->spectator ? "(SPEC)" : "",
-		          NET_AdrToString(it->client.address), it->GameTime, it->ping);
+		strMain = fmt::sprintf("(%02d): %s %s - %s - time:%d - ping:%d", it->id,
+		                       it->userinfo.netname.c_str(), it->spectator ? "(SPEC)" : "",
+		                       NET_AdrToString(it->client.address), it->GameTime, it->ping);
 
 		if (G_IsCoopGame())
 		{
 			if (G_IsLivesGame())
 			{
 				// Kills and Lives
-				StrFormat(strScore, " - kills:%d - lives:%d", it->killcount, it->lives);
+				strScore = fmt::sprintf(" - kills:%d - lives:%d", it->killcount, it->lives);
 			}
 			else
 			{
 				// Kills and Deaths
-				StrFormat(strScore, " - kills:%d - deaths:%d", it->killcount,
-				          it->deathcount);
+				strScore = fmt::sprintf(" - kills:%d - deaths:%d", it->killcount, it->deathcount);
 			}
 		}
 		else if (sv_gametype == GM_DM)
@@ -4385,13 +4383,13 @@ BEGIN_COMMAND(playerlist)
 			if (G_IsLivesGame())
 			{
 				// Wins, Lives, and Frags
-				StrFormat(strScore, " - wins:%d - lives:%d - frags:%d", it->roundwins,
+				strScore = fmt::sprintf(" - wins:%d - lives:%d - frags:%d", it->roundwins,
 				          it->lives, frags);
 			}
 			else
 			{
 				// Frags, Deaths
-				StrFormat(strScore, " - frags:%d - deaths:%d", frags, deaths);
+				strScore = fmt::sprintf(" - frags:%d - deaths:%d", frags, deaths);
 			}
 		}
 		else if (sv_gametype == GM_TEAMDM)
@@ -4399,12 +4397,12 @@ BEGIN_COMMAND(playerlist)
 			if (G_IsLivesGame())
 			{
 				// Frags and Lives
-				StrFormat(strScore, " - frags:%d - lives:%d", frags, it->lives);
+				strScore = fmt::sprintf(" - frags:%d - lives:%d", frags, it->lives);
 			}
 			else
 			{
 				// Frags
-				StrFormat(strScore, " - frags:%d", frags);
+				strScore = fmt::sprintf(" - frags:%d", frags);
 			}
 		}
 		else if (sv_gametype == GM_CTF)
@@ -4412,13 +4410,13 @@ BEGIN_COMMAND(playerlist)
 			if (G_IsLivesGame())
 			{
 				// Points and Lives
-				StrFormat(strScore, " - points:%d - lives:%d", points, it->lives);
+				strScore = fmt::sprintf(" - points:%d - lives:%d", points, it->lives);
 			}
 			else
 			{
 				// Points and Frags
 				// Special case here: frags will only be from the current round, not global.
-				StrFormat(strScore, " - points:%d - frags:%d", points, it->fragcount);
+				strScore = fmt::sprintf(" - points:%d - frags:%d", points, it->fragcount);
 			}
 		}
 

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -2836,7 +2836,7 @@ void SV_UpdateGametype(player_t& pl)
 {
 	if (G_IsHordeMode())
 	{
-		static hordeInfo_t lastInfo = {HS_STARTING, -1, -1, -1, 0, 0, -1, -1, -1, -1, -1};
+		static hordeInfo_t lastInfo = {HS_STARTING, -1, -1, -1, 0, -1, -1, -1, -1, -1};
 		static int ticsent;
 
 		// If the hordeinfo has changed since last tic, save and send it.

--- a/server/src/sv_vote.cpp
+++ b/server/src/sv_vote.cpp
@@ -91,7 +91,7 @@ class CoinflipVote : public Vote
 {
 public:
 	CoinflipVote() : Vote("coinflip", &sv_callvote_coinflip) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -99,7 +99,7 @@ public:
 		this->votestring = "coinflip";
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		std::string result;
 		CMD_CoinFlip(result);
@@ -115,7 +115,7 @@ private:
 	std::string netname;
 public:
 	ForcespecVote() : Vote("forcespec", &sv_callvote_forcespec) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -145,7 +145,7 @@ public:
 
 		return true;
 	}
-	bool tic()
+	bool tic() override
 	{
 		if (!validplayer(idplayer(this->id)))
 		{
@@ -163,7 +163,7 @@ public:
 		}
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		SV_SetPlayerSpec(idplayer(this->id), true);
 		return true;
@@ -174,7 +174,7 @@ class ForcestartVote : public Vote
 {
 public:
 	ForcestartVote() : Vote("forcestart", &sv_callvote_forcestart) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -188,7 +188,7 @@ public:
 		this->votestring = "forcestart";
 		return true;
 	}
-	bool tic()
+	bool tic() override
 	{
 		if (::levelstate.getState() != LevelState::WARMUP)
 		{
@@ -198,7 +198,7 @@ public:
 
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		AddCommandString("forcestart");
 		return true;
@@ -212,7 +212,7 @@ private:
 	unsigned int fraglimit;
 public:
 	FraglimitVote() : Vote("fraglimit", &sv_callvote_fraglimit) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		unsigned int fraglimit;
 
@@ -249,7 +249,7 @@ public:
 		this->votestring = vote_string.str();
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		sv_fraglimit.Set(this->fraglimit);
 		return true;
@@ -265,7 +265,7 @@ private:
 	std::string reason;
 public:
 	KickVote() : Vote("kick", &sv_callvote_kick) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -300,7 +300,7 @@ public:
 
 		return true;
 	}
-	bool tic()
+	bool tic() override
 	{
 		if (!validplayer(idplayer(this->id)))
 		{
@@ -311,7 +311,7 @@ public:
 		}
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		std::ostringstream buffer;
 		if (this->reason.empty())
@@ -334,7 +334,7 @@ private:
 	byte version;
 public:
 	MapVote() : Vote("map", &sv_callvote_map) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		size_t index;
 
@@ -381,7 +381,7 @@ public:
 		this->votestring = vsbuffer.str();
 		return true;
 	}
-	bool tic()
+	bool tic() override
 	{
 		if (this->version != Maplist::instance().get_version())
 		{
@@ -390,7 +390,7 @@ public:
 		}
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		G_ChangeMap(this->index);
 		return true;
@@ -401,7 +401,7 @@ class NextmapVote : public Vote
 {
 public:
 	NextmapVote() : Vote("nextmap", &sv_callvote_nextmap) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -411,7 +411,7 @@ public:
 		this->votestring = "nextmap";
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		G_ChangeMap();
 		return true;
@@ -422,7 +422,7 @@ class RandcapsVote : public Vote
 {
 public:
 	RandcapsVote() : Vote("randcaps", &sv_callvote_randcaps) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -431,7 +431,7 @@ public:
 		this->votestring = "randcaps";
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		return Pickup_DistributePlayers(sv_teamsinplay, this->error);
 	}
@@ -441,7 +441,7 @@ class RandmapVote : public Vote
 {
 public:
 	RandmapVote() : Vote("randmap", &sv_callvote_randmap) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -458,7 +458,7 @@ public:
 		this->votestring = "randmap";
 		return true;
 	}
-	bool tic()
+	bool tic() override
 	{
 		if (Maplist::instance().empty())
 		{
@@ -467,7 +467,7 @@ public:
 		}
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		return CMD_Randmap(this->error);
 	}
@@ -479,7 +479,7 @@ private:
 	size_t num_players;
 public:
 	RandpickupVote() : Vote("randpickup", &sv_callvote_randpickup) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -509,7 +509,7 @@ public:
 		this->votestring = buffer.str();
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		return Pickup_DistributePlayers(this->num_players, this->error);
 	}
@@ -519,7 +519,7 @@ class RestartVote : public Vote
 {
 public:
 	RestartVote() : Vote("restart", &sv_callvote_restart) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		if (!Vote::setup_check_cvar())
 			return false;
@@ -529,7 +529,7 @@ public:
 		this->votestring = "restart";
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		// When in warmup mode, we would rather not catch players off guard.
 		::levelstate.reset();
@@ -547,7 +547,7 @@ private:
 	unsigned int scorelimit;
 public:
 	ScorelimitVote() : Vote("scorelimit", &sv_callvote_scorelimit) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		unsigned int scorelimit;
 
@@ -591,7 +591,7 @@ public:
 		this->votestring = vote_string.str();
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		sv_scorelimit.Set(this->scorelimit);
 		return true;
@@ -604,7 +604,7 @@ private:
 	float timelimit;
 public:
 	TimelimitVote() : Vote("timelimit", &sv_callvote_timelimit) { };
-	bool setup(const std::vector<std::string> &args, const player_t &player)
+	bool setup(const std::vector<std::string> &args, const player_t &player) override
 	{
 		float timelimit;
 
@@ -648,7 +648,7 @@ public:
 		this->votestring = vote_string.str();
 		return true;
 	}
-	bool exec()
+	bool exec() override
 	{
 		sv_timelimit.Set(this->timelimit);
 		return true;


### PR DESCRIPTION
This PR is a collection of a few small things:
- Some more compiler warnings are squashed by using the `[[fallthrough]]` attribute everywhere I'm certain the fallthrough is intended, not comparing CVARs to bools, changing `SArray::iterator` and `OHashTable::iterator` to no longer inherit from the deprecated `std::iterator`, and fixing some of the simplest cases of implicit `size_t` to `int` casts.
- The `NORETURN` define has been replaced by the compiler-agnostic `[[noreturn]]` attribute that was introduced in C++11. 
- Some old comments containing outdated information have been removed or updated.
- Warnings and errors thrown by `OScanner` are now labelled `Parse Error` and `Parse Warning` instead of `Script Error` and `Script Warning`, for clarity.
- A temporary hack for compatibility between 10.0 and other 10.x versions has been removed.
- `override` is used wherever it is appropriate (except in the sdl files, there's so much there, I'm not touching that lmao).
- `StrFormat` has been removed now that we have access to `fmt::sprintf`
- A few `FIXME`s have been addressed