### PR TITLE
Add Sigil 2 to all official wads config

### DIFF
--- a/config-samples/coop-all-official-wads.cfg
+++ b/config-samples/coop-all-official-wads.cfg
@@ -30,6 +30,7 @@ addmap e2m1 doom.wad lastmap=e2m8
 addmap e3m1 doom.wad lastmap=e3m8
 addmap e4m1 doom.wad lastmap=e4m8
 addmap e5m1 doom.wad sigil.wad lastmap=e5m8
+addmap e6m1 doom.wad sigil2.wad lastmap=e6m8
 addmap map01 doom2.wad lastmap=map11
 addmap map12 doom2.wad lastmap=map20
 addmap map21 doom2.wad lastmap=map30


### PR DESCRIPTION
It was just added in Update 3 of Doom + Doom II as one of the included wads.