### PR TITLE
Upgrade JsonCPP

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -212,7 +212,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
   endif()
 
   if(USE_INTERNAL_JSONCPP)
-    target_link_libraries(odamex jsoncpp_lib_static)
+    target_link_libraries(odamex jsoncpp_static)
   else()
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(JSONCPP jsoncpp REQUIRED IMPORTED_TARGET)

--- a/libraries/jsoncpp-lib.cmake
+++ b/libraries/jsoncpp-lib.cmake
@@ -13,5 +13,5 @@ if((BUILD_CLIENT OR BUILD_SERVER) AND USE_INTERNAL_JSONCPP)
   lib_build(LIBRARY jsoncpp)
 
   find_package(jsoncpp REQUIRED)
-  set_target_properties(jsoncpp_lib_static PROPERTIES IMPORTED_GLOBAL TRUE)
+  set_target_properties(jsoncpp_static PROPERTIES IMPORTED_GLOBAL TRUE)
 endif()

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 target_link_libraries(odasrv fmt::fmt tinylibs ZLIB::ZLIB odamex-common odaproto minilzo)
 
 if(USE_INTERNAL_JSONCPP)
-  target_link_libraries(odasrv jsoncpp_lib_static)
+  target_link_libraries(odasrv jsoncpp_static)
 else()
   find_package(PkgConfig REQUIRED)
   pkg_check_modules(JSONCPP jsoncpp REQUIRED IMPORTED_TARGET)


### PR DESCRIPTION
This PR updates JsonCPP to 1.9.6 and changes the targets in odamex to static link it (since the target changes between these 2 versions.)

Resolves #1212 