### PR TITLE
[BUGFIX] Low damage from raising floor crushers

### DIFF
--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -25,6 +25,7 @@ runs:
       id: previous
       shell: pwsh
       run: |
+        Set-PSDebug -Trace 1
         $branchName = "${{ github.ref_name }}" -replace '/', '_'
         $jsonPath = "odatests-results\$branchName.json"
         if (-not (Test-Path $jsonPath)) {

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -39,13 +39,18 @@ runs:
             echo "previous-commit-ancestor=missing" >> $env:GITHUB_OUTPUT
           } else {
             Set-Location odatests-results
-            git merge-base --is-ancestor $jsonContent.commit ${{ github.sha }}
-            if ($LASTEXITCODE -eq 0) {
-              echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
-            } else {
+            try {
+              git merge-base --is-ancestor $jsonContent.commit ${{ github.sha }}
+              if ($LASTEXITCODE -eq 0) {
+                echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
+              } else {
+                echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
+              }
+            } catch {
               echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
+            } finally {
+              Set-Location ..
             }
-            Set-Location ..
           }
         } else {
           echo "previous-total=0" >> $env:GITHUB_OUTPUT

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -746,8 +746,6 @@ DFloor::DFloor(sector_t *sec, DFloor::EFloor floortype, line_t *line,
 		break;
 
 	case DFloor::floorRaiseAndCrush:
-		m_Crush = crush;
-		[[fallthrough]];
 	case DFloor::floorRaiseToLowestCeiling:
 		m_Direction = 1;
 		m_FloorDestHeight =


### PR DESCRIPTION
Addresses one part #1187

m_Crush of DFloors created by linedef types 55, 56, 65, and 94 was being set 1 instead of 10, resulting in low damage.