### PR TITLE
[BUGFIX] Unlagged fixes

### DIFF
--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -43,6 +43,7 @@
 #include "gi.h"
 #include "g_skill.h"
 #include "p_mapformat.h"
+#include "p_unlag.h"
 
 #ifdef SERVER_APP
 #include "sv_main.h"
@@ -1854,6 +1855,13 @@ void P_KillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill
 			// don't die in auto map, switch view prior to dying
 			AM_Stop();
 		}
+
+		// Clear unlagged history as the player is now dead
+		if (serverside)
+		{
+			Unlag::getInstance().clearPlayerHistory(tplayer->id);
+		}
+
 	}
 
 	if (target->health > 0) // denis - when this function is used standalone

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -1053,6 +1053,8 @@ void A_WeaponBulletAttack(AActor* mo)
 	damagebase = psp->state->args[3];
 	damagemod = psp->state->args[4];
 
+	Unlag::getInstance().reconcile(player->id);
+
 	bool refire = player->refire ? true : false;
 
 	angle = 0;
@@ -1071,6 +1073,8 @@ void A_WeaponBulletAttack(AActor* mo)
 
 		P_LineAttack(player->mo, bangle, MISSILERANGE, slope, damage);
 	}
+
+	Unlag::getInstance().restore(player->id);
 }
 
 //
@@ -1113,6 +1117,8 @@ void A_WeaponMeleeAttack(AActor* mo)
 	if (player->powers[pw_strength])
 		damage = (damage * zerkfactor) >> FRACBITS;
 
+	Unlag::getInstance().reconcile(player->id);
+
 	// slight randomization; weird vanillaism here. :P
 	angle = player->mo->angle;
 
@@ -1126,6 +1132,8 @@ void A_WeaponMeleeAttack(AActor* mo)
 
 	// attack, dammit!
 	P_LineAttack(player->mo, angle, range, slope, damage);
+
+	Unlag::getInstance().restore(player->id);
 
 	// missed? ah, welp.
 	if (!linetarget)

--- a/common/p_unlag.cpp
+++ b/common/p_unlag.cpp
@@ -658,3 +658,23 @@ void Unlag::debugReconciliation(byte shooter_id)
 		}
 	}
 }
+
+//
+// Unlag::clearPlayerHistory
+//
+// If the player has died, clear their previous positions
+//
+void Unlag::clearPlayerHistory(byte player_id)
+{
+	if (!Unlag::enabled())
+		return;
+
+	size_t cur = player_id_map[player_id];
+
+	if (cur >= player_history.size())
+		return;
+
+	PlayerHistoryRecord& record = player_history[cur];
+
+	record.history_size = 0;
+}

--- a/common/p_unlag.h
+++ b/common/p_unlag.h
@@ -52,6 +52,7 @@ public:
 									fixed_t &x, fixed_t &y, fixed_t &z);
 	void getCurrentPlayerPosition(	byte player_id,
 									fixed_t &x, fixed_t &y, fixed_t &z);
+	void clearPlayerHistory(byte player_id);
 	static bool enabled();
 private:
 	static constexpr size_t MAX_HISTORY_TICS = TICRATE;


### PR DESCRIPTION
This PR resolves the bug of players taking damage on spawn when they respawn immediately after death, generally holding `+use` to respawn immediately, and with no spawn delay, may respawn on the same tic as death.

Generally this bug can be masked by setting `sv_spawndelay`. Theoretically, without it any lagging player could shoot you up to 35 tics (1 second). 

The unlagged system is used to "rewind" players to their position on the tic a player fired their (hitscan) weapon. On death, your history is supposed to be emptied (by setting the history_size property to 0).

This property was only set during SV_SendCommands, which happens _after_ the player died and respawned in the same tic, which means their history was not cleared.

This opens the player up to being shot by a 2nd player (I haven't been able to confirm the same player being able to shoot you twice, though theoretically possible with the chaingun, not sure about SSG).

This manifests in the player who was killed and respawned, taking damage immediately upon spawn, even if they spawn in an area without any enemies.

Now, when players die, their history is immediately cleared, which resolves this.

Also, I decided to add unlagged support to the MBF21 codepointers, as they were missing.