### PR TITLE
Multiple UMAPINFO episode fixes

### DIFF
--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -291,6 +291,8 @@ oldmenuitem_t EpisodeMenu[MAX_EPISODES] =
 	{1,"","\0", M_Episode,0},
 	{1,"","\0", M_Episode,0},
 	{1,"","\0", M_Episode,0},
+	{1,"","\0", M_Episode,0},
+	{1,"","\0", M_Episode,0},
 	{1,"","\0", M_Episode,0}
 };
 
@@ -1014,7 +1016,7 @@ void M_NewGame(int choice)
 
 		if (episodenum > 4)
 		{
-			EpiDef.y -= LINEHEIGHT;
+			EpiDef.y -= LINEHEIGHT * (episodenum / 4);
 		}
 
 		epi = 0;
@@ -1043,7 +1045,7 @@ void M_DrawEpisode()
 
 	if (episodenum > 4)
 	{
-		y -= (LINEHEIGHT * (episodenum - 4));
+		y -= LINEHEIGHT * (episodenum / 4);
 	}
 
 	screen->DrawPatchClean(W_CachePatch("M_EPISOD"), 54, y);

--- a/client/src/m_menu.h
+++ b/client/src/m_menu.h
@@ -211,9 +211,3 @@ extern short	 itemOn;
 extern oldmenu_t *currentMenu;
 
 size_t M_FindCvarInMenu(cvar_t &cvar, menuitem_t *menu, size_t length);
-
-#define MAX_EPISODES	8
-
-extern oldmenuitem_t EpisodeMenu[MAX_EPISODES];
-extern OLumpName EpisodeMaps[MAX_EPISODES];
-extern oldmenu_t EpiDef;

--- a/common/g_episode.h
+++ b/common/g_episode.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#define MAX_EPISODES 8
+#define MAX_EPISODES 10
 
 struct EpisodeInfo
 {

--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -101,7 +101,7 @@ void MustGetIdentifier(OScanner& os)
 
 bool pnamemodified;
 
-int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
+bool ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 {
 	// find the next line with content.
 	// this line is no property.
@@ -144,7 +144,7 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 		if (!ValidateMapName(mape->nextmap))
 		{
 			os.error("Invalid map name {}", mape->nextmap);
-			return 0;
+			return false;
 		}
 	}
 	else if (!stricmp(pname.c_str(), "nextsecret"))
@@ -153,7 +153,7 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 		if (!ValidateMapName(mape->secretmap))
 		{
 			os.error("Invalid map name {}", mape->nextmap);
-			return 0;
+			return false;
 		}
 	}
 	else if (!stricmp(pname.c_str(), "levelpic"))
@@ -240,14 +240,14 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 	{
 		const std::string lname = ParseMultiString(os);
 		if (lname.empty())
-			return 0;
+			return false;
 		mape->intertext = lname;
 	}
 	else if (!stricmp(pname.c_str(), "intertextsecret"))
 	{
 		const std::string lname = ParseMultiString(os);
 		if (lname.empty())
-			return 0;
+			return false;
 		mape->intertextsecret = lname;
 	}
 	else if (!stricmp(pname.c_str(), "interbackdrop"))
@@ -272,7 +272,7 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 
 		const std::string lname = ParseMultiString(os);
 		if (lname.empty())
-			return 0;
+			return false;
 
 		if (lname == "-") // means "clear"
 		{
@@ -282,8 +282,11 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 		{
 			const StringTokens tokens = TokenizeString(lname, "\n");
 
-			if (episodenum >= 8)
-				return 0;
+			if (episodenum >= MAX_EPISODES)
+			{
+				os.error("Maximum episode definitions ({}) exceeded.", MAX_EPISODES);
+				return false;
+			}
 
 			EpisodeMaps[episodenum] = mape->mapname;
 			EpisodeInfos[episodenum].pic_name = tokens[0];
@@ -310,7 +313,7 @@ int ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 			if (i == MT_NULL)
 			{
 				os.error("Unknown thing type {}", os.getToken());
-				return 0;
+				return false;
 			}
 
 			// skip comma token
@@ -405,11 +408,8 @@ void ParseUMapInfoLump(int lump, const OLumpName& lumpname)
 		os.scan();
 		while (!os.compareToken("}"))
 		{
+			// TODO: should this be actually checking the return value here?
 			ParseStandardUmapInfoProperty(os, &info);
-		}
-		// if an episode title patch is missing, fall back on text name
-		for (int i = 0; i < MAX_EPISODES; i++) {
-			EpisodeInfos[i].fulltext = EpisodeInfos[i].pic_name.empty();
 		}
 
 		// Set default level progression here to simplify the checks elsewhere.
@@ -461,5 +461,9 @@ void ParseUMapInfoLump(int lump, const OLumpName& lumpname)
 				}
 			}
 		}
+	}
+	// if an episode title patch is missing or invalid, fall back on text name
+	for (auto& episode : EpisodeInfos) {
+		episode.fulltext = episode.pic_name.empty() || W_CheckNumForName(episode.pic_name) == -1;
 	}
 }


### PR DESCRIPTION
This PR fixes a few bugs with UMAPINFO episode definitions. 
- Now when the patch specified for the episode title is not found, Odamex falls back to using the text name instead of attempting to use the invalid patch.
- The error message when the number of defined episodes exceeds the maximum is much clearer now
- M_EPISOD is positioned correctly instead of being drawn offscreen when more than 4 episodes are defined
- The UMAPINFO episode limit has been raised from 8 to 10 to be in line with many other ports