### PR TITLE
Update bundled SDL mixer for Windows build to 2.8.1

### DIFF
--- a/ci/stage-inno-setup-and-run.ps1
+++ b/ci/stage-inno-setup-and-run.ps1
@@ -88,7 +88,9 @@ function BuildOutX86 {
     New-Item -Force -ItemType "directory" -Path "${OutX86}\redist"
 
     Copy-Item -Force -Path `
-        "${UnzippedX86}\libmodplug-1.dll", `
+        "${UnzippedX86}\libwavpack-1.dll", `
+        "${UnzippedX86}\libgme.dll", `
+        "${UnzippedX86}\libxmp.dll", `
         "${UnzippedX86}\libogg-0.dll", `
         "${UnzippedX86}\libopus-0.dll", `
         "${UnzippedX86}\libopusfile-0.dll", `
@@ -120,7 +122,9 @@ function BuildOutX64 {
     New-Item -Force -ItemType "directory" -Path "${OutX64}\redist"
 
     Copy-Item -Force -Path `
-        "${UnzippedX64}\libmodplug-1.dll", `
+        "${UnzippedX64}\libwavpack-1.dll", `
+        "${UnzippedX64}\libgme.dll", `
+        "${UnzippedX64}\libxmp.dll", `
         "${UnzippedX64}\libogg-0.dll", `
         "${UnzippedX64}\libopus-0.dll", `
         "${UnzippedX64}\libopusfile-0.dll", `

--- a/ci/win-release-x64.ps1
+++ b/ci/win-release-x64.ps1
@@ -109,7 +109,7 @@ function CopyFilesX64 {
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.gme.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.4\LICENSE.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.8\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
 
     ########################################

--- a/ci/win-release-x64.ps1
+++ b/ci/win-release-x64.ps1
@@ -95,15 +95,19 @@ function CopyFilesX64 {
         -Destination "${CommonDir}\README.txt"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\wad\odamex.wad" `
         -Destination "${CommonDir}"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\LICENSE.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\COPYING.SDL2_mixer.txt"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.modplug.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.xmp.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.ogg-vorbis.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.ogg-vorbis.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.opus.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.opus.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.opusfile.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.opusfile.txt" `
+        -Destination "${CommonDir}\licenses"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.wavpack.txt" `
+        -Destination "${CommonDir}\licenses"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.gme.txt" `
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.4\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
@@ -116,7 +120,9 @@ function CopyFilesX64 {
     New-Item -Force -ItemType "directory" -Path "${X64Dir}\redist"
 
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libmodplug-1.dll", `
+        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libgme.dll", `
+        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libwavpack-1.dll", `
+        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libxmp.dll", `
         "${CurrentDir}\BuildX64\client\RelWithDebInfo\libogg-0.dll", `
         "${CurrentDir}\BuildX64\client\RelWithDebInfo\libopus-0.dll", `
         "${CurrentDir}\BuildX64\client\RelWithDebInfo\libopusfile-0.dll", `

--- a/ci/win-release-x86.ps1
+++ b/ci/win-release-x86.ps1
@@ -95,15 +95,19 @@ function CopyFilesX86 {
         -Destination "${CommonDir}\README.txt"
     Copy-Item -Force -Path "${CurrentDir}\BuildX86\wad\odamex.wad" `
         -Destination "${CommonDir}"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.6.2\LICENSE.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\COPYING.SDL2_mixer.txt"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.6.2\lib\x86\optional\LICENSE.modplug.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\lib\x86\optional\LICENSE.xmp.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.6.2\lib\x86\optional\LICENSE.ogg-vorbis.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\lib\x86\optional\LICENSE.ogg-vorbis.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.6.2\lib\x86\optional\LICENSE.opus.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\lib\x86\optional\LICENSE.opus.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.6.2\lib\x86\optional\LICENSE.opusfile.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\lib\x86\optional\LICENSE.opusfile.txt" `
+        -Destination "${CommonDir}\licenses"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.wavpack.txt" `
+        -Destination "${CommonDir}\licenses"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.gme.txt" `
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2-2.32.4\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
@@ -116,7 +120,9 @@ function CopyFilesX86 {
     New-Item -Force -ItemType "directory" -Path "${X86Dir}\redist"
 
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libmodplug-1.dll", `
+        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libgme.dll", `
+        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libwavpack-1.dll", `
+        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libxmp.dll", `
         "${CurrentDir}\BuildX86\client\RelWithDebInfo\libogg-0.dll", `
         "${CurrentDir}\BuildX86\client\RelWithDebInfo\libopus-0.dll", `
         "${CurrentDir}\BuildX86\client\RelWithDebInfo\libopusfile-0.dll", `

--- a/ci/win-release-x86.ps1
+++ b/ci/win-release-x86.ps1
@@ -109,7 +109,7 @@ function CopyFilesX86 {
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.gme.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2-2.32.4\LICENSE.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2-2.32.8\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
 
     ########################################

--- a/ci/win-x32-artifact.ps1
+++ b/ci/win-x32-artifact.ps1
@@ -15,7 +15,7 @@ Copy-Item `
     -Path ".\client\RelWithDebInfo\odamex.exe", ".\client\RelWithDebInfo\odamex.pdb", `
     ".\server\RelWithDebInfo\odasrv.exe", ".\server\RelWithDebInfo\odasrv.pdb", `
     ".\wad\odamex.wad", `
-    ".\libraries\SDL2-2.32.4\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.6.2\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.6.2\lib\x86\optional\*.dll", `
+    ".\libraries\SDL2-2.32.4\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.8.1\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.8.1\lib\x86\optional\*.dll", `
     "C:\Windows\System32\msvcp140.dll", "C:\Windows\System32\vcruntime140.dll", `
     "C:\Windows\System32\vcruntime140_1.dll" `
     -Destination "artifact"

--- a/ci/win-x32-artifact.ps1
+++ b/ci/win-x32-artifact.ps1
@@ -15,7 +15,7 @@ Copy-Item `
     -Path ".\client\RelWithDebInfo\odamex.exe", ".\client\RelWithDebInfo\odamex.pdb", `
     ".\server\RelWithDebInfo\odasrv.exe", ".\server\RelWithDebInfo\odasrv.pdb", `
     ".\wad\odamex.wad", `
-    ".\libraries\SDL2-2.32.4\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.8.1\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.8.1\lib\x86\optional\*.dll", `
+    ".\libraries\SDL2-2.32.8\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.8.1\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.8.1\lib\x86\optional\*.dll", `
     "C:\Windows\System32\msvcp140.dll", "C:\Windows\System32\vcruntime140.dll", `
     "C:\Windows\System32\vcruntime140_1.dll" `
     -Destination "artifact"

--- a/cmake/modules/OdamexCopyLibs.cmake
+++ b/cmake/modules/OdamexCopyLibs.cmake
@@ -14,7 +14,9 @@ function(odamex_copy_libs TARGET)
     list(APPEND ODAMEX_DLLS "${SDL2_DLL_DIR}/SDL2.dll")
 
     # SDL2_mixer
-    list(APPEND ODAMEX_DLLS "${SDL2_MIXER_DLL_DIR}/optional/libmodplug-1.dll")
+    list(APPEND ODAMEX_DLLS "${SDL2_MIXER_DLL_DIR}/optional/libwavpack-1.dll")
+    list(APPEND ODAMEX_DLLS "${SDL2_MIXER_DLL_DIR}/optional/libgme.dll")
+    list(APPEND ODAMEX_DLLS "${SDL2_MIXER_DLL_DIR}/optional/libxmp.dll")
     list(APPEND ODAMEX_DLLS "${SDL2_MIXER_DLL_DIR}/optional/libogg-0.dll")
     list(APPEND ODAMEX_DLLS "${SDL2_MIXER_DLL_DIR}/optional/libopus-0.dll")
     list(APPEND ODAMEX_DLLS "${SDL2_MIXER_DLL_DIR}/optional/libopusfile-0.dll")

--- a/installer/windows/build_release.ps1
+++ b/installer/windows/build_release.ps1
@@ -156,7 +156,9 @@ function CopyFiles {
     New-Item -Force -ItemType "directory" -Path "${X86Dir}/redist"
 
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libmodplug-1.dll", `
+        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libwavpack-1.dll", `
+        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libgme.dll", `
+        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libxmp.dll", `
         "${CurrentDir}\BuildX86\client\RelWithDebInfo\libogg-0.dll", `
         "${CurrentDir}\BuildX86\client\RelWithDebInfo\libopus-0.dll", `
         "${CurrentDir}\BuildX86\client\RelWithDebInfo\libopusfile-0.dll", `

--- a/installer/windows/build_release.ps1
+++ b/installer/windows/build_release.ps1
@@ -115,7 +115,7 @@ function CopyFiles {
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.gme.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.4\LICENSE.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.8\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
 
     ########################################

--- a/installer/windows/build_release.ps1
+++ b/installer/windows/build_release.ps1
@@ -101,15 +101,19 @@ function CopyFiles {
         -Destination "${CommonDir}\README.txt"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\wad\odamex.wad" `
         -Destination "${CommonDir}"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\COPYING.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\COPYING.SDL2_mixer.txt"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.modplug.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.xmp.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.ogg-vorbis.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.ogg-vorbis.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.opus.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.opus.txt" `
         -Destination "${CommonDir}\licenses"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.6.2\lib\x64\optional\LICENSE.opusfile.txt" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.opusfile.txt" `
+        -Destination "${CommonDir}\licenses"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.wavpack.txt" `
+        -Destination "${CommonDir}\licenses"
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\lib\x64\optional\LICENSE.gme.txt" `
         -Destination "${CommonDir}\licenses"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2-2.32.4\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\LICENSE.SDL2.txt"
@@ -122,7 +126,9 @@ function CopyFiles {
     New-Item -Force -ItemType "directory" -Path "${X64Dir}/redist"
 
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libmodplug-1.dll", `
+        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libgme.dll", `
+        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libwavpack-1.dll", `
+        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libxmp.dll", `
         "${CurrentDir}\BuildX64\client\RelWithDebInfo\libogg-0.dll", `
         "${CurrentDir}\BuildX64\client\RelWithDebInfo\libopus-0.dll", `
         "${CurrentDir}\BuildX64\client\RelWithDebInfo\libopusfile-0.dll", `

--- a/installer/windows/odamex.iss
+++ b/installer/windows/odamex.iss
@@ -81,7 +81,9 @@ Source: {#SourcePath}\OutCommon\odamex.wad; DestDir: {app}; Flags: ignoreversion
 ;; 64-BIT FILES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-Source: {#SourcePath}\OutX64\libmodplug-1.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: Is64BitInstallMode
+Source: {#SourcePath}\OutX64\libwavpack-1.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: Is64BitInstallMode
+Source: {#SourcePath}\OutX64\libgme.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: Is64BitInstallMode
+Source: {#SourcePath}\OutX64\libxmp.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: Is64BitInstallMode
 Source: {#SourcePath}\OutX64\libogg-0.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: Is64BitInstallMode
 Source: {#SourcePath}\OutX64\libopus-0.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: Is64BitInstallMode
 Source: {#SourcePath}\OutX64\libopusfile-0.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: Is64BitInstallMode
@@ -102,7 +104,9 @@ Source: {#SourcePath}\OutX64\redist\VC_redist.x64.exe; DestDir: {tmp}; Flags: do
 ;; 32-BIT FILES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-Source: {#SourcePath}\OutX86\libmodplug-1.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: not Is64BitInstallMode
+Source: {#SourcePath}\OutX86\libwavpack-1.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: not Is64BitInstallMode
+Source: {#SourcePath}\OutX86\libgme.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: not Is64BitInstallMode
+Source: {#SourcePath}\OutX86\libxmp.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: not Is64BitInstallMode
 Source: {#SourcePath}\OutX86\libogg-0.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: not Is64BitInstallMode
 Source: {#SourcePath}\OutX86\libopus-0.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: not Is64BitInstallMode
 Source: {#SourcePath}\OutX86\libopusfile-0.dll; DestDir: {app}; Flags: ignoreversion; Components: client; Check: not Is64BitInstallMode
@@ -125,6 +129,7 @@ Type: files; Name: "{app}\libFLAC-8.dll"
 Type: files; Name: "{app}\libmpg123-0.dll"
 Type: files; Name: "{app}\libvorbis-0.dll"
 Type: files; Name: "{app}\libvorbisfile-3.dll"
+Type: files; Name: "{app}\libmodplug-1.dll"
 
 [Icons]
 Name: {group}\Odamex Client; Filename: {app}\odamex.exe; WorkingDir: {app}
@@ -146,8 +151,8 @@ begin
     RegQueryStringValue(HKCU, sUnInstPath, 'UninstallString', sUnInstallString);
   Result := sUnInstallString;
 end;
- 
- 
+
+
 function GetRegistryVersion: string;
 var
   sUnInstPath: string;
@@ -160,14 +165,14 @@ begin
     RegQueryStringValue(HKCU, sUnInstPath, 'DisplayVersion', sVersionString);
   Result := sVersionString;
 end;
- 
- 
+
+
 function IsUpgrade: Boolean;
 begin
   Result := (GetUninstallString() <> '');
 end;
- 
- 
+
+
 function Count(What, Where: String): Integer;
 begin
    Result := 0;
@@ -179,61 +184,61 @@ begin
         Result := Result + 1;
     end;
 end;
- 
- 
+
+
 //split text to array
 procedure Explode(var ADest: TArrayOfString; aText, aSeparator: String);
 var tmp: Integer;
 begin
     if aSeparator='' then
         exit;
- 
+
     SetArrayLength(ADest,Count(aSeparator,aText)+1)
- 
+
     tmp := 0;
     repeat
         if Pos(aSeparator,aText)>0 then
         begin
- 
+
             ADest[tmp] := Copy(aText,1,Pos(aSeparator,aText)-1);
             aText := Copy(aText,Pos(aSeparator,aText)+Length(aSeparator),Length(aText));
             tmp := tmp + 1;
- 
+
         end else
         begin
- 
+
              ADest[tmp] := aText;
              aText := '';
- 
+
         end;
     until Length(aText)=0;
 end;
- 
- 
+
+
 //compares two version numbers, returns -1 if vA is newer, 0 if both are identical, 1 if vB is newer
 function CompareVersion(vA,vB: String): Integer;
 var tmp: TArrayOfString;
     verA,verB: Array of Integer;
     i,len: Integer;
 begin
- 
+
     StringChange(vA,'-','.');
     StringChange(vB,'-','.');
- 
+
     Explode(tmp,vA,'.');
     SetArrayLength(verA,GetArrayLength(tmp));
     for i := 0 to GetArrayLength(tmp) - 1 do
         verA[i] := StrToIntDef(tmp[i],0);
-        
+
     Explode(tmp,vB,'.');
     SetArrayLength(verB,GetArrayLength(tmp));
     for i := 0 to GetArrayLength(tmp) - 1 do
         verB[i] := StrToIntDef(tmp[i],0);
- 
+
     len := GetArrayLength(verA);
     if GetArrayLength(verB) < len then
         len := GetArrayLength(verB);
- 
+
     for i := 0 to len - 1 do
         if verA[i] < verB[i] then
         begin
@@ -245,7 +250,7 @@ begin
             Result := -1;
             exit
         end;
- 
+
     if GetArrayLength(verA) < GetArrayLength(verB) then
     begin
         Result := 1;
@@ -256,11 +261,11 @@ begin
         Result := -1;
         exit;
     end;
- 
-    Result := 0; 
+
+    Result := 0;
 end;
- 
- 
+
+
 function InitializeSetup(): Boolean;
 var
   V: Integer;
@@ -302,7 +307,7 @@ begin
         'or installation type, press "No."' #13#10 + \
         'If you want to exit the installation, press "Cancel."',
         mbConfirmation, MB_YESNOCANCEL);
-      
+
         if V = IDYES then
         begin
           Result := True;
@@ -335,7 +340,7 @@ end;
 
 
 function VC2017RedistNeedsInstall(Platform: String): Boolean;
-var 
+var
   Version: String;
   KeyLocation: String;
 begin
@@ -344,11 +349,11 @@ begin
        KeyLocation, 'Version',
        Version) then
   begin
-    // Is the installed version at least 14.40? 
+    // Is the installed version at least 14.40?
     Log('VC Redist Version check : found ' + Version);
     Result := (CompareVersion(Version, 'v14.40.33810.0')>0);
   end
-  else 
+  else
   begin
     // Not even an old version installed
     Result := True;
@@ -390,7 +395,7 @@ Root: HKA; Subkey: {#"Software\Classes\" + OdamexDemoExt +  "\OpenWithProgids"};
 Root: HKA; Subkey: {#"Software\Classes\" + OdamexDemoFile}; ValueType: string; ValueName: ""; ValueData: {#OdamexName + " Demo"}; Flags: uninsdeletekey
 Root: HKA; Subkey: {#"Software\Classes\" + OdamexDemoFile + "\DefaultIcon"}; ValueType: string; ValueName: ""; ValueData: "{app}\odamex.exe,1"
 Root: HKA; Subkey: {#"Software\Classes\" + OdamexDemoFile + "\shell\open\command"}; ValueType: string; ValueName: ""; ValueData: """{app}\odamex.exe"" ""%1"""
-Root: HKA; Subkey: "Software\Classes\Applications\odamex.exe\SupportedTypes"; ValueType: string; ValueName: {#OdamexDemoExt}; ValueData: "" 
+Root: HKA; Subkey: "Software\Classes\Applications\odamex.exe\SupportedTypes"; ValueType: string; ValueName: {#OdamexDemoExt}; ValueData: ""
 
 ; odamex:// URI scheme
 Root: HKA; Subkey: "Software\Classes\odamex"; ValueType: string; ValueName: ""; ValueData: "URL:Odamex Protocol"; Flags: uninsdeletekey

--- a/libraries/SDL-lib.cmake
+++ b/libraries/SDL-lib.cmake
@@ -85,14 +85,14 @@ if(BUILD_CLIENT)
     if(WIN32)
       if(MSVC)
         file(DOWNLOAD
-          "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.6.2-VC.zip"
+          "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.8.1-VC.zip"
           "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-VC.zip"
-          EXPECTED_HASH SHA256=7f050663ccc7911bb9c57b11e32ca79578b712490186b8645ddbbe4e7d2fe1c9)
+          EXPECTED_HASH SHA256=12dc2bb724afaf19bcc23fdd7e6fcdcf40274edf13b8c6ec3723089a72537832)
         execute_process(COMMAND "${CMAKE_COMMAND}" -E tar xf
           "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-VC.zip"
           WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
-        set(SDL2_MIXER_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-2.6.2")
+        set(SDL2_MIXER_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-2.8.1")
         set(SDL2_MIXER_INCLUDE_DIR "${SDL2_MIXER_DIR}/include" CACHE PATH "")
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
           set(SDL2_MIXER_LIBRARY "${SDL2_MIXER_DIR}/lib/x64/SDL2_mixer.lib" CACHE FILEPATH "")
@@ -101,17 +101,17 @@ if(BUILD_CLIENT)
         endif()
       else()
         file(DOWNLOAD
-          "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.6.2-mingw.tar.gz"
+          "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.8.1-mingw.tar.gz"
           "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-mingw.tar.gz"
-          EXPECTED_HASH SHA256=6c414d05a3b867e0d59e0f9b28ea7e5e64527e612ccf961735dc2478391315b3)
+          EXPECTED_HASH SHA256=b6c98eecd308aa9922ede0aac466bb5dea6c3e9b9b59dd496009f778c90d83d7)
         execute_process(COMMAND "${CMAKE_COMMAND}" -E tar xf
           "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-mingw.tar.gz"
           WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-          set(SDL2_MIXER_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-2.6.2/x86_64-w64-mingw32")
+          set(SDL2_MIXER_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-2.8.1/x86_64-w64-mingw32")
         else()
-          set(SDL2_MIXER_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-2.6.2/i686-w64-mingw32")
+          set(SDL2_MIXER_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer-2.8.1/i686-w64-mingw32")
         endif()
         set(SDL2_MIXER_INCLUDE_DIR "${SDL2_MIXER_DIR}/include/SDL2" CACHE PATH "")
         set(SDL2_MIXER_LIBRARY "${SDL2_MIXER_DIR}/lib/libSDL2_mixer.dll.a" CACHE FILEPATH "")

--- a/libraries/SDL-lib.cmake
+++ b/libraries/SDL-lib.cmake
@@ -8,14 +8,14 @@ if(BUILD_CLIENT)
     if(WIN32)
       if(MSVC)
         file(DOWNLOAD
-          "https://www.libsdl.org/release/SDL2-devel-2.32.4-VC.zip"
+          "https://www.libsdl.org/release/SDL2-devel-2.32.8-VC.zip"
           "${CMAKE_CURRENT_BINARY_DIR}/SDL2-VC.zip"
-          EXPECTED_HASH SHA256=28681dbef9c31a2bb4af6cbda90fdabc27c7415d65b9393da83d5abd12c4a265)
+          EXPECTED_HASH SHA256=a16e5f0e5de87a804e3c240a7d92aca0318fda176b22d95550c6512fc4f18172)
         execute_process(COMMAND "${CMAKE_COMMAND}" -E tar xf
           "${CMAKE_CURRENT_BINARY_DIR}/SDL2-VC.zip"
           WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
-        set(SDL2_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2-2.32.4")
+        set(SDL2_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2-2.32.8")
         set(SDL2_INCLUDE_DIR "${SDL2_DIR}/include" CACHE PATH "")
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
           set(SDL2_LIBRARY "${SDL2_DIR}/lib/x64/SDL2.lib" CACHE FILEPATH "")
@@ -26,17 +26,17 @@ if(BUILD_CLIENT)
         endif()
       else()
         file(DOWNLOAD
-          "https://www.libsdl.org/release/SDL2-devel-2.32.4-mingw.tar.gz"
+          "https://www.libsdl.org/release/SDL2-devel-2.32.8-mingw.tar.gz"
           "${CMAKE_CURRENT_BINARY_DIR}/SDL2-mingw.tar.gz"
-          EXPECTED_HASH SHA256=c2ec09788ab99b23b8e8e472775e5f728da549ae27898280cedbb15da87f47c1)
+          EXPECTED_HASH SHA256=f590b3707689562483ded05bf15eaf0f5d33eb97f49d0fd3b894225fe17cc52b)
         execute_process(COMMAND "${CMAKE_COMMAND}" -E tar xf
           "${CMAKE_CURRENT_BINARY_DIR}/SDL2-mingw.tar.gz"
           WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
         if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-          set(SDL2_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2-2.32.4/x86_64-w64-mingw32")
+          set(SDL2_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2-2.32.8/x86_64-w64-mingw32")
         else()
-          set(SDL2_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2-2.32.4/i686-w64-mingw32")
+          set(SDL2_DIR "${CMAKE_CURRENT_BINARY_DIR}/SDL2-2.32.8/i686-w64-mingw32")
         endif()
         set(SDL2_INCLUDE_DIR "${SDL2_DIR}/include/SDL2" CACHE PATH "")
         set(SDL2_LIBRARY "${SDL2_DIR}/lib/libSDL2.dll.a" CACHE FILEPATH "")


### PR DESCRIPTION
We've been using this version on Linux since the release of the Flatpak, and it's worked without issue there. With the hope to start adding SDL3 support sooner rather than later, I wanted to get up to the latest version of SDL2_mixer