### PR TITLE
[BUGFIX] Single patch textures rendered incorrectly if patch taller than texture

### DIFF
--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -645,7 +645,7 @@ void R_RenderMaskedSegRange(drawseg_t* ds, int x1, int x2)
 
 	const int64_t topscreenclip = int64_t(centery) << 2*FRACBITS;
 	const int64_t botscreenclip = int64_t(centery - viewheight) << 2*FRACBITS;
- 
+
 	// top of texture entirely below screen?
 	if (int64_t(dcol.texturemid) * ds->scale1 <= botscreenclip &&
 		int64_t(dcol.texturemid) * ds->scale2 <= botscreenclip)
@@ -678,7 +678,7 @@ void R_RenderMaskedSegRange(drawseg_t* ds, int x1, int x2)
 	mfloorclip = ds->sprbottomclip;
 	mceilingclip = ds->sprtopclip;
 
-	dcol.textureheight = 512*FRACUNIT;
+	dcol.textureheight = 0;
 
 	// draw the columns
 	// TODO: change negonearray to the actual top/bottom
@@ -796,7 +796,7 @@ void R_PrepWall(fixed_t px1, fixed_t py1, fixed_t px2, fixed_t py2, fixed_t dist
 		// calculate the upper and lower heights of the walls in the back
 		R_FillWallHeightArray(walltopb, start, stop, rw_backcz1, rw_backcz2, scale1, scale2);
 		R_FillWallHeightArray(wallbottomb, start, stop, rw_backfz1, rw_backfz2, scale1, scale2);
-	
+
 		constexpr fixed_t tolerance = FRACUNIT / 2;
 
 		// determine if an upper texture is showing

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -411,40 +411,24 @@ void R_GenerateLookup(int texnum, int *const errors)
 	texturecomposite[texnum] = 0;
 	int csize = 0;
 
-	// [RH] Always create a composite texture for multipatch textures
-	// or tall textures in order to keep things simpler.
-	bool needcomposite = (texture->patchcount > 1 || texture->height > 254);
-
-	// [SL] Check for columns without patches.
-	// If a texture has columns without patches, generate a composite for
-	// the texture, which will create empty posts and prevent crashes.
-	for (int x = 0; x < texture->width && !needcomposite; x++)
+	int x = texture->width;
+	while (--x >= 0)
 	{
-		if (patchcount[x] == 0)
-			needcomposite = true;
-	}
+		// killough 1/25/98, 4/9/98:
+		//
+		// Fix Medusa bug, by adding room for column header
+		// and trailer bytes for each post in merged column.
+		// For now, just allocate conservatively 4 bytes
+		// per post per patch per column, since we don't
+		// yet know how many posts the merged column will
+		// require, and it's bounded above by this limit.
 
-	if (needcomposite)
-	{
-		int x = texture->width;
-		while (--x >= 0)
-		{
-			// killough 1/25/98, 4/9/98:
-			//
-			// Fix Medusa bug, by adding room for column header
-			// and trailer bytes for each post in merged column.
-			// For now, just allocate conservatively 4 bytes
-			// per post per patch per column, since we don't
-			// yet know how many posts the merged column will
-			// require, and it's bounded above by this limit.
+		collump[x] = -1;				// mark lump as in need of compositing
 
-			collump[x] = -1;				// mark lump as multipatched
+		texturecolumnofs[texnum][x] = csize;
 
-			texturecolumnofs[texnum][x] = csize;
-
-			// 4 header bytes per post + column height + 2 byte terminator
-			csize += 4 * postcount[x] + 2 + texture->height;
-		}
+		// 4 header bytes per post + column height + 2 byte terminator
+		csize += 4 * postcount[x] + 2 + texture->height;
 	}
 
 	texturecompositesize[texnum] = csize;
@@ -903,7 +887,7 @@ void R_InitColormaps()
 				int r = pal->basecolors[*map].getr();
 				int g = pal->basecolors[*map].getg();
 				int b = pal->basecolors[*map].getb();
-				
+
 				W_GetOLumpName(fakecmaps[j].name, i);
 
 				for (int k = 1; k < 256; k++)


### PR DESCRIPTION
Addresses #1122

Vanilla Doom skips generating composites for textures made up of a single patch, but when such a texture is shorter than the patch, this causes the full height of the patch to be drawn when rendering a 2-sided midtex. The majority of current widely used ports now generate composites for all textures, so this PR makes that change for Odamex.

Here is a similar commit on woof:
https://github.com/fabiangreffrath/woof/commit/55b86f01d90206315ca737fb0decd9598adc1e16
Of note here is also the mention that 2 composites are created, for 1S and 2S walls. Currently Odamex fills the transparent sections of textures with black while rendering. Perhaps this should be changed to happen during this step instead to speed up rendering of transparent textures on 1S walls.