### PR TITLE
[BUGFIX] Incorrect ID24 interlevel map numbers

### DIFF
--- a/client/src/wi_interlevel.cpp
+++ b/client/src/wi_interlevel.cpp
@@ -63,8 +63,7 @@ jsonlumpresult_t WI_ParseInterlevelCondition(const Json::Value& condition, inter
 	}
 
 	output.condition = static_cast<animcondition_t>(animcondition.asInt());
-	output.param1 = param.asInt();
-	output.param2 = 0;
+	output.param = param.asInt();
 
 	if (output.condition < animcondition_t::None || output.condition >= animcondition_t::ID24Max)
 	{
@@ -221,28 +220,6 @@ struct intermissionscript_t
 	std::vector<std::tuple<OLumpName, int, int>> spots;
 };
 
-int ValidateMapName(const OLumpName& mapname)
-{
-	// Check if the given map name can be expressed as a gameepisode/gamemap pair and be
-	// reconstructed from it.
-	OLumpName lumpname;
-	int epi = -1, map = -1;
-
-	if (gamemode != commercial)
-	{
-		if (sscanf(mapname.c_str(), "E%dM%d", &epi, &map) != 2)
-			return 0;
-		lumpname = fmt::format("E{}M{}", epi, map);
-	}
-	else
-	{
-		if (sscanf(mapname.c_str(), "MAP%d", &map) != 1)
-			return 0;
-		lumpname = fmt::format("MAP{:02d}", map);
-	}
-	return mapname == lumpname;
-}
-
 // some of the zdoom intermission conditions are the same as the logical OR of 2 id24 conditions
 // id24 offers no way to do this directly (only AND), but we can just make one animation with each condition
 // this is the purpose of the twoanims argument
@@ -326,8 +303,8 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 	std::vector<interlevelanim_t>& anims = output->layers[0].anims;
 	std::vector<interlevelanim_t>& splats = output->layers[1].anims;
 	std::vector<interlevelanim_t>& pointers = output->layers[2].anims;
-	output->layers[1].conditions.emplace_back(animcondition_t::OnEnteringScreen, 0, 0);
-	output->layers[2].conditions.emplace_back(animcondition_t::OnEnteringScreen, 0, 0);
+	output->layers[1].conditions.emplace_back(animcondition_t::OnEnteringScreen, 0);
+	output->layers[2].conditions.emplace_back(animcondition_t::OnEnteringScreen, 0);
 	LevelInfos& levels = getLevelInfos();
 	intermissionscript_t intermissionscript{};
 	const char* buffer = static_cast<char*>(W_CacheLumpNum(lumpnum, PU_STATIC));
@@ -392,8 +369,9 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			while (!os.compareToken("}"))
 			{
 				OLumpName mapname = os.getToken();
-				if (!ValidateMapName(mapname))
-					os.error("Invalid map name {}", mapname);
+				if (!levels.findByName(mapname).exists())
+					os.error("Map {} does not exist");
+
 				os.mustScanInt();
 				int x = os.getTokenInt();
 				os.mustScanInt();
@@ -414,12 +392,14 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 		{
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
-			int mapnum = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
-				WI_ParseZDoomAnim(os, anims, {animcondition_t::OnEnteringScreen, 0, 0}, {animcondition_t::CurrMapEqual, mapnum, 0});
+				WI_ParseZDoomAnim(os, anims, {animcondition_t::OnEnteringScreen, 0, 0}, {animcondition_t::CurrMapEqual, mapname});
 			else if (os.compareTokenNoCase("pic"))
-				WI_ParseZDoomPic(os, anims, {animcondition_t::OnEnteringScreen, 0, 0}, {animcondition_t::CurrMapEqual, mapnum, 0});
+				WI_ParseZDoomPic(os, anims, {animcondition_t::OnEnteringScreen, 0, 0}, {animcondition_t::CurrMapEqual, mapname});
 			else
 				os.error("Unknown command {}", os.getToken());
 		}
@@ -427,12 +407,14 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 		{
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
-			int mapnum = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
-				WI_ParseZDoomAnim(os, anims, {animcondition_t::OnFinishedScreen, 0, 0}, {animcondition_t::CurrMapNotEqual, mapnum, 0}, true);
+				WI_ParseZDoomAnim(os, anims, {animcondition_t::OnFinishedScreen, 0, 0}, {animcondition_t::CurrMapNotEqual, mapname}, true);
 			else if (os.compareTokenNoCase("pic"))
-				WI_ParseZDoomPic(os, anims, {animcondition_t::OnFinishedScreen, 0, 0}, {animcondition_t::CurrMapNotEqual, mapnum, 0}, true);
+				WI_ParseZDoomPic(os, anims, {animcondition_t::OnFinishedScreen, 0, 0}, {animcondition_t::CurrMapNotEqual, mapname}, true);
 			else
 				os.error("Unknown command {}", os.getToken());
 		}
@@ -443,9 +425,9 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			int mapnum = levels.findByName(mapname).levelnum;
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
-				WI_ParseZDoomAnim(os, anims, {animcondition_t::OnFinishedScreen, 0, 0}, {animcondition_t::CurrMapEqual, mapnum, 0});
+				WI_ParseZDoomAnim(os, anims, {animcondition_t::OnFinishedScreen, 0, 0}, {animcondition_t::CurrMapEqual, mapname});
 			else if (os.compareTokenNoCase("pic"))
-				WI_ParseZDoomPic(os, anims, {animcondition_t::OnFinishedScreen, 0, 0}, {animcondition_t::CurrMapEqual, mapnum, 0});
+				WI_ParseZDoomPic(os, anims, {animcondition_t::OnFinishedScreen, 0, 0}, {animcondition_t::CurrMapEqual, mapname});
 			else
 				os.error("Unknown command {}", os.getToken());
 		}
@@ -453,12 +435,14 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 		{
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
-			int mapnum = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
-				WI_ParseZDoomAnim(os, anims, {animcondition_t::OnEnteringScreen, 0, 0}, {animcondition_t::CurrMapNotEqual, mapnum, 0}, true);
+				WI_ParseZDoomAnim(os, anims, {animcondition_t::OnEnteringScreen, 0, 0}, {animcondition_t::CurrMapNotEqual, mapname}, true);
 			else if (os.compareTokenNoCase("pic"))
-				WI_ParseZDoomPic(os, anims, {animcondition_t::OnEnteringScreen, 0, 0}, {animcondition_t::CurrMapNotEqual, mapnum, 0}, true);
+				WI_ParseZDoomPic(os, anims, {animcondition_t::OnEnteringScreen, 0, 0}, {animcondition_t::CurrMapNotEqual, mapname}, true);
 			else
 				os.error("Unknown command {}", os.getToken());
 		}
@@ -466,12 +450,14 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 		{
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
-			int mapnum = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
-				WI_ParseZDoomAnim(os, anims, {animcondition_t::MapVisited, mapnum, 0});
+				WI_ParseZDoomAnim(os, anims, {animcondition_t::MapVisited, mapname});
 			else if (os.compareTokenNoCase("pic"))
-				WI_ParseZDoomPic(os, anims, {animcondition_t::MapVisited, mapnum, 0});
+				WI_ParseZDoomPic(os, anims, {animcondition_t::MapVisited, mapname});
 			else
 				os.error("Unknown command {}", os.getToken());
 		}
@@ -479,12 +465,14 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 		{
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
-			int mapnum = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
-				WI_ParseZDoomAnim(os, anims, {animcondition_t::MapNotVisited, mapnum, 0});
+				WI_ParseZDoomAnim(os, anims, {animcondition_t::MapNotVisited, mapname});
 			else if (os.compareTokenNoCase("pic"))
-				WI_ParseZDoomPic(os, anims, {animcondition_t::MapNotVisited, mapnum, 0});
+				WI_ParseZDoomPic(os, anims, {animcondition_t::MapNotVisited, mapname});
 			else
 				os.error("Unknown command {}", os.getToken());
 		}
@@ -492,15 +480,19 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 		{
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
-			int mapnum = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan(8);
 			OLumpName mapname2 = os.getToken();
-			int mapnum2 = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname2).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
-				WI_ParseZDoomAnim(os, anims, {animcondition_t::TravelingBetween, mapnum, mapnum2});
+				WI_ParseZDoomAnim(os, anims, {animcondition_t::TravelingBetween, mapname, mapname2});
 			else if (os.compareTokenNoCase("pic"))
-				WI_ParseZDoomPic(os, anims, {animcondition_t::TravelingBetween, mapnum, mapnum2});
+				WI_ParseZDoomPic(os, anims, {animcondition_t::TravelingBetween, mapname, mapname2});
 			else
 				os.error("Unknown command {}", os.getToken());
 		}
@@ -508,15 +500,19 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 		{
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
-			int mapnum = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan(8);
 			OLumpName mapname2 = os.getToken();
-			int mapnum2 = levels.findByName(mapname).levelnum;
+			if (!levels.findByName(mapname2).exists())
+				os.error("Map {} does not exist");
+
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
-				WI_ParseZDoomAnim(os, anims, {animcondition_t::NotTravelingBetween, mapnum, mapnum2});
+				WI_ParseZDoomAnim(os, anims, {animcondition_t::NotTravelingBetween, mapname, mapname2});
 			else if (os.compareTokenNoCase("pic"))
-				WI_ParseZDoomPic(os, anims, {animcondition_t::NotTravelingBetween, mapnum, mapnum2});
+				WI_ParseZDoomPic(os, anims, {animcondition_t::NotTravelingBetween, mapname, mapname2});
 			else
 				os.error("Unknown command {}", os.getToken());
 		}
@@ -529,10 +525,9 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 	int tnt1 = W_GetNumForName("TNT1A0", ns_sprites);
 	for (const auto& [map, x, y] : intermissionscript.spots)
 	{
-		int mapnum = levels.findByName(map).levelnum;
 		splats.emplace_back(
 			std::vector<interlevelframe_t>{{intermissionscript.splat, intermissionscript.splatnum, "", -1, interlevelframe_t::DurationInf, 0, 0}},
-			std::vector<interlevelcond_t>{{animcondition_t::MapVisited, mapnum, 0}},
+			std::vector<interlevelcond_t>{{animcondition_t::MapVisited, map}},
 			x, y
 		);
 		pointers.emplace_back(
@@ -540,7 +535,7 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 				{intermissionscript.ptr1, intermissionscript.ptr1num, intermissionscript.ptr2, intermissionscript.ptr2num, interlevelframe_t::DurationFixed, 20, 0},
 				{"TNT1A0", tnt1, "", -1, interlevelframe_t::DurationFixed, 12, 0}
 			},
-			std::vector<interlevelcond_t>{{animcondition_t::CurrMapEqual, mapnum, 0}},
+			std::vector<interlevelcond_t>{{animcondition_t::CurrMapEqual, map}},
 			x, y
 		);
 	}

--- a/client/src/wi_interlevel.h
+++ b/client/src/wi_interlevel.h
@@ -27,78 +27,86 @@
 
 enum class animcondition_t
 {
-    None,
-    CurrMapGreater,   // Current map number is greater than the param value
-    CurrMapEqual,     // Current map number is equal to the param value
-    MapVisited,       // The map number corresponding to the param value has been visited
-    CurrMapNotSecret, // The current map is not a secret map
-    AnySecretVisited, // Any secret map has been visited
-    OnFinishedScreen, // The current screen is the "finished" screen
-    OnEnteringScreen, // The current screen is the “entering” screen
+	None,
+	CurrMapGreater,   // Current map number is greater than the param value
+	CurrMapEqual,     // Current map number is equal to the param value
+	MapVisited,       // The map number corresponding to the param value has been visited
+	CurrMapNotSecret, // The current map is not a secret map
+	AnySecretVisited, // Any secret map has been visited
+	OnFinishedScreen, // The current screen is the "finished" screen
+	OnEnteringScreen, // The current screen is the “entering” screen
 
-    ID24Max,
+	ID24Max,
 
-    // vv extra conditions for zdoom intermission scripts
-    CurrMapNotEqual,
-    MapNotVisited,
-    TravelingBetween,
-    NotTravelingBetween,
+	// vv extra conditions for zdoom intermission scripts
+	CurrMapNotEqual,
+	MapNotVisited,
+	TravelingBetween,
+	NotTravelingBetween,
 };
 
 struct interlevelcond_t
 {
-    animcondition_t condition;
-    int param1;
-    int param2;
+	animcondition_t condition;
+	bool isZDoom;
+	int param;
+	OLumpName mapname1;
+	OLumpName mapname2;
 
-    interlevelcond_t(animcondition_t c = animcondition_t::None, int p1 = 0, int p2 = 0) : condition(c), param1(p1), param2(p2) {}
+	interlevelcond_t() = default;
+
+	interlevelcond_t(animcondition_t c, int p) :
+		condition(c), isZDoom(false), param(p), mapname1(), mapname2() {}
+
+	interlevelcond_t(animcondition_t c, OLumpName m1, OLumpName m2 = "") :
+		condition(c), isZDoom(true), param(0), mapname1(m1), mapname2(m2) {}
 };
 
 struct interlevelframe_t
 {
-    enum frametype_t
-    {
-        None          = 0x0000,
-        DurationInf   = 0x0001,
-        DurationFixed = 0x0002,
-        DurationRand  = 0x0004,
-        RandomStart   = 0x1000,
-        Valid         = 0x100F
-    };
+	enum frametype_t
+	{
+		None          = 0x0000,
+		DurationInf   = 0x0001,
+		DurationFixed = 0x0002,
+		DurationRand  = 0x0004,
+		RandomStart   = 0x1000,
+		Valid         = 0x100F
+	};
 
-    OLumpName imagelump;
-    int imagelumpnum;
-    OLumpName altimagelump;
-    int altimagelumpnum;
-    frametype_t type;
-    int duration;
-    int maxduration;
+	OLumpName imagelump;
+	int imagelumpnum;
+	OLumpName altimagelump;
+	int altimagelumpnum;
+	frametype_t type;
+	int duration;
+	int maxduration;
 
-    interlevelframe_t(OLumpName il = "", int iln = 0, OLumpName ail = "", int ailn = 0, frametype_t t = None, int d = 0, int md = 0) :
-        imagelump(il), imagelumpnum(iln), altimagelump(ail), altimagelumpnum(0), type(t), duration(d), maxduration(md) {}
+	interlevelframe_t(OLumpName il = "", int iln = 0, OLumpName ail = "", int ailn = 0, frametype_t t = None, int d = 0, int md = 0) :
+		imagelump(il), imagelumpnum(iln), altimagelump(ail), altimagelumpnum(0), type(t), duration(d), maxduration(md) {}
 };
 
 struct interlevelanim_t
 {
-    std::vector<interlevelframe_t> frames;
-    std::vector<interlevelcond_t> conditions;
-    int xpos;
-    int ypos;
+	std::vector<interlevelframe_t> frames;
+	std::vector<interlevelcond_t> conditions;
+	int xpos;
+	int ypos;
 
-    interlevelanim_t(std::vector<interlevelframe_t> f = {}, std::vector<interlevelcond_t> c = {}, int x = 0, int y = 0) : frames(f), conditions(c), xpos(x), ypos(y) {}
+	interlevelanim_t(std::vector<interlevelframe_t> f = {}, std::vector<interlevelcond_t> c = {}, int x = 0, int y = 0) : frames(f), conditions(c), xpos(x), ypos(y) {}
 };
 
 struct interlevellayer_t
 {
-    std::vector<interlevelanim_t> anims;
-    std::vector<interlevelcond_t> conditions;
+	std::vector<interlevelanim_t> anims;
+	std::vector<interlevelcond_t> conditions;
 };
 
 struct interlevel_t
 {
-    OLumpName musiclump;
-    OLumpName backgroundlump;
-    std::vector<interlevellayer_t> layers;
+	OLumpName musiclump;
+	OLumpName backgroundlump;
+	std::vector<interlevellayer_t> layers;
 };
 
 interlevel_t* WI_GetInterlevel(const OLumpName& lumpname);

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -249,14 +249,38 @@ static bool WI_checkConditions(const std::vector<interlevelcond_t>& conditions,
 				if (cond.isZDoom)
 					conditionsmet = conditionsmet && levels.findByName(cond.mapname1).flags & LEVEL_VISITED;
 				else
-					conditionsmet = conditionsmet && levels.findByNum(cond.param).flags & LEVEL_VISITED;
+				{
+					bool res = false;
+					for (size_t i = 0; i < levels.size(); i++)
+					{
+						const level_pwad_info_t& level = levels.at(i);
+						if ((level.mapnum == cond.param) && (level.flags & LEVEL_VISITED))
+						{
+							res = true;
+							break;
+						}
+					}
+					conditionsmet = conditionsmet && res;
+				}
 				break;
 
 			case animcondition_t::MapNotVisited:
 				if (cond.isZDoom)
 					conditionsmet = conditionsmet && !(levels.findByName(cond.mapname1).flags & LEVEL_VISITED);
 				else
-					conditionsmet = conditionsmet && !(levels.findByNum(cond.param).flags & LEVEL_VISITED);
+				{
+					bool res = true;
+					for (size_t i = 0; i < levels.size(); i++)
+					{
+						const level_pwad_info_t& level = levels.at(i);
+						if ((level.mapnum == cond.param) && (level.flags & LEVEL_VISITED))
+						{
+							res = false;
+							break;
+						}
+					}
+					conditionsmet = conditionsmet && res;
+				}
 				break;
 
 			case animcondition_t::CurrMapNotSecret:

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -217,33 +217,46 @@ static bool WI_checkConditions(const std::vector<interlevelcond_t>& conditions,
 	bool conditionsmet = true;
 
 	LevelInfos& levels = getLevelInfos();
-	level_pwad_info_t& exitinglevel = levels.findByName(wbs->current);
-	level_pwad_info_t& enteringlevel = levels.findByName(wbs->next);
-	level_pwad_info_t& currentlevel = enteringcondition ? enteringlevel : exitinglevel;
-	int map_number = currentlevel.levelnum;
+	const level_pwad_info_t& exitinglevel = levels.findByName(wbs->current);
+	const level_pwad_info_t& enteringlevel = levels.findByName(wbs->next);
+	const level_pwad_info_t& currentlevel = enteringcondition ? enteringlevel : exitinglevel;
+	const int mapnum = currentlevel.mapnum;
+	const OLumpName& mapname = currentlevel.mapname;
 
 	for (const auto& cond : conditions)
 	{
 		switch (cond.condition)
 		{
 			case animcondition_t::CurrMapGreater:
-				conditionsmet = conditionsmet && (map_number > cond.param1);
+				conditionsmet = conditionsmet && (mapnum > cond.param);
 				break;
 
 			case animcondition_t::CurrMapEqual:
-				conditionsmet = conditionsmet && (map_number == cond.param1);
+				if (cond.isZDoom)
+					conditionsmet = conditionsmet && (mapname == cond.mapname1);
+				else
+					conditionsmet = conditionsmet && (mapnum == cond.param);
 				break;
 
 			case animcondition_t::CurrMapNotEqual:
-				conditionsmet = conditionsmet && !(map_number == cond.param1);
+				if (cond.isZDoom)
+					conditionsmet = conditionsmet && (mapname != cond.mapname1);
+				else
+					conditionsmet = conditionsmet && (mapnum != cond.param);
 				break;
 
 			case animcondition_t::MapVisited:
-				conditionsmet = conditionsmet && levels.findByNum(cond.param1).flags & LEVEL_VISITED;
+				if (cond.isZDoom)
+					conditionsmet = conditionsmet && levels.findByName(cond.mapname1).flags & LEVEL_VISITED;
+				else
+					conditionsmet = conditionsmet && levels.findByNum(cond.param).flags & LEVEL_VISITED;
 				break;
 
 			case animcondition_t::MapNotVisited:
-				conditionsmet = conditionsmet && !(levels.findByNum(cond.param1).flags & LEVEL_VISITED);
+				if (cond.isZDoom)
+					conditionsmet = conditionsmet && !(levels.findByName(cond.mapname1).flags & LEVEL_VISITED);
+				else
+					conditionsmet = conditionsmet && !(levels.findByNum(cond.param).flags & LEVEL_VISITED);
 				break;
 
 			case animcondition_t::CurrMapNotSecret:
@@ -263,11 +276,11 @@ static bool WI_checkConditions(const std::vector<interlevelcond_t>& conditions,
 				break;
 
 			case animcondition_t::TravelingBetween:
-				conditionsmet = conditionsmet && (exitinglevel.levelnum == cond.param1) && (enteringlevel.levelnum == cond.param2);
+				conditionsmet = conditionsmet && (exitinglevel.mapname == cond.mapname1) && (enteringlevel.mapname == cond.mapname2);
 				break;
 
 			case animcondition_t::NotTravelingBetween:
-				conditionsmet = conditionsmet && !((exitinglevel.levelnum == cond.param1) && (enteringlevel.levelnum == cond.param2));
+				conditionsmet = conditionsmet && !((exitinglevel.mapname == cond.mapname1) && (enteringlevel.mapname == cond.mapname2));
 				break;
 
 			default:

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -90,28 +90,22 @@ struct bossaction_t;
 
 struct level_info_t
 {
-	OLumpName		mapname;
-	int				levelnum;
-	std::string		level_name;
-	byte			level_fingerprint[16];
-	OLumpName		pname;
-	OLumpName		nextmap;
-	OLumpName		secretmap;
-	int				partime;
-	OLumpName		skypic;
-	OLumpName		music;
-	levelFlags_t	flags;
-	int				cluster;
-	FLZOMemFile*	snapshot;
-	acsdefered_s*	defered;
-
-	level_info_t()
-	    : mapname(""), levelnum(0), level_name(""), pname(""), nextmap(""), secretmap(""),
-	      partime(0), skypic(""), music(""), flags(0), cluster(0), snapshot(NULL),
-	      defered(NULL)
-	{
-		ArrayInit(level_fingerprint, 0);
-	}
+	OLumpName     mapname    = "";
+	int           levelnum   = 0;
+	int           mapnum     = 0;
+	int           episodenum = 0;
+	std::string   level_name = "";
+	byte          level_fingerprint[16] = { 0 };
+	OLumpName     pname      = "";
+	OLumpName     nextmap    = "";
+	OLumpName     secretmap  = "";
+	int           partime    = 0;
+	OLumpName     skypic     = "";
+	OLumpName     music      = "";
+	levelFlags_t  flags      = 0;
+	int           cluster    = 0;
+	FLZOMemFile*  snapshot   = nullptr;
+	acsdefered_s* defered    = nullptr;
 
 	bool exists() const
 	{
@@ -140,8 +134,10 @@ struct level_pwad_info_t
 	// level_info_t
 	OLumpName		mapname;
 	int				levelnum;
+	int				mapnum;
+	int				episodenum;
 	std::string		level_name;
-	byte			level_fingerprint[16];
+	byte			level_fingerprint[16] = { 0 };
 	OLumpName		pname;
 	OLumpName		nextmap;
 	OLumpName		secretmap;
@@ -194,13 +190,13 @@ struct level_pwad_info_t
 	std::string		author;
 
 	level_pwad_info_t()
-	    : mapname(""), levelnum(0), level_name(""), pname(""), nextmap(""), secretmap(""),
+	    : mapname(""), levelnum(0), mapnum(0), episodenum(0), level_name(""), pname(""), nextmap(""), secretmap(""),
 	      partime(0), skypic(""), music(""), flags(0), cluster(0), snapshot(NULL),
 	      defered(NULL), fadetable("COLORMAP"), skypic2(""), gravity(0.0f),
 	      aircontrol(0.0f), airsupply(10),
-		    exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""), endpic(""), intertext(""),
+	      exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""), endpic(""), intertext(""),
 	      intertextsecret(""), interbackdrop(""), intermusic(""), zintermusic(""),
-	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(),
+	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(""),
 	      clearlabel(false), author()
 	{
 		ArrayInit(fadeto_color, 0);
@@ -210,15 +206,15 @@ struct level_pwad_info_t
 	}
 
 	level_pwad_info_t(const level_info_t& other)
-	    : mapname(other.mapname), levelnum(other.levelnum), level_name(other.level_name),
-	      pname(other.pname), nextmap(other.nextmap),
+	    : mapname(other.mapname), levelnum(other.levelnum), mapnum(other.mapnum), episodenum(other.episodenum),
+	      level_name(other.level_name), pname(other.pname), nextmap(other.nextmap),
 	      secretmap(other.secretmap), partime(other.partime), skypic(other.skypic),
 	      music(other.music), flags(other.flags), cluster(other.cluster),
 	      snapshot(other.snapshot), defered(other.defered), fadetable("COLORMAP"),
 	      skypic2(""), gravity(0.0f), aircontrol(0.0f), airsupply(10),
-		    exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""),
+	      exitpic(""), enterpic(""), exitscript(""), enterscript(""), exitanim(""), enteranim(""),
 	      endpic(""), intertext(""), intertextsecret(""), interbackdrop(""), intermusic(""), zintermusic(""),
-	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(),
+	      sky1ScrollDelta(0), sky2ScrollDelta(0), bossactions(), label(""),
 	      clearlabel(false), author()
 	{
 		ArrayInit(fadeto_color, 0);

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1742,6 +1742,14 @@ void G_MapNameToLevelNum(level_pwad_info_t& info)
 	}
 }
 
+void G_MapNameToID24LevelNum(level_pwad_info_t& info)
+{
+	int ep, map;
+	ValidateMapName(info.mapname, &ep, &map);
+	info.mapnum = map;
+	info.episodenum = ep;
+}
+
 namespace
 {
 
@@ -1841,6 +1849,7 @@ void ParseMapInfoLump(int lump, const OLumpName& lumpname)
 			{
 				G_MapNameToLevelNum(info);
 			}
+			G_MapNameToID24LevelNum(info);
 		}
 		else if (os.compareTokenNoCase("cluster") ||
 		         os.compareTokenNoCase("clusterdef"))

--- a/common/g_mapinfo.h
+++ b/common/g_mapinfo.h
@@ -23,4 +23,5 @@
 extern bool HexenHack; // Semi-Hexen-compatibility mode
 
 void G_MapNameToLevelNum(level_pwad_info_t& info);
+void G_MapNameToID24LevelNum(level_pwad_info_t& info);
 void G_ParseMapInfo();

--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -397,6 +397,7 @@ void ParseUMapInfoLump(int lump, const OLumpName& lumpname)
 		info.mapname = mapname;
 
 		G_MapNameToLevelNum(info);
+		G_MapNameToID24LevelNum(info);
 
 		os.mustScan();
 		os.assertTokenNoCaseIs("{");

--- a/common/g_umapinfo.h
+++ b/common/g_umapinfo.h
@@ -21,3 +21,4 @@
 #pragma once
 
 void ParseUMapInfoLump(int lump, const OLumpName& lumpname);
+int ValidateMapName(const OLumpName& mapname, int* pEpi = NULL, int* pMap = NULL);

--- a/wad/lumps/_dep2int.lmp
+++ b/wad/lumps/_dep2int.lmp
@@ -15,103 +15,103 @@
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10000", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 11 }, { "condition": 6, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 1 }, { "condition": 6, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10000", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 12 }, { "condition": 7, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 2 }, { "condition": 7, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10100", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 12 }, { "condition": 6, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 2 }, { "condition": 6, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10100", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 13 }, { "condition": 7, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 3 }, { "condition": 7, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10200", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 13 }, { "condition": 6, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 3 }, { "condition": 6, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10200", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 14 }, { "condition": 7, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 4 }, { "condition": 7, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10300", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 14 }, { "condition": 6, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 4 }, { "condition": 6, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10300", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 15 }, { "condition": 7, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 5 }, { "condition": 7, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10400", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 15 }, { "condition": 6, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 5 }, { "condition": 6, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10400", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 16 }, { "condition": 7, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 6 }, { "condition": 7, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10400", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 19 }, { "condition": 6, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 9 }, { "condition": 6, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10400", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 19 }, { "condition": 7, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 9 }, { "condition": 7, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10500", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 16 }, { "condition": 6, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 6 }, { "condition": 6, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10500", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 17 }, { "condition": 7, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 7 }, { "condition": 7, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10600", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 17 }, { "condition": 6, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 7 }, { "condition": 6, "param": 0}]
 		  },
 		  {
 		    "x": 128,
 			"y": 136,
 			"frames": [{ "image": "WIA10600", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions": [{ "condition": 2, "param": 18 }, { "condition": 7, "param": 0}]
+			"conditions": [{ "condition": 2, "param": 8 }, { "condition": 7, "param": 0}]
 		  },
 		  {
 		    "x": 192,
 			"y": 144,
 			"frames": [{ "image": "WIA10700", "type": 2, "duration": 0.333, "maxduration": 0 }, { "image": "WIA10701", "type": 2, "duration": 0.333, "maxduration": 0 }, { "image": "WIA10702", "type": 1, "duration": 0.333, "maxduration": 0 }],
-			"conditions":  [{"condition": 2, "param": 19}, {"condition": 7, "param": 0}]
+			"conditions":  [{"condition": 2, "param": 9}, {"condition": 7, "param": 0}]
 		  }
 		],
 		"conditions": null
@@ -122,55 +122,55 @@
             "x": 254,
             "y": 25,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 11 }]
+            "conditions": [{ "condition": 3, "param": 1 }]
           },
           {
             "x": 97,
             "y": 50,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 12 }]
+            "conditions": [{ "condition": 3, "param": 2 }]
           },
           {
             "x": 188,
             "y": 64,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 13 }]
+            "conditions": [{ "condition": 3, "param": 3 }]
           },
           {
             "x": 128,
             "y": 78,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 14 }]
+            "conditions": [{ "condition": 3, "param": 4 }]
           },
           {
             "x": 214,
             "y": 92,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 15 }]
+            "conditions": [{ "condition": 3, "param": 5 }]
           },
           {
             "x": 133,
             "y": 130,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 16 }]
+            "conditions": [{ "condition": 3, "param": 6 }]
           },
           {
             "x": 208,
             "y": 136,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 17 }]
+            "conditions": [{ "condition": 3, "param": 7 }]
           },
           {
             "x": 148,
             "y": 140,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 18 }]
+            "conditions": [{ "condition": 3, "param": 8 }]
           },
 		  {
             "x": 235,
             "y": 158,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 19 }]
+            "conditions": [{ "condition": 3, "param": 9 }]
           }
         ],
         "conditions": [{ "condition": 7, "param": 0 }]
@@ -181,55 +181,55 @@
             "x": 254,
             "y": 25,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 11 }]
+            "conditions": [{ "condition": 2, "param": 1 }]
           },
           {
             "x": 97,
             "y": 50,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 12 }]
+            "conditions": [{ "condition": 2, "param": 2 }]
           },
           {
             "x": 188,
             "y": 64,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 13 }]
+            "conditions": [{ "condition": 2, "param": 3 }]
           },
           {
             "x": 128,
             "y": 78,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 14 }]
+            "conditions": [{ "condition": 2, "param": 4 }]
           },
           {
             "x": 214,
             "y": 92,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 15 }]
+            "conditions": [{ "condition": 2, "param": 5 }]
           },
           {
             "x": 133,
             "y": 130,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 16 }]
+            "conditions": [{ "condition": 2, "param": 6 }]
           },
           {
             "x": 208,
             "y": 136,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 17 }]
+            "conditions": [{ "condition": 2, "param": 7 }]
           },
           {
             "x": 148,
             "y": 140,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 18 }]
+            "conditions": [{ "condition": 2, "param": 8 }]
           },
 		  {
             "x": 235,
             "y": 158,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 19 }]
+            "conditions": [{ "condition": 2, "param": 9 }]
           }
         ],
         "conditions": [{ "condition": 7, "param": 0 }]

--- a/wad/lumps/_dep3int.lmp
+++ b/wad/lumps/_dep3int.lmp
@@ -56,55 +56,55 @@
             "x": 156,
             "y": 168,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 21 }]
+            "conditions": [{ "condition": 3, "param": 1 }]
           },
           {
             "x": 48,
             "y": 154,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 22 }]
+            "conditions": [{ "condition": 3, "param": 2 }]
           },
           {
             "x": 174,
             "y": 95,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 23 }]
+            "conditions": [{ "condition": 3, "param": 3 }]
           },
           {
             "x": 265,
             "y": 75,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 24 }]
+            "conditions": [{ "condition": 3, "param": 4 }]
           },
           {
             "x": 130,
             "y": 48,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 25 }]
+            "conditions": [{ "condition": 3, "param": 5 }]
           },
           {
             "x": 279,
             "y": 23,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 26 }]
+            "conditions": [{ "condition": 3, "param": 6 }]
           },
           {
             "x": 198,
             "y": 48,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 27 }]
+            "conditions": [{ "condition": 3, "param": 7 }]
           },
           {
             "x": 140,
             "y": 25,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 28 }]
+            "conditions": [{ "condition": 3, "param": 8 }]
           },
 		  {
             "x": 281,
             "y": 136,
             "frames": [{ "image": "WISPLAT", "type": 1, "duration": 0, "maxduration": 0 }],
-            "conditions": [{ "condition": 3, "param": 29 }]
+            "conditions": [{ "condition": 3, "param": 9 }]
           }
         ],
         "conditions": [{ "condition": 7, "param": 0 }]
@@ -115,55 +115,55 @@
             "x": 156,
             "y": 168,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.667, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.333, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 21 }]
+            "conditions": [{ "condition": 2, "param": 1 }]
           },
           {
             "x": 48,
             "y": 154,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 22 }]
+            "conditions": [{ "condition": 2, "param": 2 }]
           },
           {
             "x": 174,
             "y": 95,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 23 }]
+            "conditions": [{ "condition": 2, "param": 3 }]
           },
           {
             "x": 265,
             "y": 75,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 24 }]
+            "conditions": [{ "condition": 2, "param": 4 }]
           },
           {
             "x": 130,
             "y": 48,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 25 }]
+            "conditions": [{ "condition": 2, "param": 5 }]
           },
           {
             "x": 279,
             "y": 23,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 26 }]
+            "conditions": [{ "condition": 2, "param": 6 }]
           },
           {
             "x": 198,
             "y": 48,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 27 }]
+            "conditions": [{ "condition": 2, "param": 7 }]
           },
           {
             "x": 140,
             "y": 25,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 28 }]
+            "conditions": [{ "condition": 2, "param": 8 }]
           },
 		  {
             "x": 281,
             "y": 136,
             "frames": [{ "image": "WIURH0", "altimage": "WIURH1", "type": 2, "duration": 0.58, "maxduration": 0 }, { "image": "TNT1A0", "type": 2, "duration": 0.34, "maxduration": 0 }],
-            "conditions": [{ "condition": 2, "param": 29 }]
+            "conditions": [{ "condition": 2, "param": 9 }]
           }
         ],
         "conditions": [{ "condition": 7, "param": 0 }]


### PR DESCRIPTION
Previously, all conditions used the levelnum, which uniquely identifies maps. In registered and retail mode, the conditions should actually treat all maps with the same number as if they were the same, regardless of episode. This PR makes this change, as well as using the name of the map lump for the equivalent conditions in ZDoom intermission scripts, for better compatibility there as well.