### PR TITLE
[BUGFIX] Errors and crashes when displaying cast call if monster uses multiple sprites

### DIFF
--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -438,7 +438,6 @@ castinfo_t castorder[] = {
 
 static int 		castnum;
 static int 		casttics;
-static int		castsprite;
 static state_t*	caststate;
 static bool	 	castdeath;
 static int 		castframes;
@@ -476,7 +475,6 @@ void F_StartCast()
 	wipegamestate = GS_FORCEWIPE;
 	castnum = 0;
 	caststate = &states[mobjinfo[castorder[castnum].type].seestate];
-	castsprite = caststate->sprite;
 	casttics = caststate->tics;
 	castdeath = false;
 	finalestage = 2;
@@ -511,7 +509,6 @@ void F_CastTicker()
 			S_Sound (CHAN_VOICE, mobjinfo[castorder[castnum].type].seesound, 1, atten);
 		}
 		caststate = &states[mobjinfo[castorder[castnum].type].seestate];
-		castsprite = caststate->sprite;
 		castframes = 0;
 	}
 	else
@@ -525,7 +522,6 @@ void F_CastTicker()
 		const int st = caststate->nextstate;
 
 		caststate = &states[st];
-		castsprite = caststate->sprite;
 		castframes++;
 
 		// sound hacks....
@@ -571,28 +567,16 @@ void F_CastTicker()
 		// go into attack frame
 		castattacking = true;
 		if (castonmelee)
-		{
 			caststate = &states[mobjinfo[castorder[castnum].type].meleestate];
-			castsprite = caststate->sprite;
-		}
 		else
-		{
 			caststate = &states[mobjinfo[castorder[castnum].type].missilestate];
-			castsprite = caststate->sprite;
-		}
 		castonmelee ^= 1;
 		if (caststate == &states[S_NULL])
 		{
 			if (castonmelee)
-			{
 				caststate = &states[mobjinfo[castorder[castnum].type].meleestate];
-				castsprite = caststate->sprite;
-			}
 			else
-			{
 				caststate = &states[mobjinfo[castorder[castnum].type].missilestate];
-				castsprite = caststate->sprite;
-			}
 		}
 	}
 
@@ -605,7 +589,6 @@ void F_CastTicker()
 			castattacking = false;
 			castframes = 0;
 			caststate = &states[mobjinfo[castorder[castnum].type].seestate];
-			castsprite = caststate->sprite;
 		}
 	}
 
@@ -630,7 +613,6 @@ bool F_CastResponder (event_t* ev)
 	// go into death frame
 	castdeath = true;
 	caststate = &states[mobjinfo[castorder[castnum].type].deathstate];
-	castsprite = caststate->sprite;
 	casttics = caststate->tics;
 	castframes = 0;
 	castattacking = false;
@@ -662,7 +644,7 @@ void F_CastDrawer()
 	cast_surface->getDefaultCanvas()->DrawPatch(background_patch, 0, 0);
 
 	// draw the current frame in the middle of the screen
-	const spritedef_t* sprdef = &sprites[castsprite];
+	const spritedef_t* sprdef = &sprites[caststate->sprite];
 	const spriteframe_t* sprframe = &sprdef->spriteframes[caststate->frame & FF_FRAMEMASK];
 
 	int scaled_x = (finale_width - 320) / 2;

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -80,7 +80,7 @@ finale_lump_t finalelumptype = FINALE_NONE;
 
 void	F_StartCast (void);
 void	F_CastTicker (void);
-BOOL	F_CastResponder (event_t *ev);
+bool	F_CastResponder (event_t *ev);
 void	F_CastDrawer (void);
 
 
@@ -235,7 +235,7 @@ void STACK_ARGS F_ShutdownFinale()
 }
 
 
-BOOL F_Responder (event_t *event)
+bool F_Responder (event_t *event)
 {
 	if (finalestage == 2)
 		return F_CastResponder (event);
@@ -525,6 +525,7 @@ void F_CastTicker()
 		const int st = caststate->nextstate;
 
 		caststate = &states[st];
+		castsprite = caststate->sprite;
 		castframes++;
 
 		// sound hacks....
@@ -570,18 +571,28 @@ void F_CastTicker()
 		// go into attack frame
 		castattacking = true;
 		if (castonmelee)
-			caststate=&states[mobjinfo[castorder[castnum].type].meleestate];
+		{
+			caststate = &states[mobjinfo[castorder[castnum].type].meleestate];
+			castsprite = caststate->sprite;
+		}
 		else
-			caststate=&states[mobjinfo[castorder[castnum].type].missilestate];
+		{
+			caststate = &states[mobjinfo[castorder[castnum].type].missilestate];
+			castsprite = caststate->sprite;
+		}
 		castonmelee ^= 1;
 		if (caststate == &states[S_NULL])
 		{
 			if (castonmelee)
-				caststate=
-					&states[mobjinfo[castorder[castnum].type].meleestate];
+			{
+				caststate = &states[mobjinfo[castorder[castnum].type].meleestate];
+				castsprite = caststate->sprite;
+			}
 			else
-				caststate=
-					&states[mobjinfo[castorder[castnum].type].missilestate];
+			{
+				caststate = &states[mobjinfo[castorder[castnum].type].missilestate];
+				castsprite = caststate->sprite;
+			}
 		}
 	}
 
@@ -594,6 +605,7 @@ void F_CastTicker()
 			castattacking = false;
 			castframes = 0;
 			caststate = &states[mobjinfo[castorder[castnum].type].seestate];
+			castsprite = caststate->sprite;
 		}
 	}
 
@@ -607,7 +619,7 @@ void F_CastTicker()
 // F_CastResponder
 //
 
-BOOL F_CastResponder (event_t* ev)
+bool F_CastResponder (event_t* ev)
 {
 	if (ev->type != ev_keydown)
 		return false;
@@ -618,6 +630,7 @@ BOOL F_CastResponder (event_t* ev)
 	// go into death frame
 	castdeath = true;
 	caststate = &states[mobjinfo[castorder[castnum].type].deathstate];
+	castsprite = caststate->sprite;
 	casttics = caststate->tics;
 	castframes = 0;
 	castattacking = false;

--- a/client/src/f_finale.h
+++ b/client/src/f_finale.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -18,7 +18,7 @@
 //
 // DESCRIPTION:
 //	F_FINALE
-//    
+//
 //-----------------------------------------------------------------------------
 
 #pragma once
@@ -30,7 +30,7 @@
 //
 
 // Called by main loop.
-BOOL F_Responder(event_t* ev);
+bool F_Responder(event_t* ev);
 
 // Called by main loop.
 void F_Ticker();

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -624,13 +624,13 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 		}
 
 		lump = sprframe->lump[rot];
-		flip = static_cast<bool>(sprframe->flip[rot]);
+		flip = sprframe->flip[rot];
 	}
 	else
 	{
 		// use single rotation for all views
 		lump = sprframe->lump[rot = 0];
-		flip = static_cast<bool>(sprframe->flip[0]);
+		flip = sprframe->flip[0];
 	}
 
 	if (sprframe->width[rot] == SPRITE_NEEDS_INFO)
@@ -733,7 +733,7 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 	spritedef_t*		sprdef;
 	spriteframe_t*		sprframe;
 	int 				lump;
-	BOOL 				flip;
+	bool 				flip;
 	vissprite_t*		vis;
 	vissprite_t 		avis;
 
@@ -754,7 +754,7 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 	sprframe = &sprdef->spriteframes[ psp->state->frame & FF_FRAMEMASK ];
 
 	lump = sprframe->lump[0];
-	flip = static_cast<BOOL>(sprframe->flip[0]);
+	flip = sprframe->flip[0];
 
 	if (sprframe->width[0] == SPRITE_NEEDS_INFO)
 		R_CacheSprite (sprdef);	// [RH] speeds up game startup time

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -499,7 +499,7 @@ struct post_t
 	/**
 	 * @brief Return the post's absolute topdelta accounting for tall
 	 *        patches, which treat topdelta as relative.
-	 * 
+	 *
 	 * @param lastAbs Last absolute topdelta.
 	 */
 	int abs(const int lastAbs) const
@@ -517,7 +517,7 @@ struct post_t
 	{
 		return length + 3;
 	}
-	
+
 	/**
 	 * @brief Return a pointer to post data.
 	 */
@@ -718,7 +718,7 @@ typedef vissprite_s vissprite_t;
 // Some sprites will only have one picture used
 // for all views: NNNNF0
 //
-struct spriteframe_s
+struct spriteframe_t
 {
     // If false use 0 for any position.
     // Note: as eight entries are available,
@@ -726,10 +726,10 @@ struct spriteframe_s
 	bool	rotate;
 
     // Lump to use for view angles 0-15.
-    short	lump[16];
+    int		lump[16];
 
     // Flip bit (1 = flip) to use for view angles 0-15.
-    byte	flip[16];
+    bool	flip[16];
 
 	// [RH] Move some data out of spritewidth, spriteoffset,
 	//		and spritetopoffset arrays.
@@ -737,18 +737,16 @@ struct spriteframe_s
 	fixed_t		topoffset[16];
 	fixed_t		offset[16];
 };
-typedef spriteframe_s spriteframe_t;
 
 //
 // A sprite definition:
 //	a number of animation frames.
 //
-struct spritedef_s
+struct spritedef_t
 {
 	int 			numframes;
 	spriteframe_t	*spriteframes;
 };
-typedef spritedef_s spritedef_t;
 
 //
 // The infamous visplane

--- a/common/r_sprites.cpp
+++ b/common/r_sprites.cpp
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -75,7 +75,7 @@ void R_CacheSprite(spritedef_t *sprite)
 // [RH] Removed checks for coexistance of rotation 0 with other
 //		rotations and made it look more like BOOM's version.
 //
-static void R_InstallSpriteLump(int lump, unsigned frame, unsigned rot, BOOL flipped)
+static void R_InstallSpriteLump(int lump, unsigned frame, unsigned rot, bool flipped)
 {
 	unsigned rotation;
 
@@ -83,7 +83,7 @@ static void R_InstallSpriteLump(int lump, unsigned frame, unsigned rot, BOOL fli
 		rotation = rot;
 	else
 		rotation = (rot >= 17) ? rot - 7 : 17;
-	
+
 	if (frame >= MAX_SPRITE_FRAMES || rotation > 16)
 		I_FatalError("R_InstallSpriteLump: Bad frame characters in lump %i", lump);
 
@@ -99,23 +99,23 @@ static void R_InstallSpriteLump(int lump, unsigned frame, unsigned rot, BOOL fli
 		{
 			if (sprtemp[frame].lump[r] == -1)
 			{
-				sprtemp[frame].lump[r] = static_cast<short>(lump);
-				sprtemp[frame].flip[r] = static_cast<byte>(flipped);
+				sprtemp[frame].lump[r] = lump;
+				sprtemp[frame].flip[r] = flipped;
 				sprtemp[frame].rotate = false;
 				sprtemp[frame].width[r] = SPRITE_NEEDS_INFO;
 			}
 		}
-		
+
 		return;
 	}
 
 	rotation = (rotation <= 8 ? (rotation - 1) * 2 : (rotation - 9) * 2 + 1);
-	
+
 	if (sprtemp[frame].lump[rotation] == -1)
 	{
 		// the lump is only used for one rotation
-		sprtemp[frame].lump[rotation] = static_cast<short>(lump);
-		sprtemp[frame].flip[rotation] = static_cast<byte>(flipped);
+		sprtemp[frame].lump[rotation] = lump;
+		sprtemp[frame].flip[rotation] = flipped;
 		sprtemp[frame].rotate = true;
 		sprtemp[frame].width[rotation] = SPRITE_NEEDS_INFO;
 	}
@@ -161,7 +161,7 @@ static void R_InstallSprite(const char *name, int num)
 					sprtemp[frame].flip[rotation + 1] = sprtemp[frame].flip[rotation];
 					sprtemp[frame].width[rotation + 1] = SPRITE_NEEDS_INFO;
 				}
-				
+
 				if (sprtemp[frame].lump[rotation] == -1)
 				{
 					sprtemp[frame].lump[rotation] = sprtemp[frame].lump[rotation + 1];


### PR DESCRIPTION
Currently, the cast call assumes that monsters only have a single sprite, but this is not necessarily true if they have been modified. This leads to out of bounds memory accesses, as the number of frames in a sprite may vary, which leads to crashes. This is fixed.