### PR TITLE
[BUGFIX] Fix incorrect memory tag when loading a map with vanilla nodes

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -29,6 +29,7 @@
 #include <math.h>
 #include <set>
 #include <zlib.h>
+#include <nonstd/scope.hpp>
 
 #include "m_alloc.h"
 #include "m_vectors.h"
@@ -727,22 +728,20 @@ enum nodetype_t {
 
 nodetype_t P_CheckNodeType(int lump) {
 	byte *data = (byte *) W_CacheLumpNum(lump, PU_STATIC);
+	nonstd::make_scope_exit([&]{ Z_Free(data); });
 
 	if (memcmp(data, "xNd4\0\0\0\0", 8) == 0)
 	{
-		Z_Free(data);
 		return NT_DEEP;
 	}
 
 	if (memcmp(data, "XNOD", 4) == 0)
 	{
-		Z_Free(data);
 		return NT_XNOD;
 	}
 
 	if (memcmp(data, "ZNOD", 4) == 0)
 	{
-		Z_Free(data);
 		return NT_ZNOD;
 	}
 

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -728,7 +728,7 @@ enum nodetype_t {
 
 nodetype_t P_CheckNodeType(int lump) {
 	byte *data = (byte *) W_CacheLumpNum(lump, PU_STATIC);
-	nonstd::make_scope_exit([&]{ Z_Free(data); });
+	nonstd::make_scope_exit([&]{ Z_ChangeTag(data, PU_CACHE); });
 
 	if (memcmp(data, "xNd4\0\0\0\0", 8) == 0)
 	{


### PR DESCRIPTION
~~The data from vanilla NODES lumps weren't being freed except when switching wads. This is probably mostly a nonissue for clients due to the small amount of memory, but for servers with a single wad it can add up over time. This is fixed now.~~

Lump caching actually prevented this from being a memory leak, and we do want this cached instead of freed because very shortly after, one of the functions for loading the nodes will need it. So now its not being freed here at all, but the tag is being changed.