### PR TITLE
[BUGFIX] Actor translucency not modified when clearing or setting MF_TRANSLUCENT

### DIFF
--- a/common/actor.h
+++ b/common/actor.h
@@ -204,6 +204,8 @@ enum mobjflag_t
 	MF_BOUNCES = BIT(29), // MBF - PARTIAL IMPLEMENTATION
 	MF_FRIEND  = BIT(30), // MBF - UNUSED FOR NOW
 
+	MF_TRANSLUCENT = BIT(31),
+
 	// --- mobj.flags2 ---
 	// Heretic flags
 	MF2_LOGRAV			= BIT(0),   // alternate gravity setting

--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -1333,8 +1333,7 @@ static int PatchThing(int thingy)
 			{
 				if (value[0] & MF_TRANSLUCENT)
 				{
-					info->translucency =
-					    TRANSLUC50; // Correct value should be 0.66 (BOOM)...
+					info->translucency = TRANSLUC66;
 				}
 
 				// Unsupported flags have to be announced for developers...

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2436,13 +2436,14 @@ void A_JumpIfFlagsSet(AActor* actor)
 //
 void A_AddFlags(AActor* actor)
 {
-	int flags, flags2;
-
 	if (!actor)
 		return;
 
-	flags = actor->state->args[0];
-	flags2 = actor->state->args[1];
+	const int flags = actor->state->args[0];
+	const int flags2 = actor->state->args[1];
+
+	if (flags & MF_TRANSLUCENT)
+		actor->translucency = TRANSLUC66;
 
 	actor->flags |= flags;
 	actor->flags2 |= flags2;
@@ -2456,13 +2457,14 @@ void A_AddFlags(AActor* actor)
 //
 void A_RemoveFlags(AActor* actor)
 {
-	int flags, flags2;
-
 	if (!actor)
 		return;
 
-	flags = actor->state->args[0];
-	flags2 = actor->state->args[1];
+	const int flags = actor->state->args[0];
+	const int flags2 = actor->state->args[1];
+
+	if (flags & MF_TRANSLUCENT)
+		actor->translucency = FRACUNIT;
 
 	actor->flags &= ~flags;
 	actor->flags2 &= ~flags2;


### PR DESCRIPTION
Addresses #1215
Internally, translucency is not just a binary on/off. When parsing dehacked, a things translucency is set to 50% (now 66% to better match Boom), but when adding or removing the flag, the translucency value is never modified.