### PR TITLE
[BUGFIX] Wrong map numbers for IDCLEV

### DIFF
--- a/common/m_cheat.cpp
+++ b/common/m_cheat.cpp
@@ -83,7 +83,7 @@ bool CHEAT_ChangeLevel(cheatseq_t* cheat)
 	if (gamemode == retail_chex)
 		buf = fmt::format("map 1{}", cheat->Args[1]);
 	else
-		buf = fmt::format("map {}{}\n", cheat->Args[0], cheat->Args[1]);
+		buf = fmt::format("map {:c}{:c}\n", cheat->Args[0], cheat->Args[1]);
 
 	AddCommandString(buf);
 	return true;

--- a/common/m_cheat.cpp
+++ b/common/m_cheat.cpp
@@ -81,7 +81,7 @@ bool CHEAT_ChangeLevel(cheatseq_t* cheat)
 	// FIXME: This is probably a horrible hack, it sure looks like one at least
 	// And why is there only a newline for non-chex?
 	if (gamemode == retail_chex)
-		buf = fmt::format("map 1{}", cheat->Args[1]);
+		buf = fmt::format("map 1{:c}", cheat->Args[1]);
 	else
 		buf = fmt::format("map {:c}{:c}\n", cheat->Args[0], cheat->Args[1]);
 


### PR DESCRIPTION
Addresses #1353

IDCLEV was interpreting the characters of the map number as integers instead of characters.