### PR TITLE
[FEATURE] Automap line thickness

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -1093,7 +1093,7 @@ bool AM_clipMline(mline_t* ml, fline_t* fl)
 }
 #undef DOOUTCODE
 
-
+// [EB] adapted from International Doom am_map.c
 static inline void PUTDOTP_THICK (int x, int y, byte color)
 {
 	// Thin point fast path
@@ -1104,8 +1104,7 @@ static inline void PUTDOTP_THICK (int x, int y, byte color)
 	}
 
 	// Thickness: 0 == auto (depends on resolution)
-	// TODO: implement the auto size
-	const int thickness = (am_thickness == 0) ? (1) : am_thickness.asInt();
+	const int thickness = (am_thickness == 0) ? (CleanXfac >> 2) : am_thickness.asInt() - 1;
 
 	// Clamp bbox once
 	const int fwm1 = f_w - 1, fhm1 = f_h - 1;
@@ -1120,9 +1119,6 @@ static inline void PUTDOTP_THICK (int x, int y, byte color)
 	byte* fbuf = fb;
 	const int fw = f_w;
 
-	// Paletted path: map index → pixel once
-	const byte fg = color;
-
 	for (int nx = minx; nx <= maxx; ++nx)
 	{
 		const int dx  = nx - x;
@@ -1134,7 +1130,7 @@ static inline void PUTDOTP_THICK (int x, int y, byte color)
 		{
 			const int dy = ny - y;
 			if (dx2 + dy * dy > thick_sq) continue;
-			*pix = fg;
+			*pix = color;
 		}
 	}
 }
@@ -1149,8 +1145,7 @@ static inline void PUTDOTD_THICK (int x, int y, argb_t color)
 	}
 
 	// Thickness: 0 == auto (depends on resolution)
-	// TODO: implement the auto size
-	const int thickness = (am_thickness == 0) ? (1) : am_thickness.asInt();
+	const int thickness = (am_thickness == 0) ? (CleanXfac >> 2) : am_thickness.asInt() - 1;
 
 	// Clamp bbox once
 	const int fwm1 = f_w - 1, fhm1 = f_h - 1;
@@ -1165,9 +1160,6 @@ static inline void PUTDOTD_THICK (int x, int y, argb_t color)
 	argb_t* fbuf = reinterpret_cast<argb_t*>(fb);
 	const int fw = f_p >> 2;
 
-	// Paletted path: map index → pixel once
-	const argb_t fg = color;
-
 	for (int nx = minx; nx <= maxx; ++nx)
 	{
 		const int dx  = nx - x;
@@ -1179,18 +1171,10 @@ static inline void PUTDOTD_THICK (int x, int y, argb_t color)
 		{
 			const int dy = ny - y;
 			if (dx2 + dy * dy > thick_sq) continue;
-			*pix = fg;
+			*pix = color;
 		}
 	}
 }
-
-		// argb_t* line = reinterpret_cast<argb_t*>(fb);
-		// for (int y = 0; y < f_h; y++)
-		// {
-		// 	for (int x = 0; x < f_w; x++)
-		// 		line[x] = color.rgb;
-		// 	line += f_p >> 2;
-		// }
 
 //
 // Classic Bresenham w/ whatever optimizations needed for speed

--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -177,9 +177,6 @@ EXTERN_CVAR(screenblocks)
 #define FTOM(x) FixedMul64((INT2FIXED64((x))), scale_ftom)
 #define MTOF(x) FIXED642INT(FixedMul64((x), scale_mtof))
 
-#define PUTDOTP(xx, yy, cc) fb[(yy)*f_p + (xx)] = (cc)
-#define PUTDOTD(xx, yy, cc) *((argb_t*)(fb + (yy)*f_p + ((xx) << 2))) = (cc)
-
 typedef v2int_t fpoint_t;
 
 typedef struct
@@ -1094,12 +1091,18 @@ bool AM_clipMline(mline_t* ml, fline_t* fl)
 #undef DOOUTCODE
 
 // [EB] adapted from International Doom am_map.c
-static inline void PUTDOTP_THICK (int x, int y, byte color)
+template <typename PIXEL_T>
+static inline void PUTDOT_THICK(
+	int x, int y,
+	PIXEL_T color,
+	void (*PUTDOT)(int, int, PIXEL_T),
+	PIXEL_T* fbuf,
+	int pitch)
 {
 	// Thin point fast path
 	if (am_thickness.asInt() == 1)
 	{
-		PUTDOTP(x, y, color);
+		PUTDOT(x, y, color);
 		return;
 	}
 
@@ -1115,18 +1118,14 @@ static inline void PUTDOTP_THICK (int x, int y, byte color)
 
 	const int thick_sq = thickness * thickness;
 
-	// Cache fb pointer and width
-	byte* fbuf = fb;
-	const int fw = f_w;
-
 	for (int nx = minx; nx <= maxx; ++nx)
 	{
 		const int dx  = nx - x;
 		const int dx2 = dx * dx;
 
-		byte *pix = fbuf + miny * fw + nx;
+		PIXEL_T* pix = fbuf + miny * pitch + nx;
 
-		for (int ny = miny; ny <= maxy; ++ny, pix += fw)
+		for (int ny = miny; ny <= maxy; ++ny, pix += pitch)
 		{
 			const int dy = ny - y;
 			if (dx2 + dy * dy > thick_sq) continue;
@@ -1135,54 +1134,22 @@ static inline void PUTDOTP_THICK (int x, int y, byte color)
 	}
 }
 
-static inline void PUTDOTD_THICK (int x, int y, argb_t color)
+static inline void PUTDOT_THICK(int x, int y, argb_t color)
 {
-	// Thin point fast path
-	if (am_thickness.asInt() == 1)
-	{
-		PUTDOTD(x, y, color);
-		return;
-	}
+	PUTDOT_THICK<argb_t>(x, y, color, [](int x, int y, argb_t color){ *((argb_t*)(fb + y * f_p + (x << 2))) = color; }, reinterpret_cast<argb_t*>(fb), f_p >> 2);
+}
 
-	// Thickness: 0 == auto (depends on resolution)
-	const int thickness = (am_thickness == 0) ? (CleanXfac >> 2) : am_thickness.asInt() - 1;
-
-	// Clamp bbox once
-	const int fwm1 = f_w - 1, fhm1 = f_h - 1;
-	int minx = x - thickness; if (minx < 0)   minx = 0;
-	int maxx = x + thickness; if (maxx > fwm1) maxx = fwm1;
-	int miny = y - thickness; if (miny < 0)   miny = 0;
-	int maxy = y + thickness; if (maxy > fhm1) maxy = fhm1;
-
-	const int thick_sq = thickness * thickness;
-
-	// Cache fb pointer and width
-	argb_t* fbuf = reinterpret_cast<argb_t*>(fb);
-	const int fw = f_p >> 2;
-
-	for (int nx = minx; nx <= maxx; ++nx)
-	{
-		const int dx  = nx - x;
-		const int dx2 = dx * dx;
-
-		argb_t *pix = fbuf + miny * fw + nx;
-
-		for (int ny = miny; ny <= maxy; ++ny, pix += f_p >> 2)
-		{
-			const int dy = ny - y;
-			if (dx2 + dy * dy > thick_sq) continue;
-			*pix = color;
-		}
-	}
+static inline void PUTDOT_THICK(int x, int y, byte color)
+{
+	PUTDOT_THICK<byte>(x, y, color, [](int x, int y, byte color){ fb[y * f_p + x] = color; }, fb, f_w);
 }
 
 //
 // Classic Bresenham w/ whatever optimizations needed for speed
 //
 
-// Palettized (8bpp) version:
-
-void AM_drawFlineP(fline_t* fl, byte color)
+template<typename PIXEL_T>
+void AM_drawFline(fline_t* fl, PIXEL_T color)
 {
 	fl->a.x += f.x;
 	fl->a.y += f.y;
@@ -1205,7 +1172,7 @@ void AM_drawFlineP(fline_t* fl, byte color)
 		int d = ay - ax / 2;
 		while (true)
 		{
-			PUTDOTP_THICK(x, y, (byte)color);
+			PUTDOT_THICK(x, y, color);
 			if (x == fl->b.x)
 				return;
 			if (d >= 0)
@@ -1222,66 +1189,7 @@ void AM_drawFlineP(fline_t* fl, byte color)
 		int d = ax - ay / 2;
 		while (true)
 		{
-			PUTDOTP_THICK(x, y, (byte)color);
-			if (y == fl->b.y)
-				return;
-			if (d >= 0)
-			{
-				x += sx;
-				d -= ay;
-			}
-			y += sy;
-			d += ax;
-		}
-	}
-}
-
-// Direct (32bpp) version:
-
-void AM_drawFlineD(fline_t* fl, argb_t color)
-{
-	fl->a.x += f.x;
-	fl->b.x += f.x;
-	fl->a.y += f.y;
-	fl->b.y += f.y;
-
-	const int dx = fl->b.x - fl->a.x;
-	const int ax = 2 * (dx < 0 ? -dx : dx);
-	const int sx = dx < 0 ? -1 : 1;
-
-	const int dy = fl->b.y - fl->a.y;
-	const int ay = 2 * (dy < 0 ? -dy : dy);
-	const int sy = dy < 0 ? -1 : 1;
-
-	int x = fl->a.x;
-	int y = fl->a.y;
-
-	int d;
-
-	if (ax > ay)
-	{
-		d = ay - ax / 2;
-
-		while (true)
-		{
-			PUTDOTD_THICK(x, y, color);
-			if (x == fl->b.x)
-				return;
-			if (d >= 0)
-			{
-				y += sy;
-				d -= ax;
-			}
-			x += sx;
-			d += ay;
-		}
-	}
-	else
-	{
-		d = ax - ay / 2;
-		while (true)
-		{
-			PUTDOTD_THICK(x, y, color);
+			PUTDOT_THICK(x, y, color);
 			if (y == fl->b.y)
 				return;
 			if (d >= 0)
@@ -1306,9 +1214,9 @@ void AM_drawMline(mline_t* ml, am_color_t color)
 	{
 		// draws it on frame buffer using fb coords
 		if (I_GetPrimarySurface()->getBitsPerPixel() == 8)
-			AM_drawFlineP(&fl, color.index);
+			AM_drawFline<byte>(&fl, color.index);
 		else
-			AM_drawFlineD(&fl, color.rgb);
+			AM_drawFline<argb_t>(&fl, color.rgb);
 	}
 }
 
@@ -1935,9 +1843,9 @@ void AM_drawCrosshair(am_color_t color)
 {
 	// single point for now
 	if (I_GetPrimarySurface()->getBitsPerPixel() == 8)
-		PUTDOTP(f_w / 2, (f_h + 1) / 2, (byte)color.index);
+		PUTDOT_THICK(f_w / 2, (f_h + 1) / 2, (byte)color.index);
 	else
-		PUTDOTD(f_w / 2, (f_h + 1) / 2, color.rgb);
+		PUTDOT_THICK(f_w / 2, (f_h + 1) / 2, color.rgb);
 }
 
 //

--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -1162,11 +1162,8 @@ static inline void PUTDOTD_THICK (int x, int y, argb_t color)
 	const int thick_sq = thickness * thickness;
 
 	// Cache fb pointer and width
-	argb_t* fbuf = (argb_t*)fb;
-	const int fw = f_w;
-
-	// #define PUTDOTD(xx, yy, cc) *((argb_t*)(fb + (yy)*f_p + ((xx) << 2))) = (cc)
-	// #define PUTDOTP(xx, yy, cc) fb[(yy)*f_p + (xx)] = (cc)
+	argb_t* fbuf = reinterpret_cast<argb_t*>(fb);
+	const int fw = f_p >> 2;
 
 	// Paletted path: map index → pixel once
 	const argb_t fg = color;
@@ -1178,7 +1175,7 @@ static inline void PUTDOTD_THICK (int x, int y, argb_t color)
 
 		argb_t *pix = fbuf + miny * fw + nx;
 
-		for (int ny = miny; ny <= maxy; ++ny, pix += fw)
+		for (int ny = miny; ny <= maxy; ++ny, pix += f_p >> 2)
 		{
 			const int dy = ny - y;
 			if (dx2 + dy * dy > thick_sq) continue;
@@ -1186,6 +1183,14 @@ static inline void PUTDOTD_THICK (int x, int y, argb_t color)
 		}
 	}
 }
+
+		// argb_t* line = reinterpret_cast<argb_t*>(fb);
+		// for (int y = 0; y < f_h; y++)
+		// {
+		// 	for (int x = 0; x < f_w; x++)
+		// 		line[x] = color.rgb;
+		// 	line += f_p >> 2;
+		// }
 
 //
 // Classic Bresenham w/ whatever optimizations needed for speed

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -36,7 +36,7 @@ CVAR(					am_followplayer, "1", "",
 CVAR(					am_rotate, "0", "",
 						CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
-CVAR_RANGE(				am_thickness, "1", "",
+CVAR_RANGE(				am_thickness, "1", "Scale the thickness of the automap lines by this value. Set to 0 for auto.",
 						CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 6.0f)
 
 CVAR_RANGE(				am_overlay, "0", "",

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -36,6 +36,9 @@ CVAR(					am_followplayer, "1", "",
 CVAR(					am_rotate, "0", "",
 						CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
+CVAR_RANGE(				am_thickness, "1", "",
+						CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 6.0f)
+
 CVAR_RANGE(				am_overlay, "0", "",
 						CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 3.0f)
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -835,6 +835,7 @@ void ResetCustomColors (void);
 
 EXTERN_CVAR (am_rotate)
 EXTERN_CVAR (am_overlay)
+EXTERN_CVAR (am_thickness)
 EXTERN_CVAR (am_showmonsters)
 EXTERN_CVAR (am_showitems)
 EXTERN_CVAR (am_showsecrets)
@@ -1141,9 +1142,21 @@ static value_t ClassicMapStringTypes[] = {
 	{ 1.0, "Classic" }
 };
 
+static value_t AutomapScales[] = {
+	{ 0.0, "Auto" },
+	{ 1.0, "1X" },
+	{ 2.0, "2X" },
+	{ 3.0, "3X" },
+	{ 4.0, "4X" },
+	{ 5.0, "5X" },
+	{ 6.0, "6X" },
+};
+
 static menuitem_t AutomapItems[] = {
 	{ discrete, "Rotate automap",		{&am_rotate},		   	{2.0}, {0.0},	{0.0},  {OnOff} },
 	{ discrete, "Overlay automap",		{&am_overlay},			{4.0}, {0.0},	{0.0},  {Overlays} },
+	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
+	{ discrete, "Line Thickeness",		{&am_thickness},		{7.0}, {0.0},	{0.0},  {AutomapScales} },
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
     { discrete, "Show item count",		{&am_showitems},		{2.0}, {0.0},	{0.0},  {OnOff} },
     { discrete, "Show monster count",	{&am_showmonsters},		{2.0}, {0.0},	{0.0},	{OnOff} },


### PR DESCRIPTION
This PR introduces the ability to scale the thickness of the automap lines by up to 6x, improving visibility of the lines on modern hi res displays. By default the `am_thickness` cvar is set to 1 for the original 1 pixel lines, and can be raised to thicken them or set to 0 to automatically set thickness.

`am_thickness 1` at 720p
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/05d95d9f-3acf-4157-89f5-7dfb1dfe4c89" />

`am_thickness 2` at 720p
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/05538189-b619-4da9-aef0-0e79fa614843" />
