### PR TITLE
[BUGFIX] Crash when trying to free fire sky memory

### DIFF
--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -513,19 +513,23 @@ void R_ClearSkyDefs()
 
 void spreadFire(int src, byte* firepixels, int width)
 {
-	byte pixel = firepixels[src];
+	const byte pixel = firepixels[src];
+	const int copyloc0 = src - width;
 	if(pixel == 0) {
-		firepixels[src - width] = 0;
+		if (copyloc0 >= 0)
+			firepixels[copyloc0] = 0;
 	} else {
-		int rand = (int)std::round(M_RandomFloat() * 3.0) & 3;
-		firepixels[(src - rand + 1) - width] = pixel - (rand & 1);
+		const int rand = (int)std::round(M_RandomFloat() * 3.0) & 3;
+		const int copyloc1 = copyloc0 - rand + 1;
+		if (copyloc1 >= 0)
+			firepixels[copyloc1] = pixel - (rand & 1);
 	}
 }
 
 static void R_UpdateFireSky(sky_t* sky, bool init = false)
 {
 	if (gametic % sky->fireticrate != 0 && !init) return;
-	int texnum = sky->background.texnum;
+	const int texnum = sky->background.texnum;
 	texture_t* tex = textures[texnum];
     for (int x = 0 ; x < tex->width; x++)
 	{
@@ -548,7 +552,7 @@ static void R_UpdateFireSky(sky_t* sky, bool init = false)
 void R_InitFireSky(sky_t* sky)
 {
 	int texnum = sky->background.texnum;
-	texture_t* tex = textures[texnum];
+	const texture_t* tex = textures[texnum];
 	sky->firetexturedata = (byte*)Z_Malloc(sizeof(byte) * tex->width * tex->height, PU_LEVEL, nullptr);
     for (int i = 0 ; i < tex->width*tex->height; i++)
 	{


### PR DESCRIPTION
Fire skies of certain dimensions would corrupt the zone memory when updated, leading to a crash when deallocating that memory. This has been fixed.