### PR TITLE
Add support for `compat_shorttex`

### DIFF
--- a/common/g_level.h
+++ b/common/g_level.h
@@ -40,48 +40,49 @@
  */
 typedef uint32_t levelFlags_t;
 
-const static levelFlags_t LEVEL_NOINTERMISSION = BIT(0);
-const static levelFlags_t LEVEL_SECRET = BIT(1);
-const static levelFlags_t LEVEL_DOUBLESKY = BIT(2);
-const static levelFlags_t LEVEL_NOSOUNDCLIPPING = BIT(3);
+constexpr static levelFlags_t LEVEL_NOINTERMISSION = BIT(0);
+constexpr static levelFlags_t LEVEL_SECRET = BIT(1);
+constexpr static levelFlags_t LEVEL_DOUBLESKY = BIT(2);
+constexpr static levelFlags_t LEVEL_NOSOUNDCLIPPING = BIT(3);
 
-const static levelFlags_t LEVEL_MAP07SPECIAL = BIT(4);
-const static levelFlags_t LEVEL_BRUISERSPECIAL = BIT(5);
-const static levelFlags_t LEVEL_CYBORGSPECIAL = BIT(6);
-const static levelFlags_t LEVEL_SPIDERSPECIAL = BIT(7);
+constexpr static levelFlags_t LEVEL_MAP07SPECIAL = BIT(4);
+constexpr static levelFlags_t LEVEL_BRUISERSPECIAL = BIT(5);
+constexpr static levelFlags_t LEVEL_CYBORGSPECIAL = BIT(6);
+constexpr static levelFlags_t LEVEL_SPIDERSPECIAL = BIT(7);
 
-const static levelFlags_t LEVEL_SPECLOWERFLOOR = BIT(8);
-const static levelFlags_t LEVEL_SPECOPENDOOR = BIT(9);
+constexpr static levelFlags_t LEVEL_SPECLOWERFLOOR = BIT(8);
+constexpr static levelFlags_t LEVEL_SPECOPENDOOR = BIT(9);
 const static levelFlags_t LEVEL_SPECACTIONSMASK = BIT_MASK(LEVEL_SPECLOWERFLOOR, LEVEL_SPECOPENDOOR);
-const static levelFlags_t LEVEL_MONSTERSTELEFRAG = BIT(10);
-const static levelFlags_t LEVEL_EVENLIGHTING = BIT(11);
+constexpr static levelFlags_t LEVEL_MONSTERSTELEFRAG = BIT(10);
+constexpr static levelFlags_t LEVEL_EVENLIGHTING = BIT(11);
 
-const static levelFlags_t LEVEL_SNDSEQTOTALCTRL = BIT(12);
-const static levelFlags_t LEVEL_FORCENOSKYSTRETCH = BIT(13);
-const static levelFlags_t LEVEL_JUMP_NO = BIT(14);
-const static levelFlags_t LEVEL_JUMP_YES = BIT(15);
+constexpr static levelFlags_t LEVEL_SNDSEQTOTALCTRL = BIT(12);
+constexpr static levelFlags_t LEVEL_FORCENOSKYSTRETCH = BIT(13);
+constexpr static levelFlags_t LEVEL_JUMP_NO = BIT(14);
+constexpr static levelFlags_t LEVEL_JUMP_YES = BIT(15);
 
-const static levelFlags_t LEVEL_FREELOOK_NO = BIT(16);
-const static levelFlags_t LEVEL_FREELOOK_YES = BIT(17);
-const static levelFlags_t LEVEL_COMPAT_DROPOFF = BIT(18);
-const static levelFlags_t LEVEL_COMPAT_NOPASSOVER = BIT(19);
-const static levelFlags_t LEVEL_COMPAT_LIMITPAIN = BIT(20);
+constexpr static levelFlags_t LEVEL_FREELOOK_NO = BIT(16);
+constexpr static levelFlags_t LEVEL_FREELOOK_YES = BIT(17);
+constexpr static levelFlags_t LEVEL_COMPAT_DROPOFF = BIT(18);
+constexpr static levelFlags_t LEVEL_COMPAT_NOPASSOVER = BIT(19);
+constexpr static levelFlags_t LEVEL_COMPAT_LIMITPAIN = BIT(20);
+constexpr static levelFlags_t LEVEL_COMPAT_SHORTTEX = BIT(21);
 
  // Automatically start lightning
-const static levelFlags_t LEVEL_STARTLIGHTNING = BIT(24);
+constexpr static levelFlags_t LEVEL_STARTLIGHTNING = BIT(24);
 // Apply mapthing filtering to player starts
-const static levelFlags_t LEVEL_FILTERSTARTS = BIT(25);
+constexpr static levelFlags_t LEVEL_FILTERSTARTS = BIT(25);
 // That level is a lobby, and has a few priorities
-const static levelFlags_t LEVEL_LOBBYSPECIAL = BIT(26);
+constexpr static levelFlags_t LEVEL_LOBBYSPECIAL = BIT(26);
 // Player spawns will have z-height
-const static levelFlags_t LEVEL_USEPLAYERSTARTZ = BIT(27);
+constexpr static levelFlags_t LEVEL_USEPLAYERSTARTZ = BIT(27);
 
  // Level was defined in a MAPINFO lump
-const static levelFlags_t LEVEL_DEFINEDINMAPINFO = BIT(29);
+constexpr static levelFlags_t LEVEL_DEFINEDINMAPINFO = BIT(29);
 // Don't display cluster messages
-const static levelFlags_t LEVEL_CHANGEMAPCHEAT = BIT(30);
+constexpr static levelFlags_t LEVEL_CHANGEMAPCHEAT = BIT(30);
 // Used for intermission map
-const static levelFlags_t LEVEL_VISITED = BIT(31);
+constexpr static levelFlags_t LEVEL_VISITED = BIT(31);
 
 struct acsdefered_s;
 class FBehavior;

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1319,7 +1319,7 @@ struct MapInfoDataSetter<level_pwad_info_t>
 			{ "enteranim", &MIType_LumpName, &ref.enteranim },
 			{ "exitanim", &MIType_LumpName, &ref.exitanim },
 			{ "translator", &MIType_EatNext },
-			{ "compat_shorttex", &MIType_CompatFlag, &ref.flags }, // todo: not implemented
+			{ "compat_shorttex", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_SHORTTEX },
 			{ "compat_limitpain", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_LIMITPAIN },
 			{ "compat_useblocking", &MIType_CompatFlag, &ref.flags }, // special lines block use (not implemented, default odamex behavior)
 		    { "compat_missileclip", &MIType_CompatFlag, &ref.flags }, // original height monsters when it comes to missiles (not implemented)

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -1256,7 +1256,7 @@ fixed_t P_FindShortestTextureAround (sector_t *sec)
 	int minsize = MAXINT;
 	side_t *side;
 	int i;
-	int mintex = co_boomphys ? 1 : 0;
+	int mintex = (co_boomphys && !(level.flags & LEVEL_COMPAT_SHORTTEX)) ? 1 : 0;
 
 	for (i = 0; i < sec->linecount; i++)
 	{
@@ -1291,7 +1291,7 @@ fixed_t P_FindShortestUpperAround (sector_t *sec)
 	int minsize = MAXINT;
 	side_t *side;
 	int i;
-	int mintex = co_boomphys ? 1 : 0;
+	int mintex = (co_boomphys && !(level.flags & LEVEL_COMPAT_SHORTTEX)) ? 1 : 0;
 
 	for (i = 0; i < sec->linecount; i++)
 	{


### PR DESCRIPTION
Before #1099, Odamex's behavior was as if this flag were always enabled. Now that `co_boomphys` alters this behavior, this should probably be supported. Of course, I have no idea what wad would possibly need `co_boomphys` enabled but still rely on the vanilla texture height checks.