### PR TITLE
[BUGFIX] Fix bouncing/"jittery" monsters after arch viles resurrect them

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1307,13 +1307,21 @@ static void CL_KillMobj(const odaproto::svc::KillMobj* msg)
 static void CL_RaiseMobj(const odaproto::svc::RaiseMobj* msg)
 {
 	uint32_t srcid = msg->source_netid();
-	uint32_t tgtid = msg->target().netid();
+	uint32_t cpsid = msg->corpse().netid();
 
 	AActor* source = P_FindThingById(srcid);
-	AActor* corpsehit = P_FindThingById(tgtid);
+	AActor* corpsehit = P_FindThingById(cpsid);
 
 	if (!corpsehit)
 		return;
+
+	corpsehit->x = msg->corpse().pos().x();
+	corpsehit->y = msg->corpse().pos().y();
+	corpsehit->z = msg->corpse().pos().z();
+	corpsehit->angle = msg->corpse().angle();
+	corpsehit->momx = msg->corpse().mom().x();
+	corpsehit->momy = msg->corpse().mom().y();
+	corpsehit->momz = msg->corpse().mom().z();
 
 	mobjinfo_t* info = corpsehit->info;
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -84,6 +84,7 @@ EXTERN_CVAR(hud_revealsecrets)
 EXTERN_CVAR(mute_enemies)
 EXTERN_CVAR(mute_spectators)
 EXTERN_CVAR(show_messages)
+EXTERN_CVAR(co_novileghosts)
 
 extern std::string digest;
 extern bool forcenetdemosplit;
@@ -1298,6 +1299,40 @@ static void CL_KillMobj(const odaproto::svc::KillMobj* msg)
 		target->player->lives = lives;
 
 	P_KillMobj(source, target, inflictor, joinkill);
+}
+
+//
+// CL_RaiseMobj
+//
+static void CL_RaiseMobj(const odaproto::svc::RaiseMobj* msg)
+{
+	uint32_t srcid = msg->source_netid();
+	uint32_t tgtid = msg->target().netid();
+
+	AActor* source = P_FindThingById(srcid);
+	AActor* corpsehit = P_FindThingById(tgtid);
+
+	if (!corpsehit)
+		return;
+
+	mobjinfo_t* info = corpsehit->info;
+
+	P_SetMobjState(corpsehit, info->raisestate);
+
+	// [Nes] - Classic demo compatability: Ghost monster bug.
+	if (co_novileghosts)
+	{
+		corpsehit->height = P_ThingInfoHeight(info); // [RH] Use real mobj height
+		corpsehit->radius = info->radius;            // [RH] Use real radius
+	}
+	else
+	{
+		corpsehit->height <<= 2;
+	}
+
+	corpsehit->flags = info->flags;
+	corpsehit->health = info->spawnhealth;
+	corpsehit->target = AActor::AActorPtr();
 }
 
 ///////////////////////////////////////////////////////////
@@ -3001,6 +3036,7 @@ parseError_e CL_ParseCommand()
 		SV_MSG(svc_spawnplayer, CL_SpawnPlayer, odaproto::svc::SpawnPlayer);
 		SV_MSG(svc_damageplayer, CL_DamagePlayer, odaproto::svc::DamagePlayer);
 		SV_MSG(svc_killmobj, CL_KillMobj, odaproto::svc::KillMobj);
+		SV_MSG(svc_raisemobj, CL_RaiseMobj, odaproto::svc::RaiseMobj);
 		SV_MSG(svc_fireweapon, CL_FireWeapon, odaproto::svc::FireWeapon);
 		SV_MSG(svc_updatesector, CL_UpdateSector, odaproto::svc::UpdateSector);
 		SV_MSG(svc_print, CL_Print, odaproto::svc::Print);

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -45,6 +45,7 @@ void SV_TouchSpecial(AActor *special, player_t *player) {}
 ItemEquipVal SV_FlagTouch (player_t &player, team_t f, bool firstgrab) { return IEV_NotEquipped; }
 void SV_SocketTouch (player_t &player, team_t f) {}
 void SV_SendKillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill) {}
+void SV_SendRaiseMobj(AActor* source, AActor* corpse) { }
 void SV_SendDamagePlayer(player_t *player, AActor* inflictor, int healthDamage, int armorDamage) {}
 void SV_SendDamageMobj(AActor *target, int pain) {}
 void SV_CTFEvent(team_t f, flag_score_t event, player_t &who) {}

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -1076,6 +1076,7 @@ static void InitNetMessageFormats()
 	SVC_INFO(svc_spawnplayer);
 	SVC_INFO(svc_damageplayer);
 	SVC_INFO(svc_killmobj);
+	SVC_INFO(svc_raisemobj);
 	SVC_INFO(svc_fireweapon);
 	SVC_INFO(svc_updatesector);
 	SVC_INFO(svc_print);

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -250,6 +250,7 @@ enum svc_t
 	svc_maplist_index,     // [AM] - Send the current and next map index to the client.
 	svc_toast,
 	svc_hordeinfo,
+	svc_raisemobj,
 	svc_netdemocap = 100,  // netdemos - NullPoint
 	svc_netdemostop = 101, // netdemos - NullPoint
 	svc_netdemoloadsnap = 102, // netdemos - NullPoint

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -92,6 +92,7 @@ void A_Fall (AActor *actor);
 
 
 void SV_UpdateMonsterRespawnCount();
+void SV_SendRaiseMobj(AActor* source, AActor* corpse);
 void SV_UpdateMobj(AActor* mo);
 void SV_Sound(AActor* mo, byte channel, const char* name, byte attenuation);
 
@@ -1555,7 +1556,8 @@ void A_VileChase (AActor *actor)
 						SV_UpdateMonsterRespawnCount();
 					}
 
-					P_SetMobjState (corpsehit,info->raisestate, true);
+					P_SetMobjState (corpsehit,info->raisestate);
+					SV_SendRaiseMobj(actor, corpsehit);
 
 					// [Nes] - Classic demo compatability: Ghost monster bug.
 					if ((co_novileghosts)) {
@@ -2180,7 +2182,8 @@ bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 						SV_UpdateMonsterRespawnCount();
 					}
 
-					P_SetMobjState(corpsehit, info->raisestate, true);
+					P_SetMobjState(corpsehit, info->raisestate);
+					SV_SendRaiseMobj(actor, corpsehit);
 
 					// [Nes] - Classic demo compatability: Ghost monster bug.
 					if ((co_novileghosts))

--- a/common/svc_map.cpp
+++ b/common/svc_map.cpp
@@ -66,6 +66,7 @@ static void InitMap()
 	MapProto(svc_spawnplayer, odaproto::svc::SpawnPlayer::descriptor());
 	MapProto(svc_damageplayer, odaproto::svc::DamagePlayer::descriptor());
 	MapProto(svc_killmobj, odaproto::svc::KillMobj::descriptor());
+	MapProto(svc_raisemobj, odaproto::svc::RaiseMobj::descriptor());
 	MapProto(svc_fireweapon, odaproto::svc::FireWeapon::descriptor());
 	MapProto(svc_updatesector, odaproto::svc::UpdateSector::descriptor());
 	MapProto(svc_print, odaproto::svc::Print::descriptor());

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -636,6 +636,23 @@ odaproto::svc::KillMobj SVC_KillMobj(AActor* source, AActor* target, AActor* inf
 	return msg;
 }
 
+/**
+ * @brief Resurrect a mobj.
+ */
+odaproto::svc::RaiseMobj SVC_RaiseMobj(AActor* source, AActor* corpse)
+{
+	odaproto::svc::RaiseMobj msg;
+
+	odaproto::Actor* cps = msg.mutable_target();
+
+	// corpse netid
+	cps->set_netid(corpse->netid);
+
+	msg.set_source_netid(source ? source->netid : 0);
+
+	return msg;
+}
+
 odaproto::svc::FireWeapon SVC_FireWeapon(player_t& player)
 {
 	odaproto::svc::FireWeapon msg;

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -643,10 +643,24 @@ odaproto::svc::RaiseMobj SVC_RaiseMobj(AActor* source, AActor* corpse)
 {
 	odaproto::svc::RaiseMobj msg;
 
-	odaproto::Actor* cps = msg.mutable_target();
+	odaproto::Actor* cps = msg.mutable_corpse();
 
 	// corpse netid
 	cps->set_netid(corpse->netid);
+
+	cps->set_rndindex(corpse->rndindex);
+
+	odaproto::Vec3* cpspos = cps->mutable_pos();
+	cpspos->set_x(corpse->x);
+	cpspos->set_y(corpse->y);
+	cpspos->set_z(corpse->z);
+
+	cps->set_angle(corpse->angle);
+
+	odaproto::Vec3* cpsmom = cps->mutable_mom();
+	cpsmom->set_x(corpse->momx);
+	cpsmom->set_y(corpse->momy);
+	cpsmom->set_z(corpse->momz);
 
 	msg.set_source_netid(source ? source->netid : 0);
 

--- a/common/svc_message.h
+++ b/common/svc_message.h
@@ -100,6 +100,7 @@ odaproto::svc::SpawnPlayer SVC_SpawnPlayer(player_t& player);
 odaproto::svc::DamagePlayer SVC_DamagePlayer(player_t& player, AActor *inflictor, int health, int armor);
 odaproto::svc::KillMobj SVC_KillMobj(AActor* source, AActor* target, AActor* inflictor,
                                      int mod, bool joinkill);
+odaproto::svc::RaiseMobj SVC_RaiseMobj(AActor* source, AActor* corpse);
 odaproto::svc::FireWeapon SVC_FireWeapon(player_t& player);
 odaproto::svc::UpdateSector SVC_UpdateSector(sector_t& sector);
 odaproto::svc::Print SVC_Print(printlevel_t level, const std::string& str);

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -170,7 +170,7 @@ message KillMobj
 message RaiseMobj
 {
 	uint32 source_netid = 1;
-	Actor target = 2;
+	Actor corpse = 2;
 }
 
 // svc_fireweapon

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -166,6 +166,13 @@ message KillMobj
 	sint32 lives = 7; // Default is -1.
 }
 
+// svc_raisemobj
+message RaiseMobj
+{
+	uint32 source_netid = 1;
+	Actor target = 2;
+}
+
 // svc_fireweapon
 message FireWeapon
 {

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4370,6 +4370,22 @@ void SV_SendKillMobj(AActor *source, AActor *target, AActor *inflictor,
 	}
 }
 
+void SV_SendRaiseMobj(AActor* source, AActor* corpse)
+{
+	if (!corpse)
+		return;
+
+	for (auto& player : players)
+	{
+		client_t* cl = &(player.client);
+
+		if (!SV_IsPlayerAllowedToSee(player, corpse))
+			continue;
+
+		MSG_WriteSVC(&cl->reliablebuf, SVC_RaiseMobj(source, corpse));
+	}
+}
+
 // Tells clients to remove an actor from the world as it doesn't exist anymore
 void SV_SendDestroyActor(AActor *mo)
 {


### PR DESCRIPTION
This was a bit of a doozy, since we don't classify raise states for monsters ala ZDoom, we have to create a new server message to indicate a state is raise (similar to sending a message to begin the death state).

The reason we have to send a message during raise, is because raise requires flags to be set as well as the state. Since `A_HealChase` and `A_VileChase` are serverside, these flags originally didn't make it to the client. This would result in floating monsters "bouncing" (because `MF_FLOAT` wasn't set clientside after they were raised from the dead) and "jittery" ground monsters (because `MF_SOLID` wasn't set clientside).

This largely copies the paradigm of SV_SendKillMobj.