### PR TITLE
Use `cpptrace` for printing of stack traces to the ingame console

### DIFF
--- a/3RD-PARTY-LICENSES
+++ b/3RD-PARTY-LICENSES
@@ -145,29 +145,3 @@ freely, subject to the following restrictions:
 
 Jean-loup Gailly        Mark Adler
 jloup@gzip.org          madler@alumni.caltech.edu
-
------------------------------------------------------------------------------
-License of b_stacktrace
------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) 2020-2025 Borislav Stanimirov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/3RD-PARTY-LICENSES
+++ b/3RD-PARTY-LICENSES
@@ -49,28 +49,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 License of JsonCpp
 -----------------------------------------------------------------------------
 
-The JsonCpp library's source code, including accompanying documentation, 
+The JsonCpp library's source code, including accompanying documentation,
 tests and demonstration applications, are licensed under the following
 conditions...
 
-The author (Baptiste Lepilleur) explicitly disclaims copyright in all 
-jurisdictions which recognize such a disclaimer. In such jurisdictions, 
+The author (Baptiste Lepilleur) explicitly disclaims copyright in all
+jurisdictions which recognize such a disclaimer. In such jurisdictions,
 this software is released into the Public Domain.
 
 In jurisdictions which do not recognize Public Domain property (e.g. Germany as of
 2010), this software is Copyright (c) 2007-2010 by Baptiste Lepilleur, and is
 released under the terms of the MIT License (see below).
 
-In jurisdictions which recognize Public Domain property, the user of this 
-software may choose to accept it either as 1) Public Domain, 2) under the 
-conditions of the MIT License (see below), or 3) under the terms of dual 
+In jurisdictions which recognize Public Domain property, the user of this
+software may choose to accept it either as 1) Public Domain, 2) under the
+conditions of the MIT License (see below), or 3) under the terms of dual
 Public Domain/MIT License conditions described here, as they choose.
 
 The MIT License is about as close to Public Domain as a license can get, and is
 described in clear, concise terms at:
 
    http://en.wikipedia.org/wiki/MIT_License
-   
+
 The full text of the MIT License follows:
 
 ========================================================================
@@ -145,3 +145,29 @@ freely, subject to the following restrictions:
 
 Jean-loup Gailly        Mark Adler
 jloup@gzip.org          madler@alumni.caltech.edu
+
+-----------------------------------------------------------------------------
+License of b_stacktrace
+-----------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2020-2025 Borislav Stanimirov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/3RD-PARTY-LICENSES
+++ b/3RD-PARTY-LICENSES
@@ -49,28 +49,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 License of JsonCpp
 -----------------------------------------------------------------------------
 
-The JsonCpp library's source code, including accompanying documentation,
+The JsonCpp library's source code, including accompanying documentation, 
 tests and demonstration applications, are licensed under the following
 conditions...
 
-The author (Baptiste Lepilleur) explicitly disclaims copyright in all
-jurisdictions which recognize such a disclaimer. In such jurisdictions,
+The author (Baptiste Lepilleur) explicitly disclaims copyright in all 
+jurisdictions which recognize such a disclaimer. In such jurisdictions, 
 this software is released into the Public Domain.
 
 In jurisdictions which do not recognize Public Domain property (e.g. Germany as of
 2010), this software is Copyright (c) 2007-2010 by Baptiste Lepilleur, and is
 released under the terms of the MIT License (see below).
 
-In jurisdictions which recognize Public Domain property, the user of this
-software may choose to accept it either as 1) Public Domain, 2) under the
-conditions of the MIT License (see below), or 3) under the terms of dual
+In jurisdictions which recognize Public Domain property, the user of this 
+software may choose to accept it either as 1) Public Domain, 2) under the 
+conditions of the MIT License (see below), or 3) under the terms of dual 
 Public Domain/MIT License conditions described here, as they choose.
 
 The MIT License is about as close to Public Domain as a license can get, and is
 described in clear, concise terms at:
 
    http://en.wikipedia.org/wiki/MIT_License
-
+   
 The full text of the MIT License follows:
 
 ========================================================================

--- a/ci/fedora.Dockerfile
+++ b/ci/fedora.Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 # Packages
 RUN set -x && \
-    dnf -y install gcc-c++ alsa-lib-devel libcurl-devel \
+    dnf -y install git gcc-c++ alsa-lib-devel libcurl-devel \
                    ninja-build SDL2-devel SDL2_mixer-devel wxGTK3-devel && \
    curl -LO https://github.com/Kitware/CMake/releases/download/v3.30.2/cmake-3.30.2-linux-x86_64.sh && \
    chmod +x ./cmake-3.30.2-linux-x86_64.sh && \

--- a/ci/ubuntu-focal.Dockerfile
+++ b/ci/ubuntu-focal.Dockerfile
@@ -10,7 +10,7 @@ ENV TZ=US \
 # Packages - first the majority of them, then cmake
 RUN set -x && \
     apt update && \
-    apt install -y g++ ninja-build libsdl2-dev libsdl2-mixer-dev \
+    apt install -y git g++ ninja-build libsdl2-dev libsdl2-mixer-dev \
         libpng-dev libcurl4-openssl-dev libwxgtk3.0-gtk3-dev deutex \
         apt-transport-https ca-certificates gnupg software-properties-common wget && \
     wget -O - 'https://apt.kitware.com/keys/kitware-archive-latest.asc' 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -225,7 +225,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     target_link_libraries(odamex ${PORTMIDI_LIBRARY})
   endif()
 
-  target_link_libraries(odamex ZLIB::ZLIB PNG::PNG fmt::fmt minilzo)
+  target_link_libraries(odamex ZLIB::ZLIB PNG::PNG fmt::fmt minilzo cpptrace::cpptrace)
 
   if(WIN32)
     target_link_libraries(odamex winmm wsock32 shlwapi)

--- a/common/m_stacktrace.cpp
+++ b/common/m_stacktrace.cpp
@@ -182,7 +182,7 @@ std::string M_GetStacktrace()
 	int trace_size = backtrace(trace, STACKTRACE_MAX_DEPTH);
 	char** messages = backtrace_symbols(trace, trace_size);
 
-	std::string ret = fmt::format("{}", fmt::join(nonstd::span(messages, trace_size), "\n"));
+	std::string ret = fmt::format("{}", fmt::join(nonstd::span(&messages[1], trace_size), "\n"));
 
 	M_Free(messages);
 	return ret;
@@ -203,7 +203,7 @@ std::string M_GetStacktrace()
 	char** messages = backtrace_symbols(trace, trace_size);
 	std::string ret;
 
-	for (int i = 0; i < trace_size; ++i)
+	for (int i = 1; i < trace_size; ++i)
 	{
 		void* tracei = trace[i];
 		char* msg = messages[i];
@@ -221,7 +221,7 @@ std::string M_GetStacktrace()
 			char line[2048];
 
 			FILE* fp;
-			std::string cmd = fmt::format("addr2line -e {} -f -C -p {} 2>/dev/null", messages[i], (void*)((char*)tracei - (char*)info.dli_fbase));
+			std::string cmd = fmt::format("addr2line -e {} -i -f -C -p {} 2>/dev/null", messages[i], (void*)((byte*)tracei - (byte*)info.dli_fbase));	
 
 			fp = popen(cmd.c_str(), "r");
 			if (!fp)

--- a/common/m_stacktrace.cpp
+++ b/common/m_stacktrace.cpp
@@ -25,188 +25,21 @@
 #include "odamex.h"
 
 #include "m_stacktrace.h"
-#include "m_fileio.h"
-#include "fmt/ranges.h"
 
 #include "cpptrace/cpptrace.hpp"
+#include "cpptrace/formatting.hpp"
 
-#if defined(__linux__) && !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
-#endif
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-
-#define STACKTRACE_MAX_DEPTH 1024
-
-#if defined(_WIN32)
-
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <TlHelp32.h>
-#include <DbgHelp.h>
-
-#pragma comment(lib, "DbgHelp.lib")
-
-#define STACKTRACE_ERROR_FLAG ((DWORD64)1 << 63)
-
-struct traceentry_t
+std::string M_GetStacktrace(std::string header)
 {
-	DWORD64 AddrPC_Offset;
-	DWORD64 AddrReturn_Offset;
-};
-
-static int SymInitialize_called = 0;
-
-std::string M_GetStacktrace()
-{
-	HANDLE process = GetCurrentProcess();
-	HANDLE thread = GetCurrentThread();
-	CONTEXT context;
-	STACKFRAME64 frame; /* in/out stackframe */
-	DWORD imageType;
-	std::vector<traceentry_t> entries;
-
-	if (!SymInitialize_called)
-	{
-		SymInitialize(process, NULL, TRUE);
-		SymInitialize_called = 1;
-	}
-
-	RtlCaptureContext(&context);
-
-	memset(&frame, 0, sizeof(frame));
-#ifdef _M_IX86
-	imageType = IMAGE_FILE_MACHINE_I386;
-	frame.AddrPC.Offset = context.Eip;
-	frame.AddrPC.Mode = AddrModeFlat;
-	frame.AddrFrame.Offset = context.Ebp;
-	frame.AddrFrame.Mode = AddrModeFlat;
-	frame.AddrStack.Offset = context.Esp;
-	frame.AddrStack.Mode = AddrModeFlat;
-#elif _M_X64
-	imageType = IMAGE_FILE_MACHINE_AMD64;
-	frame.AddrPC.Offset = context.Rip;
-	frame.AddrPC.Mode = AddrModeFlat;
-	frame.AddrFrame.Offset = context.Rsp;
-	frame.AddrFrame.Mode = AddrModeFlat;
-	frame.AddrStack.Offset = context.Rsp;
-	frame.AddrStack.Mode = AddrModeFlat;
-#elif _M_IA64
-	imageType = IMAGE_FILE_MACHINE_IA64;
-	frame.AddrPC.Offset = context.StIIP;
-	frame.AddrPC.Mode = AddrModeFlat;
-	frame.AddrFrame.Offset = context.IntSp;
-	frame.AddrFrame.Mode = AddrModeFlat;
-	frame.AddrBStore.Offset = context.RsBSP;
-	frame.AddrBStore.Mode = AddrModeFlat;
-	frame.AddrStack.Offset = context.IntSp;
-	frame.AddrStack.Mode = AddrModeFlat;
-#else
-	#error "Platform not supported!"
-#endif
-
-	while (true)
-	{
-		traceentry_t& entry = entries.emplace_back();
-		if (entries.size() == STACKTRACE_MAX_DEPTH)
-		{
-			entry.AddrPC_Offset = 0;
-			entry.AddrReturn_Offset = 0;
-			break;
-		}
-
-		if (!StackWalk64(imageType, process, thread, &frame, &context, NULL, SymFunctionTableAccess64, SymGetModuleBase64, NULL))
-		{
-			entry.AddrPC_Offset = frame.AddrPC.Offset;
-			entry.AddrReturn_Offset = STACKTRACE_ERROR_FLAG; /* mark error */
-			entry.AddrReturn_Offset |= GetLastError();
-			break;
-		}
-
-		entry.AddrPC_Offset = frame.AddrPC.Offset;
-		entry.AddrReturn_Offset = frame.AddrReturn.Offset;
-
-		if (frame.AddrReturn.Offset == 0)
-			break;
-	}
-
-	std::string ret;
-	IMAGEHLP_SYMBOL64* symbol = (IMAGEHLP_SYMBOL64*) M_Malloc(sizeof(IMAGEHLP_SYMBOL64) + 1024);
-	symbol->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
-	symbol->MaxNameLength = 1024;
-
-	for (const auto& entry : nonstd::span(entries).subspan(1))
-	{
-		IMAGEHLP_LINE64 lineData;
-		DWORD lineOffset = 0;
-		DWORD64 symOffset = 0;
-
-		if (entry.AddrReturn_Offset & STACKTRACE_ERROR_FLAG)
-		{
-			DWORD error = entry.AddrReturn_Offset & 0xFFFFFFFF;
-			ret += fmt::format("StackWalk64 error: {} @ {}\n", error, entry.AddrPC_Offset);
-			break;
-		}
-
-		if (entry.AddrPC_Offset == entry.AddrReturn_Offset)
-		{
-			ret += fmt::format("Stack overflow @ {}\n", entry.AddrPC_Offset);
-			break;
-		}
-
-		SymGetLineFromAddr64(process, entry.AddrPC_Offset, &lineOffset, &lineData);
-		ret += fmt::format("{}({}): ", M_ExtractFileName(lineData.FileName), lineData.LineNumber);
-
-		if (SymGetSymFromAddr64(process, entry.AddrPC_Offset, &symOffset, symbol))
-			ret += fmt::format("{}\n", symbol->Name);
-		else
-			ret += fmt::format(" Unkown symbol @ {}\n", entry.AddrPC_Offset);
-
-		if (entry.AddrReturn_Offset == 0)
-			break;
-	}
-
-	M_Free(symbol);
-	return ret;
+	auto formatter = cpptrace::formatter{}
+    	.header(header)
+		.colors(cpptrace::formatter::color_mode::none)
+    	.addresses(cpptrace::formatter::address_mode::none)
+		.paths(cpptrace::formatter::path_mode::basename)
+		.columns(false)
+    	.snippets(false)
+		.filter([](const auto& frame)
+			{ return frame.symbol.find("M_GetStacktrace") == std::string::npos; })
+		.filtered_frame_placeholders(false);
+	return formatter.format(cpptrace::generate_trace());
 }
-
-#elif defined __APPLE__ && defined HAVE_BACKTRACE
-
-#include <execinfo.h>
-#include <unistd.h>
-#include <dlfcn.h>
-
-std::string M_GetStacktrace()
-{
-	static void* trace[STACKTRACE_MAX_DEPTH];
-	int trace_size = backtrace(trace, STACKTRACE_MAX_DEPTH);
-	char** messages = backtrace_symbols(trace, trace_size);
-
-	std::string ret = fmt::format("{}", fmt::join(nonstd::span(&messages[1], trace_size), "\n"));
-
-	M_Free(messages);
-	return ret;
-}
-
-#elif defined __linux__ && defined HAVE_BACKTRACE
-
-#include <execinfo.h>
-#include <ucontext.h>
-#include <unistd.h>
-#include <dlfcn.h>
-#include <string.h>
-
-std::string M_GetStacktrace()
-{
-	return cpptrace::generate_trace().to_string();
-}
-
-#else
-
-std::string M_GetStacktrace() {
-	return "M_GetStacktrace: Unsupported platform.";
-}
-
-#endif

--- a/common/m_stacktrace.cpp
+++ b/common/m_stacktrace.cpp
@@ -1,0 +1,275 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 1993-1996 by id Software, Inc.
+// Copyright (C) 2006-2025 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	Stacktrace for more useful error messages
+//
+//-----------------------------------------------------------------------------
+
+#include "odamex.h"
+
+#include "m_stacktrace.h"
+
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#define B_STACKTRACE_MAX_DEPTH 1024
+
+#if defined(_WIN32)
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <TlHelp32.h>
+#include <DbgHelp.h>
+
+#pragma comment(lib, "DbgHelp.lib")
+
+#define B_STACKTRACE_ERROR_FLAG ((DWORD64)1 << 63)
+
+struct traceentry_t {
+    DWORD64 AddrPC_Offset;
+    DWORD64 AddrReturn_Offset;
+};
+
+static int SymInitialize_called = 0;
+
+std::string M_GetStacktrace() {
+    HANDLE process = GetCurrentProcess();
+    HANDLE thread = GetCurrentThread();
+    CONTEXT context;
+    STACKFRAME64 frame; /* in/out stackframe */
+    DWORD imageType;
+    std::vector<traceentry_t> entries;
+    int i = 0;
+
+    if (!SymInitialize_called) {
+        SymInitialize(process, NULL, TRUE);
+        SymInitialize_called = 1;
+    }
+
+    RtlCaptureContext(&context);
+
+    memset(&frame, 0, sizeof(frame));
+#ifdef _M_IX86
+    imageType = IMAGE_FILE_MACHINE_I386;
+    frame.AddrPC.Offset = context.Eip;
+    frame.AddrPC.Mode = AddrModeFlat;
+    frame.AddrFrame.Offset = context.Ebp;
+    frame.AddrFrame.Mode = AddrModeFlat;
+    frame.AddrStack.Offset = context.Esp;
+    frame.AddrStack.Mode = AddrModeFlat;
+#elif _M_X64
+    imageType = IMAGE_FILE_MACHINE_AMD64;
+    frame.AddrPC.Offset = context.Rip;
+    frame.AddrPC.Mode = AddrModeFlat;
+    frame.AddrFrame.Offset = context.Rsp;
+    frame.AddrFrame.Mode = AddrModeFlat;
+    frame.AddrStack.Offset = context.Rsp;
+    frame.AddrStack.Mode = AddrModeFlat;
+#elif _M_IA64
+    imageType = IMAGE_FILE_MACHINE_IA64;
+    frame.AddrPC.Offset = context.StIIP;
+    frame.AddrPC.Mode = AddrModeFlat;
+    frame.AddrFrame.Offset = context.IntSp;
+    frame.AddrFrame.Mode = AddrModeFlat;
+    frame.AddrBStore.Offset = context.RsBSP;
+    frame.AddrBStore.Mode = AddrModeFlat;
+    frame.AddrStack.Offset = context.IntSp;
+    frame.AddrStack.Mode = AddrModeFlat;
+#else
+    #error "Platform not supported!"
+#endif
+
+    while (true) {
+        traceentry_t entry = entries.emplace_back();
+        if (i == B_STACKTRACE_MAX_DEPTH) {
+            entry.AddrPC_Offset = 0;
+            entry.AddrReturn_Offset = 0;
+            break;
+        }
+
+        if (!StackWalk64(imageType, process, thread, &frame, &context, NULL, SymFunctionTableAccess64, SymGetModuleBase64, NULL)) {
+            entry.AddrPC_Offset = frame.AddrPC.Offset;
+            entry.AddrReturn_Offset = B_STACKTRACE_ERROR_FLAG; /* mark error */
+            entry.AddrReturn_Offset |= GetLastError();
+            break;
+        }
+
+        entry.AddrPC_Offset = frame.AddrPC.Offset;
+        entry.AddrReturn_Offset = frame.AddrReturn.Offset;
+
+        if (frame.AddrReturn.Offset == 0) {
+            break;
+        }
+        i++;
+    }
+
+    std::string ret;
+    IMAGEHLP_SYMBOL64* symbol = (IMAGEHLP_SYMBOL64*)M_Malloc(sizeof(IMAGEHLP_SYMBOL64) + 1024);
+    symbol->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+    symbol->MaxNameLength = 1024;
+
+    for (const auto& entry : entries) {
+        IMAGEHLP_LINE64 lineData;
+        DWORD lineOffset = 0;
+        DWORD64 symOffset = 0;
+
+        if (entry.AddrReturn_Offset & B_STACKTRACE_ERROR_FLAG) {
+            DWORD error = entry.AddrReturn_Offset & 0xFFFFFFFF;
+            ret += fmt::format("StackWalk64 error: {} @ {}\n", error, entry.AddrPC_Offset);
+            break;
+        }
+
+        if (entry.AddrPC_Offset == entry.AddrReturn_Offset) {
+            ret += fmt::format("Stack overflow @ {}\n", entry.AddrPC_Offset);
+            break;
+        }
+
+        SymGetLineFromAddr64(process, entry.AddrPC_Offset, &lineOffset, &lineData);
+        ret += fmt::format("{}({}): ", lineData.FileName, lineData.LineNumber);
+
+        if (SymGetSymFromAddr64(process, entry.AddrPC_Offset, &symOffset, symbol)) {
+            ret += fmt::format("{}\n", symbol->Name);
+        }
+        else {
+            ret += fmt::format(" Unkown symbol @ {}\n", entry.AddrPC_Offset);
+        }
+
+        if (entry.AddrReturn_Offset == 0) {
+            break;
+        }
+    }
+
+    M_Free(symbol);
+    return ret;
+}
+
+#elif defined(__APPLE__)
+
+#include <execinfo.h>
+#include <unistd.h>
+#include <dlfcn.h>
+
+typedef struct b_stacktrace {
+    void* trace[B_STACKTRACE_MAX_DEPTH];
+    int trace_size;
+} b_stacktrace;
+
+b_stacktrace_handle b_stacktrace_get(void) {
+    b_stacktrace* ret = (b_stacktrace*)malloc(sizeof(b_stacktrace));
+    ret->trace_size = backtrace(ret->trace, B_STACKTRACE_MAX_DEPTH);
+    return (b_stacktrace_handle)(ret);
+}
+
+char* b_stacktrace_to_string(b_stacktrace_handle h) {
+    const b_stacktrace* stacktrace = (b_stacktrace*)h;
+    char** messages = backtrace_symbols(stacktrace->trace, stacktrace->trace_size);
+    print_buf out = buf_init();
+    *out.buf = 0;
+
+    for (int i = 0; i < stacktrace->trace_size; ++i) {
+        buf_printf(&out, "%s\n", messages[i]);
+    }
+
+    free(messages);
+    return out.buf;
+}
+
+#elif defined(__linux__)
+
+#include <execinfo.h>
+#include <ucontext.h>
+#include <unistd.h>
+#include <dlfcn.h>
+#include <string.h>
+
+typedef struct b_stacktrace {
+    void* trace[B_STACKTRACE_MAX_DEPTH];
+    int trace_size;
+} b_stacktrace;
+
+b_stacktrace_handle b_stacktrace_get(void) {
+    b_stacktrace* ret = (b_stacktrace*)malloc(sizeof(b_stacktrace));
+    ret->trace_size = backtrace(ret->trace, B_STACKTRACE_MAX_DEPTH);
+    return (b_stacktrace_handle)(ret);
+}
+
+char* b_stacktrace_to_string(b_stacktrace_handle h) {
+    const b_stacktrace* stacktrace = (b_stacktrace*)h;
+    char** messages = backtrace_symbols(stacktrace->trace, stacktrace->trace_size);
+    print_buf out = buf_init();
+
+    for (int i = 0; i < stacktrace->trace_size; ++i) {
+        void* tracei = stacktrace->trace[i];
+        char* msg = messages[i];
+
+        /* calculate load offset */
+        Dl_info info;
+        dladdr(tracei, &info);
+        if (info.dli_fbase == (void*)0x400000) {
+            /* address from executable, so don't offset */
+            info.dli_fbase = NULL;
+        }
+
+        while (*msg && *msg != '(') ++msg;
+        *msg = 0;
+
+        {
+            char cmd[1024];
+            char line[2048];
+
+            FILE* fp;
+            snprintf(cmd, 1024, "addr2line -e %s -f -C -p %p 2>/dev/null", messages[i], (void*)((char*)tracei - (char*)info.dli_fbase));
+
+            fp = popen(cmd, "r");
+            if (!fp) {
+                buf_printf(&out, "Failed to generate trace further...\n");
+                break;
+            }
+
+            while (fgets(line, sizeof(line), fp)) {
+                buf_printf(&out, "%s: ", messages[i]);
+                if (strstr(line, "?? ")) {
+                    /* just output address if nothing can be found */
+                    buf_printf(&out, "%p\n", tracei);
+                }
+                else {
+                    buf_printf(&out, "%s", line);
+                }
+            }
+
+            pclose(fp);
+        }
+    }
+
+    free(messages);
+    return out.buf;
+}
+
+#else
+
+std::string M_GetStacktrace() {
+    return "M_GetStacktrace: Unsupported platform.";
+}
+
+#endif

--- a/common/m_stacktrace.cpp
+++ b/common/m_stacktrace.cpp
@@ -48,120 +48,125 @@
 
 #define B_STACKTRACE_ERROR_FLAG ((DWORD64)1 << 63)
 
-struct traceentry_t {
-    DWORD64 AddrPC_Offset;
-    DWORD64 AddrReturn_Offset;
+struct traceentry_t
+{
+	DWORD64 AddrPC_Offset;
+	DWORD64 AddrReturn_Offset;
 };
 
 static int SymInitialize_called = 0;
 
-std::string M_GetStacktrace() {
-    HANDLE process = GetCurrentProcess();
-    HANDLE thread = GetCurrentThread();
-    CONTEXT context;
-    STACKFRAME64 frame; /* in/out stackframe */
-    DWORD imageType;
-    std::vector<traceentry_t> entries;
+std::string M_GetStacktrace()
+{
+	HANDLE process = GetCurrentProcess();
+	HANDLE thread = GetCurrentThread();
+	CONTEXT context;
+	STACKFRAME64 frame; /* in/out stackframe */
+	DWORD imageType;
+	std::vector<traceentry_t> entries;
 
-    if (!SymInitialize_called) {
-        SymInitialize(process, NULL, TRUE);
-        SymInitialize_called = 1;
-    }
+	if (!SymInitialize_called)
+	{
+		SymInitialize(process, NULL, TRUE);
+		SymInitialize_called = 1;
+	}
 
-    RtlCaptureContext(&context);
+	RtlCaptureContext(&context);
 
-    memset(&frame, 0, sizeof(frame));
+	memset(&frame, 0, sizeof(frame));
 #ifdef _M_IX86
-    imageType = IMAGE_FILE_MACHINE_I386;
-    frame.AddrPC.Offset = context.Eip;
-    frame.AddrPC.Mode = AddrModeFlat;
-    frame.AddrFrame.Offset = context.Ebp;
-    frame.AddrFrame.Mode = AddrModeFlat;
-    frame.AddrStack.Offset = context.Esp;
-    frame.AddrStack.Mode = AddrModeFlat;
+	imageType = IMAGE_FILE_MACHINE_I386;
+	frame.AddrPC.Offset = context.Eip;
+	frame.AddrPC.Mode = AddrModeFlat;
+	frame.AddrFrame.Offset = context.Ebp;
+	frame.AddrFrame.Mode = AddrModeFlat;
+	frame.AddrStack.Offset = context.Esp;
+	frame.AddrStack.Mode = AddrModeFlat;
 #elif _M_X64
-    imageType = IMAGE_FILE_MACHINE_AMD64;
-    frame.AddrPC.Offset = context.Rip;
-    frame.AddrPC.Mode = AddrModeFlat;
-    frame.AddrFrame.Offset = context.Rsp;
-    frame.AddrFrame.Mode = AddrModeFlat;
-    frame.AddrStack.Offset = context.Rsp;
-    frame.AddrStack.Mode = AddrModeFlat;
+	imageType = IMAGE_FILE_MACHINE_AMD64;
+	frame.AddrPC.Offset = context.Rip;
+	frame.AddrPC.Mode = AddrModeFlat;
+	frame.AddrFrame.Offset = context.Rsp;
+	frame.AddrFrame.Mode = AddrModeFlat;
+	frame.AddrStack.Offset = context.Rsp;
+	frame.AddrStack.Mode = AddrModeFlat;
 #elif _M_IA64
-    imageType = IMAGE_FILE_MACHINE_IA64;
-    frame.AddrPC.Offset = context.StIIP;
-    frame.AddrPC.Mode = AddrModeFlat;
-    frame.AddrFrame.Offset = context.IntSp;
-    frame.AddrFrame.Mode = AddrModeFlat;
-    frame.AddrBStore.Offset = context.RsBSP;
-    frame.AddrBStore.Mode = AddrModeFlat;
-    frame.AddrStack.Offset = context.IntSp;
-    frame.AddrStack.Mode = AddrModeFlat;
+	imageType = IMAGE_FILE_MACHINE_IA64;
+	frame.AddrPC.Offset = context.StIIP;
+	frame.AddrPC.Mode = AddrModeFlat;
+	frame.AddrFrame.Offset = context.IntSp;
+	frame.AddrFrame.Mode = AddrModeFlat;
+	frame.AddrBStore.Offset = context.RsBSP;
+	frame.AddrBStore.Mode = AddrModeFlat;
+	frame.AddrStack.Offset = context.IntSp;
+	frame.AddrStack.Mode = AddrModeFlat;
 #else
-    #error "Platform not supported!"
+	#error "Platform not supported!"
 #endif
 
-    while (true) {
-        traceentry_t& entry = entries.emplace_back();
-        if (entries.size() == B_STACKTRACE_MAX_DEPTH) {
-            entry.AddrPC_Offset = 0;
-            entry.AddrReturn_Offset = 0;
-            break;
-        }
+	while (true)
+	{
+		traceentry_t& entry = entries.emplace_back();
+		if (entries.size() == B_STACKTRACE_MAX_DEPTH)
+		{
+			entry.AddrPC_Offset = 0;
+			entry.AddrReturn_Offset = 0;
+			break;
+		}
 
-        if (!StackWalk64(imageType, process, thread, &frame, &context, NULL, SymFunctionTableAccess64, SymGetModuleBase64, NULL)) {
-            entry.AddrPC_Offset = frame.AddrPC.Offset;
-            entry.AddrReturn_Offset = B_STACKTRACE_ERROR_FLAG; /* mark error */
-            entry.AddrReturn_Offset |= GetLastError();
-            break;
-        }
+		if (!StackWalk64(imageType, process, thread, &frame, &context, NULL, SymFunctionTableAccess64, SymGetModuleBase64, NULL))
+		{
+			entry.AddrPC_Offset = frame.AddrPC.Offset;
+			entry.AddrReturn_Offset = B_STACKTRACE_ERROR_FLAG; /* mark error */
+			entry.AddrReturn_Offset |= GetLastError();
+			break;
+		}
 
-        entry.AddrPC_Offset = frame.AddrPC.Offset;
-        entry.AddrReturn_Offset = frame.AddrReturn.Offset;
+		entry.AddrPC_Offset = frame.AddrPC.Offset;
+		entry.AddrReturn_Offset = frame.AddrReturn.Offset;
 
-        if (frame.AddrReturn.Offset == 0) {
-            break;
-        }
-    }
+		if (frame.AddrReturn.Offset == 0)
+			break;
+	}
 
-    std::string ret;
-    IMAGEHLP_SYMBOL64* symbol = (IMAGEHLP_SYMBOL64*) M_Malloc(sizeof(IMAGEHLP_SYMBOL64) + 1024);
-    symbol->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
-    symbol->MaxNameLength = 1024;
+	std::string ret;
+	IMAGEHLP_SYMBOL64* symbol = (IMAGEHLP_SYMBOL64*) M_Malloc(sizeof(IMAGEHLP_SYMBOL64) + 1024);
+	symbol->SizeOfStruct = sizeof(IMAGEHLP_SYMBOL64);
+	symbol->MaxNameLength = 1024;
 
-    for (const auto& entry : nonstd::span(entries).subspan(1)) {
-        IMAGEHLP_LINE64 lineData;
-        DWORD lineOffset = 0;
-        DWORD64 symOffset = 0;
+	for (const auto& entry : nonstd::span(entries).subspan(1))
+	{
+		IMAGEHLP_LINE64 lineData;
+		DWORD lineOffset = 0;
+		DWORD64 symOffset = 0;
 
-        if (entry.AddrReturn_Offset & B_STACKTRACE_ERROR_FLAG) {
-            DWORD error = entry.AddrReturn_Offset & 0xFFFFFFFF;
-            ret += fmt::format("StackWalk64 error: {} @ {}\n", error, entry.AddrPC_Offset);
-            break;
-        }
+		if (entry.AddrReturn_Offset & B_STACKTRACE_ERROR_FLAG)
+		{
+			DWORD error = entry.AddrReturn_Offset & 0xFFFFFFFF;
+			ret += fmt::format("StackWalk64 error: {} @ {}\n", error, entry.AddrPC_Offset);
+			break;
+		}
 
-        if (entry.AddrPC_Offset == entry.AddrReturn_Offset) {
-            ret += fmt::format("Stack overflow @ {}\n", entry.AddrPC_Offset);
-            break;
-        }
+		if (entry.AddrPC_Offset == entry.AddrReturn_Offset)
+		{
+			ret += fmt::format("Stack overflow @ {}\n", entry.AddrPC_Offset);
+			break;
+		}
 
-        SymGetLineFromAddr64(process, entry.AddrPC_Offset, &lineOffset, &lineData);
-        ret += fmt::format("{}({}): ", M_ExtractFileName(lineData.FileName), lineData.LineNumber);
+		SymGetLineFromAddr64(process, entry.AddrPC_Offset, &lineOffset, &lineData);
+		ret += fmt::format("{}({}): ", M_ExtractFileName(lineData.FileName), lineData.LineNumber);
 
-        if (SymGetSymFromAddr64(process, entry.AddrPC_Offset, &symOffset, symbol)) {
-            ret += fmt::format("{}\n", symbol->Name);
-        }
-        else {
-            ret += fmt::format(" Unkown symbol @ {}\n", entry.AddrPC_Offset);
-        }
+		if (SymGetSymFromAddr64(process, entry.AddrPC_Offset, &symOffset, symbol))
+			ret += fmt::format("{}\n", symbol->Name);
+		else
+			ret += fmt::format(" Unkown symbol @ {}\n", entry.AddrPC_Offset);
 
-        if (entry.AddrReturn_Offset == 0) {
-            break;
-        }
-    }
+		if (entry.AddrReturn_Offset == 0)
+			break;
+	}
 
-    M_Free(symbol);
-    return ret;
+	M_Free(symbol);
+	return ret;
 }
 
 #elif defined(__APPLE__)
@@ -171,28 +176,28 @@ std::string M_GetStacktrace() {
 #include <dlfcn.h>
 
 typedef struct b_stacktrace {
-    void* trace[B_STACKTRACE_MAX_DEPTH];
-    int trace_size;
+	void* trace[B_STACKTRACE_MAX_DEPTH];
+	int trace_size;
 } b_stacktrace;
 
 b_stacktrace_handle b_stacktrace_get(void) {
-    b_stacktrace* ret = (b_stacktrace*)malloc(sizeof(b_stacktrace));
-    ret->trace_size = backtrace(ret->trace, B_STACKTRACE_MAX_DEPTH);
-    return (b_stacktrace_handle)(ret);
+	b_stacktrace* ret = (b_stacktrace*)malloc(sizeof(b_stacktrace));
+	ret->trace_size = backtrace(ret->trace, B_STACKTRACE_MAX_DEPTH);
+	return (b_stacktrace_handle)(ret);
 }
 
 char* b_stacktrace_to_string(b_stacktrace_handle h) {
-    const b_stacktrace* stacktrace = (b_stacktrace*)h;
-    char** messages = backtrace_symbols(stacktrace->trace, stacktrace->trace_size);
-    print_buf out = buf_init();
-    *out.buf = 0;
+	const b_stacktrace* stacktrace = (b_stacktrace*)h;
+	char** messages = backtrace_symbols(stacktrace->trace, stacktrace->trace_size);
+	print_buf out = buf_init();
+	*out.buf = 0;
 
-    for (int i = 0; i < stacktrace->trace_size; ++i) {
-        buf_printf(&out, "%s\n", messages[i]);
-    }
+	for (int i = 0; i < stacktrace->trace_size; ++i) {
+		buf_printf(&out, "%s\n", messages[i]);
+	}
 
-    free(messages);
-    return out.buf;
+	free(messages);
+	return out.buf;
 }
 
 #elif defined(__linux__)
@@ -203,73 +208,61 @@ char* b_stacktrace_to_string(b_stacktrace_handle h) {
 #include <dlfcn.h>
 #include <string.h>
 
-typedef struct b_stacktrace {
-    void* trace[B_STACKTRACE_MAX_DEPTH];
-    int trace_size;
-} b_stacktrace;
+std::string M_GetStacktrace()
+{
+	static void* trace[B_STACKTRACE_MAX_DEPTH];
+	int trace_size = backtrace(trace, B_STACKTRACE_MAX_DEPTH);
+	char** messages = backtrace_symbols(trace, trace_size);
+	std::string ret;
 
-b_stacktrace_handle b_stacktrace_get(void) {
-    b_stacktrace* ret = (b_stacktrace*)malloc(sizeof(b_stacktrace));
-    ret->trace_size = backtrace(ret->trace, B_STACKTRACE_MAX_DEPTH);
-    return (b_stacktrace_handle)(ret);
-}
+	for (int i = 0; i < trace_size; ++i)
+	{
+		void* tracei = trace[i];
+		char* msg = messages[i];
 
-char* b_stacktrace_to_string(b_stacktrace_handle h) {
-    const b_stacktrace* stacktrace = (b_stacktrace*)h;
-    char** messages = backtrace_symbols(stacktrace->trace, stacktrace->trace_size);
-    print_buf out = buf_init();
+		/* calculate load offset */
+		Dl_info info;
+		dladdr(tracei, &info);
+		if (info.dli_fbase == (void*)0x400000)
+			info.dli_fbase = NULL; // address from executable, so don't offset
 
-    for (int i = 0; i < stacktrace->trace_size; ++i) {
-        void* tracei = stacktrace->trace[i];
-        char* msg = messages[i];
+		while (*msg && *msg != '(') ++msg;
+		*msg = 0;
 
-        /* calculate load offset */
-        Dl_info info;
-        dladdr(tracei, &info);
-        if (info.dli_fbase == (void*)0x400000) {
-            /* address from executable, so don't offset */
-            info.dli_fbase = NULL;
-        }
+		{
+			char line[2048];
 
-        while (*msg && *msg != '(') ++msg;
-        *msg = 0;
+			FILE* fp;
+			std::string cmd = fmt::format("addr2line -e {} -f -C -p {} 2>/dev/null", messages[i], (void*)((char*)tracei - (char*)info.dli_fbase));
 
-        {
-            char cmd[1024];
-            char line[2048];
+			fp = popen(cmd.c_str(), "r");
+			if (!fp)
+			{
+				ret += "Failed to generate trace further...\n";
+				break;
+			}
 
-            FILE* fp;
-            snprintf(cmd, 1024, "addr2line -e %s -f -C -p %p 2>/dev/null", messages[i], (void*)((char*)tracei - (char*)info.dli_fbase));
+			while (fgets(line, sizeof(line), fp))
+			{
+				ret += fmt::format("{}: ", messages[i]);
+				if (strstr(line, "?? "))
+					ret += fmt::format("{}\n", tracei); // just output address if nothing can be found
+				else
+					ret += fmt::format("{}", line);
+			}
 
-            fp = popen(cmd, "r");
-            if (!fp) {
-                buf_printf(&out, "Failed to generate trace further...\n");
-                break;
-            }
+			pclose(fp);
+		}
+	}
 
-            while (fgets(line, sizeof(line), fp)) {
-                buf_printf(&out, "%s: ", messages[i]);
-                if (strstr(line, "?? ")) {
-                    /* just output address if nothing can be found */
-                    buf_printf(&out, "%p\n", tracei);
-                }
-                else {
-                    buf_printf(&out, "%s", line);
-                }
-            }
-
-            pclose(fp);
-        }
-    }
-
-    free(messages);
-    return out.buf;
+	M_Free(messages);
+	return ret;
 }
 
 #else
 
 std::string M_GetStacktrace() {
-    return "M_GetStacktrace: Unsupported platform.";
+	return "M_GetStacktrace: Unsupported platform.";
 }
 
 #endif

--- a/common/m_stacktrace.cpp
+++ b/common/m_stacktrace.cpp
@@ -18,7 +18,6 @@
 //
 // DESCRIPTION:
 //	Stacktrace for more useful error messages
-//  Adapted from https://github.com/iboB/b_stacktrace
 //
 //-----------------------------------------------------------------------------
 
@@ -32,12 +31,12 @@
 std::string M_GetStacktrace(std::string header)
 {
 	auto formatter = cpptrace::formatter{}
-    	.header(header)
+		.header(header)
 		.colors(cpptrace::formatter::color_mode::none)
-    	.addresses(cpptrace::formatter::address_mode::none)
+		.addresses(cpptrace::formatter::address_mode::none)
 		.paths(cpptrace::formatter::path_mode::basename)
 		.columns(false)
-    	.snippets(false)
+		.snippets(false)
 		.filter([](const auto& frame)
 			{ return frame.symbol.find("M_GetStacktrace") == std::string::npos; })
 		.filtered_frame_placeholders(false);

--- a/common/m_stacktrace.h
+++ b/common/m_stacktrace.h
@@ -1,0 +1,26 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 1993-1996 by id Software, Inc.
+// Copyright (C) 2006-2025 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	Stacktrace for more useful error messages
+//
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+std::string M_GetStacktrace();

--- a/common/m_stacktrace.h
+++ b/common/m_stacktrace.h
@@ -23,4 +23,4 @@
 
 #pragma once
 
-std::string M_GetStacktrace();
+std::string M_GetStacktrace(std::string header = "Stack trace:");

--- a/common/szp.h
+++ b/common/szp.h
@@ -38,7 +38,7 @@
 
 #pragma once
 
-
+#include "m_stacktrace.h"
 
 template <typename T>
 class szp
@@ -78,7 +78,7 @@ public:
 	inline T* operator ->()
 	{
 		if(!naive || !*naive)
-			throw CRecoverableError("szp pointer was NULL");
+			throw CRecoverableError(M_GetStacktrace("szp pointer was NULL:"));
 
 		return *naive;
 	}
@@ -86,7 +86,7 @@ public:
 	const inline T* operator ->() const
 	{
 		if(!naive || !*naive)
-			throw CRecoverableError("szp pointer was NULL");
+			throw CRecoverableError(M_GetStacktrace("szp pointer was NULL:"));
 
 		return *naive;
 	}
@@ -113,7 +113,7 @@ public:
 	void update_all(T *target)
 	{
 		if(!naive)
-			throw CRecoverableError("szp pointer was NULL on update_all");
+			throw CRecoverableError(M_GetStacktrace("szp pointer was NULL on update_all:"));
 
 		// all copies already have naive, so their pointers will update too
 		*naive = target;

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -134,6 +134,14 @@ if(BUILD_CLIENT OR BUILD_SERVER)
   target_include_directories(minilzo PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/minilzo")
 endif()
 
+include(FetchContent)
+FetchContent_Declare(
+  cpptrace
+  GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+  GIT_TAG        v0.8.2 # <HASH or TAG>
+)
+FetchContent_MakeAvailable(cpptrace)
+
 include(zlib-lib.cmake)
 
 include(libpng-lib.cmake)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -138,7 +138,7 @@ include(FetchContent)
 FetchContent_Declare(
   cpptrace
   GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-  GIT_TAG        v0.8.2 # <HASH or TAG>
+  GIT_TAG        88d75647903b8fe9383601d1cf87a98016e9041b
 )
 FetchContent_MakeAvailable(cpptrace)
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -46,7 +46,7 @@ if(WIN32)
   target_include_directories(odasrv PRIVATE win32)
 endif()
 
-target_link_libraries(odasrv fmt::fmt tinylibs ZLIB::ZLIB odamex-common odaproto minilzo)
+target_link_libraries(odasrv fmt::fmt tinylibs ZLIB::ZLIB odamex-common odaproto minilzo cpptrace::cpptrace)
 
 if(USE_INTERNAL_JSONCPP)
   target_link_libraries(odasrv jsoncpp_static)


### PR DESCRIPTION
This PR introduces `M_GetStacktrace`, which returns the current call stack as a string. Currently, it is used by the `szp` errors, as tracking down the location where these get thrown has been difficult in the past.

![image](https://github.com/user-attachments/assets/7ee45e11-ba07-4462-986f-e75746d9eb20)
