### PR TITLE
Add donation link to metainfo.xml

### DIFF
--- a/packaging/linux/net.odamex.Odamex.metainfo.xml
+++ b/packaging/linux/net.odamex.Odamex.metainfo.xml
@@ -14,6 +14,7 @@
   <url type="vcs-browser">https://github.com/odamex/odamex</url>
   <url type="bugtracker">https://github.com/odamex/odamex/issues</url>
   <url type="help">https://github.com/odamex/odamex/wiki</url>
+  <url type="donation">https://www.paypal.com/donate/?hosted_button_id=EL7NY74YC79BG</url>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
   <supports>


### PR DESCRIPTION
This will make our Flathub page display a donate button next to the install button. It links to the same place as the donate button on odamex.net.