### PR TITLE
Add new default master at odamex.electricbrass.net

### DIFF
--- a/odalaunch/src/oda_defs.h
+++ b/odalaunch/src/oda_defs.h
@@ -84,6 +84,7 @@ static const char* def_masterlist[] =
 {
 	"master1.odamex.net:15000"
 	,"voxelsoft.com:15000"
+	,"odamex.electricbrass.net:15000"
 	,NULL
 };
 

--- a/server/src/sv_master.cpp
+++ b/server/src/sv_master.cpp
@@ -35,7 +35,7 @@
 
 // [Russell] - default master list
 // This is here for complete master redundancy, including domain name failure
-static const char* def_masterlist[] = { "master1.odamex.net", "voxelsoft.com", NULL };
+static constexpr std::string_view def_masterlist[] = { "master1.odamex.net", "voxelsoft.com", "odamex.electricbrass.net" };
 
 class masterserver
 {
@@ -114,8 +114,8 @@ void SV_InitMasters(void)
 			// so we can dump them to the server cfg file if one does not exist
 			if (masters.empty())
 			{
-				for (int i = 0; def_masterlist[i] != NULL; i++)
-					SV_AddMaster(def_masterlist[i]);
+				for (std::string_view master : def_masterlist)
+					SV_AddMaster(master.data());
 			}
 		}
 		else


### PR DESCRIPTION
I am working on a new version of the master server in order to address issues such as the long delay before new servers show up. To test it further, and for more redundancy over the current 2 masters, I am hosting an instance of it at `odamex.electricbrass.net:15000` and have added it to the list of default masters.