### PR TITLE
Fix a few more edge cases with the odatests discord bot

### DIFF
--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -43,7 +43,7 @@ runs:
             git merge-base --is-ancestor $jsonContent.commit ${{ github.sha }}
             if ($LASTEXITCODE -eq 0) {
               echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
-            } else if ($LASTEXITCODE -eq 1) {
+            } elseif ($LASTEXITCODE -eq 1) {
               echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
             } else {
               echo "previous-commit-ancestor=error" >> $env:GITHUB_OUTPUT
@@ -51,7 +51,7 @@ runs:
             git merge-base --is-ancestor ${{ github.sha }} $jsonContent.commit
             if ($LASTEXITCODE -eq 0) {
               echo "previous-commit-descendant=true" >> $env:GITHUB_OUTPUT
-            } else if ($LASTEXITCODE -eq 1) {
+            } elseif ($LASTEXITCODE -eq 1) {
               echo "previous-commit-descendant=false" >> $env:GITHUB_OUTPUT
             } else {
               echo "previous-commit-descendant=error" >> $env:GITHUB_OUTPUT

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -37,13 +37,24 @@ runs:
           echo "previous-passes=$($jsonContent.demos_passed)" >> $env:GITHUB_OUTPUT
           if (-not $jsonContent.commit) {
             echo "previous-commit-ancestor=missing" >> $env:GITHUB_OUTPUT
+            echo "previous-commit-descendant=missing" >> $env:GITHUB_OUTPUT
           } else {
             Set-Location odatests-results
             git merge-base --is-ancestor $jsonContent.commit ${{ github.sha }}
             if ($LASTEXITCODE -eq 0) {
               echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
-            } else {
+            } else if ($LASTEXITCODE -eq 1) {
               echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
+            } else {
+              echo "previous-commit-ancestor=error" >> $env:GITHUB_OUTPUT
+            }
+            git merge-base --is-ancestor ${{ github.sha }} $jsonContent.commit
+            if ($LASTEXITCODE -eq 0) {
+              echo "previous-commit-descendant=true" >> $env:GITHUB_OUTPUT
+            } else if ($LASTEXITCODE -eq 1) {
+              echo "previous-commit-descendant=false" >> $env:GITHUB_OUTPUT
+            } else {
+              echo "previous-commit-descendant=error" >> $env:GITHUB_OUTPUT
             }
             $global:LASTEXITCODE = 0
             Set-Location ..
@@ -52,6 +63,7 @@ runs:
           echo "previous-total=0" >> $env:GITHUB_OUTPUT
           echo "previous-passes=0" >> $env:GITHUB_OUTPUT
           echo "previous-commit-ancestor=missing" >> $env:GITHUB_OUTPUT
+          echo "previous-commit-descendant=missing" >> $env:GITHUB_OUTPUT
         }
 
     - name: Determine embed color
@@ -102,7 +114,7 @@ runs:
           🔁 [Workflow Run](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>)
 
     - name: Write current run values
-      if: steps.previous.outputs.previous-commit-ancestor != 'false'
+      if: steps.previous.outputs.previous-commit-descendant != 'true'
       shell: pwsh
       run: |
         $branchName = "${{ github.ref_name }}" -replace '/', '_'

--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -39,18 +39,14 @@ runs:
             echo "previous-commit-ancestor=missing" >> $env:GITHUB_OUTPUT
           } else {
             Set-Location odatests-results
-            try {
-              git merge-base --is-ancestor $jsonContent.commit ${{ github.sha }}
-              if ($LASTEXITCODE -eq 0) {
-                echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
-              } else {
-                echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
-              }
-            } catch {
+            git merge-base --is-ancestor $jsonContent.commit ${{ github.sha }}
+            if ($LASTEXITCODE -eq 0) {
+              echo "previous-commit-ancestor=true" >> $env:GITHUB_OUTPUT
+            } else {
               echo "previous-commit-ancestor=false" >> $env:GITHUB_OUTPUT
-            } finally {
-              Set-Location ..
             }
+            $global:LASTEXITCODE = 0
+            Set-Location ..
           }
         } else {
           echo "previous-total=0" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
Hopefully that's the last of them. There shouldn't be any more failing workflows from inside the discord action and test results should be saved in all cases now except for if the commit an action is running on is an ancestor of the currently stored commit for that branch. This should fix some problems with actions running out of order.