### PR TITLE
Allow null metadata in ID24 json lumps

### DIFF
--- a/common/m_jsonlump.cpp
+++ b/common/m_jsonlump.cpp
@@ -73,7 +73,7 @@ jsonlumpresult_t M_ParseJSONLump(int lumpindex, const char* lumptype, const JSON
 	if(root.size() != 4
 	   || !type.isString()
 	   || !version.isString()
-	   || !metadata.isObject()
+	   || (!metadata.isObject() && !metadata.isNull())
 	   || !data.isObject())
 	{
 		return jsonlumpresult_t::MALFORMEDROOT;


### PR DESCRIPTION
The ID24 spec, as of revision 0.99.2, specifies that the `metadata` field in the root of any ID24 JSON lumps must be an object containing the three properties `author`, `timestamp`, and `application`. Nearly all ports supporting these lumps, including Kex, but excluding Odamex and Rum & Raisin, also allow this field to be null. Many wads now have null metadata fields in JSON lumps and will not load in Odamex because of this. This PR makes it so that the JSON lump parser will accept a null metadata field as valid.