### PR TITLE
[FEATURE] Add support for MAPINFO AirSupply property

### DIFF
--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -817,6 +817,7 @@ void G_InitLevelLocals()
 	{
 		::level.aircontrol = static_cast<fixed_t>(info.aircontrol * 65536.f);
 	}
+	::level.airsupply = info.airsupply;
 
 	::level.partime = info.partime;
 	::level.cluster = info.cluster;

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -165,6 +165,7 @@ struct level_pwad_info_t
 	OLumpName		skypic2;
 	float			gravity;
 	float			aircontrol;
+	int				airsupply;
 
 	// The following are necessary for UMAPINFO compatibility
 	OLumpName		exitpic;
@@ -193,7 +194,8 @@ struct level_pwad_info_t
 	    : mapname(""), levelnum(0), level_name(""), pname(""), nextmap(""), secretmap(""),
 	      partime(0), skypic(""), music(""), flags(0), cluster(0), snapshot(NULL),
 	      defered(NULL), fadetable("COLORMAP"), skypic2(""), gravity(0.0f),
-	      aircontrol(0.0f), exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""), endpic(""), intertext(""),
+	      aircontrol(0.0f), airsupply(10),
+		  exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""), endpic(""), intertext(""),
 	      intertextsecret(""), interbackdrop(""), intermusic(""),
 	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(),
 	      clearlabel(false), author()
@@ -210,7 +212,8 @@ struct level_pwad_info_t
 	      secretmap(other.secretmap), partime(other.partime), skypic(other.skypic),
 	      music(other.music), flags(other.flags), cluster(other.cluster),
 	      snapshot(other.snapshot), defered(other.defered), fadetable("COLORMAP"),
-	      skypic2(""), gravity(0.0f), aircontrol(0.0f), exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""),
+	      skypic2(""), gravity(0.0f), aircontrol(0.0f), airsupply(10),
+		  exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""),
 	      endpic(""), intertext(""), intertextsecret(""), interbackdrop(""), intermusic(""),
 	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(),
 	      clearlabel(false), author()
@@ -246,6 +249,7 @@ struct level_pwad_info_t
 		skypic2 = other.skypic2;
 		gravity = other.gravity;
 		aircontrol = other.aircontrol;
+		airsupply = other.airsupply;
 		exitpic = other.exitpic;
 		exitscript = other.exitscript;
 		exitanim = other.exitanim;
@@ -323,6 +327,7 @@ struct level_locals_t
 	float			gravity;
 	fixed_t			aircontrol;
 	fixed_t			airfriction;
+	int 			airsupply;
 
 	// The following are all used for ACS scripting
 	FBehavior*		behavior;

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1307,6 +1307,7 @@ struct MapInfoDataSetter<level_pwad_info_t>
 			{ "warptrans", &MIType_EatNext },
 			{ "gravity", &MIType_Float, &ref.gravity },
 			{ "aircontrol", &MIType_Float, &ref.aircontrol },
+			{ "airsupply", &MIType_Int, &ref.airsupply },
 			{ "islobby", &MIType_SetFlag, &ref.flags, LEVEL_LOBBYSPECIAL },
 			{ "lobby", &MIType_SetFlag, &ref.flags, LEVEL_LOBBYSPECIAL },
 			{ "nocrouch" },

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -1123,9 +1123,9 @@ void P_PlayerThink (player_t *player)
 	// Handle air supply
 	if (player->mo->waterlevel < 3 || player->powers[pw_ironfeet] || player->cheats & CF_GODMODE)
 	{
-		player->air_finished = level.time + 10*TICRATE;
+		player->air_finished = level.time + level.airsupply * TICRATE;
 	}
-	else if (player->air_finished <= level.time && !(level.time & 31))
+	else if (level.airsupply != 0 && player->air_finished <= level.time && !(level.time & 31))
 	{
 		P_DamageMobj (player->mo, NULL, NULL, 2 + 2*((level.time-player->air_finished)/TICRATE), MOD_WATER, DMG_NO_ARMOR);
 	}


### PR DESCRIPTION
This allows specifying the amount of time, in seconds, before a player starts taking damage while underwater. It can also be set to 0 to allow players to be underwater indefinitely. The default value is 10, the same as ZDaemon and ZDoom 1.23b33. This differs from modern GZDoom and Zandronum which have a default value of 20, and also apply less damage when drowning.