### PR TITLE
[FEATURE + BUGFIX] Basic COMPLVL support

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -739,6 +739,9 @@ CVAR(			r_flashhom, "0", "Draws flashing colors where there is HOM",
 CVAR(			r_drawflat, "0", "Disables all texturing of walls, floors and ceilings",
 				CVARTYPE_BOOL, CVAR_NULL)
 
+CVAR(			r_clipmaskedspecial, "1", "Vertically clip masked midtextures when surrounding sectors have differing specials (mimics Hexen and DSDA-Doom behavior)",
+				CVARTYPE_BOOL, CVAR_NULL)
+
 #if 0
 CVAR(			r_drawhitboxes, "0", "Draws a box outlining every actor's hitboxes",
 				CVARTYPE_BOOL, CVAR_NULL)

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -601,6 +601,69 @@ bool HashOk(std::string &required, std::string &available)
 
 void CL_NetDemoPlay(const std::string &filename);
 
+EXTERN_CVAR(co_boomphys)
+EXTERN_CVAR(co_zdoomphys)
+EXTERN_CVAR(co_mbfphys)
+EXTERN_CVAR(co_zdoomammo)
+EXTERN_CVAR(co_novileghosts)
+EXTERN_CVAR(co_removesoullimit)
+EXTERN_CVAR(co_allowdropoff)
+EXTERN_CVAR(r_clipmaskedspecial)
+
+void G_ReadCOMPLVL()
+{
+	int lumpnum = W_CheckNumForName("COMPLVL");
+	if (lumpnum != -1)
+	{
+		char* complvl = static_cast<char*>(W_CacheLumpNum(lumpnum, PU_STATIC));
+
+		co_zdoomphys.Set(0.0f);
+		co_zdoomammo.Set(0.0f);
+
+		if (iequals("vanilla", complvl))
+		{
+			co_boomphys.Set(0.0f);
+			co_mbfphys.Set(0.0f);
+			co_novileghosts.Set(0.0f);
+			co_allowdropoff.Set(0.0f);
+			co_removesoullimit.Set(0.0f);
+			r_clipmaskedspecial.Set(0.0f);
+		}
+		else if (iequals("boom", complvl))
+		{
+			co_boomphys.Set(1.0f);
+			co_mbfphys.Set(0.0f);
+			co_novileghosts.Set(1.0f);
+			co_allowdropoff.Set(1.0f);
+			co_removesoullimit.Set(1.0f);
+			r_clipmaskedspecial.Set(0.0f);
+		}
+		else if (iequals("mbf", complvl))
+		{
+			co_boomphys.Set(1.0f);
+			co_mbfphys.Set(1.0f);
+			co_novileghosts.Set(1.0f);
+			co_allowdropoff.Set(1.0f);
+			co_removesoullimit.Set(1.0f);
+			r_clipmaskedspecial.Set(0.0f);
+		}
+		else if (iequals("mbf21", complvl))
+		{
+			co_boomphys.Set(1.0f);
+			co_mbfphys.Set(1.0f);
+			co_novileghosts.Set(1.0f);
+			co_allowdropoff.Set(1.0f);
+			co_removesoullimit.Set(1.0f);
+			r_clipmaskedspecial.Set(1.0f);
+		}
+		else
+		{
+			DPrintFmt("Unrecognized COMPLVL value: {}", complvl);
+		}
+
+		Z_Free(complvl);
+	}
+}
 
 //
 // D_Init
@@ -648,6 +711,7 @@ void D_Init()
 	G_ParseMusInfo();
 	S_ParseSndInfo();
 	G_ParseHordeDefs();
+	G_ReadCOMPLVL();
 
 	// init the menu subsystem
 	if (first_time)

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -612,6 +612,9 @@ EXTERN_CVAR(r_clipmaskedspecial)
 
 void G_ReadCOMPLVL()
 {
+	if (!serverside)
+		return;
+
 	int lumpnum = W_CheckNumForName("COMPLVL");
 	if (lumpnum != -1)
 	{

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -97,6 +97,7 @@ extern float yfoc;
 
 static tallpost_t** masked_midposts;
 
+EXTERN_CVAR(r_clipmaskedspecial)
 
 //
 // R_TexScaleX
@@ -941,6 +942,9 @@ void R_StoreWallRange(int start, int stop)
 
 				// killough 4/17/98: draw floors if different light levels
 				|| backsector->floorlightsec != frontsector->floorlightsec
+
+				// [EB] check for special too for DSDA-compatibility on MBF21
+				|| (r_clipmaskedspecial && backsector->special != frontsector->special)
 
 				// [RH] Add checks for colormaps
 				|| backsector->colormap != frontsector->colormap

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -1134,7 +1134,7 @@ ClusterInfos& getClusterInfos()
 // P_AllowDropOff()
 bool P_AllowDropOff()
 {
-	return !(level.flags & LEVEL2_COMPAT_CROSSDROPOFF) || co_allowdropoff;
+	return co_allowdropoff && !(level.flags & LEVEL2_COMPAT_CROSSDROPOFF);
 }
 
 bool P_AllowPassover()

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -1042,6 +1042,7 @@ BEGIN_COMMAND(mapinfo)
 	flags += (info.flags & LEVEL_CHANGEMAPCHEAT ? " CHANGEMAPCHEAT" : "");
 	flags += (info.flags & LEVEL_VISITED ? " VISITED" : "");
 	flags += (info.flags & LEVEL_COMPAT_DROPOFF ? " COMPAT_DROPOFF" : "");
+	flags += (info.flags2 & LEVEL2_COMPAT_CROSSDROPOFF ? " COMPAT_CROSSDROPOFF" : "");
 	flags += (info.flags & LEVEL_COMPAT_NOPASSOVER ? " COMPAT_NOPASSOVER" : "");
 	flags += (info.flags & LEVEL_COMPAT_LIMITPAIN ? " COMPAT_LIMITPAIN" : "");
 	flags += (info.flags & LEVEL_COMPAT_SHORTTEX ? " COMPAT_SHORTTEX" : "");
@@ -1133,7 +1134,7 @@ ClusterInfos& getClusterInfos()
 // P_AllowDropOff()
 bool P_AllowDropOff()
 {
-	return level.flags & LEVEL_COMPAT_DROPOFF || co_allowdropoff;
+	return !(level.flags & LEVEL2_COMPAT_CROSSDROPOFF) || co_allowdropoff;
 }
 
 bool P_AllowPassover()

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -89,6 +89,7 @@ constexpr static levelFlags_t LEVEL2_NORMALINFIGHTING = BIT(0);
 constexpr static levelFlags_t LEVEL2_NOINFIGHTING = BIT(1);
 constexpr static levelFlags_t LEVEL2_TOTALINFIGHTING = BIT(2);
 constexpr static levelFlags_t LEVEL2_INFIGHTINGMASK = BIT_MASK(0, 2);
+constexpr static levelFlags_t LEVEL2_COMPAT_CROSSDROPOFF = BIT(18);
 
 struct acsdefered_s;
 class FBehavior;

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1313,7 +1313,8 @@ struct MapInfoDataSetter<level_pwad_info_t>
 			{ "compat_limitpain", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_LIMITPAIN },
 			{ "compat_useblocking", &MIType_CompatFlag, &ref.flags }, // special lines block use (not implemented, default odamex behavior)
 		    { "compat_missileclip", &MIType_CompatFlag, &ref.flags }, // original height monsters when it comes to missiles (not implemented)
-			{ "compat_dropoff", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_DROPOFF },
+			{ "compat_dropoff", &MIType_CompatFlag, &ref.flags, LEVEL_COMPAT_DROPOFF }, // todo: not implemented
+			{ "compat_crossdropoff", &MIType_CompatFlag, &ref.flags2, LEVEL2_COMPAT_CROSSDROPOFF },
 			{ "compat_trace", &MIType_CompatFlag, &ref.flags }, // todo: not implemented
 			{ "compat_boomscroll", &MIType_CompatFlag, &ref.flags }, // todo: not implemented
 			{ "compat_sectorsounds", &MIType_CompatFlag, &ref.flags }, // todo: not implemented

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -127,6 +127,56 @@ void D_DoomLoop (void)
 	}
 }
 
+EXTERN_CVAR(co_boomphys)
+EXTERN_CVAR(co_zdoomphys)
+EXTERN_CVAR(co_mbfphys)
+EXTERN_CVAR(co_zdoomammo)
+EXTERN_CVAR(co_allowdropoff)
+
+void G_ReadCOMPLVL()
+{
+	int lumpnum = W_CheckNumForName("COMPLVL");
+	if (lumpnum != -1)
+	{
+		char* complvl = static_cast<char*>(W_CacheLumpNum(lumpnum, PU_STATIC));
+
+		co_zdoomphys.Set(0.0f);
+		co_zdoomammo.Set(0.0f);
+
+		if (iequals("vanilla", complvl))
+		{
+			co_boomphys.Set(0.0f);
+			co_mbfphys.Set(0.0f);
+			co_allowdropoff.Set(0.0f);
+		}
+		else if (iequals("boom", complvl))
+		{
+			co_boomphys.Set(1.0f);
+			co_mbfphys.Set(0.0f);
+			co_allowdropoff.Set(1.0f);
+		}
+		else if (iequals("mbf", complvl))
+		{
+			co_boomphys.Set(1.0f);
+			co_mbfphys.Set(1.0f);
+			co_allowdropoff.Set(1.0f);
+		}
+		else if (iequals("mbf21", complvl))
+		{
+			co_boomphys.Set(1.0f);
+			co_mbfphys.Set(1.0f);
+			co_allowdropoff.Set(1.0f);
+		}
+		else
+		{
+			DPrintFmt("Unrecognized COMPLVL value: {}", complvl);
+		}
+
+		Z_Free(complvl);
+	}
+}
+
+
 //
 // D_Init
 //
@@ -164,6 +214,7 @@ void D_Init()
 	G_ParseMusInfo();
 	S_ParseSndInfo();
 	G_ParseHordeDefs();
+	G_ReadCOMPLVL();
 
 	if (first_time)
 		PrintFmt(PRINT_HIGH, "P_Init: Init Playloop state.\n");


### PR DESCRIPTION
Addresses #1081
Partially addresses #1305

With this both the client and server read COMPLVL lumps and set certain cvars accordingly. I've mostly matched the logic described in #1305, with a few differences:
- There is no complete client override that prevents a cvar from being changed while the wad is loaded. I would like to add this in the future (perhaps disabling this when `developer 1`?)
- `co_realactorheight` is left untouched
- `co_allowdropoff` is modified on the server, because many Boom and above wads can break without it enabled
- The new cvar `r_clipmaskedspecial` is introduced clientside to account for DSDA's differing behavior for determining whether planes are identical or not. It is enabled when COMPLVL specifies `mbf21`

Additionally, the behavior of the Mapinfo compat flag `compat_dropoff` has been changed. Currently, in Odamex this flag allows things to drop off of ledges, when in ZDoom, the actual intended behavior is that enabling it allows monsters to get stuck on ledges instead of backing away from them. The flag that dictates whether things can drop off ledges is actually `compat_crossdropoff`, and it works inversely to how Odamex was implementing it. Setting the flag *disables* the ability to drop off ledges. I have reworked it so that currently `compat_dropoff` does nothing, and `compat_crossdropoff` behaves as it should.