### PR TITLE
[BUGFIX] Various issues introduced by #630 and #1135 

### DIFF
--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -974,7 +974,8 @@ std::vector<IInputDeviceInfo> ISDL20InputSubsystem::getJoystickDevices() const
 		devices.push_back(IInputDeviceInfo());
 		IInputDeviceInfo& device_info = devices.back();
 		device_info.mId = i;
-		device_info.mDeviceName = fmt::format("SDL 2.0 joystick ({})", SDL_GameControllerNameForIndex(i));
+		const char* name = SDL_GameControllerNameForIndex(i);
+		device_info.mDeviceName = fmt::format("SDL 2.0 joystick ({})", name ? name : "unknown");
 	}
 
 	return devices;

--- a/client/src/wi_interlevel.cpp
+++ b/client/src/wi_interlevel.cpp
@@ -240,6 +240,7 @@ int ValidateMapName(const OLumpName& mapname)
 		if (sscanf(mapname.c_str(), "MAP%d", &map) != 1)
 			return 0;
 		lumpname = fmt::format("MAP{:02d}", map);
+		epi = 1;
 	}
 	return mapname == lumpname;
 }

--- a/client/src/wi_interlevel.cpp
+++ b/client/src/wi_interlevel.cpp
@@ -240,7 +240,6 @@ int ValidateMapName(const OLumpName& mapname)
 		if (sscanf(mapname.c_str(), "MAP%d", &map) != 1)
 			return 0;
 		lumpname = fmt::format("MAP{:02d}", map);
-		epi = 1;
 	}
 	return mapname == lumpname;
 }

--- a/client/src/wi_interlevel.cpp
+++ b/client/src/wi_interlevel.cpp
@@ -239,7 +239,7 @@ int ValidateMapName(const OLumpName& mapname)
 	{
 		if (sscanf(mapname.c_str(), "MAP%d", &map) != 1)
 			return 0;
-		lumpname = fmt::format("MAP{:2d}", map);
+		lumpname = fmt::format("MAP{:02d}", map);
 	}
 	return mapname == lumpname;
 }

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -1392,8 +1392,8 @@ void WI_loadData()
 		name = exitanim->backgroundlump;
 	else if (!winpic.empty())
 		name = winpic;
-	else if (currentlevel.exitpic[0] != '\0')
-		currentlevel.exitpic;
+	else if (!currentlevel.exitpic.empty())
+		name = currentlevel.exitpic;
 	else
 		name = "INTERPIC";
 

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -507,7 +507,7 @@ static int WI_DrawName (const char *str, int x, int y)
 	::V_ColorMap = translationref_t(::Ranges + CR_GREY * 256);
 	while (*str)
 	{
-		int lump = W_CheckNumForName(fmt::format("FONTB{:2d}", toupper(*str) - 32));
+		int lump = W_CheckNumForName(fmt::format("FONTB{:02d}", toupper(*str) - 32));
 
 		if (lump != -1)
 		{

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -525,7 +525,7 @@ OLumpName CalcMapName(int episode, int level)
 {
 	if (gameinfo.flags & GI_MAPxx)
 	{
-		return fmt::format("MAP{:2d}", level);
+		return fmt::format("MAP{:02d}", level);
 	}
 	else
 	{

--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -452,7 +452,7 @@ void ParseUMapInfoLump(int lump, const OLumpName& lumpname)
 				map++;
 				if (gamemode == commercial)
 				{
-					info.nextmap = fmt::format("MAP{:2d}", map);
+					info.nextmap = fmt::format("MAP{:02d}", map);
 				}
 				else
 				{

--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -31,27 +31,27 @@ int ValidateMapName(const OLumpName& mapname, int* pEpi = NULL, int* pMap = NULL
 {
 	// Check if the given map name can be expressed as a gameepisode/gamemap pair and be
 	// reconstructed from it.
-	char lumpname[9];
+	OLumpName lumpname;
 	int epi = -1, map = -1;
 
 	if (gamemode != commercial)
 	{
 		if (sscanf(mapname.c_str(), "E%dM%d", &epi, &map) != 2)
 			return 0;
-		snprintf(lumpname, 9, "E%dM%d", epi, map);
+		lumpname = fmt::format("E{}D{}", epi, map);
 	}
 	else
 	{
 		if (sscanf(mapname.c_str(), "MAP%d", &map) != 1)
 			return 0;
-		snprintf(lumpname, 9, "MAP%02d", map);
+		lumpname = fmt::format("MAP{:02d}", map);
 		epi = 1;
 	}
 	if (pEpi)
 		*pEpi = epi;
 	if (pMap)
 		*pMap = map;
-	return !strcmp(mapname.c_str(), lumpname);
+	return mapname == lumpname;
 }
 
 // used for munching the strings in UMAPINFO

--- a/server/src/s_sound.cpp
+++ b/server/src/s_sound.cpp
@@ -452,7 +452,7 @@ void S_ParseSndInfo()
 				{
 					// Hexen-style $MAP command
 					os.mustScanInt();
-					OLumpName mapname = fmt::format("MAP{:2d}", os.getTokenInt());
+					OLumpName mapname = fmt::format("MAP{:02d}", os.getTokenInt());
 					level_pwad_info_t& info = getLevelInfos().findByName(mapname);
 					os.mustScan();
 					if (info.mapname[0])


### PR DESCRIPTION
Both of these PRs introduced a few bugs. This fixes all that I've found so far that haven't already been merged.

- Broken format strings for determining `MAPxx` map lump names
- Comparison of OLumpName to `'\0'` resulting in incorrect evaluation of if statement
- Broken format string for finding big font patches for the intermission screen
- Crash from an unhandled exception when trying to format a possibly NULL char*

Those listed so far are game breaking, completely preventing use of odasrv with MAPxx maps, immediate errors on certain intermissions, and a crash when controllers without names recognized by SDL are used (Thank you @rakohus for finding this last one).