### PR TITLE
[BUGFIX] Multiplayer only monsters dormant when spawned in singleplayer, ghosts in multiplayer

### DIFF
--- a/common/doomdata.h
+++ b/common/doomdata.h
@@ -296,8 +296,6 @@ typedef struct MapThing
 #define MTF_COOPERATIVE		0x0200	// Thing appears in cooperative games
 #define MTF_DEATHMATCH		0x0400	// Thing appears in deathmatch games
 
-#define MTF_FRIEND			0x0080 // mbf
-#define MTF_RESERVED		0x0100   // mbf reserved bit
 #define MTF_FRIENDLY			0x2000 // zdoom
 
 // Custom MapThing Flags
@@ -310,6 +308,8 @@ typedef struct MapThing
 #define BTF_NOTSINGLE		0x0010	// (TF_COOPERATIVE|TF_DEATHMATCH)
 #define BTF_NOTDEATHMATCH	0x0020	// (TF_SINGLE|TF_COOPERATIVE)
 #define BTF_NOTCOOPERATIVE	0x0040	// (TF_SINGLE|TF_DEATHMATCH)
+#define BTF_FRIEND			0x0080	// mbf
+#define BTF_RESERVED		0x0100	// mbf reserved bit
 
 #define NO_CRUSH	-1
 #define DOOM_CRUSH	10

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2932,53 +2932,21 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 		return;
 	}
 
-	if (map_format.getZDoom())
+	// Filter mapthings based on the gamemode
+	if (!multiplayer && g_thingfilter != -1 && !G_GetCurrentSkill().spawn_multi)
 	{
-		// Filter mapthings based on the gamemode
-		if (!multiplayer && g_thingfilter != -1 && !G_GetCurrentSkill().spawn_multi)
-		{
-			if (!(mthing->flags & MTF_SINGLE))
-				return;
-		}
-		else if (sv_gametype == GM_DM || sv_gametype == GM_TEAMDM)
-		{
-			if (!(mthing->flags & MTF_DEATHMATCH))
-				return;
-		}
-		else if (G_IsCoopGame())
-		{
-			if (g_thingfilter == 1)
-				mthing->flags |= MTF_FILTER_COOPWPN;
-			else if (!(mthing->flags & MTF_COOPERATIVE) || g_thingfilter == 2)
-				return;
-		}
+		if (!(mthing->flags & MTF_SINGLE))
+			return;
 	}
-	else
+	else if (sv_gametype == GM_DM || sv_gametype == GM_TEAMDM)
 	{
-		if (mthing->flags & BTF_NOTSINGLE)
-		{
-			if (G_IsCoopGame() && multiplayer)
-			{
-				if (g_thingfilter == 1)
-					mthing->flags |= MTF_FILTER_COOPWPN;
-				else if (g_thingfilter == 2)
-					return;
-			}
-			else if (!multiplayer && g_thingfilter != -1)
-				return;
-		}
-		else if (mthing->flags & BTF_NOTDEATHMATCH)
-		{
-			if (sv_gametype == GM_DM || sv_gametype == GM_TEAMDM)
-				return;
-		}
-		else if (mthing->flags & BTF_NOTCOOPERATIVE)
-		{
-			if (G_IsCoopGame() && multiplayer)
-			{
-				return;
-			}
-		}
+		if (!(mthing->flags & MTF_DEATHMATCH))
+			return;
+	}
+	else if (G_IsCoopGame())
+	{
+		if (!(mthing->flags & MTF_COOPERATIVE))
+			return;
 	}
 
 	if (g_thingfilter == 3 && P_IsPickupableThing(mthing->type))
@@ -3204,16 +3172,8 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 	if (mthing->flags & MTF_AMBUSH)
 		mobj->flags |= MF_AMBUSH;
 
-	if (map_format.getZDoom())
-	{
-		if (mthing->flags & MTF_FRIENDLY)
-			mobj->flags |= MF_FRIEND;
-	}
-	else
-	{
-		if (mthing->flags & MTF_FRIEND)
-			mobj->flags |= MF_FRIEND;
-	}
+	if (mthing->flags & MTF_FRIENDLY)
+		mobj->flags |= MF_FRIEND;
 
 	// [RH] Add ThingID to mobj and link it in with the others
 	mobj->tid = mthing->thingid;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -921,8 +921,26 @@ void P_LoadThings (int lump)
 		//		handle these and more cases better, so we just pass it
 		//		everything and let it decide what to do with them.
 
+		// [RH] Need to translate the spawn flags to Hexen format.
 		short flags = LESHORT(mt->options);
-		mt2.flags = flags;
+		mt2.flags = (short)((flags & 0xf) | 0x7e0);
+		if (flags & BTF_NOTSINGLE)
+		{
+			#ifdef SERVER_APP
+			if (G_IsCoopGame())
+			{
+				if (g_thingfilter == 1)
+					mt2.flags |= MTF_FILTER_COOPWPN;
+				else if (g_thingfilter == 2)
+					mt2.flags &= ~MTF_COOPERATIVE;
+			}
+			else
+			#endif
+				mt2.flags &= ~MTF_SINGLE;
+		}
+		if (flags & BTF_NOTDEATHMATCH)		mt2.flags &= ~MTF_DEATHMATCH;
+		if (flags & BTF_NOTCOOPERATIVE)		mt2.flags &= ~MTF_COOPERATIVE;
+		if (flags & BTF_FRIEND)				mt2.flags |= MTF_FRIENDLY;
 
 		mt2.x = LESHORT(mt->x);
 		mt2.y = LESHORT(mt->y);


### PR DESCRIPTION
The removal of translating Doom/Boom/MBF's mapthing flags over to Odamex/ZDoom's when loading things resulted various issues due to conflicting flags in the 2 sets. This PR restores the old method of translating the flags, instead of using the map format to determine their behavior. MBF's friend flag is now turned into the ZDoom friend flag, so that friendly monsters continue to work under this system.

This fixes multiplayer only monsters being dormant when spawned in singleplayer, and appearing as unkillable ghosts in multiplayer.