### PR TITLE
[BUGFIX] Bottom of Doom episode 1 sky renders incorrectly.

### DIFF
--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -253,6 +253,19 @@ void R_DrawColumnInCache(const tallpost_t *post, byte *cache,
 	}
 }
 
+// Some vanilla textures use patch offsets that were ignored by the vanilla executable
+// In Odamex, these cause issues and need to be set to zero manually
+void R_VanillaTextureHacks(texture_t* tex)
+{
+	if (iequals(tex->name, "SKY1") &&
+	    tex->height == 128 &&
+		tex->patchcount == 1 &&
+		tex->patches[0].originy == -8)
+	{
+		tex->patches[0].originy = 0;
+	}
+}
+
 //
 // R_GenerateComposite
 // Using the texture definition,
@@ -268,9 +281,10 @@ void R_GenerateComposite (int texnum)
 	texturecomposite[texnum] = block;
 	texture_t *texture = textures[texnum];
 
+	R_VanillaTextureHacks(texture);
+
 	// Composite the columns together.
 	texpatch_t *texpatch = texture->patches;
-	short *collump = texturecolumnlump[texnum];
 
 	// killough 4/9/98: marks to identify transparent regions in merged textures
 	byte *marks = new byte[texture->width * texture->height];
@@ -288,15 +302,12 @@ void R_GenerateComposite (int texnum)
 
 		for (; x1 < x2 ; x1++)
 		{
-			if (collump[x1] == -1)			// Column has multiple patches?
-			{
-				// killough 1/25/98, 4/9/98: Fix medusa bug.
-				tallpost_t *srcpost = (tallpost_t*)((byte*)patch + LELONG(cofs[x1]));
-				tallpost_t *destpost = (tallpost_t*)(block + texturecolumnofs[texnum][x1]);
+			// killough 1/25/98, 4/9/98: Fix medusa bug.
+			tallpost_t *srcpost = (tallpost_t*)((byte*)patch + LELONG(cofs[x1]));
+			tallpost_t *destpost = (tallpost_t*)(block + texturecolumnofs[texnum][x1]);
 
-				R_DrawColumnInCache(srcpost, destpost->data(), texpatch->originy, texture->height,
-									marks + x1 * texture->height);
-			}
+			R_DrawColumnInCache(srcpost, destpost->data(), texpatch->originy, texture->height,
+								marks + x1 * texture->height);
 		}
 	}
 
@@ -306,9 +317,6 @@ void R_GenerateComposite (int texnum)
 	byte *tmpdata = new byte[texture->height];		// temporary post data
 	for (int i = 0; i < texture->width; i++)
 	{
-		if (collump[i] != -1)	// process only multipatched columns
-			continue;
-
 		tallpost_t *post = (tallpost_t *)(block + texturecolumnofs[texnum][i]);
 		const byte *mark = marks + i * texture->height;
 		int j = 0;
@@ -360,14 +368,10 @@ void R_GenerateLookup(int texnum, int *const errors)
 
 	// Composited texture not created yet.
 
-	short *collump = texturecolumnlump[texnum];
-
 	// killough 4/9/98: keep count of posts in addition to patches.
 	// Part of fix for medusa bug for multipatched 2s normals.
-	unsigned short *patchcount = new unsigned short[texture->width];
 	unsigned short *postcount = new unsigned short[texture->width];
 
-	memset(patchcount, 0, sizeof(unsigned short) * texture->width);
 	memset(postcount, 0, sizeof(unsigned short) * texture->width);
 
 	const texpatch_t *texpatch = texture->patches;
@@ -393,9 +397,6 @@ void R_GenerateLookup(int texnum, int *const errors)
 			// NOTE: this offset will be rewritten later if a composite is generated
 			// for this texture (eg, there's more than one patch)
 			texturecolumnofs[texnum][x] = (byte *)post - (byte *)patch;
-
-			patchcount[x]++;
-			collump[x] = patchnum;
 
 			while (!post->end())
 			{
@@ -423,8 +424,6 @@ void R_GenerateLookup(int texnum, int *const errors)
 		// yet know how many posts the merged column will
 		// require, and it's bounded above by this limit.
 
-		collump[x] = -1;				// mark lump as in need of compositing
-
 		texturecolumnofs[texnum][x] = csize;
 
 		// 4 header bytes per post + column height + 2 byte terminator
@@ -433,7 +432,6 @@ void R_GenerateLookup(int texnum, int *const errors)
 
 	texturecompositesize[texnum] = csize;
 
-	delete [] patchcount;
 	delete [] postcount;
 }
 

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -257,7 +257,7 @@ void R_DrawColumnInCache(const tallpost_t *post, byte *cache,
 // In Odamex, these cause issues and need to be set to zero manually
 void R_VanillaTextureHacks(texture_t* tex)
 {
-	if (iequals(tex->name, "SKY1") &&
+	if (tex->name == "SKY1" &&
 	    tex->height == 128 &&
 		tex->patchcount == 1 &&
 		tex->patches[0].originy == -8)
@@ -621,8 +621,7 @@ void R_InitTextures (void)
 		texture->height = SAFESHORT(mtexture->height);
 		texture->patchcount = SAFESHORT(mtexture->patchcount);
 
-		strncpy (texture->name, mtexture->name, 9); // denis - todo string limit?
-		std::transform(texture->name, texture->name + strlen(texture->name), texture->name, toupper);
+		texture->name = mtexture->name;
 
 		mpatch = &mtexture->patches[0];
 		patch = &texture->patches[0];
@@ -634,7 +633,7 @@ void R_InitTextures (void)
 			patch->patch = patchlookup[LESHORT(mpatch->patch)];
 			if (patch->patch == -1)
 			{
-				Printf (PRINT_WARNING, "R_InitTextures: Missing patch in texture %s\n", texture->name);
+				PrintFmt(PRINT_WARNING, "R_InitTextures: Missing patch in texture {}\n", texture->name);
 				errors++;
 			}
 		}
@@ -1010,21 +1009,17 @@ int R_FlatNumForName (const char* name)
 //
 int R_CheckTextureNumForName (const char *name)
 {
-	unsigned char uname[9];
-	int  i;
-
 	// "NoTexture" marker.
 	if (name[0] == '-')
 		return 0;
 
 	// [RH] Use a hash table instead of linear search
-	strncpy ((char *)uname, name, 9); // denis - todo - string limit?
-	std::transform(uname, uname + sizeof(uname), uname, toupper);
+	OLumpName uname = name;
 
-	i = textures[/*W_LumpNameHash (uname) % (unsigned) numtextures*/0]->index; // denis - todo - replace with map<>
+	int i = textures[/*W_LumpNameHash (uname) % (unsigned) numtextures*/0]->index; // denis - todo - replace with map<>
 
 	while (i != -1) {
-		if (!strncmp (textures[i]->name, (char *)uname, 8))
+		if (textures[i]->name == uname)
 			break;
 		i = textures[i]->next;
 	}

--- a/common/r_data.h
+++ b/common/r_data.h
@@ -60,7 +60,7 @@ typedef struct
 typedef struct
 {
 	// Keep name for switch changing, etc.
-	char		name[9];
+	OLumpName	name;
 	short		width;
 	short		height;
 


### PR DESCRIPTION
#1138 introduced an issue when rendering the episode 1 sky. As seen below, the bottom 8 rows of the texture are uninitialized in memory. It turns out that the patch used by the sky has a y offset of -8. In vanilla, negative y offsets on patches are ignored, and offsets were also ignored in single patch textures. Odamex apparently supports negative patch offsets, and now that all textures go through the compositing step, the offset in SKY1 becomes visible. To fix this, I took the same approach as Eternity and GZDoom. When loading textures, the bad offset is set to 0 if the texture being loaded is this one.

![image](https://github.com/user-attachments/assets/0e606277-c36d-409f-9f40-06a029ddb5c8)
