### PR TITLE
Make carried flags have radius and height 0

### DIFF
--- a/common/info.cpp
+++ b/common/info.cpp
@@ -8072,9 +8072,9 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 	S_NULL,		// xdeathstate
 	NULL,		// deathsound
 	0,		// speed
-	20*FRACUNIT,		// radius
-	48*FRACUNIT,		// height
-	48*FRACUNIT,	// cdheight
+	0,		// radius
+	0,				// height
+	0,			// cdheight
 	100,		// mass
 	0,		// damage
 	NULL,		// activesound
@@ -8112,9 +8112,9 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 	S_NULL,		// xdeathstate
 	NULL,		// deathsound
 	0,		// speed
-	20*FRACUNIT,		// radius
-	48*FRACUNIT,		// height
-	48*FRACUNIT,	// cdheight
+	0,		// radius
+	0,			// height
+	0,		// cdheight
 	100,		// mass
 	0,		// damage
 	NULL,		// activesound
@@ -8931,9 +8931,9 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 	S_NULL,		// xdeathstate
 	NULL,		// deathsound
 	0,		// speed
-	20 * FRACUNIT,		// radius
-	48 * FRACUNIT,		// height
-	48 * FRACUNIT,	// cdheight
+	0,		// radius
+	0,				// height
+	0,			// cdheight
 	100,		// mass
 	0,		// damage
 	NULL,		// activesound


### PR DESCRIPTION
This prevents them jumping into the air when standing next to raised platforms.