### PR TITLE
[BUGFIX] Bad format strings in sv_vote.cpp

### DIFF
--- a/server/src/sv_vote.cpp
+++ b/server/src/sv_vote.cpp
@@ -1056,7 +1056,7 @@ bool Vote::vote(player_t &player, bool ballot)
 
 		if (timeout < timeout_check)
 		{
-			SV_PlayerPrintFmt(PRINT_HIGH, player.id, "Please wait another %d second%s to change your vote.\n",
+			SV_PlayerPrintFmt(PRINT_HIGH, player.id, "Please wait another {} second{} to change your vote.\n",
 			                  timeout_waitsec, timeout_waitsec != 1 ? "s" : "");
 			return false;
 		}
@@ -1203,7 +1203,7 @@ void SV_Callvote(player_t &player)
 	// abort the vote and print a message to the player.
 	if (!valid)
 	{
-		SV_PlayerPrintFmt(PRINT_HIGH, player.id, "%s\n", vote->get_error());
+		SV_PlayerPrintFmt(PRINT_HIGH, player.id, "{}\n", vote->get_error());
 		delete vote;
 		vote = 0;
 		return;


### PR DESCRIPTION
The format strings for some voting errors got messed up. This fixes them so they actually print useful stuff again.