### PR TITLE
[BUGFIX] Out of bounds access to S_sfx when ambient sound is not found

### DIFF
--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -1539,7 +1539,7 @@ void S_ActivateAmbient(AActor *origin, int ambient)
 	if (!(amb->type & 3) && !amb->periodmin)
 	{
 		const int sndnum = S_FindSound(amb->sound);
-		if (sndnum == 0)
+		if (sndnum == 0 || sndnum == -1)
 			return;
 
 		sfxinfo_t *sfx = &S_sfx[sndnum];


### PR DESCRIPTION
This would cause WDL2022 MAP29 to not load with debug builds, and have UB for release builds.