### PR TITLE
[BUGFIX] `odamex://` URIs not being recognized

### DIFF
--- a/client/sdl/i_main.cpp
+++ b/client/sdl/i_main.cpp
@@ -173,18 +173,18 @@ int main(int argc, char *argv[])
 		if(argc == 2 && argv && argv[1])
 		{
 			static constexpr std::string_view protocol = "odamex://";
-			const char *uri = argv[1];
+			std::string_view uri = argv[1];
 
-			if(protocol == uri)
+			if(uri.substr(0, protocol.size()) == protocol)
 			{
-				std::string location = uri + protocol.length();
+				std::string_view location = uri.substr(protocol.length());
 				size_t term = location.find_first_of('/');
 
 				if(term == std::string::npos)
 					term = location.length();
 
 				Args.AppendArg("-connect");
-				Args.AppendArg(location.substr(0, term).c_str());
+				Args.AppendArg(location.substr(0, term).data());
 			}
 		}
 

--- a/client/sdl/i_main.cpp
+++ b/client/sdl/i_main.cpp
@@ -175,7 +175,7 @@ int main(int argc, char *argv[])
 			static constexpr std::string_view protocol = "odamex://";
 			std::string_view uri = argv[1];
 
-			if(uri.substr(0, protocol.size()) == protocol)
+			if(uri.substr(0, protocol.length()) == protocol)
 			{
 				std::string_view location = uri.substr(protocol.length());
 				size_t term = location.find_first_of('/');

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1603,7 +1603,7 @@ bool CL_PrepareConnect()
 			return false;
 		}
 
-		PrintFmt("> {]\n   {]\n", file.getBasename(),
+		PrintFmt("> {}\n   {}\n", file.getBasename(),
 		         file.getWantedMD5().getHexStr());
 	}
 

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -657,7 +657,7 @@ static bool CommercialIWADWarning(const OWantFile& wanted)
 		{
 			// Found a file, but it's not recognized at all.
 			PrintFmt("Odamex found a possible data file, but Odamex does not recognize "
-			         "it.\n> {]\n\n",
+			         "it.\n> {}\n\n",
 			         sameNameRes.getFullpath());
 		}
 


### PR DESCRIPTION
After #1240, `odamex://` URIs weren't being parsed properly and would get ignored after Odamex started. This also fixes an old bug where the argument to the connect option was a pointer into freed memory that just happened to still contain the string.

Also fixes a couple issues with format strings elsewhere.