### PR TITLE
[BUGFIX] Broken deserialization of `DPusher`s

### DIFF
--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -467,7 +467,9 @@ void DPusher::Serialize (FArchive &arc)
 	else
 	{
 		arc >> m_Type;
-		arc.ReadObject((DObject*&)m_Source, DPusher::StaticType());
+		DObject* temp = nullptr;
+		arc.ReadObject(temp, DPusher::StaticType());
+		m_Source.init(static_cast<AActor*>(temp));
 		arc >> m_Xmag >> m_Ymag >> m_Magnitude >> m_Radius >> m_X >> m_Y >> m_Affectee;
 	}
 }

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -467,7 +467,7 @@ void DPusher::Serialize (FArchive &arc)
 	else
 	{
 		arc >> m_Type;
-		arc.ReadObject((DObject*&)*m_Source, DPusher::StaticType());
+		arc.ReadObject((DObject*&)m_Source, DPusher::StaticType());
 		arc >> m_Xmag >> m_Ymag >> m_Magnitude >> m_Radius >> m_X >> m_Y >> m_Affectee;
 	}
 }

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -469,7 +469,7 @@ void DPusher::Serialize (FArchive &arc)
 		arc >> m_Type;
 		DObject* temp = nullptr;
 		arc.ReadObject(temp, DPusher::StaticType());
-		m_Source.init(static_cast<AActor*>(temp));
+		m_Source = temp ? static_cast<AActor*>(temp)->ptr() : AActor::AActorPtr();
 		arc >> m_Xmag >> m_Ymag >> m_Magnitude >> m_Radius >> m_X >> m_Y >> m_Affectee;
 	}
 }

--- a/common/szp.h
+++ b/common/szp.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -18,19 +18,19 @@
 // DESCRIPTION:
 //
 //  denis - szp<T>, the self zeroing pointer
-//  
-//  Once upon a time, actors held raw pointers to other actors. 
-//  
-//  To destroy an object, one cycled though all the others searching for its 
-//  pointer and resetting every copy to NULL. Then one did the cycling for 
-//  the players, then the sector sound origins, and so on; with hack upon 
-//  hack. Ironically, zero dereferencing is what often crashed the 
+//
+//  Once upon a time, actors held raw pointers to other actors.
+//
+//  To destroy an object, one cycled though all the others searching for its
+//  pointer and resetting every copy to NULL. Then one did the cycling for
+//  the players, then the sector sound origins, and so on; with hack upon
+//  hack. Ironically, zero dereferencing is what often crashed the
 //  program altogether.
-//  
-//  The idea behind szp is that all copies of one szp pointer can be made 
-//  to point to the same object in O(1) time. This means that having a 
-//  single szp of an actor, you can set them all to NULL without iteration. 
-//  And, as a bonus, on every pointer access, a NULL check can throw a 
+//
+//  The idea behind szp is that all copies of one szp pointer can be made
+//  to point to the same object in O(1) time. This means that having a
+//  single szp of an actor, you can set them all to NULL without iteration.
+//  And, as a bonus, on every pointer access, a NULL check can throw a
 //  specific exception. Naturally, you should always be careful with pointers.
 //
 //-----------------------------------------------------------------------------
@@ -51,7 +51,7 @@ class szp
 
 	// this should never be used
 	// spawn from other pointers, or use init()
-	szp &operator =(T *other) {};
+	szp &operator=(T *other) = delete;
 
 	// utility function to remove oneself from the linked list
 	void inline unlink()
@@ -61,17 +61,17 @@ class szp
 
 		next->prev = prev;
 		prev->next = next;
-			
+
 		if(!naive)
 			return;
 
 		// last in ring?
 		if(this == next)
 			delete naive;
-			
+
 		naive = NULL;
 	}
-	
+
 public:
 
 	// use as pointer, checking validity
@@ -82,7 +82,7 @@ public:
 
 		return *naive;
 	}
-	
+
 	// use as raw pointer
 	inline operator T*()
 	{
@@ -97,11 +97,11 @@ public:
 	{
 		if(!naive)
 			throw CRecoverableError("szp pointer was NULL on update_all");
-		
+
 		// all copies already have naive, so their pointers will update too
 		*naive = target;
 	}
-	
+
 	// copy a pointer and add self to the "i have this pointer" list
 	inline szp &operator =(szp other)
 	{
@@ -116,31 +116,31 @@ public:
 			next = prev = this;
 			return *this;
 		}
-		
+
 		// link
 		naive = other.naive;
 		prev = other.next->prev;
 		next = other.next;
 		prev->next = next->prev = this;
-		
+
 		return *this;
 	}
-	
+
 	// creates the first (original) pointer
 	void init(T *target)
 	{
 		unlink();
-		
+
 		// first link
 		naive = new T*(target);
 		prev = next = this;
 	}
-	
+
 	// cheap constructor
 	inline szp()
 		: naive(NULL), prev(NULL), next(NULL)
 	{ }
-	
+
 	// copy constructor
 	inline szp(const szp &other)
 		: naive(NULL)
@@ -150,7 +150,7 @@ public:
 			prev = next = this;
 			return;
 		}
-		
+
 		// link
 		naive = other.naive;
 		prev = other.next->prev;


### PR DESCRIPTION
Levels containing pushers would crash upon being reloaded from an archive due to the sources of the pushers not being set correctly. Addresses one part of #751

Also, the `szp` operator that should never be used is now `delete`d so that trying to use it won't even compile instead of just silently doing nothing. (Though I'm not sure why it exists in the first place. I don't think it's something the compiler would generate?)