### PR TITLE
Vertically clip masked midtextures when surrounding sectors have differing specials

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -742,6 +742,9 @@ CVAR(			r_flashhom, "0", "Draws flashing colors where there is HOM",
 CVAR(			r_drawflat, "0", "Disables all texturing of walls, floors and ceilings",
 				CVARTYPE_BOOL, CVAR_NULL)
 
+CVAR(			r_clipmaskedspecial, "1", "Vertically clip masked midtextures when surrounding sectors have differing specials (mimics Hexen and DSDA-Doom behavior)",
+				CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 #if 0
 CVAR(			r_drawhitboxes, "0", "Draws a box outlining every actor's hitboxes",
 				CVARTYPE_BOOL, CVAR_NULL)

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -97,6 +97,7 @@ extern float yfoc;
 
 static tallpost_t** masked_midposts;
 
+EXTERN_CVAR(r_clipmaskedspecial)
 
 //
 // R_TexScaleX
@@ -941,6 +942,8 @@ void R_StoreWallRange(int start, int stop)
 
 				// killough 4/17/98: draw floors if different light levels
 				|| backsector->floorlightsec != frontsector->floorlightsec
+
+				|| (r_clipmaskedspecial && backsector->special != frontsector->special)
 
 				// [RH] Add checks for colormaps
 				|| backsector->colormap != frontsector->colormap


### PR DESCRIPTION
Addresses #1081

In case there are wads taking advantage of the vanilla behavior (which seems likely, as there are multiple prominent examples which the same lack of clipping in situations without sector specials), `r_clipmaskedspecial` can be disabled to revert back to it.

This isn't an ideal solution, but there doesn't seem to be one at the moment. Yet another problem from Eviternity II only being tested on GZ and DSDA...