### PR TITLE
[BUGFIX] Netdemos failing to record when saving to the default location

### DIFF
--- a/common/m_fileio.cpp
+++ b/common/m_fileio.cpp
@@ -534,7 +534,7 @@ std::string M_GetNetDemoFileName(const std::string& file, const std::string& alt
 	else
 	{
 		// Direct our path to our netdemo directory.
-		fs::path path = M_GetNetDemoDir();
+		path = M_GetNetDemoDir();
 	}
 	path /= file;
 #endif


### PR DESCRIPTION
The directory wasn't being prepended to the filename if cl_netdemodir was unset.