### PR TITLE
WIP: Make sure mouse sensitivity is consistent across video modes and resolutions. 

### DIFF
--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -40,8 +40,6 @@ EXTERN_CVAR(joy_deadzone)
 EXTERN_CVAR(joy_lefttrigger_deadzone)
 EXTERN_CVAR(joy_righttrigger_deadzone)
 
-EXTERN_CVAR(m_rawmouse)
-
 // ============================================================================
 //
 // SDL 2.x Implementation
@@ -436,24 +434,17 @@ void ISDL20MouseInputDevice::resume()
 	mActive = true;
 	reset();
 
-	// [RV] Add these unscaled relative mouse hints to ensure motion deltas are true device deltas.
-	// This was implemented so that motion deltas aren't scaled by desktop DPI or resolution.
-	// tl;dr keeps mouse sensitivity the same across all video modes and resolutions.
-#if SDL_VERSION_ATLEAST(2, 0, 18)
-	if (m_rawmouse)
-	{
-		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE, "0");
-		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SCALING, "0");
-	}
-	else
-	{
-		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE, "1");
-		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SCALING, "1");
-	}
-#endif
-	// -------------------------------------------
-
+	// [RV] Always use relative mouse mode and 
+	// force unscaled relative motion across supported SDL versions
 	SDL_SetRelativeMouseMode(SDL_TRUE);
+
+	#if SDL_VERSION_ATLEAST(2, 0, 14)
+			SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_SCALING, "0", SDL_HINT_OVERRIDE);
+	#endif
+
+	#if SDL_VERSION_ATLEAST(2, 26, 0)
+			SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE, "0", SDL_HINT_OVERRIDE);
+	#endif
 
 	SDL_EventState(SDL_MOUSEMOTION, SDL_ENABLE);
 	SDL_EventState(SDL_MOUSEBUTTONDOWN, SDL_ENABLE);

--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -40,6 +40,8 @@ EXTERN_CVAR(joy_deadzone)
 EXTERN_CVAR(joy_lefttrigger_deadzone)
 EXTERN_CVAR(joy_righttrigger_deadzone)
 
+EXTERN_CVAR(m_rawmouse)
+
 // ============================================================================
 //
 // SDL 2.x Implementation
@@ -433,12 +435,30 @@ void ISDL20MouseInputDevice::resume()
 {
 	mActive = true;
 	reset();
+
+	// [RV] Add these unscaled relative mouse hints to ensure motion deltas are true device deltas.
+	// This was implemented so that motion deltas aren't scaled by desktop DPI or resolution.
+	// tl;dr keeps mouse sensitivity the same across all video modes and resolutions.
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+	if (m_rawmouse)
+	{
+		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE, "0");
+		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SCALING, "0");
+	}
+	else
+	{
+		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE, "1");
+		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SCALING, "1");
+	}
+#endif
+	// -------------------------------------------
+
 	SDL_SetRelativeMouseMode(SDL_TRUE);
+
 	SDL_EventState(SDL_MOUSEMOTION, SDL_ENABLE);
 	SDL_EventState(SDL_MOUSEBUTTONDOWN, SDL_ENABLE);
 	SDL_EventState(SDL_MOUSEBUTTONUP, SDL_ENABLE);
 }
-
 
 //
 // ISDL20MouseInputDevice::gatherEvents

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -518,8 +518,6 @@ CVAR(			hud_mousegraph, "0", "Display mouse values",
 CVAR(			idmypos, "0", "Shows current player position on map",
 				CVARTYPE_BOOL, CVAR_NULL)
 
-CVAR(			m_rawmouse, "1", "Use raw, unscaled relative mouse input (consistent across resolutions)", CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
-
 // Heads up display
 // ----------------
 CVAR(hud_bigfont, "0",

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -518,6 +518,8 @@ CVAR(			hud_mousegraph, "0", "Display mouse values",
 CVAR(			idmypos, "0", "Shows current player position on map",
 				CVARTYPE_BOOL, CVAR_NULL)
 
+CVAR(			m_rawmouse, "1", "Use raw, unscaled relative mouse input (consistent across resolutions)", CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 // Heads up display
 // ----------------
 CVAR(hud_bigfont, "0",


### PR DESCRIPTION
Addresses #976 by adding a cvar, `m_rawinput`, to ensure motion deltas are true device deltas, not based on desktop DPI or Odamex's resolution. The cvar is on by default in this build so players can test it on and off.

If we confirm that this resolve the issue in a way we want, I'd advocate for the removal of the cvar prior to adding it to the source.