### PR TITLE
[BUGFIX] Broadcast flat changes to clients in EV_DoChange

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2396,6 +2396,8 @@ static void CL_SectorProperties(const odaproto::svc::SectorProperties* msg)
 			sector->base_ceiling_yoffs = msg->sector().base_ceiling_yoffs();
 			sector->base_floor_angle = msg->sector().base_floor_angle();
 			sector->base_floor_yoffs = msg->sector().base_floor_yoffs();
+		case SPC_Special:
+			sector->special = msg->sector().special();
 		default:
 			break;
 		}

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -32,6 +32,7 @@
 
 void P_ResetTransferSpecial(newspecial_s* newspecial);
 unsigned int P_ResetSectorTransferFlags(const unsigned int flags);
+void SV_BroadcastSectorProperties(int sectornum);
 
 EXTERN_CVAR(co_boomphys)
 
@@ -1134,6 +1135,10 @@ bool EV_DoChange (line_t *line, EChange changetype, int tag)
 			if (line) { // [RH] if no line, no change
 				sec->floorpic = line->frontsector->floorpic;
 				sec->special = line->frontsector->special;
+				sec->SectorChanges |= SPC_FlatPic;
+				SERVER_ONLY(
+					SV_BroadcastSectorProperties(secnum);
+				)
 			}
 			break;
 		case numChangeOnly:
@@ -1142,6 +1147,10 @@ bool EV_DoChange (line_t *line, EChange changetype, int tag)
 			{
 				sec->floorpic = secm->floorpic;
 				sec->special = secm->special;
+				sec->SectorChanges |= SPC_FlatPic;
+				SERVER_ONLY(
+					SV_BroadcastSectorProperties(secnum);
+				)
 			}
 			break;
 		default:

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -1135,7 +1135,7 @@ bool EV_DoChange (line_t *line, EChange changetype, int tag)
 			if (line) { // [RH] if no line, no change
 				sec->floorpic = line->frontsector->floorpic;
 				sec->special = line->frontsector->special;
-				sec->SectorChanges |= SPC_FlatPic;
+				sec->SectorChanges |= SPC_FlatPic | SPC_Special;
 				SERVER_ONLY(
 					SV_BroadcastSectorProperties(secnum);
 				)
@@ -1147,7 +1147,7 @@ bool EV_DoChange (line_t *line, EChange changetype, int tag)
 			{
 				sec->floorpic = secm->floorpic;
 				sec->special = secm->special;
-				sec->SectorChanges |= SPC_FlatPic;
+				sec->SectorChanges |= SPC_FlatPic | SPC_Special;
 				SERVER_ONLY(
 					SV_BroadcastSectorProperties(secnum);
 				)

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -151,7 +151,8 @@ enum SectorPropChanges
 	SPC_Scale = 64,
 	SPC_Rotation = 128,
 	SPC_AlignBase = 256,
-	SPC_Max = 512,
+	SPC_Special = 512,
+	SPC_Max = 1024,
 };
 
 enum SideDefPropChanges

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1270,6 +1270,9 @@ odaproto::svc::SectorProperties SVC_SectorProperties(sector_t& sector)
 			secmsg->set_base_floor_angle(sector.base_floor_angle);
 			secmsg->set_base_floor_yoffs(sector.base_floor_yoffs);
 			break;
+		case SPC_Special:
+			secmsg->set_special(sector.special);
+			break;
 		default:
 			break;
 		}

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1241,7 +1241,7 @@ void SV_UpdateSector(client_t* cl, int sectornum)
 	sector_t* sector = &sectors[sectornum];
 
 	// Only update moveable sectors to clients
-	if (sector != NULL && sector->moveable)
+	if (sector != nullptr && sector->moveable)
 	{
 		MSG_WriteSVC(&cl->reliablebuf, SVC_UpdateSector(*sector));
 	}
@@ -1251,6 +1251,23 @@ void SV_BroadcastSector(int sectornum)
 {
 	for (auto& player : players)
 		SV_UpdateSector(&(player.client), sectornum);
+}
+
+void SV_UpdateSectorProperties(client_t* cl, int sectornum)
+{
+	sector_t* sector = &sectors[sectornum];
+
+	// Only update sectors with changes
+	if (sector != nullptr && sector->SectorChanges)
+	{
+		MSG_WriteSVC(&cl->reliablebuf, SVC_SectorProperties(*sector));
+	}
+}
+
+void SV_BroadcastSectorProperties(int sectornum)
+{
+	for (auto& player : players)
+		SV_UpdateSectorProperties(&(player.client), sectornum);
 }
 
 //


### PR DESCRIPTION
EV_DoChange modifies the floorpic and special of a sector. This needs to be broadcast to clients to keep the level state in sync.