### PR TITLE
[BUGFIX] Remove toasts that haven't happened yet on rewinding netdemo

### DIFF
--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -1143,7 +1143,9 @@ void ToastTicker()
 	{
 		const int tics = ::gametic - it->tic;
 
-		if (tics >= fadeDoneTics)
+		// The gametic may move backwards in case of netdemo rewinding
+		// If this happens, we need to remove the toast as it hasn't happened yet.
+		if (tics >= fadeDoneTics || it->tic > gametic)
 		{
 			it = g_Toasts.erase(it);
 		}

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -1145,7 +1145,7 @@ void ToastTicker()
 
 		// The gametic may move backwards in case of netdemo rewinding
 		// If this happens, we need to remove the toast as it hasn't happened yet.
-		if (tics >= fadeDoneTics || it->tic > gametic)
+		if (tics >= fadeDoneTics || it->tic > ::gametic)
 		{
 			it = g_Toasts.erase(it);
 		}


### PR DESCRIPTION
Does as the title says, if you rewind behind the tic where the toast was created, the toast wouldn't go away because of the large number of tics needed to remove it, now that you went back in time. The event didn't happen yet so we should remove them.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a5d06d5e-409c-41b1-b67b-ea0606e4197d" />
