### PR TITLE
[BUGFIX] Enteranim animations displaying over exiting screen

### DIFF
--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -375,7 +375,7 @@ static void WI_updateAnimation(bool enteringcondition)
 	{
 		animation.states = &animation.exiting_states;
 	}
-	else if (enteranim)
+	else if (enteringcondition && enteranim)
 	{
 		animation.states = &animation.entering_states;
 	}


### PR DESCRIPTION
Fixes TropicHell_Beta_RC4fix.wad

A minor oversight was leading to animations intended for the entering screen to be drawn on the finished screen if there is an enteranim defined but no exitanim.