### PR TITLE
Revert "[BUGFIX] Don't draw lives counter in single-player or non-lives games."

### DIFF
--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1017,7 +1017,7 @@ void ST_drawWidgets(bool force_refresh)
 		w_frags.update(force_refresh);
 	}
 
-	w_lives.update(true, !G_IsLivesGame()); // Force refreshing to avoid tens
+	w_lives.update(true, G_IsLivesGame()); // Force refreshing to avoid tens
 	                                       // to be hidden by Doomguy's face
 }
 

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1008,17 +1008,14 @@ void ST_drawWidgets(bool force_refresh)
 	w_faces.update(force_refresh);
 
 	for (int i = 0; i < 3; i++)
-	{
 		w_keyboxes[i].update(force_refresh);
-	}
 
 	if (!G_IsCoopGame())
-	{
 		w_frags.update(force_refresh);
-	}
 
-	w_lives.update(true, G_IsLivesGame()); // Force refreshing to avoid tens
-	                                       // to be hidden by Doomguy's face
+	if (G_IsLivesGame())
+		w_lives.update(true); // Force refreshing to avoid tens
+		                      // to be hidden by Doomguy's face
 }
 
 


### PR DESCRIPTION
Reverts odamex/odamex#1121

#1121 did not address the core issue behind it and introduced a few issues with the lives counter, such as overlapping numbers, and the area where it is drawn being cleared unnecessarily and drawing over the status bar face.

![image](https://github.com/user-attachments/assets/84a2a572-1928-4330-85c2-366e81686d65)
![image](https://github.com/user-attachments/assets/34408a03-88a4-4e81-a20e-c9d4c5ed2585)
