### PR TITLE
[BUGFIX] Crash when switching from libADLMidi to another music system

### DIFF
--- a/client/sdl/i_musicsystem_adlmidi.cpp
+++ b/client/sdl/i_musicsystem_adlmidi.cpp
@@ -92,6 +92,7 @@ AdlMidiMusicSystem::~AdlMidiMusicSystem()
 	_StopSong();
 
 	adl_close(m_midiPlayer);
+	m_isInitialized = false;
 }
 
 


### PR DESCRIPTION
`m_isInitialized` was not being set to false, leading to the `Mix_HookMusic` callback being called after the call to `adl_close`, trying to continue playing music with an invalid player.