### PR TITLE
Notify Discord webhook when OdaTests results change

### DIFF
--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -35,7 +35,7 @@ runs:
           if (-not $jsonContent.commit) {
             echo "previous-commit-ancestor=missing" >> $env:GITHUB_OUTPUT
           } else {
-            git merge-base --is-ancestor $commit $env:GITHUB_SHA
+            git merge-base --is-ancestor $commit ${{ github.sha }}
             if ($LASTEXITCODE -eq 0) {
               echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
             } else {
@@ -106,7 +106,7 @@ runs:
           demos_run = ${{ inputs.demos-run }}
           demos_passed = ${{ inputs.demos-passed }}
           updated_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-          commit = ${{ github.sha }}
+          commit = "${{ github.sha }}"
         }
 
         $jsonContent = $obj | ConvertTo-Json -Depth 3

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -73,7 +73,7 @@ runs:
           **Commit Hash:** `${{ steps.short-sha.outputs.short-sha }}`
           **Previous:** `${{ steps.previous.outputs.previous-passes }}/${{ steps.previous.outputs.previous-total }}`
           **Current:** `${{ inputs.demos-passed }}/${{ inputs.demos-run }}`
-
+        embed-footer: |
           🔗 [Commit](<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}>)
           🔁 [Workflow Run](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>)
 

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -25,17 +25,22 @@ runs:
       run: |
         $branchName = "${{ github.ref_name }}" -replace '/', '_'
         $jsonPath = "odatests-results\$branchName.json"
+        if (-not (Test-Path $jsonPath)) {
+          $jsonPath = "odatests-results\stable.json"
+        }
         if (Test-Path $jsonPath) {
           $jsonContent = Get-Content $jsonPath -Raw | ConvertFrom-Json
           echo "previous-total=$($jsonContent.demos_run)" >> $env:GITHUB_OUTPUT
           echo "previous-passes=$($jsonContent.demos_passed)" >> $env:GITHUB_OUTPUT
-        } elseif (Test-Path "odatests-results\stable.json") {
-          $jsonContent = Get-Content "odatests-results\stable.json" -Raw | ConvertFrom-Json
-          echo "previous-total=$($jsonContent.demos_run)" >> $env:GITHUB_OUTPUT
-          echo "previous-passes=$($jsonContent.demos_passed)" >> $env:GITHUB_OUTPUT
+          if (git merge-base --is-ancestor $jsonContent.commit ${{ github.sha }}) {
+            echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
+          } else {
+            echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
+          }
         } else {
           echo "previous-total=0" >> $env:GITHUB_OUTPUT
           echo "previous-passes=0" >> $env:GITHUB_OUTPUT
+          echo "previous-commit-ancestor=missing" >> $env:GITHUB_OUTPUT
         }
 
     - name: Determine embed color
@@ -68,7 +73,8 @@ runs:
     - name: Notify discord if values changed
       if: >
         (steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed) &&
-        (steps.previous.outputs.previous-total != 0 || steps.previous.outputs.previous-passes != 0)
+        (steps.previous.outputs.previous-total != 0 || steps.previous.outputs.previous-passes != 0) &&
+        steps.previous.outputs.previous-commit-ancestor == 'true'
       uses: tsickert/discord-webhook@v7.0.0
       with:
         webhook-url: ${{ inputs.discord-url }}
@@ -85,6 +91,7 @@ runs:
           🔁 [Workflow Run](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>)
 
     - name: Write current run values
+      if: steps.previous.outputs.previous-commit-ancestor != 'false'
       shell: pwsh
       run: |
         $branchName = "${{ github.ref_name }}" -replace '/', '_'
@@ -94,6 +101,7 @@ runs:
           demos_run = ${{ inputs.demos-run }}
           demos_passed = ${{ inputs.demos-passed }}
           updated_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          commit = ${{ github.sha }}
         }
 
         $jsonContent = $obj | ConvertTo-Json -Depth 3

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -7,6 +7,9 @@ inputs:
   demos-passed:
     description: "The number of demo tests that passed"
     required: true
+  discord-url:
+    description: "Webhook url for discord"
+    required: true
 
 runs:
   using: "composite"
@@ -59,7 +62,7 @@ runs:
       if: steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed
       uses: tsickert/discord-webhook@7.0.0
       with:
-        webhook-url: ${{ secrets.WEBHOOK_URL }}
+        webhook-url: ${{ inputs.discord-url }}
         content: |
           🧪 **OdaTests Results Have Changed**
 

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout odatests-results branch
-      use: actions/checkout@v4
+      uses: actions/checkout@v4
       with:
         ref: odatests-results
         path: ./odatests-results
@@ -43,6 +43,7 @@ runs:
         embed-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         embed-color: 16711680
         embed-description: |
+          **Branch:** `${{ github.ref_name }}`
           **Previous:** `${{ steps.previous.outputs.previous-passes }}/${{ steps.previous.outputs.previous-total }}`
           **Current:** `${{ inputs.demos-passed }}/${{ inputs.demos-run }}`
 

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -32,10 +32,15 @@ runs:
           $jsonContent = Get-Content $jsonPath -Raw | ConvertFrom-Json
           echo "previous-total=$($jsonContent.demos_run)" >> $env:GITHUB_OUTPUT
           echo "previous-passes=$($jsonContent.demos_passed)" >> $env:GITHUB_OUTPUT
-          if (git merge-base --is-ancestor $jsonContent.commit ${{ github.sha }}) {
-            echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
+          if (-not $jsonContent.commit) {
+            echo "previous-commit-ancestor=missing" >> $env:GITHUB_OUTPUT
           } else {
-            echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
+            git merge-base --is-ancestor $commit $env:GITHUB_SHA
+            if ($LASTEXITCODE -eq 0) {
+              echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
+            } else {
+              echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
+            }
           }
         } else {
           echo "previous-total=0" >> $env:GITHUB_OUTPUT

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -62,7 +62,9 @@ runs:
         echo "short-sha=$calculatedSha" >> $GITHUB_OUTPUT
 
     - name: Notify discord if values changed
-      # if: steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed
+      if: >
+        (steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed) &&
+        (steps.previous.outputs.previous-total != 0 || steps.previous.outputs.previous-passes != 0)
       uses: tsickert/discord-webhook@v7.0.0
       with:
         webhook-url: ${{ inputs.discord-url }}

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -68,13 +68,13 @@ runs:
         webhook-url: ${{ inputs.discord-url }}
         embed-title: OdaTests Results Have Changed
         embed-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        embed-color: ${{ steps.previous.outputs.color }}
+        embed-color: ${{ steps.color.outputs.color }}
         embed-description: |
           **Branch:** `${{ github.ref_name }}`
           **Commit Hash:** `${{ steps.short-sha.outputs.short-sha }}`
           **Previous:** `${{ steps.previous.outputs.previous-passes }}/${{ steps.previous.outputs.previous-total }}`
           **Current:** `${{ inputs.demos-passed }}/${{ inputs.demos-run }}`
-        embed-footer: |
+
           🔗 [Commit](<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}>)
           🔁 [Workflow Run](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>)
 

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -29,6 +29,10 @@ runs:
           $jsonContent = Get-Content $jsonPath -Raw | ConvertFrom-Json
           echo "previous-total=$($jsonContent.demos_run)" >> $env:GITHUB_OUTPUT
           echo "previous-passes=$($jsonContent.demos_passed)" >> $env:GITHUB_OUTPUT
+        } elseif (Test-Path "odatests-results\stable.json") {
+          $jsonContent = Get-Content "odatests-results\stable.json" -Raw | ConvertFrom-Json
+          echo "previous-total=$($jsonContent.demos_run)" >> $env:GITHUB_OUTPUT
+          echo "previous-passes=$($jsonContent.demos_passed)" >> $env:GITHUB_OUTPUT
         } else {
           echo "previous-total=0" >> $env:GITHUB_OUTPUT
           echo "previous-passes=0" >> $env:GITHUB_OUTPUT

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -1,0 +1,75 @@
+name: OdaTests Notifier
+
+inputs:
+  demos-run:
+    description: "Number of demo tests that were run"
+    required: true
+  demos-passed:
+    description: "The number of demo tests that passed"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Get previous run ID"
+      id: get-run
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const runs = await github.rest.actions.listWorkflowRuns({
+            owner: = context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: context.workflow,
+            branch: context.ref.replace("/refs/heads/", ""),
+            status: "success"
+          });
+          if (runs.data.workflow_runs.length > 1) {
+            core.setOutput("run_id", runs.data.workflow_runs[1].id);
+          }
+
+    - name: Download previous run artifact
+      uses: actions/download-artifact@v5
+      with:
+        name: test-data
+        repository: ${{ github.repository }}
+        run-id: ${{ steps.get-run.outputs.run_id }}
+        path: ./test-data
+
+    - name: Load previous run values
+      id: previous
+      shell: bash
+      run: |
+        if [[ -f ./test-data/results.txt ]]; then
+          read -r total passes < ./test-data/results.txt
+          echo "previous-total=$total" >> $GITHUB_OUTPUT
+          echo "previous-passes=$passes" >> $GITHUB_OUTPUT
+        else
+          echo "previous-total=0" >> $GITHUB_OUTPUT
+          echo "previous-passes=0" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Notify discord if values changed
+      if: steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed
+      uses: tsickert/discord-webhook@7.0.0
+      with:
+        webhook-url: ${{ secrets.WEBHOOK_URL }}
+        content: |
+          🧪 **OdaTests Results Have Changed**
+
+          **Previous:** `${{ steps.previous.outputs.previous-passes }}/${{ steps.previous.outputs.previous-total }}`
+          **Current:** `${{ inputs.demos-passed }}/${{ inputs.demos-run }}`
+
+          🔗 [Commit](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          🔁 [Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+    - name: Write current run values
+      shell: bash
+      run: |
+        echo "${{ inputs.demos-run }} ${{ inputs.demos-passed }}" > results.txt
+
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-data
+        path: results.txt

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -99,6 +99,6 @@ runs:
         git config --global user.email "actions@github.com"
 
         git add $jsonPath
-        $commitMsg = "Update CI state for $branchName [ci skip]"
+        $commitMsg = "Update OdaTests results for $branchName [ci skip]"
         git commit -m $commitMsg -a || Write-Host "No changes to commit"
         git push origin odatests-results

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -14,30 +14,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Get previous run ID"
-      id: get-run
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const runs = await github.rest.actions.listWorkflowRuns({
-            owner: = context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: context.workflow,
-            branch: context.ref.replace("/refs/heads/", ""),
-            status: "success"
-          });
-          if (runs.data.workflow_runs.length > 1) {
-            core.setOutput("run_id", runs.data.workflow_runs[1].id);
-          }
-
-    - name: Download previous run artifact
-      uses: actions/download-artifact@v5
-      with:
-        name: test-data
-        repository: ${{ github.repository }}
-        run-id: ${{ steps.get-run.outputs.run_id }}
-        path: ./test-data
-
     - name: Load previous run values
       id: previous
       shell: pwsh

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -14,17 +14,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout odatests-results branch
+      use: actions/checkout@v4
+      with:
+        ref: odatests-results
+        path: ./odatests-results
     - name: Load previous run values
       id: previous
       shell: pwsh
       run: |
         $branchName = "${{ github.ref_name }}" -replace '/', '_'
-        git config --global user.name "github-actions"
-        git config --global user.email "actions@github.com"
-        git fetch origin odatests-results
-        git checkout odatests-results
-
-        $jsonPath = "$branchName.json"
+        $jsonPath = "odatests-results\$branchName.json"
         if (Test-Path $jsonPath) {
           $jsonContent = Get-Content $jsonPath -Raw | ConvertFrom-Json
           echo "previous-total=$($jsonContent.demos_run)" >> $env:GITHUB_OUTPUT
@@ -39,19 +39,21 @@ runs:
       uses: tsickert/discord-webhook@v7.0.0
       with:
         webhook-url: ${{ inputs.discord-url }}
-        content: |
-          🧪 **OdaTests Results Have Changed**
-
+        embed-title: OdaTests Results Have Changed
+        embed-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        embed-color: 16711680
+        embed-description: |
           **Previous:** `${{ steps.previous.outputs.previous-passes }}/${{ steps.previous.outputs.previous-total }}`
           **Current:** `${{ inputs.demos-passed }}/${{ inputs.demos-run }}`
 
-          🔗 [Commit](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
-          🔁 [Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          🔗 [Commit](<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}>)
+          🔁 [Workflow Run](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>)
 
     - name: Write current run values
       shell: pwsh
       run: |
         $branchName = "${{ github.ref_name }}" -replace '/', '_'
+        Set-Location odatests-results
         $jsonPath = "$branchName.json"
         $obj = @{
           demos_run = ${{ inputs.demos-run }}
@@ -64,8 +66,6 @@ runs:
 
         git config --global user.name "github-actions"
         git config --global user.email "actions@github.com"
-        git fetch origin odatests-results
-        git checkout odatests-results
 
         git add $jsonPath
         $commitMsg = "Update CI state for $branchName [ci skip]"

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -34,6 +34,32 @@ runs:
           echo "previous-passes=0" >> $env:GITHUB_OUTPUT
         }
 
+    - name: Determine embed color
+      id: color
+      shell: bash
+      run: |
+        prev_total=${{ steps.previous.outputs.previous-total }}
+        prev_passed=${{ steps.previous.outputs.previous-passes }}
+        current_total=${{ inputs.demos-run }}
+        current_passed=${{ inputs.demos-passed }}
+
+        # Set red (16711680) if failures increased or total changed
+        if [ "$current_passed" -lt "$prev_passed" ]; then
+          color=16711680 # red
+        elif [ "$current_total" -ne "$prev_total" ]; then
+          color=16776960 # yellow
+        else
+          color=65280 # green
+        fi
+
+        echo "color=$color" >> $GITHUB_OUTPUT
+
+    - name: Set short git commit SHA
+      id: short-sha
+      run: |
+        calculatedSha=$(git rev-parse --short ${{ github.sha }})
+        echo "short-sha=$calculatedSha" >> $GITHUB_OUTPUT
+
     - name: Notify discord if values changed
       # if: steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed
       uses: tsickert/discord-webhook@v7.0.0
@@ -41,9 +67,10 @@ runs:
         webhook-url: ${{ inputs.discord-url }}
         embed-title: OdaTests Results Have Changed
         embed-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        embed-color: 16711680
+        embed-color: ${{ steps.previous.outputs.color }}
         embed-description: |
           **Branch:** `${{ github.ref_name }}`
+          **Commit Hash:** `${{ steps.short-sha.outputs.short-sha }}`
           **Previous:** `${{ steps.previous.outputs.previous-passes }}/${{ steps.previous.outputs.previous-total }}`
           **Current:** `${{ inputs.demos-passed }}/${{ inputs.demos-run }}`
 

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -60,7 +60,7 @@ runs:
 
     - name: Notify discord if values changed
       if: steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed
-      uses: tsickert/discord-webhook@7.0.0
+      uses: tsickert/discord-webhook@v7.0.0
       with:
         webhook-url: ${{ inputs.discord-url }}
         content: |

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -35,7 +35,7 @@ runs:
         }
 
     - name: Notify discord if values changed
-      if: steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed
+      # if: steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed
       uses: tsickert/discord-webhook@v7.0.0
       with:
         webhook-url: ${{ inputs.discord-url }}

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -37,16 +37,23 @@ runs:
 
     - name: Load previous run values
       id: previous
-      shell: bash
+      shell: pwsh
       run: |
-        if [[ -f ./test-data/results.txt ]]; then
-          read -r total passes < ./test-data/results.txt
-          echo "previous-total=$total" >> $GITHUB_OUTPUT
-          echo "previous-passes=$passes" >> $GITHUB_OUTPUT
-        else
-          echo "previous-total=0" >> $GITHUB_OUTPUT
-          echo "previous-passes=0" >> $GITHUB_OUTPUT
-        fi
+        $branchName = "${{ github.ref_name }}" -replace '/', '_'
+        git config --global user.name "github-actions"
+        git config --global user.email "actions@github.com"
+        git fetch origin odatests-results
+        git checkout odatests-results
+
+        $jsonPath = "$branchName.json"
+        if (Test-Path $jsonPath) {
+          $jsonContent = Get-Content $jsonPath -Raw | ConvertFrom-Json
+          echo "previous-total=$($jsonContent.demos_run)" >> $env:GITHUB_OUTPUT
+          echo "previous-passes=$($jsonContent.demos_passed)" >> $env:GITHUB_OUTPUT
+        } else {
+          echo "previous-total=0" >> $env:GITHUB_OUTPUT
+          echo "previous-passes=0" >> $env:GITHUB_OUTPUT
+        }
 
     - name: Notify discord if values changed
       if: steps.previous.outputs.previous-total != inputs.demos-run || steps.previous.outputs.previous-passes != inputs.demos-passed
@@ -63,13 +70,25 @@ runs:
           🔁 [Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
     - name: Write current run values
-      shell: bash
+      shell: pwsh
       run: |
-        echo "${{ inputs.demos-run }} ${{ inputs.demos-passed }}" > results.txt
+        $branchName = "${{ github.ref_name }}" -replace '/', '_'
+        $jsonPath = "$branchName.json"
+        $obj = @{
+          demos_run = ${{ inputs.demos-run }}
+          demos_passed = ${{ inputs.demos-passed }}
+          updated_at = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        }
 
+        $jsonContent = $obj | ConvertTo-Json -Depth 3
+        Set-Content -Path $jsonPath -Value $jsonContent -Encoding UTF8
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-data
-        path: results.txt
+        git config --global user.name "github-actions"
+        git config --global user.email "actions@github.com"
+        git fetch origin odatests-results
+        git checkout odatests-results
+
+        git add $jsonPath
+        $commitMsg = "Update CI state for $branchName [ci skip]"
+        git commit -m $commitMsg -a || Write-Host "No changes to commit"
+        git push origin odatests-results

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -56,6 +56,7 @@ runs:
 
     - name: Set short git commit SHA
       id: short-sha
+      shell: bash
       run: |
         calculatedSha=$(git rev-parse --short ${{ github.sha }})
         echo "short-sha=$calculatedSha" >> $GITHUB_OUTPUT

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,7 +74,7 @@ jobs:
       working-directory: .\build\demotester
       continue-on-error: true
     - name: Read OdaTests results
-      if: steps.odatests.outcome == 'success'
+      if: steps.odatests.conclusion == 'success'
       id: odatests-results
       shell: pwsh
       run: |
@@ -83,7 +83,7 @@ jobs:
         echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
       working-directory: .\build\demotester
     - name: Notify Discord
-      if: env.DISCORD_URL != '' && steps.odatests.outcome == 'success'
+      if: env.DISCORD_URL != '' && steps.odatests.conclusion == 'success'
       uses: ./.github/actions/odatests-notify
       with:
         demos-run: ${{ steps.odatests-results.outputs.tests_total }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,7 +79,7 @@ jobs:
         echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
       working-directory: .\build\demotester
     - name: Notify Discord
-      # if: env.DISCORD_URL != '' && contains('stable,protobreak', github.ref_name)
+      if: env.DISCORD_URL != '' && contains('stable,protobreak', github.ref_name)
       uses: ./.github/actions/odatests-notify
       with:
         demos-run: ${{ steps.odatests-results.outputs.tests_total }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,7 +79,7 @@ jobs:
         echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
       working-directory: .\build\demotester
     - name: Notify Discord
-      if: env.DISCORD_URL != '' && contains('stable,protobreak', github.ref_name)
+      # if: env.DISCORD_URL != '' && contains('stable,protobreak', github.ref_name)
       uses: ./.github/actions/odatests-notify
       with:
         demos-run: ${{ steps.odatests-results.outputs.tests_total }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,12 +46,14 @@ jobs:
     - name: Stage artifacts for testing
       run: .\ci\win-prepare-demotest.ps1
     - name: Download OdaTests and Testing Resources
+      id: get-odatests
       run: .\ci\win-get-demotester.ps1
       env:
         DEMOTESTER_URL: ${{ vars.DEMOTESTER_DOWNLOAD_URL }}
         DEMORESOURCES_URL: ${{ vars.DEMORESOURCES_DOWNLOAD_URL }}
       continue-on-error: true
     - name: Decrypt IWADs
+      if: steps.get-odatests.outcome == 'success'
       run: |
         python .\secret.py decrypt plutonia
         python .\secret.py decrypt tnt
@@ -61,16 +63,16 @@ jobs:
       env:
         SECRET_KEY: ${{ secrets.DEMOTESTER_IWAD_KEY }}
       working-directory: .\build\demotester
-      continue-on-error: true
     - name: Run OdaTests
+      if: steps.get-odatests.outcome == 'success'
       shell: pwsh
       run: |
         python .\odatestcases.py
       env:
         ODAMEX_BIN: ..\demotest\odamex.exe
       working-directory: .\build\demotester
-      continue-on-error: true
     - name: Read OdaTests results
+      if: steps.get-odatests.outcome == 'success'
       id: odatests-results
       shell: pwsh
       run: |
@@ -78,7 +80,6 @@ jobs:
         echo "tests_total=$($csvData[0].total)" >> $env:GITHUB_OUTPUT
         echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
       working-directory: .\build\demotester
-      continue-on-error: true
     - name: Notify Discord
       if: env.DISCORD_URL != ''
       uses: ./.github/actions/odatests-notify

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,8 @@ jobs:
         $output | ForEach-Object { Write-Output $_ }
 
         # Capture the first line
-        $firstLine = $output[0]
+        $firstLine = [string]($output[0])
+        echo $firstLine
 
         $fCount = ($firstLine.ToCharArray() | Where-Object { $_ -eq 'F' }).Count
         $dotCount = ($firstLine.ToCharArray() | Where-Object { $_ -eq '.' }).Count
@@ -93,6 +94,7 @@ jobs:
       with:
         demos-run: ${{ steps.odatests.outputs.tests_total }}
         demos-passed: ${{ steps.odatests.outputs.tests_passed }}
+        discord-url: ${{ secrets.WEBHOOK_URL }}
     - name: Upload artifact to B2
       run: python .\ci\upload-b2.py .\build\archive Win-x64
       env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,6 +78,7 @@ jobs:
         echo "tests_total=$($csvData[0].total)" >> $env:GITHUB_OUTPUT
         echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
       working-directory: .\build\demotester
+      continue-on-error: true
     - name: Notify Discord
       if: env.DISCORD_URL != ''
       uses: ./.github/actions/odatests-notify

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,6 +90,7 @@ jobs:
       working-directory: .\build\demotester
       continue-on-error: true
     - name: Notify Discord
+      # if: github.repository_owner == 'odamex' && contains('stable,protobreak', github.ref_name)
       uses: ./.github/actions/odatests-notify
       with:
         demos-run: ${{ steps.odatests.outputs.tests_total }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -64,6 +64,7 @@ jobs:
         SECRET_KEY: ${{ secrets.DEMOTESTER_IWAD_KEY }}
       working-directory: .\build\demotester
     - name: Run OdaTests
+      id: odatests
       if: steps.get-odatests.outcome == 'success'
       shell: pwsh
       run: |
@@ -71,8 +72,9 @@ jobs:
       env:
         ODAMEX_BIN: ..\demotest\odamex.exe
       working-directory: .\build\demotester
+      continue-on-error: true
     - name: Read OdaTests results
-      if: steps.get-odatests.outcome == 'success'
+      if: steps.odatests.outcome == 'success'
       id: odatests-results
       shell: pwsh
       run: |
@@ -81,7 +83,7 @@ jobs:
         echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
       working-directory: .\build\demotester
     - name: Notify Discord
-      if: env.DISCORD_URL != ''
+      if: env.DISCORD_URL != '' && steps.odatests.outcome == 'success'
       uses: ./.github/actions/odatests-notify
       with:
         demos-run: ${{ steps.odatests-results.outputs.tests_total }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -64,11 +64,35 @@ jobs:
       working-directory: .\build\demotester
       continue-on-error: true
     - name: Run OdaTests
-      run: python .\odatestcases.py
+      id: odatests
+      shell: pwsh
+      run: |
+        $output = & python .\odatestcases.py 2>&1
+
+        # Print full output to the Actions log
+        $output | ForEach-Object { Write-Output $_ }
+
+        # Capture the first line
+        $firstLine = $output[0]
+
+        $fCount = ($firstLine.ToCharArray() | Where-Object { $_ -eq 'F' }).Count
+        $dotCount = ($firstLine.ToCharArray() | Where-Object { $_ -eq '.' }).Count
+
+        # Calculate total (dots + Fs only)
+        $totalCount = $fCount + $dotCount
+
+        # Set outputs
+        echo "tests_total=$totalCount" >> $env:GITHUB_OUTPUT
+        echo "tests_passed=$dotCount" >> $env:GITHUB_OUTPUT
       env:
         ODAMEX_BIN: ..\demotest\odamex.exe
       working-directory: .\build\demotester
       continue-on-error: true
+    - name: Notify Discord
+      uses: ./.github/actions/odatests-notify
+      with:
+        demos-run: ${{ steps.odatests.outputs.tests_total }}
+        demos-passed: ${{ steps.odatests.outputs.tests_passed }}
     - name: Upload artifact to B2
       run: python .\ci\upload-b2.py .\build\archive Win-x64
       env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,7 +79,7 @@ jobs:
         echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
       working-directory: .\build\demotester
     - name: Notify Discord
-      if: env.DISCORD_URL != '' && contains('stable,protobreak', github.ref_name)
+      if: env.DISCORD_URL != ''
       uses: ./.github/actions/odatests-notify
       with:
         demos-run: ${{ steps.odatests-results.outputs.tests_total }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,44 +58,35 @@ jobs:
         python .\secret.py decrypt doom
         python .\secret.py decrypt doom1
         python .\secret.py decrypt doom2
-        python .\secret.py decrypt hacx
       env:
         SECRET_KEY: ${{ secrets.DEMOTESTER_IWAD_KEY }}
       working-directory: .\build\demotester
       continue-on-error: true
     - name: Run OdaTests
-      id: odatests
       shell: pwsh
       run: |
-        $output = & python .\odatestcases.py 2>&1
-
-        # Print full output to the Actions log
-        $output | ForEach-Object { Write-Output $_ }
-
-        # Capture the first line
-        $firstLine = [string]($output[0])
-        echo $firstLine
-
-        $fCount = ($firstLine.ToCharArray() | Where-Object { $_ -eq 'F' }).Count
-        $dotCount = ($firstLine.ToCharArray() | Where-Object { $_ -eq '.' }).Count
-
-        # Calculate total (dots + Fs only)
-        $totalCount = $fCount + $dotCount
-
-        # Set outputs
-        echo "tests_total=$totalCount" >> $env:GITHUB_OUTPUT
-        echo "tests_passed=$dotCount" >> $env:GITHUB_OUTPUT
+        python .\odatestcases.py
       env:
         ODAMEX_BIN: ..\demotest\odamex.exe
       working-directory: .\build\demotester
       continue-on-error: true
+    - name: Read OdaTests results
+      id: odatests-results
+      shell: pwsh
+      run: |
+        $csvData = Import-Csv -Path .\odatests_results_summary.csv
+        echo "tests_total=$($csvData[0].total)" >> $env:GITHUB_OUTPUT
+        echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
+      working-directory: .\build\demotester
     - name: Notify Discord
-      # if: github.repository_owner == 'odamex' && contains('stable,protobreak', github.ref_name)
+      if: env.DISCORD_URL != '' && contains('stable,protobreak', github.ref_name)
       uses: ./.github/actions/odatests-notify
       with:
-        demos-run: ${{ steps.odatests.outputs.tests_total }}
-        demos-passed: ${{ steps.odatests.outputs.tests_passed }}
-        discord-url: ${{ secrets.WEBHOOK_URL }}
+        demos-run: ${{ steps.odatests-results.outputs.tests_total }}
+        demos-passed: ${{ steps.odatests-results.outputs.tests_passed }}
+        discord-url: ${{ env.DISCORD_URL }}
+      env:
+        DISCORD_URL: ${{ secrets.ODATESTS_WEBHOOK_URL }}
     - name: Upload artifact to B2
       run: python .\ci\upload-b2.py .\build\archive Win-x64
       env:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can restore this functionality by:
 3. Replacing the encrypted IWADs with your own set of encrypted IWADs.
 Encrypt using `python .\secret.py encrypt doom2` with the environment variable
 `SECRET_KEY` defined to encrypt the IWADs with. The following IWADs (latest version) are needed to run all tests:
-`doom, doom1, doom2, tnt, plutonia, hacx`
+`doom, doom1, doom2, tnt, plutonia`
 4. Create a release for your forked OdaTest-Resources repo.
 5. Enter the following Secrets / Repository Variables in GitHub:
   - `secrets.DEMOTESTER_IWAD_KEY` - Encryption key for the IWADs

--- a/ci/win-get-demotester.ps1
+++ b/ci/win-get-demotester.ps1
@@ -2,22 +2,22 @@ Set-PSDebug -Trace 1
 
 if (!([String]::IsNullOrWhiteSpace($env:DEMOTESTER_URL)) -and !([String]::IsNullOrWhiteSpace($env:DEMORESOURCES_URL)))
 {
-		Write-Output "OdaTests Download URL: $env:DEMOTESTER_URL"
-		Write-Output "OdaTests WAD Resources Download URL: $env:DEMORESOURCES_URL"
+	Write-Output "OdaTests Download URL: $env:DEMOTESTER_URL"
+	Write-Output "OdaTests WAD Resources Download URL: $env:DEMORESOURCES_URL"
 
-		$DemoTesterPath = $env:DEMOTESTER_URL
-		$DemoResourcePath = $env:DEMORESOURCES_URL
+	$DemoTesterPath = $env:DEMOTESTER_URL
+	$DemoResourcePath = $env:DEMORESOURCES_URL
 
-		Set-Location "build"
-		New-Item -Name "demotester" -ItemType "directory" | Out-Null
+	Set-Location "build"
+	New-Item -Name "demotester" -ItemType "directory" | Out-Null
 
-		Invoke-WebRequest -Uri $DemoTesterPath -OutFile .\odatests.zip
-		Invoke-WebRequest -Uri $DemoResourcePath -OutFile .\odatests-resources.zip
+	Invoke-WebRequest -Uri $DemoTesterPath -OutFile .\odatests.zip
+	Invoke-WebRequest -Uri $DemoResourcePath -OutFile .\odatests-resources.zip
 
-		7z.exe x odatests.zip -odemotester -y
-		7z.exe x odatests-resources.zip -odemotester -y
+	7z.exe x odatests.zip -odemotester -y
+	7z.exe x odatests-resources.zip -odemotester -y
 
-		Set-Location ..
+	Set-Location ..
 }
 else
 {

--- a/ci/win-get-demotester.ps1
+++ b/ci/win-get-demotester.ps1
@@ -22,4 +22,5 @@ if (!([String]::IsNullOrWhiteSpace($env:DEMOTESTER_URL)) -and !([String]::IsNull
 else
 {
 	Write-Output "OdaTests URL or OdaTests Resources URL missing, skipping..."
+	exit 1
 }


### PR DESCRIPTION
Addresses #1352

Results of odatests runs on all branches are tracked on the [odatests-results](https://github.com/electricbrass/odamex/tree/odatests-results) branch. On each commit, if a change is detected, it will send a message like the one in the screenshot below. If the number of passed tests increased, the stripe is green. If it decreased, the stripe is red. If the total number of test cases ever changes, the stripe is yellow.

<img width="486" height="317" alt="image" src="https://github.com/user-attachments/assets/3e8e867c-a6cc-4b87-8a64-46fddf4f0624" />

The Discord webhook url should be set as a repo secret named `ODATESTS_WEBHOOK_URL`.
This requires an update to OdaTests and will not function without it. See https://github.com/odamex/odatests/pull/4
I also have a fix for odatests resource: https://github.com/odamex/odatests-resources/pull/1

The resource and tester updates will also bring us up to 75/90 passing tests. The Chex Quest and Hacx demos actually play back without issue, but were not being run correctly.