### PR TITLE
[BUGFIX] IDCLEV causes infinite loop, freezing client and using huge amounts of memory

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2058,7 +2058,7 @@ static void CL_SecretEvent(const odaproto::svc::SecretEvent* msg)
 	if (!::hud_revealsecrets || ::hud_revealsecrets > 2)
 		return;
 
-	PrintFmt("{}", "{}{} {}found a secret!\n", TEXTCOLOR_YELLOW,
+	PrintFmt("{}{} {}found a secret!\n", TEXTCOLOR_YELLOW,
 	                player.userinfo.netname, TEXTCOLOR_NORMAL);
 
 	if (::hud_revealsecrets == 1)

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -608,6 +608,11 @@ void R_ProjectSprite(AActor *thing, int fakeside)
 		flip = sprframe->flip[0];
 	}
 
+	if (lump == -1) {
+		char frame = (thing->frame & FF_FRAMEMASK) + 'A';
+		I_Error("Frame {} for sprite {} could not be found.", frame, sprnames[thing->sprite]);
+	}
+
 	if (sprframe->width[rot] == SPRITE_NEEDS_INFO)
 	{
 		R_CacheSprite (sprdef);	// [RH] speeds up game startup time

--- a/common/c_dispatch.cpp
+++ b/common/c_dispatch.cpp
@@ -562,10 +562,10 @@ std::optional<std::string> ParseString2(std::string_view& data)
 {
 	std::string token;
 
-	const auto white = data.find_first_not_of(' ');
-	if (white != std::string_view::npos)
-		data.remove_prefix(white);
-	else
+	while (!data.empty() && data[0] <= ' ')
+		data.remove_prefix(1);
+
+	if (data.empty())
 		return std::nullopt;
 
 	// Ch0wW : If having a comment, break immediately the line!


### PR DESCRIPTION
After the rewrite of ParseString2, it accidentally only considered spaces and not other whitespace when skipping whitespace, so it would never consume a newline that is for some reason passed at the end of idclev.

Also included is a check in R_ProjectSprite for missing sprite lumps. This greatly improves the error message from "4294967295 >= numlumps" to "Frame \<frame letter> for sprite \<sprite name> could not be found."