### PR TITLE
Remove `sv_mapliststayonwad`

### DIFF
--- a/server/src/sv_cvarlist.cpp
+++ b/server/src/sv_cvarlist.cpp
@@ -101,9 +101,6 @@ CVAR(			sv_nextmap, "", "Set to the next map to be played",
 CVAR_FUNC_DECL(	sv_shufflemaplist, "0", "Randomly shuffle the maplist",
 				CVARTYPE_BOOL, CVAR_SERVERARCHIVE)
 
-CVAR(			sv_mapliststayonwad, "0", "Stay on the current wad when changing maps, proceed to next maplist entry when the wad is finished",
-				CVARTYPE_BOOL, CVAR_SERVERARCHIVE)
-
 // Network settings
 // ----------------
 

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -76,7 +76,6 @@ EXTERN_CVAR (sv_warmup)
 EXTERN_CVAR (sv_timelimit)
 EXTERN_CVAR (sv_teamsinplay)
 EXTERN_CVAR(g_resetinvonexit)
-EXTERN_CVAR(sv_mapliststayonwad)
 
 extern int mapchange;
 extern std::string forcedlastmap;


### PR DESCRIPTION
Looks like when reworking this functionality to not use `sv_mapliststayonwad`, I forgot to remove the CVAR.