### PR TITLE
[BUGFIX] Incorrect ACS P-codes outside 0-239 range

### DIFF
--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -2191,7 +2191,19 @@ void DLevelScript::RunScript ()
 			break;
 		}
 
-		pcd = NEXTBYTE;
+		if (fmt == ACS_LittleEnhanced)
+		{
+			pcd = getbyte(pc);
+			if (pcd >= 240)
+			{
+				pcd = 240 + ((pcd - 240) << 8) + getbyte(pc);
+			}
+		}
+		else
+		{
+			pcd = NEXTWORD;
+		}
+
 		switch (pcd)
 		{
 		default:


### PR DESCRIPTION
Addresses #1127

ACSe uses 2 bytes for instructions after the first 240. Odamex was reading only the first byte, resulting in executing the wrong instruction and undefined behavior.