### PR TITLE
[BUGFIX] Crash when playing empty Doom format sound

### DIFF
--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -157,6 +157,9 @@ static void WriteWAV(char* filename, byte* data, uint32_t length, int samplerate
 static void ExpandSoundData(byte* data, int samplerate, int bits, int length,
                             Mix_Chunk* destination)
 {
+	if (length <= 0)
+		return;
+
 	Sint16* expanded = reinterpret_cast<Sint16*>(destination->abuf);
 	size_t samplecount = length / (bits / 8);
 

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -157,9 +157,6 @@ static void WriteWAV(char* filename, byte* data, uint32_t length, int samplerate
 static void ExpandSoundData(byte* data, int samplerate, int bits, int length,
                             Mix_Chunk* destination)
 {
-	if (length <= 0)
-		return;
-
 	Sint16* expanded = reinterpret_cast<Sint16*>(destination->abuf);
 	size_t samplecount = length / (bits / 8);
 
@@ -309,6 +306,9 @@ static void getsfx(sfxinfo_struct *sfx)
     // [Russell] - Ignore doom's sound format length info
     // if the lump is longer than the value, fixes exec.wad's ssg
     length = (sfx->length - 8 > length) ? sfx->length - 8 : length;
+
+	if (length <= 0)
+		return;
 
     Uint32 expanded_length = (uint32_t)((((uint64_t)length) * mixer_freq) / samplerate);
 

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -29,6 +29,7 @@
 #include "i_sdl.h"
 #include <SDL_mixer.h>
 #include <stdlib.h>
+#include <nonstd/scope.hpp>
 
 #include "z_zone.h"
 
@@ -270,6 +271,7 @@ static void getsfx(sfxinfo_struct *sfx)
 		return;
 
     Uint8* data = (Uint8*)W_CacheLumpNum(sfx->lumpnum, PU_STATIC);
+	auto guard = nonstd::make_scope_exit([&]{ Z_ChangeTag(data, PU_CACHE); });
 
     // [Russell] - ICKY QUICKY HACKY SPACKY *I HATE THIS SOUND MANAGEMENT SYSTEM!*
     // get the lump size, shouldn't this be filled in elsewhere?
@@ -324,8 +326,6 @@ static void getsfx(sfxinfo_struct *sfx)
 
     ExpandSoundData((byte*)data + 8, samplerate, 8, length, chunk);
     sfx->data = chunk;
-
-    Z_ChangeTag(data, PU_CACHE);
 }
 
 //


### PR DESCRIPTION
Addresses #352
d64d2.wad uses empty sounds to make some of the boss brain/cube actions silent, but Odamex was still trying to play the sounds despite having a length of zero.