### PR TITLE
[FEATURE] Allow more control over maplist `lastmap` parameter

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -111,15 +111,6 @@ void G_DeferedReset() {
 
 BEGIN_COMMAND (wad) // denis - changes wads
 {
-	std::string lastmap = argv[argc-1];
-	if (lastmap.rfind("lastmap=", 0) == 0)
-	{
-		lastmap = lastmap.substr(8);
-		argc--;
-	}
-	else
-		lastmap = "";
-
 	// [Russell] print out some useful info
 	if (argc == 1)
 	{
@@ -141,7 +132,7 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	C_HideConsole();
 
 	std::string wadstr = C_EscapeWadList(VectorArgs(argc, argv));
-	G_LoadWadString(wadstr, lastmap);
+	G_LoadWadString(wadstr);
 
 	D_StartTitle ();
 	CL_QuitNetGame(NQ_SILENT);

--- a/client/src/cl_maplist.cpp
+++ b/client/src/cl_maplist.cpp
@@ -381,22 +381,22 @@ void CMD_MaplistCallback(const maplist_qrows_t &result) {
 	bool show_this_map = MaplistCache::instance().get_this_index(this_index);
 	MaplistCache::instance().get_next_index(next_index);
 	for (const auto& [index, entry] : result) {
-		const auto& [map, lastmap, wads] = *entry;
+		const auto& [map, lastmap, _, wads] = *entry;
 		char flag = ' ';
 		if (show_this_map && index == this_index) {
 			flag = '*';
 		} else if (index == next_index) {
 			flag = '+';
 		}
-		Printf(PRINT_HIGH, "%c%lu. %s %s%s\n", flag, index + 1,
+		PrintFmt(PRINT_HIGH, "{}{}. {} {}{}\n", flag, index + 1,
 			   JoinStrings(wads, " "), map,
-			   lastmap.empty() ? "" : fmt::sprintf(" lastmap=%s", lastmap));
+			   lastmap.empty() ? "" : fmt::format(" lastmap={}", lastmap));
 	}
 }
 
 // Clientside maplist query errback.
 void CMD_MaplistErrback(const std::string &error) {
-	Printf(PRINT_HIGH, "%s\n", error);
+	PrintFmt(PRINT_HIGH, "{}\n", error);
 }
 
 // Clientside maplist query.

--- a/common/c_maplist.h
+++ b/common/c_maplist.h
@@ -20,9 +20,9 @@
 //
 //-----------------------------------------------------------------------------
 
-#ifndef __C_MAPLIST__
-#define __C_MAPLIST__
+#pragma once
 
+#include <nonstd/expected.hpp>
 
 // Maplist statuses
 enum maplist_status_t
@@ -50,11 +50,13 @@ inline auto format_as(maplist_status_t eStatus)
 }
 
 struct maplist_lastmaps_t {
-	std::vector<std::pair<OLumpName, OLumpName>> entries;
+	std::vector<std::pair<std::string, std::string>> entries;
 
 	bool empty() const {
 		return entries.empty();
 	}
+
+	static nonstd::expected<maplist_lastmaps_t, std::string> parse(const std::string& lastmaps);
 };
 
 // Map list entry structure
@@ -90,5 +92,3 @@ inline auto format_as(const maplist_lastmaps_t& lastmaps)
 // Query result
 typedef std::pair<size_t, maplist_entry_t*> maplist_qrow_t;
 typedef std::vector<maplist_qrow_t> maplist_qrows_t;
-
-#endif

--- a/common/c_maplist.h
+++ b/common/c_maplist.h
@@ -49,12 +49,43 @@ inline auto format_as(maplist_status_t eStatus)
 	return fmt::underlying(eStatus);
 }
 
+struct maplist_lastmaps_t {
+	std::vector<std::pair<OLumpName, OLumpName>> entries;
+
+	bool empty() const {
+		return entries.empty();
+	}
+};
+
 // Map list entry structure
-typedef struct {
+struct maplist_entry_t {
 	std::string map;
+	// FIXME: there's some lastmap duplication here because of this being in common
+	// and requiring compatibility with 11.x
+	// rework this for 12.0.0
 	std::string lastmap;
+	maplist_lastmaps_t lastmaps;
 	std::vector<std::string> wads;
-} maplist_entry_t;
+};
+
+inline auto format_as(const maplist_lastmaps_t& lastmaps)
+{
+	std::string out;
+	bool first = true;
+	for (const auto& [from, to] : lastmaps.entries)
+	{
+		if (!first)
+			out += ",";
+
+		if (!to.empty())
+			out += fmt::format("{}->{}", from, to);
+		else
+			out += from.c_str();
+
+		first = false;
+	}
+	return out;
+}
 
 // Query result
 typedef std::pair<size_t, maplist_entry_t*> maplist_qrow_t;

--- a/common/cmdlib.cpp
+++ b/common/cmdlib.cpp
@@ -368,7 +368,7 @@ StringTokens TokenizeString(const std::string& str, const std::string& delim) {
 	while (delimPos != std::string::npos) {
 		delimPos = str.find(delim, prevDelim);
 		tokens.push_back(str.substr(prevDelim, delimPos - prevDelim));
-		prevDelim = delimPos + 1;
+		prevDelim = delimPos + delim.length();
 	}
 
 	return tokens;

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -30,6 +30,7 @@
 
 #include "c_console.h"
 #include "c_dispatch.h"
+#include "c_maplist.h"
 #include "d_event.h"
 #include "d_main.h"
 #include "g_game.h"
@@ -46,7 +47,7 @@
 #include "w_ident.h"
 
 level_locals_t level;			// info about current level
-std::string forcedlastmap;		// forced last map for the current wad
+maplist_lastmaps_t forcedlastmaps;		// forced last map for the current wad
 
 level_pwad_info_t g_EmptyLevel;
 cluster_info_t g_EmptyCluster;
@@ -394,7 +395,7 @@ const char *ParseString2(const char *data);
 // Takes a string of random wads and patches, which is sorted through and
 // trampolined to the implementation of G_LoadWad.
 //
-bool G_LoadWadString(const std::string& str, const std::string& mapname, const std::string& lastmap)
+bool G_LoadWadString(const std::string& str, const std::string& mapname, const maplist_lastmaps_t& lastmaps)
 {
 	const std::vector<std::string>& wad_exts = M_FileTypeExts(OFILE_WAD);
 	const std::vector<std::string>& deh_exts = M_FileTypeExts(OFILE_DEH);
@@ -452,7 +453,7 @@ bool G_LoadWadString(const std::string& str, const std::string& mapname, const s
 		continue;
 	}
 
-	forcedlastmap = StdStringToUpper(lastmap);
+	forcedlastmaps = lastmaps;
 	return G_LoadWad(newwadfiles, newpatchfiles, mapname);
 }
 

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "cmdlib.h"
+#include "c_maplist.h"
 #include "m_fixed.h"
 #include "m_resfile.h"
 #include "olumpname.h"
@@ -489,7 +490,7 @@ void P_RemoveDefereds();
 
 bool G_LoadWad(const OWantFiles& newwadfiles, const OWantFiles& newpatchfiles,
                const std::string& mapname = "");
-bool G_LoadWadString(const std::string& str, const std::string& mapname = "", const std::string& lastmap = "");
+bool G_LoadWadString(const std::string& str, const std::string& mapname = "", const maplist_lastmaps_t& lastmaps = {});
 
 LevelInfos& getLevelInfos();
 ClusterInfos& getClusterInfos();

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1512,8 +1512,8 @@ odaproto::svc::MaplistUpdate SVC_MaplistUpdate(const maplist_status_t status,
 			const uint32_t mapidx = indexer.getIndex(map);
 			row->set_map(mapidx);
 
-			const std::string& lastmap = entry->lastmap;
-			const uint32_t lastmapidx = indexer.getIndex(lastmap);
+			const std::string lastmaps = fmt::format("{}", entry->lastmaps);
+			const uint32_t lastmapidx = indexer.getIndex(lastmaps);
 			row->set_lastmap(lastmapidx);
 
 			for (const auto& wad : entry->wads)

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -152,15 +152,6 @@ const char* GetBase(const char* in)
 
 BEGIN_COMMAND (wad) // denis - changes wads
 {
-	std::string lastmap = argv[argc-1];
-	if (lastmap.rfind("lastmap=", 0) == 0)
-	{
-		lastmap = lastmap.substr(8);
-		argc--;
-	}
-	else
-		lastmap = "";
-
 	// [Russell] print out some useful info
 	if (argc == 1)
 	{
@@ -172,6 +163,15 @@ BEGIN_COMMAND (wad) // denis - changes wads
 
 	    return;
 	}
+
+	std::string lastmap = argv[argc-1];
+	if (lastmap.rfind("lastmap=", 0) == 0)
+	{
+		lastmap = lastmap.substr(8);
+		argc--;
+	}
+	else
+		lastmap = "";
 
 	std::string wadstr = C_EscapeWadList(VectorArgs(argc, argv));
 	G_LoadWadString(wadstr, "", lastmap);
@@ -242,7 +242,7 @@ void G_ChangeMap()
 		if (!Maplist::instance().lobbyempty())
 		{
 			std::string wadstr = C_EscapeWadList(lobby_entry.wads);
-			G_LoadWadString(wadstr, "", lobby_entry.map);
+			G_LoadWadString(wadstr, lobby_entry.map);
 		}
 		else
 		{

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -75,7 +75,7 @@ EXTERN_CVAR (sv_teamsinplay)
 EXTERN_CVAR(g_resetinvonexit)
 
 extern int mapchange;
-extern std::string forcedlastmap;
+extern maplist_lastmaps_t forcedlastmaps;
 
 // [AM] Stores the reset snapshot
 FLZOMemFile	*reset_snapshot = NULL;
@@ -165,16 +165,20 @@ BEGIN_COMMAND (wad) // denis - changes wads
 	}
 
 	std::string lastmap = argv[argc-1];
+	maplist_lastmaps_t lastmaps;
 	if (lastmap.rfind("lastmap=", 0) == 0)
 	{
-		lastmap = lastmap.substr(8);
+		auto lastmap_result = maplist_lastmaps_t::parse(lastmap.substr(8));
+		if (!lastmap_result) {
+			PrintFmt(PRINT_HIGH, "Failed to parse lastmap: {}\n", lastmap_result.error());
+			return;
+		}
+		lastmaps = lastmap_result.value();
 		argc--;
 	}
-	else
-		lastmap = "";
 
 	std::string wadstr = C_EscapeWadList(VectorArgs(argc, argv));
-	G_LoadWadString(wadstr, "", lastmap);
+	G_LoadWadString(wadstr, "", lastmaps);
 }
 END_COMMAND (wad)
 
@@ -184,7 +188,12 @@ EXTERN_CVAR(sv_shufflemaplist)
 
 bool isLastMap()
 {
-	return level.nextmap == "" || level.mapname == forcedlastmap;
+	return level.nextmap.empty() ||
+		std::any_of(
+			forcedlastmaps.entries.begin(), forcedlastmaps.entries.end(),
+			[&](const auto& entry) {
+				return entry.first == level.mapname && (entry.second.empty() || entry.second == level.nextmap);
+		});
 }
 
 // Returns the next map, assuming there is no maplist.
@@ -193,7 +202,7 @@ OLumpName G_NextMap()
 {
 	OLumpName next = level.nextmap;
 
-	if (gamestate == GS_STARTUP || (sv_gametype != GM_COOP && forcedlastmap.empty()) || next.empty())
+	if (gamestate == GS_STARTUP || (sv_gametype != GM_COOP && forcedlastmaps.empty()) || next.empty())
 	{
 		// if not coop, and lastmap is not specified, stay on same level
 		// [ML] 1/25/10: OR if next is empty
@@ -207,9 +216,9 @@ OLumpName G_NextMap()
 
 	// NES - exiting a Doom 1 episode moves to the next episode,
 	// rather than always going back to E1M1
-	if (level.nextmap == "" || level.mapname == forcedlastmap ||
-			(next.substr(0, 7) == "EndGame") ||
-			(gamemode == retail_chex && (level.nextmap == "E1M6")))
+	if (isLastMap() ||
+		(next.substr(0, 7) == "EndGame") ||
+		(gamemode == retail_chex && (level.nextmap == "E1M6")))
 	{
 		if (gameinfo.flags & GI_MAPxx || gamemode == shareware ||
 			(((gamemode == registered && level.cluster == 3) ||
@@ -247,7 +256,7 @@ void G_ChangeMap()
 		else
 		{
 			size_t next_index;
-			if ((!forcedlastmap.empty() && !isLastMap()) || !Maplist::instance().get_next_index(next_index))
+			if ((!forcedlastmaps.empty() && !isLastMap()) || !Maplist::instance().get_next_index(next_index))
 			{
 				// We don't have a maplist, so grab the next 'natural' map lump.
 				G_DeferedInitNew(G_NextMap());
@@ -258,7 +267,7 @@ void G_ChangeMap()
 				Maplist::instance().get_map_by_index(next_index, maplist_entry);
 
 				std::string wadstr = C_EscapeWadList(maplist_entry.wads);
-				G_LoadWadString(wadstr, maplist_entry.map, maplist_entry.lastmap);
+				G_LoadWadString(wadstr, maplist_entry.map, maplist_entry.lastmaps);
 
 				// Set the new map as the current map
 				Maplist::instance().set_index(next_index);
@@ -284,7 +293,7 @@ void G_ChangeMap(size_t index) {
 	}
 
 	std::string wadstr = C_EscapeWadList(maplist_entry.wads);
-	G_LoadWadString(wadstr, maplist_entry.map, maplist_entry.lastmap);
+	G_LoadWadString(wadstr, maplist_entry.map, maplist_entry.lastmaps);
 
 	// Set the new map as the current map
 	Maplist::instance().set_index(index);

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4098,7 +4098,7 @@ void SV_RunTics()
 		if (!Maplist::instance().lobbyempty())
 		{
 			std::string wadstr = C_EscapeWadList(lobby_entry.wads);
-			G_LoadWadString(wadstr, "", lobby_entry.map);
+			G_LoadWadString(wadstr, lobby_entry.map);
 		}
 		else
 		{

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -669,6 +669,14 @@ BEGIN_COMMAND (maplist) {
 } END_COMMAND (maplist)
 
 BEGIN_COMMAND (addmap) {
+	if (argc < 2) {
+		Printf(PRINT_HIGH, "Usage: addmap <map lump> [wad name] [...]\n");
+		Printf(PRINT_HIGH, "If you don't specify a wad name, it'll load the IWAD by default.\n");
+		return;
+	}
+
+	std::vector<std::string> arguments = VectorArgs(argc, argv);
+
 	std::string lastmap = argv[argc-1];
 	if (lastmap.rfind("lastmap=", 0) == 0)
 	{
@@ -677,14 +685,6 @@ BEGIN_COMMAND (addmap) {
 	}
 	else
 		lastmap = "";
-
-	if (argc < 2) {
-		Printf(PRINT_HIGH, "Usage: addmap <map lump> [wad name] [...]\n");
-		Printf(PRINT_HIGH, "If you don't specify a wad name, it'll load the IWAD by default.\n");
-		return;
-	}
-
-	std::vector<std::string> arguments = VectorArgs(argc, argv);
 
 	// Grab the map lump.
 	maplist_entry_t maplist_entry;
@@ -707,6 +707,10 @@ BEGIN_COMMAND (addmap) {
 } END_COMMAND(addmap)
 
 BEGIN_COMMAND(insertmap) {
+	if (argc < 3) {
+		Printf(PRINT_HIGH, "Usage: insertmap <maplist position> <map lump> [wad name] [...]\n");
+	}
+
 	std::string lastmap = argv[argc-1];
 	if (lastmap.rfind("lastmap=", 0) == 0)
 	{
@@ -715,10 +719,6 @@ BEGIN_COMMAND(insertmap) {
 	}
 	else
 		lastmap = "";
-
-	if (argc < 3) {
-		Printf(PRINT_HIGH, "Usage: insertmap <maplist position> <map lump> [wad name] [...]\n");
-	}
 
 	std::vector<std::string> arguments = VectorArgs(argc, argv);
 


### PR DESCRIPTION
Addresses #1293

This PR makes two enhancements to the `lastmap=` feature introduced to the maplist in 11.0.0.

1. Multiple lastmaps can be specified in a comma-separated list
2. Lastmap behavior can be triggered only on specific level transitions (so as to only take effect when taking a secret or non-secret exit, for example). This is done by specifying the next map after a `->`.

The Eviternity episode 3 maplist entry described in the issue can now be written like this:
`addmap map11 $doom2-1.9 eviternity.wad lastmap=map15->map16,map32`

A few bugs with lobby maps have also been fixed.