### PR TITLE
[BUGFIX] Blue flag appearing as imp in certain demos

### DIFF
--- a/common/teaminfo.cpp
+++ b/common/teaminfo.cpp
@@ -53,6 +53,7 @@ void InitTeamInfo()
 	teamInfo->FlagSocketSprite = SPR_BSOK;
 	teamInfo->FlagSprite = SPR_BFLG;
 	teamInfo->FlagDownSprite = SPR_BDWN;
+	teamInfo->FlagCarrySprite = SPR_BCAR;
 	teamInfo->FlagWaypointSprite = SPR_WPBF;
 	teamInfo->Points = 0;
 	teamInfo->RoundWins = 0;


### PR DESCRIPTION
When reading demo snapshots, things' sprites are compared against the flag carry sprites defined in teaminfo to determine if they are the flag. For the blue flag, the carry sprite was being set to 0 (SPR_TROO), which led to the first mobj found with that sprite would be used instead of the actual flag.