### PR TITLE
Fix crash when changing music type while using libadlmidi

### DIFF
--- a/client/sdl/i_musicsystem.h
+++ b/client/sdl/i_musicsystem.h
@@ -31,9 +31,7 @@
 class MusicSystem
 {
   public:
-	MusicSystem() : m_isPlaying(false), m_isPaused(false), m_tempo(120.0f), m_volume(1.0f)
-	{
-	}
+	MusicSystem() { }
 	virtual ~MusicSystem() { }
 
 	virtual void startSong(byte* data, size_t length, bool loop);
@@ -60,11 +58,11 @@ class MusicSystem
 	virtual bool isWaveCapable() const { return false; }
 
   private:
-	bool m_isPlaying;
-	bool m_isPaused;
+	bool m_isPlaying = false;
+	bool m_isPaused = false;
 
-	float m_tempo;
-	float m_volume;
+	float m_tempo = 120.0f;
+	float m_volume = 1.0f;
 };
 
 /**

--- a/client/sdl/i_musicsystem_adlmidi.cpp
+++ b/client/sdl/i_musicsystem_adlmidi.cpp
@@ -161,6 +161,8 @@ void AdlMidiMusicSystem::_StopSong()
 	if (!m_isPlaying)
 		return;
 
+	m_isPlaying = false;
+
 	Mix_HookMusic(nullptr, nullptr);
 }
 


### PR DESCRIPTION
Even after stopping playing, the midi hook was still being set, leading to it being called by the sdl mixer thread in circumstances where the midi player object is not valid.