### PR TITLE
Add option to highlight locked doors on the automap when not using custom colors

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -71,6 +71,7 @@ EXTERN_CVAR(am_showitems)
 EXTERN_CVAR(am_showtime)
 EXTERN_CVAR(am_classicmapstring)
 EXTERN_CVAR(am_usecustomcolors)
+EXTERN_CVAR(am_showlocked)
 EXTERN_CVAR(am_ovshare)
 
 EXTERN_CVAR(am_backcolor)
@@ -114,102 +115,44 @@ EXTERN_CVAR(am_ovteleportcolor)
 
 BEGIN_COMMAND(resetcustomcolors)
 {
-	if (argc < 2)
-	{
-		PrintFmt(PRINT_WARNING, "Resets custom automap colors to one of the following defaults.\n");
-		PrintFmt(PRINT_WARNING, "Usage: resetcustomcolors <preset>\n");
-		PrintFmt(PRINT_WARNING, "  odamex      - odamex's classic blue automap\n");
-		PrintFmt(PRINT_WARNING, "  vanillaplus - the automap colors of vanilla Doom plus a few enhancements\n");
-		return;
-	}
+	am_backcolor = "00 00 3a";
+	am_yourcolor = "fc e8 d8";
+	am_wallcolor = "00 8b ff";
+	am_tswallcolor = "10 32 7e";
+	am_fdwallcolor = "1a 1a 8a";
+	am_cdwallcolor = "00 00 5a";
+	am_thingcolor = "9f d3 ff";
+	am_thingcolor_item = "navy";
+	am_thingcolor_countitem = "sky blue";
+	am_thingcolor_monster = "74 fc 6c";
+	am_thingcolor_nocountmonster = "yellow";
+	am_thingcolor_friend = "dark green";
+	am_thingcolor_projectile = "orange";
+	am_gridcolor = "44 44 88";
+	am_xhaircolor = "80 80 80";
+	am_notseencolor = "00 22 6e";
+	am_lockedcolor = "bb bb bb";
+	am_exitcolor = "ff ff 00";
+	am_teleportcolor = "ff a3 00";
 
-	if (iequals(argv[1], "odamex"))
-	{
-		am_backcolor = "00 00 3a";
-		am_yourcolor = "fc e8 d8";
-		am_wallcolor = "00 8b ff";
-		am_tswallcolor = "10 32 7e";
-		am_fdwallcolor = "1a 1a 8a";
-		am_cdwallcolor = "00 00 5a";
-		am_thingcolor = "9f d3 ff";
-		am_thingcolor_item = "navy";
-		am_thingcolor_countitem = "sky blue";
-		am_thingcolor_monster = "74 fc 6c";
-		am_thingcolor_nocountmonster = "yellow";
-		am_thingcolor_friend = "dark green";
-		am_thingcolor_projectile = "orange";
-		am_gridcolor = "44 44 88";
-		am_xhaircolor = "80 80 80";
-		am_notseencolor = "00 22 6e";
-		am_lockedcolor = "bb bb bb";
-		am_exitcolor = "ff ff 00";
-		am_teleportcolor = "ff a3 00";
-
-		am_ovyourcolor = "fc e8 d8";
-		am_ovwallcolor = "00 8b ff";
-		am_ovtswallcolor = "10 32 7e";
-		am_ovfdwallcolor = "1a 1a 8a";
-		am_ovcdwallcolor = "00 00 5a";
-		am_ovthingcolor = "9f d3 ff";
-		am_ovthingcolor_item = "navy";
-		am_ovthingcolor_countitem = "sky blue";
-		am_ovthingcolor_monster = "74 fc 6c";
-		am_ovthingcolor_nocountmonster = "yellow";
-		am_ovthingcolor_friend = "dark green";
-		am_ovthingcolor_projectile = "orange";
-		am_ovgridcolor = "44 44 88";
-		am_ovxhaircolor = "80 80 80";
-		am_ovnotseencolor = "00 22 6e";
-		am_ovlockedcolor = "bb bb bb";
-		am_ovexitcolor = "ff ff 00";
-		am_ovteleportcolor = "ff a3 00";
-	}
-	else if (iequals(argv[1], "vanillaplus"))
-	{
-		am_backcolor = "00 00 00";
-		am_yourcolor = "ff ff ff";
-		am_wallcolor = "fc 00 00";
-		am_tswallcolor = "80 80 80";
-		am_fdwallcolor = "bc 78 48";
-		am_cdwallcolor = "fc fc 00";
-		am_thingcolor = "dark grey";
-		am_thingcolor_item = "navy";
-		am_thingcolor_countitem = "sky blue";
-		am_thingcolor_monster = "74 fc 6c";
-		am_thingcolor_nocountmonster = "yellow";
-		am_thingcolor_friend = "dark green";
-		am_thingcolor_projectile = "orange";
-		am_gridcolor = "4c 4c 4c";
-		am_xhaircolor = "80 80 80";
-		am_notseencolor = "6c 6c 6c";
-		am_lockedcolor = "ff ff ff";
-		am_exitcolor = "ff ff 00";
-		am_teleportcolor = "ff a3 00";
-
-		am_ovyourcolor = "ff ff ff";
-		am_ovwallcolor = "fc 00 00";
-		am_ovtswallcolor = "80 80 80";
-		am_ovfdwallcolor = "bc 78 48";
-		am_ovcdwallcolor = "fc fc 00";
-		am_ovthingcolor = "dark grey";
-		am_ovthingcolor_item = "navy";
-		am_ovthingcolor_countitem = "sky blue";
-		am_ovthingcolor_monster = "74 fc 6c";
-		am_ovthingcolor_nocountmonster = "yellow";
-		am_ovthingcolor_friend = "dark green";
-		am_ovthingcolor_projectile = "orange";
-		am_ovgridcolor = "4c 4c 4c";
-		am_ovxhaircolor = "80 80 80";
-		am_ovnotseencolor = "6c 6c 6c";
-		am_ovlockedcolor = "ff ff ff";
-		am_ovexitcolor = "ff ff 00";
-		am_ovteleportcolor = "ff a3 00";
-	}
-	else
-	{
-		PrintFmt(PRINT_HIGH, "Unknown automap preset {}", argv[1]);
-		return;
-	}
+	am_ovyourcolor = "fc e8 d8";
+	am_ovwallcolor = "00 8b ff";
+	am_ovtswallcolor = "10 32 7e";
+	am_ovfdwallcolor = "1a 1a 8a";
+	am_ovcdwallcolor = "00 00 5a";
+	am_ovthingcolor = "9f d3 ff";
+	am_ovthingcolor_item = "navy";
+	am_ovthingcolor_countitem = "sky blue";
+	am_ovthingcolor_monster = "74 fc 6c";
+	am_ovthingcolor_nocountmonster = "yellow";
+	am_ovthingcolor_friend = "dark green";
+	am_ovthingcolor_projectile = "orange";
+	am_ovgridcolor = "44 44 88";
+	am_ovxhaircolor = "80 80 80";
+	am_ovnotseencolor = "00 22 6e";
+	am_ovlockedcolor = "bb bb bb";
+	am_ovexitcolor = "ff ff 00";
+	am_ovteleportcolor = "ff a3 00";
 
 	PrintFmt(PRINT_HIGH, "Custom automap colors reset to default.\n");
 }
@@ -751,6 +694,12 @@ void AM_initColors(const bool overlayed)
 			AM_GetColorFromString(palette_colors, gameinfo.defaultAutomapColors.XHairColor);
 		gameinfo.currentAutomapColors.NotSeenColor =
 			AM_GetColorFromString(palette_colors, gameinfo.defaultAutomapColors.NotSeenColor);
+	}
+
+	if (am_showlocked)
+	{
+		gameinfo.currentAutomapColors.LockedColor =
+			AM_GetColorFromString(palette_colors, "ff ff ff");
 	}
 }
 
@@ -1415,7 +1364,7 @@ void AM_drawWalls()
 						g = gameinfo.currentAutomapColors.LockedColor.rgb.getg();
 						b = gameinfo.currentAutomapColors.LockedColor.rgb.getb();
 
-						if (am_usecustomcolors)
+						if (am_usecustomcolors || am_showlocked)
 						{
 							if (lines[i].args[3] == (zk_blue_card | zk_blue))
 							{
@@ -1463,7 +1412,7 @@ void AM_drawWalls()
 						g = gameinfo.currentAutomapColors.LockedColor.rgb.getg();
 						b = gameinfo.currentAutomapColors.LockedColor.rgb.getb();
 
-						if (am_usecustomcolors)
+						if (am_usecustomcolors || am_showlocked)
 						{
 							if (P_IsCompatibleBlueDoorLine(lines[i].special))
 							{

--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -114,45 +114,104 @@ EXTERN_CVAR(am_ovteleportcolor)
 
 BEGIN_COMMAND(resetcustomcolors)
 {
-	am_backcolor = "00 00 3a";
-	am_yourcolor = "fc e8 d8";
-	am_wallcolor = "00 8b ff";
-	am_tswallcolor = "10 32 7e";
-	am_fdwallcolor = "1a 1a 8a";
-	am_cdwallcolor = "00 00 5a";
-	am_thingcolor = "9f d3 ff";
-	am_thingcolor_item = "navy";
-	am_thingcolor_countitem = "sky blue";
-	am_thingcolor_monster = "74 fc 6c";
-	am_thingcolor_nocountmonster = "yellow";
-	am_thingcolor_friend = "dark green";
-	am_thingcolor_projectile = "orange";
-	am_gridcolor = "44 44 88";
-	am_xhaircolor = "80 80 80";
-	am_notseencolor = "00 22 6e";
-	am_lockedcolor = "bb bb bb";
-	am_exitcolor = "ff ff 00";
-	am_teleportcolor = "ff a3 00";
+	if (argc < 2)
+	{
+		PrintFmt(PRINT_WARNING, "Resets custom automap colors to one of the following defaults.\n");
+		PrintFmt(PRINT_WARNING, "Usage: resetcustomcolors <preset>\n");
+		PrintFmt(PRINT_WARNING, "  odamex      - odamex's classic blue automap\n");
+		PrintFmt(PRINT_WARNING, "  vanillaplus - the automap colors of vanilla Doom plus a few enhancements\n");
+		return;
+	}
 
-	am_ovyourcolor = "fc e8 d8";
-	am_ovwallcolor = "00 8b ff";
-	am_ovtswallcolor = "10 32 7e";
-	am_ovfdwallcolor = "1a 1a 8a";
-	am_ovcdwallcolor = "00 00 5a";
-	am_ovthingcolor = "9f d3 ff";
-	am_ovthingcolor_item = "navy";
-	am_ovthingcolor_countitem = "sky blue";
-	am_ovthingcolor_monster = "74 fc 6c";
-	am_ovthingcolor_nocountmonster = "yellow";
-	am_ovthingcolor_friend = "dark green";
-	am_ovthingcolor_projectile = "orange";
-	am_ovgridcolor = "44 44 88";
-	am_ovxhaircolor = "80 80 80";
-	am_ovnotseencolor = "00 22 6e";
-	am_ovlockedcolor = "bb bb bb";
-	am_ovexitcolor = "ff ff 00";
-	am_ovteleportcolor = "ff a3 00";
-	Printf(PRINT_HIGH, "Custom automap colors reset to default.\n");
+	if (iequals(argv[1], "odamex"))
+	{
+		am_backcolor = "00 00 3a";
+		am_yourcolor = "fc e8 d8";
+		am_wallcolor = "00 8b ff";
+		am_tswallcolor = "10 32 7e";
+		am_fdwallcolor = "1a 1a 8a";
+		am_cdwallcolor = "00 00 5a";
+		am_thingcolor = "9f d3 ff";
+		am_thingcolor_item = "navy";
+		am_thingcolor_countitem = "sky blue";
+		am_thingcolor_monster = "74 fc 6c";
+		am_thingcolor_nocountmonster = "yellow";
+		am_thingcolor_friend = "dark green";
+		am_thingcolor_projectile = "orange";
+		am_gridcolor = "44 44 88";
+		am_xhaircolor = "80 80 80";
+		am_notseencolor = "00 22 6e";
+		am_lockedcolor = "bb bb bb";
+		am_exitcolor = "ff ff 00";
+		am_teleportcolor = "ff a3 00";
+
+		am_ovyourcolor = "fc e8 d8";
+		am_ovwallcolor = "00 8b ff";
+		am_ovtswallcolor = "10 32 7e";
+		am_ovfdwallcolor = "1a 1a 8a";
+		am_ovcdwallcolor = "00 00 5a";
+		am_ovthingcolor = "9f d3 ff";
+		am_ovthingcolor_item = "navy";
+		am_ovthingcolor_countitem = "sky blue";
+		am_ovthingcolor_monster = "74 fc 6c";
+		am_ovthingcolor_nocountmonster = "yellow";
+		am_ovthingcolor_friend = "dark green";
+		am_ovthingcolor_projectile = "orange";
+		am_ovgridcolor = "44 44 88";
+		am_ovxhaircolor = "80 80 80";
+		am_ovnotseencolor = "00 22 6e";
+		am_ovlockedcolor = "bb bb bb";
+		am_ovexitcolor = "ff ff 00";
+		am_ovteleportcolor = "ff a3 00";
+	}
+	else if (iequals(argv[1], "vanillaplus"))
+	{
+		am_backcolor = "00 00 00";
+		am_yourcolor = "ff ff ff";
+		am_wallcolor = "fc 00 00";
+		am_tswallcolor = "80 80 80";
+		am_fdwallcolor = "bc 78 48";
+		am_cdwallcolor = "fc fc 00";
+		am_thingcolor = "dark grey";
+		am_thingcolor_item = "navy";
+		am_thingcolor_countitem = "sky blue";
+		am_thingcolor_monster = "74 fc 6c";
+		am_thingcolor_nocountmonster = "yellow";
+		am_thingcolor_friend = "dark green";
+		am_thingcolor_projectile = "orange";
+		am_gridcolor = "4c 4c 4c";
+		am_xhaircolor = "80 80 80";
+		am_notseencolor = "6c 6c 6c";
+		am_lockedcolor = "ff ff ff";
+		am_exitcolor = "ff ff 00";
+		am_teleportcolor = "ff a3 00";
+
+		am_ovyourcolor = "ff ff ff";
+		am_ovwallcolor = "fc 00 00";
+		am_ovtswallcolor = "80 80 80";
+		am_ovfdwallcolor = "bc 78 48";
+		am_ovcdwallcolor = "fc fc 00";
+		am_ovthingcolor = "dark grey";
+		am_ovthingcolor_item = "navy";
+		am_ovthingcolor_countitem = "sky blue";
+		am_ovthingcolor_monster = "74 fc 6c";
+		am_ovthingcolor_nocountmonster = "yellow";
+		am_ovthingcolor_friend = "dark green";
+		am_ovthingcolor_projectile = "orange";
+		am_ovgridcolor = "4c 4c 4c";
+		am_ovxhaircolor = "80 80 80";
+		am_ovnotseencolor = "6c 6c 6c";
+		am_ovlockedcolor = "ff ff ff";
+		am_ovexitcolor = "ff ff 00";
+		am_ovteleportcolor = "ff a3 00";
+	}
+	else
+	{
+		PrintFmt(PRINT_HIGH, "Unknown automap preset {}", argv[1]);
+		return;
+	}
+
+	PrintFmt(PRINT_HIGH, "Custom automap colors reset to default.\n");
 }
 END_COMMAND(resetcustomcolors)
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -60,7 +60,10 @@ CVAR(					am_classicmapstring, "0", "",
 CVAR(					am_usecustomcolors, "0", "",
 						CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
-CVAR(					am_ovshare, "0", "",
+CVAR(					am_showlocked, "0", "Show locked doors on the automap even when custom colors are disabled.",
+						CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
+CVAR(					am_ovshare, "0", "Overlay automap uses the same custom colors as the non-overlayed automap.",
 						CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
 CVAR(					am_backcolor, "00 00 3a", "",

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -842,6 +842,7 @@ EXTERN_CVAR (am_showsecrets)
 EXTERN_CVAR (am_showtime)
 EXTERN_CVAR (am_classicmapstring)
 EXTERN_CVAR (am_usecustomcolors)
+EXTERN_CVAR (am_showlocked)
 EXTERN_CVAR (st_scale)
 EXTERN_CVAR (r_stretchsky)
 EXTERN_CVAR (r_linearsky)
@@ -1166,6 +1167,7 @@ static menuitem_t AutomapItems[] = {
 
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
 	{ yellowtext, "Automap Colors",		{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
+	{ discrete, "Highlight locked doors",{&am_showlocked},		{2.0}, {0.0},	{0.0},  {OnOff} },
 	{ discrete, "Custom map colors",	{&am_usecustomcolors},	{2.0}, {0.0},	{0.0},  {OnOff} },
 	{ more,     "Reset custom map colors",  {NULL},    {0.0}, {0.0},   {0.0},  {(value_t *)ResetCustomColors} },
 };
@@ -2560,12 +2562,7 @@ static void StartAutomapMenu (void)
 
 void ResetCustomColors (void)
 {
-	AddCommandString ("resetcustomcolors odamex");
-}
-
-void ResetCustomColors2 (void)
-{
-	AddCommandString ("resetcustomcolors vanillaplus");
+	AddCommandString ("resetcustomcolors");
 }
 
 void MouseSetup (void) // [Toke] for mouse menu

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1167,7 +1167,7 @@ static menuitem_t AutomapItems[] = {
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
 	{ yellowtext, "Automap Colors",		{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
 	{ discrete, "Custom map colors",	{&am_usecustomcolors},	{2.0}, {0.0},	{0.0},  {OnOff} },
-	{ more,     "Reset custom map colors",  {NULL},             {0.0}, {0.0},   {0.0},  {(value_t *)ResetCustomColors} },
+	{ more,     "Reset custom map colors",  {NULL},    {0.0}, {0.0},   {0.0},  {(value_t *)ResetCustomColors} },
 };
 
 menu_t AutomapMenu = {
@@ -2560,7 +2560,12 @@ static void StartAutomapMenu (void)
 
 void ResetCustomColors (void)
 {
-	AddCommandString ("resetcustomcolors");
+	AddCommandString ("resetcustomcolors odamex");
+}
+
+void ResetCustomColors2 (void)
+{
+	AddCommandString ("resetcustomcolors vanillaplus");
 }
 
 void MouseSetup (void) // [Toke] for mouse menu


### PR DESCRIPTION
Currently, Odamex only allows colored + flashing locked doors when `am_usecustomcolors` is enabled. For players who just want the default colors with that one change, its a hassle to set the correct colors, and it means that their colors will always override any colors set in gameinfo, which some players may not prefer. This PR introduces `am_showlocked`, and a corresponding option in the automap menu, which when enabled will cause the locked doors to be colored and flash just the same as when custom colors are enabled but otherwise not having any effect on automap colors.