### PR TITLE
[BUGFIX] `addmap` and `insertmap` commands adding odamex.wad to entry lists if maplist is empty

### DIFF
--- a/common/doomfunc.h
+++ b/common/doomfunc.h
@@ -149,4 +149,28 @@ struct reverse_wrapper
 template <typename T>
 inline reverse_wrapper<T> reverse(T&& iterable) { return { iterable }; }
 
+// Wrapper for skipping the first N elements in a range-based for loop
+template <typename T>
+struct drop_wrapper
+{
+    T& iterable;
+    size_t count;
+
+    auto begin() {
+        auto it = std::begin(iterable);
+        auto end_it = std::end(iterable);
+        for (size_t i = 0; i < count && it != end_it; ++i)
+            ++it;
+        return it;
+    }
+
+    inline auto end() { return std::end(iterable); }
+};
+
+/**
+ * @brief Skip the first `count` elements in a range-based for loop
+ */
+template <typename T>
+inline drop_wrapper<T> drop(T&& iterable, std::size_t count) { return { iterable, count }; }
+
 }

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -113,7 +113,7 @@ bool Maplist::insert(const size_t &position, maplist_entry_t &maplist_entry) {
 			// loaded WAD files.  Add one to the beginning of wadfiles, since
 			// position 0 stores odamex.wad.
 			maplist_entry.wads.clear();
-			for (const auto& file : ::wadfiles)
+			for (const auto& file : OUtil::drop(::wadfiles, 1))
 			{
 				maplist_entry.wads.push_back(file.getBasename());
 			}


### PR DESCRIPTION
When used with an empty maplist, and without specifying a wad list, `insertmap` and `addmap` are supposed to use the currently loaded set of wads, *not* including odamex.wad, as the wad list for the new maplist entry. Currently, they *do* include odamex.wad. This fixes that.