### PR TITLE
Fix a couple mistakes in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,10 +290,10 @@ jobs:
         asset_path: odamex.flatpak
         asset_name: odamex-linux-arm64-${{ env.new_version }}.flatpak
         asset_content_type: application/octet-stream
-  package-and-upload:
+  package-and-upload-windows:
     name: Package and Upload Artifacts
     runs-on: windows-latest
-    needs: [pre_job, build-windows, build-windows-x32, build-flatpak, build-flatpak-arm]
+    needs: [pre_job, build-windows, build-windows-x32]
     env:
       new_version: ${{ needs.pre_job.outputs.new_version }}
       upload_url: ${{ needs.pre_job.outputs.upload_url }}

--- a/ci/stage-inno-setup-and-run.ps1
+++ b/ci/stage-inno-setup-and-run.ps1
@@ -74,7 +74,7 @@ function BuildOutCommon {
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${UnzippedX64}\licenses\LICENSE.opusfile.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${UnzippedX64}\licenses\COPYING.SDL2.txt" `
+    Copy-Item -Force -Path "${UnzippedX64}\licenses\LICENSE.SDL2.txt" `
         -Destination "${CommonDir}\licenses"
 }
 

--- a/ci/win-release-x64.ps1
+++ b/ci/win-release-x64.ps1
@@ -105,8 +105,8 @@ function CopyFilesX64 {
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.opusfile.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.4\COPYING.txt" `
-        -Destination "${CommonDir}\licenses\COPYING.SDL2.txt"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.4\LICENSE.txt" `
+        -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
 
     ########################################
     ## 64-BIT FILES

--- a/ci/win-release-x86.ps1
+++ b/ci/win-release-x86.ps1
@@ -105,8 +105,8 @@ function CopyFilesX86 {
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.6.2\lib\x86\optional\LICENSE.opusfile.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2-2.32.4\COPYING.txt" `
-        -Destination "${CommonDir}\licenses\COPYING.SDL2.txt"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2-2.32.4\LICENSE.txt" `
+        -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
 
     ########################################
     ## 32-BIT FILES

--- a/installer/windows/build_release.ps1
+++ b/installer/windows/build_release.ps1
@@ -111,8 +111,8 @@ function CopyFiles {
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.opusfile.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.4\COPYING.txt" `
-        -Destination "${CommonDir}\licenses\COPYING.SDL2.txt"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.4\LICENSE.txt" `
+        -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
 
     ########################################
     ## 64-BIT FILES


### PR DESCRIPTION
A couple files were renamed that I missed, and the dependencies of a job in the release workflow were wrong. This fixes those issues.