### PR TITLE
Update Fedora 28 and Ubuntu 18.04 workflows to Fedora 32 and Ubuntu 20.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Run build
       run: cmake --build ./build/
   build-centos:
-    name: Build (Fedora 28)
+    name: Build (Fedora 32)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Run build
       run: bash ci/fedora-buildgen.sh
   build-ubuntu-bionic:
-    name: Build (Ubuntu 18.04 LTS)
+    name: Build (Ubuntu 20.04 LTS)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
@@ -109,4 +109,4 @@ jobs:
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Run build
-      run: bash ci/ubuntu-bionic-buildgen.sh
+      run: bash ci/ubuntu-focal-buildgen.sh

--- a/ci/fedora.Dockerfile
+++ b/ci/fedora.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM fedora:32
 
 WORKDIR odamex
 

--- a/ci/ubuntu-focal-buildgen.sh
+++ b/ci/ubuntu-focal-buildgen.sh
@@ -7,5 +7,5 @@ IFS=$'\n\t'
 
 set -x
 
-docker build -t odamex -f ci/ubuntu-bionic.Dockerfile .
+docker build -t odamex -f ci/ubuntu-focal.Dockerfile .
 docker run --rm odamex

--- a/ci/ubuntu-focal.Dockerfile
+++ b/ci/ubuntu-focal.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 WORKDIR odamex
 

--- a/ci/ubuntu-focal.Dockerfile
+++ b/ci/ubuntu-focal.Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 
 # Packages - first the majority of them, then cmake
 RUN set -x && \
+    DEBIAN_FRONTEND=noninteractive \
     apt update && \
     apt install -y ninja-build libsdl2-dev libsdl2-mixer-dev \
         libpng-dev libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex \

--- a/ci/ubuntu-focal.Dockerfile
+++ b/ci/ubuntu-focal.Dockerfile
@@ -12,7 +12,7 @@ RUN set -x && \
         libpng-dev libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex \
         apt-transport-https ca-certificates gnupg software-properties-common wget && \
     wget -O - 'https://apt.kitware.com/keys/kitware-archive-latest.asc' 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
     apt update && apt install -y cmake
 
 WORKDIR build

--- a/ci/ubuntu-focal.Dockerfile
+++ b/ci/ubuntu-focal.Dockerfile
@@ -10,7 +10,7 @@ ENV TZ=US \
 # Packages - first the majority of them, then cmake
 RUN set -x && \
     apt update && \
-    apt install -y ninja-build libsdl2-dev libsdl2-mixer-dev \
+    apt install -y g++ ninja-build libsdl2-dev libsdl2-mixer-dev \
         libpng-dev libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex \
         apt-transport-https ca-certificates gnupg software-properties-common wget && \
     wget -O - 'https://apt.kitware.com/keys/kitware-archive-latest.asc' 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \

--- a/ci/ubuntu-focal.Dockerfile
+++ b/ci/ubuntu-focal.Dockerfile
@@ -4,9 +4,11 @@ WORKDIR odamex
 
 COPY . .
 
+ENV TZ=US \
+    DEBIAN_FRONTEND=noninteractive
+
 # Packages - first the majority of them, then cmake
 RUN set -x && \
-    DEBIAN_FRONTEND=noninteractive \
     apt update && \
     apt install -y ninja-build libsdl2-dev libsdl2-mixer-dev \
         libpng-dev libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex \


### PR DESCRIPTION
With the move to C++17, Odamex requires a higher minimum version of gcc than provided by the older releases, at least to be able to make full use of the features of 17. I've bumped the Ubuntu workflow to the next LTS, and the Fedora release is updated to be from around the same time.