### PR TITLE
[FEATURE] Linear horizontal sky scaling

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -737,6 +737,9 @@ CVAR(			r_particles, "1", "Draw particles",
 CVAR_RANGE_FUNC_DECL(r_stretchsky, "2", "Stretch sky textures. (0 - always off, 1 - always on, 2 - auto)",
 				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
 
+CVAR(			r_linearsky, "0", "Render skies without horizonal stretching",
+				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 CVAR(			r_skypalette, "0", "Invulnerability sphere changes the palette of the sky",
 				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -839,6 +839,7 @@ EXTERN_CVAR (am_classicmapstring)
 EXTERN_CVAR (am_usecustomcolors)
 EXTERN_CVAR (st_scale)
 EXTERN_CVAR (r_stretchsky)
+EXTERN_CVAR (r_linearsky)
 EXTERN_CVAR (r_skypalette)
 EXTERN_CVAR (r_wipetype)
 EXTERN_CVAR (r_drawplayersprites)
@@ -921,7 +922,8 @@ static menuitem_t VideoItems[] = {
 	{ slider,   "UI Background Visibility", {&ui_dimamount},        {0.0}, {1.0},   {0.1},  {NULL} },
 	{ redtext,	" ",					    {NULL},					{0.0}, {0.0},	{0.0},  {NULL} },
 	{ discrete, "See killer on Death",			{&cl_deathcam},   {2.0}, {0.0}, {0.0}, {OnOff}},
-	{ discrete, "Stretch short skies",	    {&r_stretchsky},	   	{3.0}, {0.0},	{0.0},  {OnOffAuto} },
+	{ discrete, "Stretch short skies",	    {&r_stretchsky},	   	{2.0}, {0.0},	{0.0},  {OnOff} },
+	{ discrete, "Linear Skies",			    {&r_linearsky},	   		{3.0}, {0.0},	{0.0},  {OnOffAuto} },
 	{ discrete, "Invuln changes skies",		{&r_skypalette},		{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Use softer invuln effect", {&r_softinvulneffect},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Screen wipe style",	    {&r_wipetype},			{4.0}, {0.0},	{0.0},  {Wipes} },

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -45,6 +45,7 @@ extern fixed_t freelookviewheight;
 EXTERN_CVAR(sv_freelook)
 EXTERN_CVAR(cl_mouselook)
 EXTERN_CVAR(r_skypalette)
+EXTERN_CVAR(r_linearsky)
 
 
 //
@@ -62,6 +63,7 @@ int			sky1shift,        sky2shift;
 // to the lowest viewangle that maps back to x ranges
 // from clipangle to -clipangle.
 static angle_t xtoviewangle[MAXWIDTH + 1];
+static angle_t linearskyangle[MAXWIDTH + 1];
 
 CVAR_FUNC_IMPL(r_stretchsky)
 {
@@ -235,17 +237,27 @@ static void R_InitXToViewAngle()
 			const fixed_t dfocus = FocalLengthX >> DBITS;
 
 			for (int i = centerx, slope = 0; i <= t; i++, slope += slopestep)
-				xtoviewangle[i] = (angle_t)-(signed)tantoangle[slope >> DBITS];
+			{
+				xtoviewangle[i]   = (angle_t)-(signed)tantoangle[slope >> DBITS];
+				linearskyangle[i] = (0.5 - i / (double)viewwidth) * FIXED2DOUBLE(hitan) * ANG90;
+			}
 
 			for (int i = t + 1; i <= viewwidth; i++)
-				xtoviewangle[i] = ANG270+tantoangle[dfocus / (i - centerx)];
+			{
+				xtoviewangle[i]   = ANG270+tantoangle[dfocus / (i - centerx)];
+				linearskyangle[i] = (0.5 - i / (double)viewwidth) * FIXED2DOUBLE(hitan) * ANG90;
+			}
 
 			for (int i = 0; i < centerx; i++)
-				xtoviewangle[i] = (angle_t)(-(signed)xtoviewangle[viewwidth-i-1]);
+			{
+				xtoviewangle[i]   = (angle_t)(-(signed)xtoviewangle[viewwidth-i-1]);
+				linearskyangle[i] = (angle_t)(-(signed)linearskyangle[viewwidth-i-1]);
+			}
 		}
 		else
 		{
 			memset(xtoviewangle, 0, sizeof(angle_t) * viewwidth + 1);
+			memset(linearskyangle, 0, sizeof(angle_t) * viewwidth + 1);
 		}
 
 		last_viewwidth = viewwidth;
@@ -724,6 +736,7 @@ void R_RenderSkyRange(visplane_t* pl)
 	fixed_t frontrow_offset = 0;
 	fixed_t backrow_offset = 0;
 	angle_t skyflip = 0;
+	const angle_t* xtoskyangle = r_linearsky.asBool() ? linearskyangle : xtoviewangle;
 
 	auto skyflat = skyflatlookup.find(pl->picnum);
 
@@ -838,7 +851,7 @@ void R_RenderSkyRange(visplane_t* pl)
 
 		for (int x = pl->minx; x <= pl->maxx; x++)
 		{
-			int sky2colnum = ((((viewangle + xtoviewangle[x]) ^ skyflip) >> sky2shift) + back_offset) >> FRACBITS;
+			int sky2colnum = ((((viewangle + xtoskyangle[x]) ^ skyflip) >> sky2shift) + back_offset) >> FRACBITS;
 			sky2colnum = FIXED2INT(FixedMul(INT2FIXED(sky2colnum), sky2scalex));
 			tallpost_t* skypost = R_GetTextureColumn(backskytex, sky2colnum);
 			skyposts[x] = skypost;
@@ -857,7 +870,7 @@ void R_RenderSkyRange(visplane_t* pl)
 	{
 		for (int x = pl->minx; x <= pl->maxx; x++)
 		{
-			int sky1colnum = ((((viewangle + xtoviewangle[x]) ^ skyflip) >> sky1shift) + front_offset) >> FRACBITS;
+			int sky1colnum = ((((viewangle + xtoskyangle[x]) ^ skyflip) >> sky1shift) + front_offset) >> FRACBITS;
 			sky1colnum = FIXED2INT(FixedMul(INT2FIXED(sky1colnum), sky1scalex));
 			tallpost_t* skypost = R_GetTextureColumn(frontskytex, sky1colnum);
 			skyposts[x] = skypost;
@@ -870,7 +883,7 @@ void R_RenderSkyRange(visplane_t* pl)
 	{
 		for (int x = pl->minx; x <= pl->maxx; x++)
 		{
-			int sky1colnum = ((((viewangle + xtoviewangle[x]) ^ skyflip) >> sky1shift) + front_offset) >> FRACBITS;
+			int sky1colnum = ((((viewangle + xtoskyangle[x]) ^ skyflip) >> sky1shift) + front_offset) >> FRACBITS;
 			sky1colnum = FIXED2INT(FixedMul(INT2FIXED(sky1colnum), sky1scalex));
 			tallpost_t* skypost = R_GetTextureColumn(frontskytex, sky1colnum);
 

--- a/server/src/r_main.cpp
+++ b/server/src/r_main.cpp
@@ -55,17 +55,6 @@ int 			viewangleoffset;
 // precalculated math tables
 //
 
-// The viewangletox[viewangle + FINEANGLES/4] lookup
-// maps the visible view angles to screen X coordinates,
-// flattening the arc to a flat projection plane.
-// There will be many angles mapped to the same X.
-int 			viewangletox[FINEANGLES/2];
-
-// The xtoviewangleangle[] table maps a screen pixel
-// to the lowest viewangle that maps back to x ranges
-// from clipangle to -clipangle.
-angle_t 		*xtoviewangle;
-
 const fixed_t	*finecosine = &finesine[FINEANGLES/4];
 
 int				scalelight[LIGHTLEVELS][MAXLIGHTSCALE];


### PR DESCRIPTION
Addresses #1174

This PR introduces the cvar `r_linearsky`. When enabled, the sky's horizontal scaling does not change with distance from the center.

`r_linearsky 0`
![image](https://github.com/user-attachments/assets/d20098af-51be-4e93-8671-bf94b5e84a89)
`r_linearsky 1`
![image](https://github.com/user-attachments/assets/79d44467-862f-423f-8d51-73d4523a3d49)
