### PR TITLE
Fix crashdir error messages to use the correct name of the parameter

### DIFF
--- a/common/i_crash_posix.cpp
+++ b/common/i_crash_posix.cpp
@@ -159,7 +159,7 @@ void I_SetCrashDir(const char* crashdir)
 	if (len > CRASH_DIR_LEN)
 	{
 		I_FatalError(
-		    "Crash directory \"{}\" is too long.  Please pass a correct -crashout param.",
+		    "Crash directory \"{}\" is too long.  Please pass a correct -crashdir param.",
 		    crashdir);
 		abort();
 	}
@@ -169,7 +169,7 @@ void I_SetCrashDir(const char* crashdir)
 	int res = mkstemp(testfile);
 	if (res == -1)
 	{
-		I_FatalError("Crash directory \"{}\" is not writable.  Please point -crashout to "
+		I_FatalError("Crash directory \"{}\" is not writable.  Please point -crashdir to "
 		             "a directory with write permissions.",
 		             crashdir);
 		abort();

--- a/common/i_crash_win32.cpp
+++ b/common/i_crash_win32.cpp
@@ -217,7 +217,7 @@ void I_SetCrashDir(const char* crashdir)
 	if (len > CRASH_DIR_LEN)
 	{
 		I_FatalError(
-		    "Crash directory \"{}\" is too long.  Please pass a correct -crashout param.",
+		    "Crash directory \"{}\" is too long.  Please pass a correct -crashdir param.",
 		    crashdir);
 		abort();
 	}
@@ -226,7 +226,7 @@ void I_SetCrashDir(const char* crashdir)
 	UINT res = GetTempFileName(crashdir, "crash", 0, testfile);
 	if (res == 0 || res == ERROR_BUFFER_OVERFLOW)
 	{
-		I_FatalError("Crash directory \"{}\" is not writable.  Please point -crashout to "
+		I_FatalError("Crash directory \"{}\" is not writable.  Please point -crashdir to "
 		             "a directory with write permissions.",
 		             crashdir);
 		abort();


### PR DESCRIPTION
Setting the location for crash dumps is done with the `-crashdir` parameter. Errors relating to this directory refer to it as `-crashout` instead. This fixes those error messages.