### PR TITLE
[BUGFIX] Set player.mo health during CL_PlayerInfo

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -274,6 +274,11 @@ static void CL_PlayerInfo(const odaproto::svc::PlayerInfo* msg)
 
 	P_SetPlayerPowerupStatuses(&p, p.powers);
 
+	// Sync mo health with player health
+	// For crosshaircolor, etc.
+	if (p.mo)
+		p.mo->health = p.health;
+
 	if (!p.spectator)
 		p.cheats = msg->player().cheats();
 


### PR DESCRIPTION
Updating player.mo during CL_PlayerInfo will roll this down to other systems that require it, like hud_crosshairhealth.

Fixes #757 