### PR TITLE
[BUGFIX] Remove MF2_NODMGTHRUST from archviles

### DIFF
--- a/common/info.cpp
+++ b/common/info.cpp
@@ -1477,7 +1477,7 @@ mobjinfo_t mobjinfo[NUMMOBJTYPES] = {
 	0,		// damage
 	"vile/active",		// activesound
 	MF_SOLID|MF_SHOOTABLE|MF_COUNTKILL,		// flags
-     MF2_MCROSS | MF2_PASSMOBJ | MF2_PUSHWALL | MF2_NODMGTHRUST, // flags2
+     MF2_MCROSS | MF2_PASSMOBJ | MF2_PUSHWALL, // flags2
 	S_NULL,		// raisestate
 	0x10000,
 	"MT_VILE",


### PR DESCRIPTION
It looks like this flag was accidentally added to archviles when implementing MBF21. Reverting this change fixes 2 of the failing demos.