### PR TITLE
[FEATURE] Add summon cheat

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2161,6 +2161,16 @@ void CL_SendGiveCheat(const char* item)
 	MSG_WriteString(&net_buffer, item);
 }
 
+//
+// CL_SendSummonCheat
+//
+void CL_SendSummonCheat(const char* summon)
+{
+	MSG_WriteMarker(&net_buffer, clc_cheat);
+	MSG_WriteByte(&net_buffer, 2);
+	MSG_WriteString(&net_buffer, summon);
+}
+
 
 void PickupMessage (AActor *toucher, const char *message)
 {

--- a/client/src/cl_main.h
+++ b/client/src/cl_main.h
@@ -70,6 +70,7 @@ bool CL_Connect();
 
 void CL_SendCheat(int cheats);
 void CL_SendGiveCheat(const char* item);
+void CL_SendSummonCheat(const char* summon);
 
 void CL_DisplayTics();
 void CL_RunTics();

--- a/common/c_dispatch.cpp
+++ b/common/c_dispatch.cpp
@@ -971,7 +971,7 @@ void C_ExecCmdLineParams (bool onlyset, bool onlylogfile)
 	if (onlylogfile && !didlogfile) AddCommandString("version");
 }
 
-BEGIN_COMMAND (dumpactors)
+BEGIN_COMMAND (actorlist)
 {
 	AActor *mo;
 	TThinkerIterator<AActor> iterator;
@@ -981,7 +981,7 @@ BEGIN_COMMAND (dumpactors)
 		Printf (PRINT_HIGH, "%s (%x, %x, %x | %x) state: %zd tics: %d\n", mobjinfo[mo->type].name, mo->x, mo->y, mo->z, mo->angle, mo->state - states, mo->tics);
 	}
 }
-END_COMMAND (dumpactors)
+END_COMMAND(actorlist)
 
 BEGIN_COMMAND(logfile)
 {

--- a/common/infomap.cpp
+++ b/common/infomap.cpp
@@ -302,10 +302,9 @@ static void InitMap()
 	MapMobj(MT_EXTRA98, "Deh_Actor_248", MC_NONE);
 	MapMobj(MT_EXTRA99, "Deh_Actor_249", MC_NONE);
 
-	std::sort(::g_MonsterMap.begin(), ::g_MonsterMap.end(),
-	          [](const auto& left, const auto& right) {
-		          return left.second < right.second;
-	          });
+	std::sort(
+	    ::g_MonsterMap.begin(), ::g_MonsterMap.end(),
+	    [](const auto& left, const auto& right) { return left.second < right.second; });
 }
 
 /**
@@ -320,17 +319,7 @@ mobjtype_t P_NameToMobj(const std::string& name)
 
 	MobjMap::iterator it = std::find_if(
 	    ::g_MonsterMap.begin(), ::g_MonsterMap.end(),
-	    [name](const std::pair<std::string, mobjtype_t>& p) 
-			{
-		    std::string first = p.first;
-		    std::string uppername = name;
-		    std::transform(p.first.begin(), p.first.end(), uppername.begin(),
-		                   ::toupper);
-		    std::transform(name.begin(), name.end(), first.begin(),
-		                   ::toupper);
-		    return first == uppername; 
-			}
-	);
+	    [name](const std::pair<std::string, mobjtype_t>& p) { return p.first == name; });
 
 	if (it == ::g_MonsterMap.end())
 	{
@@ -340,7 +329,8 @@ mobjtype_t P_NameToMobj(const std::string& name)
 }
 
 /**
- * @brief Convert a UMAPINFO/ZDoom class name to a MT Mobj index. Case insensitive for UMAPINFO
+ * @brief Convert a UMAPINFO/ZDoom class name to a MT Mobj index. Case insensitive for
+ * UMAPINFO
  */
 mobjtype_t P_INameToMobj(const std::string& name)
 {

--- a/common/m_cheat.cpp
+++ b/common/m_cheat.cpp
@@ -183,7 +183,7 @@ BEGIN_COMMAND(tntem)
 }
 END_COMMAND(tntem)
 
- BEGIN_COMMAND(summon)
+BEGIN_COMMAND(summon)
 {
 	if (!CHEAT_AreCheatsEnabled())
 		return;
@@ -195,14 +195,14 @@ END_COMMAND(tntem)
 
 	if (!CHEAT_ValidSummonActor(mobname.c_str()))
 	{
-		Printf(PRINT_HIGH, "Invalid summon argument: %s. Please use `dumpactorlist` for a valid list of ids and actor names.\n", mobname.c_str());
+		Printf(PRINT_HIGH, "Invalid summon argument: %s. Please use `dumpactors` for a valid list of actor names.\n", mobname.c_str());
 		return;
 	}
 
 	CHEAT_Summon(&consoleplayer(), mobname.c_str(), false);
 	CL_SendSummonCheat(mobname.c_str());
  }
- END_COMMAND(summon)
+END_COMMAND(summon)
 
 BEGIN_COMMAND(mdk)
 {
@@ -478,8 +478,6 @@ AActor* CHEAT_Summon(player_s* player, const char* sum, bool friendly)
 	AActor* entity = AActor::AActorPtr();
 	AActor* source = player->mo;
 
-	std::string mobname = "";
-
 	if (player->spectator || source == NULL)
 		return entity;
 
@@ -490,8 +488,8 @@ AActor* CHEAT_Summon(player_s* player, const char* sum, bool friendly)
 
 		if (mobjtype == MT_NULL)
 		{
-				Printf(PRINT_HIGH, "%s tried to cheat but can't even summon right\n",
-				       player->userinfo.netname.c_str());
+			PrintFmt(PRINT_HIGH, "{} tried to cheat but can't even summon right\n",
+				       player->userinfo.netname);
 				return entity;
 		}
 
@@ -511,12 +509,14 @@ AActor* CHEAT_Summon(player_s* player, const char* sum, bool friendly)
 
 			entity->angle = source->angle;
 		}
-
-		return entity;
 	}
 
-	Printf(PRINT_HIGH, "%s is a cheater: summon %s\n", player->userinfo.netname.c_str(),
-	       mobname.c_str());
+	if (multiplayer)
+		PrintFmt(PRINT_HIGH, "{} is a cheater: summon {}\n",
+		         player->userinfo.netname,
+		 sum);
+
+	return entity;
 }
 
 void CHEAT_GiveTo(player_t* player, const char* name)

--- a/common/m_cheat.cpp
+++ b/common/m_cheat.cpp
@@ -463,7 +463,7 @@ void CHEAT_DoCheat(player_t* player, int cheat, bool silentmsg)
 bool CHEAT_ValidSummonActor(const char* summon) {
 	std::string mobname = "";
 
-	mobjtype_t mobjtype = P_NameToMobj(summon);
+	mobjtype_t mobjtype = P_INameToMobj(summon);
 
 	if (mobjtype == MT_NULL)
 	{
@@ -486,7 +486,7 @@ AActor* CHEAT_Summon(player_s* player, const char* sum, bool friendly)
 	if (serverside)
 	{
 		// First, find whatever the heck we summoned.
-		mobjtype_t mobjtype = P_NameToMobj(sum);
+		mobjtype_t mobjtype = P_INameToMobj(sum);
 
 		if (mobjtype == MT_NULL)
 		{

--- a/common/m_cheat.cpp
+++ b/common/m_cheat.cpp
@@ -501,10 +501,16 @@ AActor* CHEAT_Summon(player_s* player, const char* sum, bool friendly)
 		                                 finesine[source->angle >> ANGLETOFINESHIFT]);
 		fixed_t z = source->z + 8 * FRACUNIT;
 
+		if (mobjinfo[mobjtype].flags & MF_MISSILE)
+		{
+			entity = P_SpawnPlayerMissile(source, mobjtype);
+		}
+		else
+		{
+			entity = new AActor(x, y, z, mobjtype);
 
-		entity = new AActor(x, y, z, mobjtype);
-
-		entity->angle = source->angle;
+			entity->angle = source->angle;
+		}
 
 		return entity;
 	}

--- a/common/m_cheat.h
+++ b/common/m_cheat.h
@@ -83,6 +83,8 @@ enum ECheatFlags
 class player_s;
 void CHEAT_DoCheat (player_s *player, int cheat, bool silentmsg=false);
 void CHEAT_GiveTo (player_s *player, const char *item);
+AActor* CHEAT_Summon(player_s* player, const char* sum, bool friendly);
+bool CHEAT_ValidSummonActor(const char* summon);
 
 // Heretic code (unused)
 #if 0

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -122,7 +122,7 @@ bool	P_SetMobjState (AActor* mobj, statenum_t state, bool cl_update = false);
 
 void	P_SpawnBlood (fixed_t x, fixed_t y, fixed_t z, int damage);
 AActor* P_SpawnMissile (AActor* source, AActor* dest, mobjtype_t type);
-void	P_SpawnPlayerMissile (AActor* source, mobjtype_t type);
+AActor* P_SpawnPlayerMissile(AActor* source, mobjtype_t type);
 void P_SpawnMBF21PlayerMissile(AActor* source, mobjtype_t type, fixed_t angle,
                                fixed_t pitch, fixed_t xyofs, fixed_t zofs);
 bool P_CheckSwitchWeapon(player_t* player, weapontype_t weapon);

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2372,10 +2372,11 @@ AActor* P_SpawnMissile (AActor *source, AActor *dest, mobjtype_t type)
 // P_SpawnPlayerMissile
 // Tries to aim at a nearby monster
 //
-void P_SpawnPlayerMissile (AActor *source, mobjtype_t type)
+AActor* P_SpawnPlayerMissile (AActor *source, mobjtype_t type)
 {
+	AActor* th = AActor::AActorPtr();
 	if(!serverside)
-		return;
+		return th;
 
 	fixed_t slope;
 	fixed_t pitchslope = finetangent[FINEANGLES/4 - (source->pitch>>ANGLETOFINESHIFT)];
@@ -2403,7 +2404,7 @@ void P_SpawnPlayerMissile (AActor *source, mobjtype_t type)
 		slope = pitchslope;
 	}
 
-	AActor *th = new AActor (source->x, source->y, source->z + 4*8*FRACUNIT, type);
+	th = new AActor (source->x, source->y, source->z + 4*8*FRACUNIT, type);
 
 	if (th->info->seesound)
 		S_Sound (th, CHAN_VOICE, th->info->seesound, 1, ATTN_NORM);
@@ -2434,6 +2435,8 @@ void P_SpawnPlayerMissile (AActor *source, mobjtype_t type)
 	}
 
 	P_CheckMissileSpawn (th);
+
+	return th;
 }
 
 

--- a/common/p_mobj.h
+++ b/common/p_mobj.h
@@ -142,7 +142,7 @@ void P_SpawnTracerPuff(fixed_t x, fixed_t y, fixed_t z);
 void P_SpawnBlood(fixed_t x, fixed_t y, fixed_t z, angle_t dir, int damage);
 bool P_CheckMissileSpawn(AActor* th);
 AActor* P_SpawnMissile(AActor *source, AActor *dest, mobjtype_t type);
-void P_SpawnPlayerMissile(AActor *source, mobjtype_t type);
+AActor* P_SpawnPlayerMissile(AActor* source, mobjtype_t type);
 size_t P_GetMapThingPlayerNumber(mapthing2_t* mthing);
 bool P_VisibleToPlayers(AActor *mo);
 void P_SetMobjBaseline(AActor& mo);

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3880,6 +3880,24 @@ void SV_Cheat(player_t &player)
 		}
 
 	}
+	else if (cheatType == 2)
+	{
+		const char* wantsummon = MSG_ReadString();
+
+		if (!CHEAT_AreCheatsEnabled())
+			return;
+
+		AActor* actor = CHEAT_Summon(&player, wantsummon, false);
+
+		if (actor == NULL)
+			return;
+
+		for (Players::iterator it = players.begin(); it != players.end(); ++it)
+		{
+			client_t* cl = &it->client;
+			SV_SendMobjToClient(actor, cl);
+		}
+	}
 }
 
 void SV_WantWad(player_t &player)


### PR DESCRIPTION
Something that adds to the toolbox with MBF21 + DSDHacked, I created a simple summon cheat emulating (but not copying!!) the behavior of the summon cheat from ZDoom. This is mainly to help people creating new monsters. They spawn not looking at you so you can play with a trap setup, or turn on `notarget` for a more elaborate setup.

I also renamed our current `dumpactors` cvar to `actorlist` to more closely resemble their ZDoom counterparts. `dumpactors` will dump the name of every actor in the game, which is what you need to summon things.

This also works online.

(Don't mind the formatting changes in m_cheats)