### PR TITLE
[FEATURE] Add support for ZDoom extended GL nodes

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -573,7 +573,7 @@ bool P_LoadXNOD(int lump, bool compressed)
 	byte *data = static_cast<byte *>(W_CacheLumpNum(lump, PU_STATIC));
 	byte* output = nullptr;
 
-	nonstd::make_scope_exit([&]{
+	auto guard = nonstd::make_scope_exit([&]{
 		Z_Free(data);
 		Z_Free(output);
 	});
@@ -712,7 +712,7 @@ bool P_LoadXGLN(int lump, bool compressed)
 	byte *data = static_cast<byte *>(W_CacheLumpNum(lump, PU_STATIC));
 	byte* output = nullptr;
 
-	nonstd::make_scope_exit([&]{
+	auto guard = nonstd::make_scope_exit([&]{
 		Z_Free(data);
 		Z_Free(output);
 	});
@@ -893,7 +893,7 @@ bool P_LoadXGL3(int lump, bool compressed)
 	byte *data = static_cast<byte *>(W_CacheLumpNum(lump, PU_STATIC));
 	byte* output = nullptr;
 
-	nonstd::make_scope_exit([&]{
+	auto guard = nonstd::make_scope_exit([&]{
 		Z_Free(data);
 		Z_Free(output);
 	});
@@ -1056,7 +1056,7 @@ bool P_LoadXGL3(int lump, bool compressed)
 		{
 			for (int k = 0; k < 4; k++)
 			{
-				node->bbox[j][k] = LELONG(*(int *)p); p += 4;
+				node->bbox[j][k] = LESHORT(*(short *)p)<<FRACBITS; p += 2;
 			}
 		}
 
@@ -1084,7 +1084,7 @@ enum class nodetype_t {
 
 nodetype_t P_CheckNodeType(int lump) {
 	byte *data = (byte *) W_CacheLumpNum(lump, PU_STATIC);
-	nonstd::make_scope_exit([&]{ Z_ChangeTag(data, PU_CACHE); });
+	auto guard = nonstd::make_scope_exit([&]{ Z_ChangeTag(data, PU_CACHE); });
 
 	static constexpr struct {
         std::string_view bytes;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -767,11 +767,11 @@ void P_LoadExtendedNodes(int lump, nodetype_t nodetype)
 		}
 	}();
 	byte *data = static_cast<byte *>(W_CacheLumpNum(lump, PU_STATIC));
-	byte* output = nullptr;
+	byte* data_decompressed = nullptr;
 
 	auto guard = nonstd::make_scope_exit([&]{
 		Z_Free(data);
-		Z_Free(output);
+		Z_Free(data_decompressed);
 	});
 
 	byte *p;
@@ -779,7 +779,7 @@ void P_LoadExtendedNodes(int lump, nodetype_t nodetype)
 	// adapted from Crispy Doom
 	if (compressed)
 	{
-		p = output = P_DecompressNodes(data, W_LumpLength(lump));
+		p = data_decompressed = P_DecompressNodes(data, W_LumpLength(lump));
 	}
 	else
 	{

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -564,7 +564,7 @@ void P_LoadNodes_DeePBSP(int lump)
 	Z_Free (data - 8);
 }
 
-byte* decompressNodes(byte* data, size_t len) {
+static byte* P_DecompressNodes(byte* data, size_t len) {
 	byte* output = nullptr;
 	int outlen, err;
 	z_stream *zstream;
@@ -583,7 +583,7 @@ byte* decompressNodes(byte* data, size_t len) {
 	zstream->avail_out = outlen;
 
 	if (inflateInit(zstream) != Z_OK)
-		I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression initialization!");
+		I_Error("P_DecompressNodes: Error during ZDBSP nodes decompression initialization!");
 
 	// resize if output buffer runs full
 	while ((err = inflate(zstream, Z_SYNC_FLUSH)) == Z_OK)
@@ -596,13 +596,13 @@ byte* decompressNodes(byte* data, size_t len) {
 	}
 
 	if (err != Z_STREAM_END)
-		I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression!");
+		I_Error("P_DecompressNodes: Error during ZDBSP nodes decompression!");
 
-	fmt::print(stderr, "P_LoadXNOD: ZDBSP nodes compression ratio {:.3f}\n",
+	fmt::print(stderr, "P_DecompressNodes: ZDBSP nodes compression ratio {:.3f}\n",
 	           (float)zstream->total_out/zstream->total_in);
 
 	if (inflateEnd(zstream) != Z_OK)
-		I_Error("P_LoadXNOD: Error during ZDBSP nodes decompression shut-down!");
+		I_Error("P_DecompressNodes: Error during ZDBSP nodes decompression shut-down!");
 
 	M_Free(zstream);
 	return output;
@@ -691,7 +691,7 @@ byte* P_LoadSegs_XGL(byte* p)
 			{
 				if (line >= numlines)
 				{
-					I_Error("P_LoadXGLN: idk man bad seg or smth");
+					I_Error("P_LoadSegs_XGL: seg {}, {} references a non-existent linedef {}", i, j, line);
 				}
 
 				line_t* linedef = &lines[line];
@@ -699,7 +699,7 @@ byte* P_LoadSegs_XGL(byte* p)
 
 				if (side != 0 && side != 1)
 				{
-					I_Error("fasfasdf");
+					I_Error("P_LoadSegs_XGL: seg {}, {} references a non-existent sidedef {}", i, j, side);
 				}
 
 				seg->sidedef = &sides[linedef->sidenum[side]];
@@ -711,7 +711,7 @@ byte* P_LoadSegs_XGL(byte* p)
 				else
 				{
 					seg->frontsector = nullptr;
-					fmt::print(stderr, "");
+					fmt::print(stderr, "P_LoadSegs_XGL: front of seg {}, {} has no sidedef\n", i, j);
 				}
 
 				if ((linedef->flags & ML_TWOSIDED) &&
@@ -779,7 +779,7 @@ void P_LoadExtendedNodes(int lump, nodetype_t nodetype)
 	// adapted from Crispy Doom
 	if (compressed)
 	{
-		p = output = decompressNodes(data, W_LumpLength(lump));
+		p = output = P_DecompressNodes(data, W_LumpLength(lump));
 	}
 	else
 	{

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -933,6 +933,20 @@ nodetype_t P_CheckNodeType(int lump) {
 	return nodetype_t::STANDARD;
 }
 
+static bool isCompressedNodeType(nodetype_t type)
+{
+	switch (type)
+	{
+		case nodetype_t::ZNOD:
+		case nodetype_t::ZGLN:
+		case nodetype_t::ZGL2:
+		case nodetype_t::ZGL3:
+			return true;
+		default:
+			return false;
+	}
+}
+
 //
 // P_LoadThings
 //
@@ -2205,12 +2219,12 @@ void P_SetupLevel (const char *lumpname, int position)
 	switch (nodetype) {
 		case nodetype_t::XNOD:
 		case nodetype_t::ZNOD:
-			P_LoadXNOD(lumpnum+ML_NODES, nodetype == nodetype_t::ZNOD);
+			P_LoadXNOD(lumpnum+ML_NODES, isCompressedNodeType(nodetype));
 			break;
 
 		case nodetype_t::XGLN:
 		case nodetype_t::ZGLN:
-			P_LoadXGLN(lumpnum+ML_SSECTORS, nodetype == nodetype_t::ZGLN);
+			P_LoadXGLN(lumpnum+ML_SSECTORS, isCompressedNodeType(nodetype));
 			break;
 
 		case nodetype_t::DEEP:

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -590,7 +590,7 @@ static byte* P_DecompressNodes(byte* data, size_t len) {
 	{
 		int outlen_old = outlen;
 		outlen = 2 * outlen_old;
-		output = (byte*)M_Realloc(output, outlen);
+		output = (byte*)Z_Realloc(output, outlen, PU_STATIC, 0);
 		zstream->next_out = output + outlen_old;
 		zstream->avail_out = outlen - outlen_old;
 	}

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -176,7 +176,7 @@ class OZone
 		block.fileLine.file = fileline.file;
 		block.fileLine.line = fileline.line;
 
-		m_heap.insert(std::make_pair(ptr, block));
+		m_heap.emplace(ptr, block);
 		if (block.user != NULL)
 		{
 			*block.user = ptr;

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -24,7 +24,7 @@
 
 #include "odamex.h"
 
-#include <map>
+#include <unordered_map>
 #include <stdlib.h>
 
 #include "z_zone.h"
@@ -107,7 +107,7 @@ class OZone
 		OFileLine fileLine; // __FILE__, __LINE__
 	};
 
-	typedef std::map<void*, MemoryBlockInfo> MemoryBlockTable;
+	typedef std::unordered_map<void*, MemoryBlockInfo> MemoryBlockTable;
 	MemoryBlockTable m_heap;
 
 	MemoryBlockTable::iterator dealloc(MemoryBlockTable::iterator& block)
@@ -183,6 +183,33 @@ class OZone
 		}
 
 		return ptr;
+	}
+
+	void* realloc(void* ptr, size_t size, zoneTag_e tag, void* user, const OFileLine& info)
+	{
+		if (!ptr)
+			return alloc(size, tag, user, info);
+
+		if (size == 0)
+		{
+			deallocPtr(ptr, info);
+			return nullptr;
+		}
+
+		MemoryBlockTable::iterator it = m_heap.find(ptr);
+		if (it == m_heap.end())
+		{
+			I_Error("{}: Address 0x{:p} is not tracked by zone at {}:{}.\n{}", __FUNCTION__,
+			        it->first, info.shortFile(), info.line, M_GetStacktrace());
+		}
+
+		const size_t copySize = std::min(size, static_cast<size_t>(it->second.size));
+		void* newPtr = alloc(size, tag, user, info);
+
+		memcpy(newPtr, ptr, copySize);
+		deallocPtr(ptr, info);
+
+		return newPtr;
 	}
 
 	void changeTag(void* ptr, zoneTag_e tag, const OFileLine& info)
@@ -311,6 +338,11 @@ void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,
 	return g_zone.alloc(size, tag, user, OFileLine::create(file, line));
 }
 
+void* Z_Realloc2(void* ptr, size_t size, const zoneTag_e tag, void* user, const char* file,
+                const int line)
+{
+	return g_zone.realloc(ptr, size, tag, user, OFileLine::create(file, line));
+}
 
 //
 // Z_FreeTags

--- a/common/z_zone.h
+++ b/common/z_zone.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -53,6 +53,8 @@ void Z_DumpHeap(const zoneTag_e lowtag, const zoneTag_e hightag);
 // Don't use these, use the macros instead!
 void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,
                 const int line);
+void* Z_Realloc2(void* ptr, size_t size, const zoneTag_e tag, void* user, const char* file,
+                 const int line);
 void Z_Free2(void* ptr, const char* file, int line);
 void Z_Discard2(void** ptr, const char* file, int line);
 void Z_ChangeTag2(void* ptr, const zoneTag_e tag, const char* file, int line);
@@ -105,6 +107,7 @@ inline void Z_Discard2(P ptr, const char* file, int line)
 }
 
 #define Z_Malloc(s,t,p) Z_Malloc2(s,t,p,__FILE__,__LINE__)
+#define Z_Realloc(p,s,t,u) Z_Realloc2(p,s,t,u,__FILE__,__LINE__)
 #define Z_Free(p) Z_Free2(p,__FILE__,__LINE__)
 #define Z_Discard(p) Z_Discard2(p,__FILE__,__LINE__)
 #define Z_ChangeTag(p,t) Z_ChangeTag2(p,t,__FILE__,__LINE__)


### PR DESCRIPTION
This PR adds support for 6 new node types: XGLN, XGL2, XGL3, and their compressed variants. At the moment, there are very few additional maps this allows, but this is a prerequisite for UDMF support, with XGL2 and XGL3 removing the 16-bit linedef limit and allowing for nodes with fractional precision, respectively.