### PR TITLE
[BUGFIX] Crash when setting the angle of Hexen format DPushers

### DIFF
--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -311,7 +311,7 @@ public:
 	}
 	void ChangeValues (int magnitude, int angle)
 	{
-		angle_t ang = (angle<<24) >> ANGLETOFINESHIFT;
+		angle_t ang = (static_cast<angle_t>(angle)<<24) >> ANGLETOFINESHIFT;
 		m_Xmag = (magnitude * finecosine[ang]) >> FRACBITS;
 		m_Ymag = (magnitude * finesine[ang]) >> FRACBITS;
 		m_Magnitude = magnitude;


### PR DESCRIPTION
Addresses #1271

`angle_t` is an unsigned 32 bit integer. Shifting the signed `angle` left was resulting in the sign bit being set, which remained when shifting it right, and a negative number was being cast to an unsigned. This resulted in attempting to index `finecosine` and `finesine` with a ridiculously large number. ZDoom 1.23 has the same fix of just casting `angle` to an `angle_t` before shifting.