### PR TITLE
Skip running workflows on changes to certain files

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches-ignore:
     - 'release/[0-9]+.[0-9]+.[0-9]+'
+    paths-ignore:
+    - "**/*.md"
+    - README
+    - LICENSE
+    - MAINTAINERS
+    - CHANGELOG
+    - 3RD-PARTY-LICENSES
+    - config-samples/*
+    - documentation/**
   pull_request:
 
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,17 +3,9 @@ name: Linux
 on:
   push:
     branches-ignore:
-      - "release/[0-9]+.[0-9]+.[0-9]+"
-    paths-ignore:
-      - "**/*.md"
-      - README
-      - LICENSE
-      - MAINTAINERS
-      - CHANGELOG
-      - 3RD-PARTY-LICENSES
-      - config-samples/*
-      - documentation/**
+    - 'release/[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+
 
 jobs:
   pre_job:
@@ -33,23 +25,23 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Prepare build
-        run: bash ci/ubuntu-buildgen.sh
-      - name: Turn on problem matcher
-        uses: ammaraskar/gcc-problem-matcher@master
-      - name: Run build
-        run: cmake --build ./build/
-      - name: Prepare artifact
-        run: bash ci/ubuntu-artifact.sh
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Odamex-Linux-x86_64
-          path: "build/artifact/*"
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Prepare build
+      run: bash ci/ubuntu-buildgen.sh
+    - name: Turn on problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
+    - name: Run build
+      run: cmake --build ./build/
+    - name: Prepare artifact
+      run: bash ci/ubuntu-artifact.sh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Odamex-Linux-x86_64
+        path: 'build/artifact/*'
   build-sdl12:
     name: Build (SDL 1.2)
     needs: pre_job
@@ -58,14 +50,14 @@ jobs:
     env:
       USE_SDL12: 1
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Prepare build
-        run: bash ci/ubuntu-buildgen.sh
-      - name: Run build
-        run: cmake --build ./build/
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Prepare build
+      run: bash ci/ubuntu-buildgen.sh
+    - name: Run build
+      run: cmake --build ./build/
   build-clang:
     name: Build (Clang)
     needs: pre_job
@@ -75,127 +67,127 @@ jobs:
       CC: /usr/bin/clang
       CXX: /usr/bin/clang++
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Prepare build
-        run: bash ci/ubuntu-buildgen.sh
-      - name: Run build
-        run: cmake --build ./build/
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Prepare build
+      run: bash ci/ubuntu-buildgen.sh
+    - name: Run build
+      run: cmake --build ./build/
   build-arm:
     name: Build (ARM64)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-24.04-arm
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Prepare build
-        run: bash ci/ubuntu-buildgen.sh
-      - name: Turn on problem matcher
-        uses: ammaraskar/gcc-problem-matcher@master
-      - name: Run build
-        run: cmake --build ./build/
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Prepare build
+      run: bash ci/ubuntu-buildgen.sh
+    - name: Turn on problem matcher
+      uses: ammaraskar/gcc-problem-matcher@master
+    - name: Run build
+      run: cmake --build ./build/
   build-fedora:
     name: Build (Fedora 32)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Run build
-        run: bash ci/fedora-buildgen.sh
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Run build
+      run: bash ci/fedora-buildgen.sh
   build-ubuntu-focal:
     name: Build (Ubuntu 20.04 LTS)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Run build
-        run: bash ci/ubuntu-focal-buildgen.sh
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Run build
+      run: bash ci/ubuntu-focal-buildgen.sh
   build-flatpak:
     name: Build Flatpak (Ubuntu Latest)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Update metainfo dates
-        shell: bash
-        run: |
-          DATE=$(date +'%Y-%m-%d')
-          sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.metainfo.xml
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Install flatpak
-        run: sudo apt update && sudo apt install flatpak flatpak-builder
-      - name: Create escaped branch name
-        env:
-          name: "${{ github.ref_name }}"
-        run: |
-          echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
-      - name: Set flatpak repo
-        run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-      - name: Run build
-        run: |
-          flatpak-builder --force-clean --user --install-deps-from=flathub \
-          --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-          --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
-      - name: Pack flatpak
-        run: |
-          flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
-          --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Odamex-Flatpak-x86_64
-          path: odamex.flatpak
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Update metainfo dates
+      shell: bash
+      run: |
+        DATE=$(date +'%Y-%m-%d')
+        sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.metainfo.xml
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Install flatpak
+      run: sudo apt update && sudo apt install flatpak flatpak-builder
+    - name: Create escaped branch name
+      env:
+        name: "${{ github.ref_name }}"
+      run: |
+        echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
+    - name: Set flatpak repo
+      run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    - name: Run build
+      run: |
+        flatpak-builder --force-clean --user --install-deps-from=flathub \
+        --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
+        --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
+    - name: Pack flatpak
+      run: |
+        flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
+        --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Odamex-Flatpak-x86_64
+        path: odamex.flatpak
   build-flatpak-arm:
     name: Build Flatpak (Ubuntu 24.04 ARM)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-24.04-arm
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Update metainfo dates
-        shell: bash
-        run: |
-          DATE=$(date +'%Y-%m-%d')
-          sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.metainfo.xml
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Install flatpak
-        run: sudo apt update && sudo apt install flatpak flatpak-builder
-      - name: Create escaped branch name
-        env:
-          name: "${{ github.ref_name }}"
-        run: |
-          echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
-      - name: Set flatpak repo
-        run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-      - name: Run build
-        run: |
-          flatpak-builder --force-clean --user --install-deps-from=flathub \
-          --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-          --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
-      - name: Pack flatpak
-        run: |
-          flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
-          --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Odamex-Flatpak-ARM64
-          path: odamex.flatpak
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Update metainfo dates
+      shell: bash
+      run: |
+        DATE=$(date +'%Y-%m-%d')
+        sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.metainfo.xml
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Install flatpak
+      run: sudo apt update && sudo apt install flatpak flatpak-builder
+    - name: Create escaped branch name
+      env:
+        name: "${{ github.ref_name }}"
+      run: |
+        echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
+    - name: Set flatpak repo
+      run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+    - name: Run build
+      run: |
+        flatpak-builder --force-clean --user --install-deps-from=flathub \
+        --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
+        --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
+    - name: Pack flatpak
+      run: |
+        flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
+        --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Odamex-Flatpak-ARM64
+        path: odamex.flatpak

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,7 @@ on:
     - 3RD-PARTY-LICENSES
     - config-samples/*
     - documentation/**
+    - tools/**
   pull_request:
 
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,9 +3,17 @@ name: Linux
 on:
   push:
     branches-ignore:
-    - 'release/[0-9]+.[0-9]+.[0-9]+'
+      - "release/[0-9]+.[0-9]+.[0-9]+"
+    paths-ignore:
+      - "**/*.md"
+      - README
+      - LICENSE
+      - MAINTAINERS
+      - CHANGELOG
+      - 3RD-PARTY-LICENSES
+      - config-samples/*
+      - documentation/**
   pull_request:
-
 
 jobs:
   pre_job:
@@ -25,23 +33,23 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Prepare build
-      run: bash ci/ubuntu-buildgen.sh
-    - name: Turn on problem matcher
-      uses: ammaraskar/gcc-problem-matcher@master
-    - name: Run build
-      run: cmake --build ./build/
-    - name: Prepare artifact
-      run: bash ci/ubuntu-artifact.sh
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: Odamex-Linux-x86_64
-        path: 'build/artifact/*'
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare build
+        run: bash ci/ubuntu-buildgen.sh
+      - name: Turn on problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
+      - name: Run build
+        run: cmake --build ./build/
+      - name: Prepare artifact
+        run: bash ci/ubuntu-artifact.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Odamex-Linux-x86_64
+          path: "build/artifact/*"
   build-sdl12:
     name: Build (SDL 1.2)
     needs: pre_job
@@ -50,14 +58,14 @@ jobs:
     env:
       USE_SDL12: 1
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Prepare build
-      run: bash ci/ubuntu-buildgen.sh
-    - name: Run build
-      run: cmake --build ./build/
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare build
+        run: bash ci/ubuntu-buildgen.sh
+      - name: Run build
+        run: cmake --build ./build/
   build-clang:
     name: Build (Clang)
     needs: pre_job
@@ -67,127 +75,127 @@ jobs:
       CC: /usr/bin/clang
       CXX: /usr/bin/clang++
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Prepare build
-      run: bash ci/ubuntu-buildgen.sh
-    - name: Run build
-      run: cmake --build ./build/
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare build
+        run: bash ci/ubuntu-buildgen.sh
+      - name: Run build
+        run: cmake --build ./build/
   build-arm:
     name: Build (ARM64)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-24.04-arm
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Prepare build
-      run: bash ci/ubuntu-buildgen.sh
-    - name: Turn on problem matcher
-      uses: ammaraskar/gcc-problem-matcher@master
-    - name: Run build
-      run: cmake --build ./build/
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare build
+        run: bash ci/ubuntu-buildgen.sh
+      - name: Turn on problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
+      - name: Run build
+        run: cmake --build ./build/
   build-fedora:
     name: Build (Fedora 32)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Run build
-      run: bash ci/fedora-buildgen.sh
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Run build
+        run: bash ci/fedora-buildgen.sh
   build-ubuntu-focal:
     name: Build (Ubuntu 20.04 LTS)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Run build
-      run: bash ci/ubuntu-focal-buildgen.sh
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Run build
+        run: bash ci/ubuntu-focal-buildgen.sh
   build-flatpak:
     name: Build Flatpak (Ubuntu Latest)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Update metainfo dates
-      shell: bash
-      run: |
-        DATE=$(date +'%Y-%m-%d')
-        sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.metainfo.xml
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Install flatpak
-      run: sudo apt update && sudo apt install flatpak flatpak-builder
-    - name: Create escaped branch name
-      env:
-        name: "${{ github.ref_name }}"
-      run: |
-        echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
-    - name: Set flatpak repo
-      run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-    - name: Run build
-      run: |
-        flatpak-builder --force-clean --user --install-deps-from=flathub \
-        --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-        --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
-    - name: Pack flatpak
-      run: |
-        flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
-        --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: Odamex-Flatpak-x86_64
-        path: odamex.flatpak
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Update metainfo dates
+        shell: bash
+        run: |
+          DATE=$(date +'%Y-%m-%d')
+          sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.metainfo.xml
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Install flatpak
+        run: sudo apt update && sudo apt install flatpak flatpak-builder
+      - name: Create escaped branch name
+        env:
+          name: "${{ github.ref_name }}"
+        run: |
+          echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
+      - name: Set flatpak repo
+        run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      - name: Run build
+        run: |
+          flatpak-builder --force-clean --user --install-deps-from=flathub \
+          --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
+          --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
+      - name: Pack flatpak
+        run: |
+          flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
+          --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Odamex-Flatpak-x86_64
+          path: odamex.flatpak
   build-flatpak-arm:
     name: Build Flatpak (Ubuntu 24.04 ARM)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-24.04-arm
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Update metainfo dates
-      shell: bash
-      run: |
-        DATE=$(date +'%Y-%m-%d')
-        sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.metainfo.xml
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Install flatpak
-      run: sudo apt update && sudo apt install flatpak flatpak-builder
-    - name: Create escaped branch name
-      env:
-        name: "${{ github.ref_name }}"
-      run: |
-        echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
-    - name: Set flatpak repo
-      run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-    - name: Run build
-      run: |
-        flatpak-builder --force-clean --user --install-deps-from=flathub \
-        --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-        --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
-    - name: Pack flatpak
-      run: |
-        flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
-        --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: Odamex-Flatpak-ARM64
-        path: odamex.flatpak
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Update metainfo dates
+        shell: bash
+        run: |
+          DATE=$(date +'%Y-%m-%d')
+          sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.metainfo.xml
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Install flatpak
+        run: sudo apt update && sudo apt install flatpak flatpak-builder
+      - name: Create escaped branch name
+        env:
+          name: "${{ github.ref_name }}"
+        run: |
+          echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
+      - name: Set flatpak repo
+        run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      - name: Run build
+        run: |
+          flatpak-builder --force-clean --user --install-deps-from=flathub \
+          --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
+          --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
+      - name: Pack flatpak
+        run: |
+          flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
+          --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Odamex-Flatpak-ARM64
+          path: odamex.flatpak

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,17 +1,6 @@
 name: macOS
 
-on:
-  push:
-    paths-ignore:
-      - "**/*.md"
-      - README
-      - LICENSE
-      - MAINTAINERS
-      - CHANGELOG
-      - 3RD-PARTY-LICENSES
-      - config-samples/*
-      - documentation/**
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   pre_job:
@@ -31,11 +20,11 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: macos-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Prepare build
-        run: bash ci/macos-buildgen.sh
-      - name: Run build
-        run: cmake --build ./build/
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Prepare build
+      run: bash ci/macos-buildgen.sh
+    - name: Run build
+      run: cmake --build ./build/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,6 +11,7 @@ on:
     - 3RD-PARTY-LICENSES
     - config-samples/*
     - documentation/**
+    - tools/**
   pull_request:
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,17 @@
 name: macOS
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - "**/*.md"
+    - README
+    - LICENSE
+    - MAINTAINERS
+    - CHANGELOG
+    - 3RD-PARTY-LICENSES
+    - config-samples/*
+    - documentation/**
+  pull_request:
 
 jobs:
   pre_job:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,17 @@
 name: macOS
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+      - README
+      - LICENSE
+      - MAINTAINERS
+      - CHANGELOG
+      - 3RD-PARTY-LICENSES
+      - config-samples/*
+      - documentation/**
+  pull_request:
 
 jobs:
   pre_job:
@@ -20,11 +31,11 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: macos-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Prepare build
-      run: bash ci/macos-buildgen.sh
-    - name: Run build
-      run: cmake --build ./build/
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Prepare build
+        run: bash ci/macos-buildgen.sh
+      - name: Run build
+        run: cmake --build ./build/

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches-ignore:
     - 'release/[0-9]+.[0-9]+.[0-9]+'
+    paths-ignore:
+    - "**/*.md"
+    - README
+    - LICENSE
+    - MAINTAINERS
+    - CHANGELOG
+    - 3RD-PARTY-LICENSES
+    - config-samples/*
+    - documentation/**
   pull_request:
 
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,7 @@ on:
     - 3RD-PARTY-LICENSES
     - config-samples/*
     - documentation/**
+    - tools/**
   pull_request:
 
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,9 +3,17 @@ name: Windows
 on:
   push:
     branches-ignore:
-    - 'release/[0-9]+.[0-9]+.[0-9]+'
+      - "release/[0-9]+.[0-9]+.[0-9]+"
+    paths-ignore:
+      - "**/*.md"
+      - README
+      - LICENSE
+      - MAINTAINERS
+      - CHANGELOG
+      - 3RD-PARTY-LICENSES
+      - config-samples/*
+      - documentation/**
   pull_request:
-
 
 jobs:
   pre_job:
@@ -25,115 +33,115 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: windows-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Install Python packages
-      uses: insightsengineering/pip-action@v2
-      with:
-        packages: |
-          b2sdk
-          PyNaCl
-    - name: Prepare build
-      run: .\ci\win-buildgen.ps1
-    - name: Turn on problem matcher
-      uses: ammaraskar/msvc-problem-matcher@master
-    - name: Run build
-      run: cmake --build .\build\ --config RelWithDebInfo --parallel
-    - name: Prepare artifact
-      run: .\ci\win-artifact.ps1
-    - name: Stage artifacts for testing
-      run: .\ci\win-prepare-demotest.ps1
-    - name: Download OdaTests and Testing Resources
-      id: get-odatests
-      run: .\ci\win-get-demotester.ps1
-      env:
-        DEMOTESTER_URL: ${{ vars.DEMOTESTER_DOWNLOAD_URL }}
-        DEMORESOURCES_URL: ${{ vars.DEMORESOURCES_DOWNLOAD_URL }}
-      continue-on-error: true
-    - name: Decrypt IWADs
-      if: steps.get-odatests.outcome == 'success'
-      run: |
-        python .\secret.py decrypt plutonia
-        python .\secret.py decrypt tnt
-        python .\secret.py decrypt doom
-        python .\secret.py decrypt doom1
-        python .\secret.py decrypt doom2
-      env:
-        SECRET_KEY: ${{ secrets.DEMOTESTER_IWAD_KEY }}
-      working-directory: .\build\demotester
-    - name: Run OdaTests
-      id: odatests
-      if: steps.get-odatests.outcome == 'success'
-      shell: pwsh
-      run: |
-        python .\odatestcases.py
-      env:
-        ODAMEX_BIN: ..\demotest\odamex.exe
-      working-directory: .\build\demotester
-      continue-on-error: true
-    - name: Read OdaTests results
-      if: steps.odatests.conclusion == 'success'
-      id: odatests-results
-      shell: pwsh
-      run: |
-        $csvData = Import-Csv -Path .\odatests_results_summary.csv
-        echo "tests_total=$($csvData[0].total)" >> $env:GITHUB_OUTPUT
-        echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
-      working-directory: .\build\demotester
-    - name: Notify Discord
-      if: env.DISCORD_URL != '' && steps.odatests.conclusion == 'success'
-      uses: ./.github/actions/odatests-notify
-      with:
-        demos-run: ${{ steps.odatests-results.outputs.tests_total }}
-        demos-passed: ${{ steps.odatests-results.outputs.tests_passed }}
-        discord-url: ${{ env.DISCORD_URL }}
-      env:
-        DISCORD_URL: ${{ secrets.ODATESTS_WEBHOOK_URL }}
-    - name: Upload artifact to B2
-      run: python .\ci\upload-b2.py .\build\archive Win-x64
-      env:
-        B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
-        B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
-        B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
-    - name: Upload artifact to Github
-      uses: actions/upload-artifact@v4
-      with:
-        name: Odamex-Win-x64
-        path: 'build/artifact/*'
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Install Python packages
+        uses: insightsengineering/pip-action@v2
+        with:
+          packages: |
+            b2sdk
+            PyNaCl
+      - name: Prepare build
+        run: .\ci\win-buildgen.ps1
+      - name: Turn on problem matcher
+        uses: ammaraskar/msvc-problem-matcher@master
+      - name: Run build
+        run: cmake --build .\build\ --config RelWithDebInfo --parallel
+      - name: Prepare artifact
+        run: .\ci\win-artifact.ps1
+      - name: Stage artifacts for testing
+        run: .\ci\win-prepare-demotest.ps1
+      - name: Download OdaTests and Testing Resources
+        id: get-odatests
+        run: .\ci\win-get-demotester.ps1
+        env:
+          DEMOTESTER_URL: ${{ vars.DEMOTESTER_DOWNLOAD_URL }}
+          DEMORESOURCES_URL: ${{ vars.DEMORESOURCES_DOWNLOAD_URL }}
+        continue-on-error: true
+      - name: Decrypt IWADs
+        if: steps.get-odatests.outcome == 'success'
+        run: |
+          python .\secret.py decrypt plutonia
+          python .\secret.py decrypt tnt
+          python .\secret.py decrypt doom
+          python .\secret.py decrypt doom1
+          python .\secret.py decrypt doom2
+        env:
+          SECRET_KEY: ${{ secrets.DEMOTESTER_IWAD_KEY }}
+        working-directory: .\build\demotester
+      - name: Run OdaTests
+        id: odatests
+        if: steps.get-odatests.outcome == 'success'
+        shell: pwsh
+        run: |
+          python .\odatestcases.py
+        env:
+          ODAMEX_BIN: ..\demotest\odamex.exe
+        working-directory: .\build\demotester
+        continue-on-error: true
+      - name: Read OdaTests results
+        if: steps.odatests.conclusion == 'success'
+        id: odatests-results
+        shell: pwsh
+        run: |
+          $csvData = Import-Csv -Path .\odatests_results_summary.csv
+          echo "tests_total=$($csvData[0].total)" >> $env:GITHUB_OUTPUT
+          echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
+        working-directory: .\build\demotester
+      - name: Notify Discord
+        if: env.DISCORD_URL != '' && steps.odatests.conclusion == 'success'
+        uses: ./.github/actions/odatests-notify
+        with:
+          demos-run: ${{ steps.odatests-results.outputs.tests_total }}
+          demos-passed: ${{ steps.odatests-results.outputs.tests_passed }}
+          discord-url: ${{ env.DISCORD_URL }}
+        env:
+          DISCORD_URL: ${{ secrets.ODATESTS_WEBHOOK_URL }}
+      - name: Upload artifact to B2
+        run: python .\ci\upload-b2.py .\build\archive Win-x64
+        env:
+          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
+          B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
+          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+      - name: Upload artifact to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: Odamex-Win-x64
+          path: "build/artifact/*"
   build-x32:
     name: Build (Visual Studio, 32-bit)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: windows-latest
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Install Python packages
-      uses: insightsengineering/pip-action@v2
-      with:
-        packages: |
-          b2sdk
-    - name: Prepare build
-      run: .\ci\win-x32-buildgen.ps1
-    - name: Run build
-      run: cmake --build .\build-x32\ --config RelWithDebInfo --parallel
-    - name: Prepare artifact
-      run: .\ci\win-x32-artifact.ps1
-    - name: Upload artifact to B2
-      run: python .\ci\upload-b2.py .\build-x32\archive Win-x32
-      env:
-        B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
-        B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
-        B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
-    - name: Upload artifact to Github
-      uses: actions/upload-artifact@v4
-      with:
-        name: Odamex-Win-x32
-        path: 'build-x32/artifact/*'
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Install Python packages
+        uses: insightsengineering/pip-action@v2
+        with:
+          packages: |
+            b2sdk
+      - name: Prepare build
+        run: .\ci\win-x32-buildgen.ps1
+      - name: Run build
+        run: cmake --build .\build-x32\ --config RelWithDebInfo --parallel
+      - name: Prepare artifact
+        run: .\ci\win-x32-artifact.ps1
+      - name: Upload artifact to B2
+        run: python .\ci\upload-b2.py .\build-x32\archive Win-x32
+        env:
+          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
+          B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
+          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+      - name: Upload artifact to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: Odamex-Win-x32
+          path: "build-x32/artifact/*"
   # build-mingw:
   #   name: Build (MinGW)
   #   runs-on: windows-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,17 +3,9 @@ name: Windows
 on:
   push:
     branches-ignore:
-      - "release/[0-9]+.[0-9]+.[0-9]+"
-    paths-ignore:
-      - "**/*.md"
-      - README
-      - LICENSE
-      - MAINTAINERS
-      - CHANGELOG
-      - 3RD-PARTY-LICENSES
-      - config-samples/*
-      - documentation/**
+    - 'release/[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+
 
 jobs:
   pre_job:
@@ -33,115 +25,115 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: windows-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Install Python packages
-        uses: insightsengineering/pip-action@v2
-        with:
-          packages: |
-            b2sdk
-            PyNaCl
-      - name: Prepare build
-        run: .\ci\win-buildgen.ps1
-      - name: Turn on problem matcher
-        uses: ammaraskar/msvc-problem-matcher@master
-      - name: Run build
-        run: cmake --build .\build\ --config RelWithDebInfo --parallel
-      - name: Prepare artifact
-        run: .\ci\win-artifact.ps1
-      - name: Stage artifacts for testing
-        run: .\ci\win-prepare-demotest.ps1
-      - name: Download OdaTests and Testing Resources
-        id: get-odatests
-        run: .\ci\win-get-demotester.ps1
-        env:
-          DEMOTESTER_URL: ${{ vars.DEMOTESTER_DOWNLOAD_URL }}
-          DEMORESOURCES_URL: ${{ vars.DEMORESOURCES_DOWNLOAD_URL }}
-        continue-on-error: true
-      - name: Decrypt IWADs
-        if: steps.get-odatests.outcome == 'success'
-        run: |
-          python .\secret.py decrypt plutonia
-          python .\secret.py decrypt tnt
-          python .\secret.py decrypt doom
-          python .\secret.py decrypt doom1
-          python .\secret.py decrypt doom2
-        env:
-          SECRET_KEY: ${{ secrets.DEMOTESTER_IWAD_KEY }}
-        working-directory: .\build\demotester
-      - name: Run OdaTests
-        id: odatests
-        if: steps.get-odatests.outcome == 'success'
-        shell: pwsh
-        run: |
-          python .\odatestcases.py
-        env:
-          ODAMEX_BIN: ..\demotest\odamex.exe
-        working-directory: .\build\demotester
-        continue-on-error: true
-      - name: Read OdaTests results
-        if: steps.odatests.conclusion == 'success'
-        id: odatests-results
-        shell: pwsh
-        run: |
-          $csvData = Import-Csv -Path .\odatests_results_summary.csv
-          echo "tests_total=$($csvData[0].total)" >> $env:GITHUB_OUTPUT
-          echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
-        working-directory: .\build\demotester
-      - name: Notify Discord
-        if: env.DISCORD_URL != '' && steps.odatests.conclusion == 'success'
-        uses: ./.github/actions/odatests-notify
-        with:
-          demos-run: ${{ steps.odatests-results.outputs.tests_total }}
-          demos-passed: ${{ steps.odatests-results.outputs.tests_passed }}
-          discord-url: ${{ env.DISCORD_URL }}
-        env:
-          DISCORD_URL: ${{ secrets.ODATESTS_WEBHOOK_URL }}
-      - name: Upload artifact to B2
-        run: python .\ci\upload-b2.py .\build\archive Win-x64
-        env:
-          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
-          B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
-          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
-      - name: Upload artifact to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: Odamex-Win-x64
-          path: "build/artifact/*"
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Install Python packages
+      uses: insightsengineering/pip-action@v2
+      with:
+        packages: |
+          b2sdk
+          PyNaCl
+    - name: Prepare build
+      run: .\ci\win-buildgen.ps1
+    - name: Turn on problem matcher
+      uses: ammaraskar/msvc-problem-matcher@master
+    - name: Run build
+      run: cmake --build .\build\ --config RelWithDebInfo --parallel
+    - name: Prepare artifact
+      run: .\ci\win-artifact.ps1
+    - name: Stage artifacts for testing
+      run: .\ci\win-prepare-demotest.ps1
+    - name: Download OdaTests and Testing Resources
+      id: get-odatests
+      run: .\ci\win-get-demotester.ps1
+      env:
+        DEMOTESTER_URL: ${{ vars.DEMOTESTER_DOWNLOAD_URL }}
+        DEMORESOURCES_URL: ${{ vars.DEMORESOURCES_DOWNLOAD_URL }}
+      continue-on-error: true
+    - name: Decrypt IWADs
+      if: steps.get-odatests.outcome == 'success'
+      run: |
+        python .\secret.py decrypt plutonia
+        python .\secret.py decrypt tnt
+        python .\secret.py decrypt doom
+        python .\secret.py decrypt doom1
+        python .\secret.py decrypt doom2
+      env:
+        SECRET_KEY: ${{ secrets.DEMOTESTER_IWAD_KEY }}
+      working-directory: .\build\demotester
+    - name: Run OdaTests
+      id: odatests
+      if: steps.get-odatests.outcome == 'success'
+      shell: pwsh
+      run: |
+        python .\odatestcases.py
+      env:
+        ODAMEX_BIN: ..\demotest\odamex.exe
+      working-directory: .\build\demotester
+      continue-on-error: true
+    - name: Read OdaTests results
+      if: steps.odatests.conclusion == 'success'
+      id: odatests-results
+      shell: pwsh
+      run: |
+        $csvData = Import-Csv -Path .\odatests_results_summary.csv
+        echo "tests_total=$($csvData[0].total)" >> $env:GITHUB_OUTPUT
+        echo "tests_passed=$($csvData[0].passed)" >> $env:GITHUB_OUTPUT
+      working-directory: .\build\demotester
+    - name: Notify Discord
+      if: env.DISCORD_URL != '' && steps.odatests.conclusion == 'success'
+      uses: ./.github/actions/odatests-notify
+      with:
+        demos-run: ${{ steps.odatests-results.outputs.tests_total }}
+        demos-passed: ${{ steps.odatests-results.outputs.tests_passed }}
+        discord-url: ${{ env.DISCORD_URL }}
+      env:
+        DISCORD_URL: ${{ secrets.ODATESTS_WEBHOOK_URL }}
+    - name: Upload artifact to B2
+      run: python .\ci\upload-b2.py .\build\archive Win-x64
+      env:
+        B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
+        B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
+        B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+    - name: Upload artifact to Github
+      uses: actions/upload-artifact@v4
+      with:
+        name: Odamex-Win-x64
+        path: 'build/artifact/*'
   build-x32:
     name: Build (Visual Studio, 32-bit)
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: windows-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: Install Python packages
-        uses: insightsengineering/pip-action@v2
-        with:
-          packages: |
-            b2sdk
-      - name: Prepare build
-        run: .\ci\win-x32-buildgen.ps1
-      - name: Run build
-        run: cmake --build .\build-x32\ --config RelWithDebInfo --parallel
-      - name: Prepare artifact
-        run: .\ci\win-x32-artifact.ps1
-      - name: Upload artifact to B2
-        run: python .\ci\upload-b2.py .\build-x32\archive Win-x32
-        env:
-          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
-          B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
-          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
-      - name: Upload artifact to Github
-        uses: actions/upload-artifact@v4
-        with:
-          name: Odamex-Win-x32
-          path: "build-x32/artifact/*"
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Install Python packages
+      uses: insightsengineering/pip-action@v2
+      with:
+        packages: |
+          b2sdk
+    - name: Prepare build
+      run: .\ci\win-x32-buildgen.ps1
+    - name: Run build
+      run: cmake --build .\build-x32\ --config RelWithDebInfo --parallel
+    - name: Prepare artifact
+      run: .\ci\win-x32-artifact.ps1
+    - name: Upload artifact to B2
+      run: python .\ci\upload-b2.py .\build-x32\archive Win-x32
+      env:
+        B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
+        B2_BUCKET_ID: ${{ secrets.B2_BUCKET_ID }}
+        B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+    - name: Upload artifact to Github
+      uses: actions/upload-artifact@v4
+      with:
+        name: Odamex-Win-x32
+        path: 'build-x32/artifact/*'
   # build-mingw:
   #   name: Build (MinGW)
   #   runs-on: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /build*
 *.vscode
+*.zed
 
 # Used by Visual Studio when loading this project as a folder, which uses CMake.
 /.vs


### PR DESCRIPTION
There's no reason to be running the workflows for changes to things like the config samples, readme, maintainers list, etc., so I have added a `paths-ignore` section to the main workflow files. I did not remove them from the rc or release workflows, since we want to be sure new artifacts with the changes are generated there. I also did not remove them from pull requests, as this could cause issues with prs from forks being left waiting on required workflows that never run.

(.zed was added to gitignore since I am using that editor on some of my computers and it was aggressively auto formatting the yml files and it makes a .zed directory for project settings when I disabled that).