### PR TITLE
[BUGFIX] Text screen backgrounds blank

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -751,7 +751,7 @@ void G_WorldDone()
 	cluster_info_t& thiscluster = clusters.findByCluster(level.cluster);
 
 	// Sort out default options to pass to F_StartFinale
-	finale_options_t options = { 0, 0, 0, 0 };
+	finale_options_t options = { "", "", "", "" };
 	options.music = !level.intermusic.empty() ? level.intermusic.c_str() : thiscluster.messagemusic.c_str();
 
 	if (!level.interbackdrop.empty())


### PR DESCRIPTION
The improved GameInfo support unfortunately made the backgrounds of finale texts all black. This is now fixed.