### PR TITLE
[BUGFIX] FLTK error window when using certain command line arguments

### DIFF
--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -591,12 +591,20 @@ scannedWADs_t GUI_BootWindow()
 	// deforms the window.
 	Fl::keyboard_screen_scaling(0);
 
+	// find arguments for fltk
+	DArgs fltkargs = DArgs();
+	fltkargs.AppendArg(::Args.GetArg(0));
+	const char* rawargs = ::Args.CheckValue("-fltk");
+	if (rawargs != nullptr)
+		for (auto& arg : TokenizeString(rawargs, " "))
+			fltkargs.AppendArg(arg.c_str());
+
 	BootWindow* win = MakeBootWindow();
 	win->initWADDirs();
 	win->updateWADDirBrowser();
 	win->rescanIWADs();
 	win->position((Fl::w() - win->w()) / 2, (Fl::h() - win->h()) / 2);
-	win->show(::Args.NumArgs(), (char**)::Args.GetArgv().data());
+	win->show(fltkargs.NumArgs(), (char**)fltkargs.GetArgv().data());
 
 	// Blocks until the boot window has been closed.
 	Fl::run();


### PR DESCRIPTION
Currently, if any command line arguments are passed to Odamex, and none of them include any of those that skip the boot window (`-iwad`, `+connect`, `-connect`, `+map`, `-warp`, `+netplay`, `+playdemo`, `-file`, `-playdemo`, `-timedemo`), all arguments will be passed to FLTK, which will bring up the error window message below.
![image](https://github.com/user-attachments/assets/94ec5538-fb3f-4f70-a1ea-3c53ba039671)
This PR introduces `-fltk`, which will pass its parameter as the command line arguments for the FLTK frontend.

Example -- start Odamex with the FLTK scheme set to Oxy:
`./odamex -fltk "-scheme oxy"`