### PR TITLE
[BUGFIX] Garbage data being displayed for quit messages.

### DIFF
--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1248,7 +1248,8 @@ void M_QuitDOOM(int choice)
 {
 	// We pick index 0 which is language sensitive,
 	//  or one at random, between 1 and maximum number.
-	std::string endstring =
+	static std::string endstring;
+	endstring =
 		fmt::sprintf("%s\n\n%s",
 		             GStrings.getIndex(GStrings.toIndex(QUITMSG) + (gametic % NUM_QUITMESSAGES)),
 		             GStrings(DOSY));


### PR DESCRIPTION
#1257 broke quit messages entirely (it worked when I tested it...), because M_StartMessage assumes that the pointer it receives will remain valid after returning. So endstring is static again, but now is properly reassigned whenever the message should change.