### PR TITLE
[BUGFIX] Dehacked strings not being changed on the server

### DIFF
--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -155,9 +155,6 @@ void D_Init()
 	V_InitPalette("PLAYPAL");
 	R_InitColormaps();
 
-	// [RH] Initialize localizable strings.
-	::GStrings.loadStrings(false);
-
 	// init the renderer
 	if (first_time)
 		Printf(PRINT_HIGH, "R_Init: Init DOOM refresh daemon.\n");


### PR DESCRIPTION
Addresses #1313

D_Init, on the server only, had a call to GStrings.loadStrings that occurred *after* dehacked parsing. This was resetting the strings. String are already loaded from the LANGUAGE lump at an earlier point in LoadResolvedFiles, so this call was unnecessary. It looked to be a remnant from an earlier organization of the startup process, so it has been removed.