### PR TITLE
[BUGFIX] `netplay` command doesn't search netdemo directory.

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1161,8 +1161,12 @@ void CL_NetDemoPlay(const std::string& filename)
 	std::string found = M_FindUserFileName(filename, ".odd");
 	if (found.empty())
 	{
-		Printf(PRINT_WARNING, "Could not find demo %s.\n", filename);
-		return;
+		found = M_GetNetDemoFileName(filename, cl_netdemodir);
+		if (found.empty())
+		{
+			Printf(PRINT_WARNING, "Could not find demo %s.\n", filename);
+			return;
+		}
 	}
 
 	netdemo.startPlaying(found);


### PR DESCRIPTION
The recent changes to netdemo save locations didn't account for the `netplay` command, which still searches only in the user directory. With this fix it now also searches the configured netdemo directory.