### PR TITLE
[BUGFIX] Crash when displaying messages on Linux

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1179,7 +1179,7 @@ void C_AddNotifyString(int printlevel, const char* color_code, const char* sourc
 	{
 		if (addtype == NEWLINE)
 			memmove(&NotifyStrings[0], &NotifyStrings[1], sizeof(struct NotifyText) * (NUMNOTIFIES-1));
-		strncpy((char *)NotifyStrings[NUMNOTIFIES-1].text, lines[i].string, lines[i].width);
+		strcpy((char *)NotifyStrings[NUMNOTIFIES-1].text, lines[i].string);
 		NotifyStrings[NUMNOTIFIES-1].timeout = gametic + (con_notifytime.asInt() * TICRATE);
 		NotifyStrings[NUMNOTIFIES-1].printlevel = printlevel;
 		addtype = NEWLINE;


### PR DESCRIPTION
A call to `strcpy` was replaced with `strncpy`, presumably under the assumption that it was safer, but the length being passed to it was wrong, and since `strncpy` doesn't care about null termination, it was causing crashes.