### PR TITLE
Draw scoreboard over crosshair instead of vice versa

### DIFF
--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -570,6 +570,9 @@ void HU_Drawer()
 	// [AM] Voting HUD!
 	ST_voteDraw(11 * CleanYfac);
 
+	if (gamestate == GS_LEVEL)
+		HU_DrawCrosshair();
+
 	if (consoleplayer().camera && !(demoplayback))
 	{
 		if ((gamestate != GS_INTERMISSION && Actions[ACTION_SHOWSCORES]) ||
@@ -579,9 +582,6 @@ void HU_Drawer()
 			HU_DrawScores(&displayplayer());
 		}
 	}
-
-	if (gamestate == GS_LEVEL)
-		HU_DrawCrosshair();
 
 	if (HU_ChatMode() != CHAT_INACTIVE)
 		HU_DrawChatPrompt();


### PR DESCRIPTION
Addresses #1338

Before:
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/b05c2f14-2b7f-40b5-8f69-32ac1c30697d" />

After:
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/aa734f0e-1119-4a3c-bf34-90bb2f8896b6" />
