### PR TITLE
[BUGFIX] ZDoom line of sight checks sometimes allow enemies to be alerted through walls

### DIFF
--- a/common/p_sight.cpp
+++ b/common/p_sight.cpp
@@ -360,7 +360,26 @@ bool P_SightPathTraverse (fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2)
 		if (mapxstep == 0 && mapystep == 0)
 			break;
 
-		if ( (yintercept >> FRACBITS) == mapy)
+		// if vanilla Heretic/Hexen demo playback is ever introduced, this branch needs to be disabled
+		if ((xintercept >> FRACBITS) == mapx && (yintercept >> FRACBITS) == mapy)
+		{
+			// The trace goes directly through the corner of a blockmap block. Need to check other blocks adjacent to the corner
+			if (!P_SightBlockLinesIterator (mapx + mapxstep, mapy) ||
+				!P_SightBlockLinesIterator (mapx, mapy + mapystep))
+			{
+				sightcounts2[1]++;
+				return false;
+			}
+			xintercept += xstep;
+			yintercept += ystep;
+			mapx += mapxstep;
+			mapy += mapystep;
+			if (mapx == xt2)
+				mapxstep = 0;
+			if (mapy == yt2)
+				mapystep = 0;
+		}
+		else if ( (yintercept >> FRACBITS) == mapy)
 		{
 			yintercept += ystep;
 			mapx += mapxstep;


### PR DESCRIPTION
Addresses #951

Heretic/Hexen, and by extension ZDoom, have a bug where P_CheckSight will sometimes falsely indicate that there is line of sight if the line from one thing to the other passes through the corner of a blockmap block.  This PR fixes that.

One thing to note is that if we ever do implement complete support for Heretic and Hexen and want vanilla demo playback, this change will need to be reverted when playing demos.