### PR TITLE
[FEATURE] Support Skulltag Style Win/Lose Interpics & Music

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -412,6 +412,22 @@ void G_DoCompleted (void)
 		}
 	}
 
+	const WinInfo& win = levelstate.getWinInfo();
+	switch (win.type)
+	{
+		case WinInfo::WIN_EVERYBODY:
+			wminfo.winner = true;
+			break;
+		case WinInfo::WIN_TEAM:
+			wminfo.winner = consoleplayer().userinfo.team == win.id;
+			break;
+		case WinInfo::WIN_PLAYER:
+			wminfo.winner = consoleplayer_id == win.id;
+			break;
+		default:
+			wminfo.winner = false;
+	}
+
 	AM_Stop();
 
 	wminfo.epsd = level.cluster - 1;		// Only used for DOOM I.

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1163,6 +1163,8 @@ void WI_updateStats()
 					S_ChangeMusic(enteranim->musiclump.c_str(), true);
 				else if (!nextlevel.zintermusic.empty())
 					S_ChangeMusic(nextlevel.zintermusic.c_str(), true);
+				else
+					S_ChangeMusic(gameinfo.intermissionMusic.c_str(), true);
 				// background
 				const char* bg_lump = enteranim == nullptr ? enterpic.c_str() : enteranim->backgroundlump.c_str();
 				const patch_t* bg_patch = W_CachePatch(bg_lump);
@@ -1278,17 +1280,14 @@ void WI_Ticker()
 	if (bcnt == 1)
 	{
 		level_pwad_info_t& currentlevel = getLevelInfos().findByName(wbs->current);
-		OLumpName winmusic;
-		if (W_CheckNumForName(wbs->winner ? "D_OWIN" : "D_OLOSE") != -1)
-			winmusic = wbs->winner ? "D_OWIN" : "D_OLOSE";
-		else if (W_CheckNumForName(wbs->winner ? "D_STWIN" : "D_STLOSE") != -1)
-			winmusic = wbs->winner ? "D_STWIN" : "D_STLOSE";
 
 		// intermission music
 		if (exitanim != nullptr && !exitanim->musiclump.empty())
 			S_ChangeMusic (exitanim->musiclump.c_str(), true);
-		else if (!winmusic.empty())
-			S_ChangeMusic (winmusic.c_str(), true);
+		else if (W_CheckNumForName(wbs->winner ? "D_OWIN" : "D_OLOSE") != -1)
+			S_ChangeMusic (wbs->winner ? "D_OWIN" : "D_OLOSE", true);
+		else if (W_CheckNumForName(wbs->winner ? "D_STWIN" : "D_STLOSE") != -1)
+			S_ChangeMusic (wbs->winner ? "D_STWIN" : "D_STLOSE", true);
 		else if (!currentlevel.zintermusic.empty())
 			S_ChangeMusic (currentlevel.zintermusic.c_str(), true);
 		else

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1398,12 +1398,12 @@ void WI_loadData()
 
 	if (exitanim != nullptr)
 		strcpy(name, exitanim->backgroundlump.c_str());
+	else if (!winpic.empty())
+		strcpy(name, winpic.c_str());
 	else if (currentlevel.exitpic[0] != '\0')
 		strcpy(name, currentlevel.exitpic.c_str());
-	else if ((gameinfo.flags & GI_MAPxx) || ((gameinfo.flags & GI_MENUHACK_RETAIL) && wbs->epsd >= 3))
-		winpic.empty() ? strcpy(name, "INTERPIC") : strcpy(name, winpic.c_str());
 	else
-		snprintf(name, 17, "WIMAP%d", wbs->epsd);
+		strcpy(name, "INTERPIC");
 
 	// background
 	const patch_t* bg_patch = W_CachePatch(name);

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1376,22 +1376,17 @@ void WI_loadData()
 	animation = new wi_animation_t();
 
 	if (!winanim.empty())
-	{
 		exitanim = WI_GetInterlevel(winanim.c_str());
-	} else if (!currentlevel.exitanim.empty())
-	{
+	else if (!currentlevel.exitanim.empty())
 		exitanim = WI_GetInterlevel(currentlevel.exitanim.c_str());
-	} else if (!currentlevel.exitscript.empty())
-	{
+	else if (!currentlevel.exitscript.empty())
 		exitanim = WI_GetIntermissionScript(currentlevel.exitscript.c_str());
-	}
+
 	if (!nextlevel.enteranim.empty())
-	{
 		enteranim = WI_GetInterlevel(nextlevel.enteranim.c_str());
-	} else if (!nextlevel.enterscript.empty())
-	{
+	else if (!nextlevel.enterscript.empty())
 		enteranim = WI_GetIntermissionScript(nextlevel.enterscript.c_str());
-	}
+
 	WI_initAnimation();
 
 	OLumpName name;

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1169,6 +1169,8 @@ void WI_updateStats()
 			{
 				if (enteranim != nullptr && !enteranim->musiclump.empty())
 					S_ChangeMusic(enteranim->musiclump.c_str(), true);
+				else if (!nextlevel.intermusic.empty())
+					S_ChangeMusic(nextlevel.intermusic.c_str(), true);
 				// background
 				const char* bg_lump = enteranim == nullptr ? enterpic.c_str() : enteranim->backgroundlump.c_str();
 				const patch_t* bg_patch = W_CachePatch(bg_lump);
@@ -1283,11 +1285,14 @@ void WI_Ticker()
 
 	if (bcnt == 1)
 	{
+		level_pwad_info_t& currentlevel = getLevelInfos().findByName(wbs->current);
 		// intermission music
 		if (exitanim != nullptr && !exitanim->musiclump.empty())
 			S_ChangeMusic (exitanim->musiclump.c_str(), true);
 		else if (!winlumps.music.empty())
 			S_ChangeMusic (winlumps.music.c_str(), true);
+		else if (!currentlevel.intermusic.empty())
+			S_ChangeMusic (currentlevel.intermusic.c_str(), true);
 		else
 			S_ChangeMusic (gameinfo.intermissionMusic.c_str(), true);
 	}

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1394,16 +1394,16 @@ void WI_loadData()
 	}
 	WI_initAnimation();
 
-	char name[17];
+	OLumpName name;
 
 	if (exitanim != nullptr)
-		strcpy(name, exitanim->backgroundlump.c_str());
+		name = exitanim->backgroundlump;
 	else if (!winpic.empty())
-		strcpy(name, winpic.c_str());
+		name = winpic;
 	else if (currentlevel.exitpic[0] != '\0')
-		strcpy(name, currentlevel.exitpic.c_str());
+		currentlevel.exitpic;
 	else
-		strcpy(name, "INTERPIC");
+		name = "INTERPIC";
 
 	// background
 	const patch_t* bg_patch = W_CachePatch(name);
@@ -1443,8 +1443,8 @@ void WI_loadData()
 	for (int i = 0; i < 10; i++)
 	{
 		// numbers 0-9
-		snprintf(name, 17, "WINUM%d", i);
-			num[i] = W_CachePatchHandle(name, PU_STATIC);
+		name = fmt::format("WINUM{}", i);
+		num[i] = W_CachePatchHandle(name.c_str(), PU_STATIC);
 	}
 
 	wiminus = W_CachePatchHandle("WIMINUS", PU_STATIC);
@@ -1527,8 +1527,8 @@ void WI_loadData()
 	// [Nes] Classic vanilla lifebars.
 	for (int i = 0; i < 4; i++)
 	{
-		sprintf(name, "STPB%d", i);
-		faceclassic[i] = W_CachePatchHandle(name, PU_STATIC);
+		name = fmt::format("STPB{}", i);
+		faceclassic[i] = W_CachePatchHandle(name.c_str(), PU_STATIC);
 	}
 }
 

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1169,8 +1169,8 @@ void WI_updateStats()
 			{
 				if (enteranim != nullptr && !enteranim->musiclump.empty())
 					S_ChangeMusic(enteranim->musiclump.c_str(), true);
-				else if (!nextlevel.intermusic.empty())
-					S_ChangeMusic(nextlevel.intermusic.c_str(), true);
+				else if (!nextlevel.zintermusic.empty())
+					S_ChangeMusic(nextlevel.zintermusic.c_str(), true);
 				// background
 				const char* bg_lump = enteranim == nullptr ? enterpic.c_str() : enteranim->backgroundlump.c_str();
 				const patch_t* bg_patch = W_CachePatch(bg_lump);
@@ -1291,8 +1291,8 @@ void WI_Ticker()
 			S_ChangeMusic (exitanim->musiclump.c_str(), true);
 		else if (!winlumps.music.empty())
 			S_ChangeMusic (winlumps.music.c_str(), true);
-		else if (!currentlevel.intermusic.empty())
-			S_ChangeMusic (currentlevel.intermusic.c_str(), true);
+		else if (!currentlevel.zintermusic.empty())
+			S_ChangeMusic (currentlevel.zintermusic.c_str(), true);
 		else
 			S_ChangeMusic (gameinfo.intermissionMusic.c_str(), true);
 	}

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -176,14 +176,6 @@ static IWindowSurface*	anim_surface;
 static interlevel_t* enteranim;
 static interlevel_t* exitanim;
 
-struct wi_win_t
-{
-	OLumpName music;
-	OLumpName pic;
-	OLumpName anim;
-};
-static wi_win_t winlumps;
-
 EXTERN_CVAR (sv_maxplayers)
 EXTERN_CVAR (wi_oldintermission)
 EXTERN_CVAR (cl_autoscreenshot)
@@ -1286,11 +1278,17 @@ void WI_Ticker()
 	if (bcnt == 1)
 	{
 		level_pwad_info_t& currentlevel = getLevelInfos().findByName(wbs->current);
+		OLumpName winmusic;
+		if (W_CheckNumForName(wbs->winner ? "D_OWIN" : "D_OLOSE") != -1)
+			winmusic = wbs->winner ? "D_OWIN" : "D_OLOSE";
+		else if (W_CheckNumForName(wbs->winner ? "D_STWIN" : "D_STLOSE") != -1)
+			winmusic = wbs->winner ? "D_STWIN" : "D_STLOSE";
+
 		// intermission music
 		if (exitanim != nullptr && !exitanim->musiclump.empty())
 			S_ChangeMusic (exitanim->musiclump.c_str(), true);
-		else if (!winlumps.music.empty())
-			S_ChangeMusic (winlumps.music.c_str(), true);
+		else if (!winmusic.empty())
+			S_ChangeMusic (winmusic.c_str(), true);
 		else if (!currentlevel.zintermusic.empty())
 			S_ChangeMusic (currentlevel.zintermusic.c_str(), true);
 		else
@@ -1369,11 +1367,18 @@ void WI_loadData()
 	level_pwad_info_t& currentlevel = levels.findByName(wbs->current);
 	level_pwad_info_t& nextlevel = levels.findByName(wbs->next);
 
+	OLumpName winanim;
+	OLumpName winpic;
+	if (W_CheckNumForName(wbs->winner ? "WINANIM" : "LOSEANIM") != -1)
+		winanim = wbs->winner ? "WINANIM" : "LOSEANIM";
+	else if (W_CheckNumForName(wbs->winner ? "WINERPIC" : "LOSERPIC") != -1)
+		winpic = wbs->winner ? "WINERPIC" : "LOSERPIC";
+
 	animation = new wi_animation_t();
 
-	if (!winlumps.anim.empty())
+	if (!winanim.empty())
 	{
-		exitanim = WI_GetInterlevel(winlumps.anim.c_str());
+		exitanim = WI_GetInterlevel(winanim.c_str());
 	} else if (!currentlevel.exitanim.empty())
 	{
 		exitanim = WI_GetInterlevel(currentlevel.exitanim.c_str());
@@ -1397,7 +1402,7 @@ void WI_loadData()
 	else if (currentlevel.exitpic[0] != '\0')
 		strcpy(name, currentlevel.exitpic.c_str());
 	else if ((gameinfo.flags & GI_MAPxx) || ((gameinfo.flags & GI_MENUHACK_RETAIL) && wbs->epsd >= 3))
-		winlumps.pic.empty() ? strcpy(name, "INTERPIC") : strcpy(name, winlumps.pic.c_str());
+		winpic.empty() ? strcpy(name, "INTERPIC") : strcpy(name, winpic.c_str());
 	else
 		snprintf(name, 17, "WIMAP%d", wbs->epsd);
 
@@ -1604,29 +1609,6 @@ void WI_initVariables (wbstartstruct_t *wbstartstruct)
 	cnt = bcnt = 0;
 	me = wbs->pnum;
 	plrs = wbs->plyr;
-
-	if (W_CheckNumForName(wbs->winner ? "D_OWIN" : "D_OLOSE") != -1)
-		winlumps.music = wbs->winner ? "D_OWIN" : "D_OLOSE";
-	else if (W_CheckNumForName(wbs->winner ? "D_STWIN" : "D_STLOSE") != -1)
-		winlumps.music = wbs->winner ? "D_STWIN" : "D_STLOSE";
-	else
-		winlumps.music.clear();
-
-	if (W_CheckNumForName(wbs->winner ? "WINANIM" : "LOSEANIM") != -1)
-	{
-		winlumps.anim = wbs->winner ? "WINANIM" : "LOSEANIM";
-		winlumps.pic.clear();
-	}
-	else if (W_CheckNumForName(wbs->winner ? "WINERPIC" : "LOSERPIC") != -1)
-	{
-		winlumps.pic = wbs->winner ? "WINERPIC" : "LOSERPIC";
-		winlumps.anim.clear();
-	}
-	else
-	{
-		winlumps.pic.clear();
-		winlumps.anim.clear();
-	}
 }
 
 void WI_Start (wbstartstruct_t *wbstartstruct)

--- a/common/d_player.h
+++ b/common/d_player.h
@@ -690,6 +690,7 @@ typedef struct wbstartstruct_s
 	unsigned	pnum;
 
 	bool		didsecret = false;
+	bool		winner;
 
 	std::vector<wbplayerstruct_s> plyr;
 } wbstartstruct_t;

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -926,6 +926,7 @@ void G_InitLevelLocals()
 	::level.intertextsecret = info.intertextsecret;
 	::level.interbackdrop = info.interbackdrop;
 	::level.intermusic = info.intermusic;
+	::level.zintermusic = info.zintermusic;
 
 	::level.bossactions = info.bossactions;
 	::level.label = info.label;

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -179,6 +179,7 @@ struct level_pwad_info_t
 	std::string		intertextsecret;
 	OLumpName		interbackdrop;
 	OLumpName		intermusic;
+	OLumpName		zintermusic;
 
 	fixed_t			sky1ScrollDelta;
 	fixed_t			sky2ScrollDelta;
@@ -194,7 +195,7 @@ struct level_pwad_info_t
 	      partime(0), skypic(""), music(""), flags(0), cluster(0), snapshot(NULL),
 	      defered(NULL), fadetable("COLORMAP"), skypic2(""), gravity(0.0f),
 	      aircontrol(0.0f), exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""), endpic(""), intertext(""),
-	      intertextsecret(""), interbackdrop(""), intermusic(""),
+	      intertextsecret(""), interbackdrop(""), intermusic(""), zintermusic(""),
 	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(),
 	      clearlabel(false), author()
 	{
@@ -211,7 +212,7 @@ struct level_pwad_info_t
 	      music(other.music), flags(other.flags), cluster(other.cluster),
 	      snapshot(other.snapshot), defered(other.defered), fadetable("COLORMAP"),
 	      skypic2(""), gravity(0.0f), aircontrol(0.0f), exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""),
-	      endpic(""), intertext(""), intertextsecret(""), interbackdrop(""), intermusic(""),
+	      endpic(""), intertext(""), intertextsecret(""), interbackdrop(""), intermusic(""), zintermusic(""),
 	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(),
 	      clearlabel(false), author()
 	{
@@ -257,6 +258,7 @@ struct level_pwad_info_t
 		intertextsecret = other.intertextsecret;
 		interbackdrop = other.interbackdrop;
 		intermusic = other.intermusic;
+		zintermusic = other.zintermusic;
 		sky1ScrollDelta = other.sky1ScrollDelta;
 		sky2ScrollDelta = other.sky2ScrollDelta;
 		bossactions.clear();
@@ -340,7 +342,10 @@ struct level_locals_t
 	std::string		intertext;
 	std::string		intertextsecret;
 	OLumpName		interbackdrop;
+	// umapinfo intermusic -- used for text screens
 	OLumpName		intermusic;
+	// zdoom intermusic -- used for intermissions
+	OLumpName		zintermusic;
 
 	std::vector<bossaction_t> bossactions;
 

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1317,7 +1317,6 @@ struct MapInfoDataSetter<level_pwad_info_t>
 			{ "exitpic", &MIType_InterLumpName, &exitpicscript },
 			{ "enteranim", &MIType_LumpName, &ref.enteranim },
 			{ "exitanim", &MIType_LumpName, &ref.exitanim },
-			{ "interpic", &MIType_EatNext },
 			{ "translator", &MIType_EatNext },
 			{ "compat_shorttex", &MIType_CompatFlag, &ref.flags }, // todo: not implemented
 			{ "compat_limitpain", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_LIMITPAIN },

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1310,7 +1310,7 @@ struct MapInfoDataSetter<level_pwad_info_t>
 			{ "islobby", &MIType_SetFlag, &ref.flags, LEVEL_LOBBYSPECIAL },
 			{ "lobby", &MIType_SetFlag, &ref.flags, LEVEL_LOBBYSPECIAL },
 			{ "nocrouch" },
-			{ "intermusic", &MIType_EatNext },
+			{ "intermusic", &MIType_LumpName, &ref.zintermusic },
 			{ "par", &MIType_Int, &ref.partime },
 			{ "sucktime", &MIType_EatNext },
 			{ "enterpic", &MIType_InterLumpName, &enterpicscript },


### PR DESCRIPTION
Addresses  #1054

Adds support for 8 new lumps: `WINERPIC`, `LOSERPIC`, `D_STWIN`, `D_STLOSE`, `WINANIM`, `LOSEANIM`, `D_OWIN`, and `D_OLOSE`.

The first 4 are those used by Skulltag for custom intermission pics and music depending on whether the player viewing them won or lost. `D_OWIN` and `D_OLOSE` are the same as `D_STWIN` and `D_STLOSE`. `WINANIM` and `LOSEANIM` will be loaded as ID24 interlevel lumps, and take precedence over `WINERPIC` and `LOSERPIC`.

Also adds support for `InterMusic` in `MAPINFO`. This allows specifying custom music on intermission screens. Note this is not the same as `UMAPINFO`'s `intermusic`, which sets the music for text screens.