### PR TITLE
[BUGFIX] Renderer crash on some transparent textures

### DIFF
--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -276,7 +276,7 @@ static inline void R_BlastSolidSegColumn(void (*drawfunc)())
 				destpostlen += translen;
 			}
 
-			if (!srcpost->next()->end() && destpostlen >= srcpost->topdelta + srcpost->length)
+			if (!srcpost->end() && !srcpost->next()->end() && destpostlen >= srcpost->topdelta + srcpost->length)
 			{
 				srcpost = srcpost->next();
 			}

--- a/client/src/r_sky.cpp
+++ b/client/src/r_sky.cpp
@@ -916,7 +916,7 @@ void R_RenderSkyRange(visplane_t* pl)
 					destpostlen += translen;
 				}
 
-				if (!skypost->next()->end() && destpostlen >= skypost->topdelta + skypost->length)
+				if (!skypost->end() && !skypost->next()->end() && destpostlen >= skypost->topdelta + skypost->length)
 				{
 					skypost = skypost->next();
 				}


### PR DESCRIPTION
Resolves the crash mentioned in #1298. The HOMs are a separate issue and are not addressed by this.

When drawing transparent textures on a single sided line, an illegal memory access could be triggered if a column of that texture contained only transparency. This is fixed.