### PR TITLE
Fix a couple invalid format strings

### DIFF
--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -566,7 +566,7 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 #ifdef RANGECHECK
 	if (static_cast<unsigned>(thing->sprite) >= static_cast<unsigned>(numsprites))
 	{
-		DPrintFmt("R_ProjectSprite: invalid sprite number %i\n", thing->sprite);
+		DPrintFmt("R_ProjectSprite: invalid sprite number {}\n", thing->sprite);
 		return;
 	}
 #endif
@@ -576,7 +576,7 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 #ifdef RANGECHECK
 	if ( (thing->frame & FF_FRAMEMASK) >= sprdef->numframes )
 	{
-		DPrintFmt("R_ProjectSprite: invalid sprite frame %i : %i\n ", thing->sprite, thing->frame);
+		DPrintFmt("R_ProjectSprite: invalid sprite frame {} : {}\n ", thing->sprite, thing->frame);
 		return;
 	}
 #endif
@@ -715,14 +715,14 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 	// decide which patch to use
 #ifdef RANGECHECK
 	if ( (unsigned)psp->state->sprite >= (unsigned)numsprites) {
-		DPrintFmt("R_DrawPSprite: invalid sprite number %i\n", psp->state->sprite);
+		DPrintFmt("R_DrawPSprite: invalid sprite number {}\n", psp->state->sprite);
 		return;
 	}
 #endif
 	sprdef = &sprites[psp->state->sprite];
 #ifdef RANGECHECK
 	if ( (psp->state->frame & FF_FRAMEMASK) >= sprdef->numframes) {
-		DPrintFmt("R_DrawPSprite: invalid sprite frame %i : %i\n", psp->state->sprite, psp->state->frame);
+		DPrintFmt("R_DrawPSprite: invalid sprite frame {} : {}\n", psp->state->sprite, psp->state->frame);
 		return;
 	}
 #endif


### PR DESCRIPTION
Missed a couple when changing things from the old to new format syntax. This fixes them.