### PR TITLE
Fix PrintFmt issues found by compiling as C++20

### DIFF
--- a/client/sdl/i_system.h
+++ b/client/sdl/i_system.h
@@ -95,21 +95,21 @@ void I_BaseError(const std::string& errortext);
 [[noreturn]] void I_BaseFatalError(const std::string& errortext);
 
 template <typename... ARGS>
-void I_Warning(const fmt::string_view format, const ARGS&... args)
+void I_Warning(fmt::format_string<ARGS...> format, ARGS&&... args)
 {
-	I_BaseWarning(fmt::format(format, args...));
+	I_BaseWarning(fmt::format(format, std::forward<ARGS>(args)...));
 }
 
 template <typename... ARGS>
-void I_Error(const fmt::string_view format, const ARGS&... args)
+void I_Error(fmt::format_string<ARGS...> format, ARGS&&... args)
 {
-	I_BaseError(fmt::format(format, args...));
+	I_BaseError(fmt::format(format, std::forward<ARGS>(args)...));
 }
 
 template <typename... ARGS>
-[[noreturn]] void I_FatalError(const fmt::string_view format, const ARGS&... args)
+[[noreturn]] void I_FatalError(fmt::format_string<ARGS...> format, ARGS&&... args)
 {
-	I_BaseFatalError(fmt::format(format, args...));
+	I_BaseFatalError(fmt::format(format, std::forward<ARGS>(args)...));
 }
 
 void addterm (void (STACK_ARGS *func)(void), const char *name);

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -883,7 +883,7 @@ BEGIN_COMMAND (serverinfo)
 	std::sort(server_cvars.begin(), server_cvars.end());
 
     // Heading
-    PrintFmt("\n{:>{}} - Value\n", MaxFieldLength, "Name");
+    PrintFmt("\n{1:>{0}} - Value\n", MaxFieldLength, "Name");
 
     // Data
 	for (const auto& varname : server_cvars)
@@ -891,7 +891,7 @@ BEGIN_COMMAND (serverinfo)
 		cvar_t *dummy;
 		Cvar = cvar_t::FindCVar(varname.c_str(), &dummy);
 
-		PrintFmt("{:>{}} - {}\n",
+		PrintFmt("{1:>{0}} - {2}\n",
 			     MaxFieldLength,
 			     Cvar->name(),
 			     Cvar->str());

--- a/client/src/wi_interlevel.cpp
+++ b/client/src/wi_interlevel.cpp
@@ -370,7 +370,7 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			{
 				OLumpName mapname = os.getToken();
 				if (!levels.findByName(mapname).exists())
-					os.error("Map {} does not exist");
+					os.error("Map {} does not exist", mapname);
 
 				os.mustScanInt();
 				int x = os.getTokenInt();
@@ -393,7 +393,7 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
 			if (!levels.findByName(mapname).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname);
 
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
@@ -408,7 +408,7 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
 			if (!levels.findByName(mapname).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname);
 
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
@@ -423,7 +423,7 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
 			if (!levels.findByName(mapname).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname);
 
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
@@ -438,7 +438,7 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
 			if (!levels.findByName(mapname).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname);
 
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
@@ -453,7 +453,7 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
 			if (!levels.findByName(mapname).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname);
 
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
@@ -468,7 +468,7 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
 			if (!levels.findByName(mapname).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname);
 
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
@@ -483,12 +483,12 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
 			if (!levels.findByName(mapname).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname);
 
 			os.mustScan(8);
 			OLumpName mapname2 = os.getToken();
 			if (!levels.findByName(mapname2).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname2);
 
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))
@@ -503,12 +503,12 @@ interlevel_t* WI_GetIntermissionScript(const OLumpName& lumpname)
 			os.mustScan(8);
 			OLumpName mapname = os.getToken();
 			if (!levels.findByName(mapname).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname);
 
 			os.mustScan(8);
 			OLumpName mapname2 = os.getToken();
 			if (!levels.findByName(mapname2).exists())
-				os.error("Map {} does not exist");
+				os.error("Map {} does not exist", mapname2);
 
 			os.mustScan();
 			if (os.compareTokenNoCase("animation"))

--- a/common/c_dispatch.cpp
+++ b/common/c_dispatch.cpp
@@ -1037,7 +1037,7 @@ END_COMMAND (puke)
 BEGIN_COMMAND (error)
 {
 	std::string text = C_ArgCombine(argc - 1, (const char **)(argv + 1));
-	I_Error (text);
+	I_Error ("{}", text);
 }
 END_COMMAND (error)
 

--- a/common/g_horde.cpp
+++ b/common/g_horde.cpp
@@ -73,8 +73,7 @@ static void ParsePowerupConfig(OScanner& os, hordeDefine_t::powConfig_t& outConf
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer = fmt::sprintf("Unknown Powerup Token \"%s\".", os.getToken());
-			os.error(buffer);
+			os.error("Unknown Powerup Token \"{}\".", os.getToken());
 		}
 	}
 }
@@ -110,8 +109,7 @@ static void ParseMonsterConfig(OScanner& os, hordeDefine_t::monConfig_t& outConf
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer = fmt::sprintf("Unknown Monster/Boss Token \"%s\".", os.getToken());
-			os.error(buffer);
+			os.error("Unknown Monster/Boss Token \"{}\".", os.getToken());
 		}
 	}
 }
@@ -174,9 +172,7 @@ static void ParseDefine(OScanner& os)
 					}
 					else
 					{
-						std::string buffer = fmt::sprintf("Unknown weapon \"%s\".",
-						                                  os.getToken());
-						os.error(buffer);
+						os.error("Unknown weapon \"{}\".", os.getToken());
 					}
 				}
 				define.weapons.push_back(weapon);
@@ -196,8 +192,7 @@ static void ParseDefine(OScanner& os)
 			const mobjtype_t type = NameOrAliasToMobj(os.getToken());
 			if (type == MT_NULL)
 			{
-				std::string buffer = fmt::sprintf("Unknown powerup \"%s\".", os.getToken());
-				os.error(buffer);
+				os.error("Unknown powerup \"{}\".", os.getToken());
 			}
 
 			// Config block.
@@ -222,8 +217,7 @@ static void ParseDefine(OScanner& os)
 			const mobjtype_t type = NameOrAliasToMobj(os.getToken());
 			if (type == MT_NULL)
 			{
-				std::string buffer = fmt::sprintf("Unknown monster \"%s\".", os.getToken());
-				os.error(buffer);
+				os.error("Unknown monster \"{}\".", os.getToken());
 			}
 
 			// Config block.
@@ -248,8 +242,7 @@ static void ParseDefine(OScanner& os)
 			const mobjtype_t type = NameOrAliasToMobj(os.getToken());
 			if (type == MT_NULL)
 			{
-				std::string buffer = fmt::sprintf("Unknown boss \"%s\".", os.getToken());
-				os.error(buffer);
+				os.error("Unknown boss \"{}\".", os.getToken());
 			}
 
 			// Config block.
@@ -270,8 +263,7 @@ static void ParseDefine(OScanner& os)
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer = fmt::sprintf("Unknown Token \"%s\".", os.getToken());
-			os.error(buffer);
+			os.error("Unknown Token \"{}\".", os.getToken());
 		}
 	}
 
@@ -302,61 +294,51 @@ static void ParseDefine(OScanner& os)
 		define.ammos.push_back(ammo);
 	}
 
-	std::string buf;
 	if (define.name.empty())
 	{
 		os.error("Define doesn't have a name.");
 	}
 	if (define.weapons.empty())
 	{
-		buf = fmt::sprintf("No weapon pickups found for define \"%s\".", define.name);
-		os.warning(buf);
+		os.warning("No weapon pickups found for define \"{}\".", define.name);
 	}
 	if (define.monsters.empty())
 	{
-		buf = fmt::sprintf("No monsters found for define \"%s\".", define.name);
-		os.error(buf);
+		os.error("No monsters found for define \"{}\".", define.name);
 	}
 	if (define.powerups.empty())
 	{
-		buf = fmt::sprintf("No powerups found for define \"%s\".", define.name);
-		os.error(buf);
+		os.error("No powerups found for define \"{}\".", define.name);
 	}
 	if (define.minGroupHealth < 0)
 	{
-		buf = fmt::sprintf("Minimum group health for define \"%s\" was not set.",
-		                   define.name);
-		os.error(buf);
+		os.error("Minimum group health for define \"{}\" was not set.",
+		         define.name);
 	}
 	if (define.maxGroupHealth <= 0)
 	{
-		buf = fmt::sprintf("Maximum group health for define \"%s\" was not set.",
-		                   define.name);
-		os.error(buf);
+		os.error("Maximum group health for define \"{}\" was not set.",
+		         define.name);
 	}
 	if (define.minGroupHealth > define.maxGroupHealth)
 	{
-		buf = fmt::sprintf("Maximum group health for define \"%s\" is less than minimum.",
-		                   define.name);
-		os.error(buf);
+		os.error("Maximum group health for define \"{}\" is less than minimum.",
+		         define.name);
 	}
 	if (define.minBossHealth < 0)
 	{
-		buf = fmt::sprintf("Minimum boss health for define \"%s\" was not set.",
-		                   define.name);
-		os.error(buf);
+		os.error("Minimum boss health for define \"{}\" was not set.",
+		         define.name);
 	}
 	if (define.maxBossHealth <= 0)
 	{
-		buf = fmt::sprintf("Maximum boss health for define \"%s\" was not set.",
-		                   define.name);
-		os.error(buf);
+		os.error("Maximum boss health for define \"{}\" was not set.",
+		         define.name);
 	}
 	if (define.minBossHealth > define.maxBossHealth)
 	{
-		buf = fmt::sprintf("Maximum boss health for define \"%s\" is less than minimum.",
-		                   define.name);
-		os.error(buf);
+		os.error("Maximum boss health for define \"{}\" is less than minimum.",
+		         define.name);
 	}
 
 	::WAVE_DEFINES.push_back(define);
@@ -374,15 +356,13 @@ static void ParseAlias(OScanner& os)
 	if (otype == MT_NULL)
 	{
 		// We don't know what this token is.
-		std::string buffer = fmt::sprintf("Can't alias unknown thing \"%s\".", original);
-		os.error(buffer);
+		os.error("Can't alias unknown thing \"{}\".", original);
 	}
 
 	if (!CheckIfDehActorDefined(otype))
 	{
 		// [Blair] DEHEXTRA monster not defined
-		std::string buffer = fmt::sprintf("The following actor is undefined: \"%s\".", original);
-		os.error(buffer);
+		os.error("The following actor is undefined: \"{}\".", original);
 	}
 
 	g_aliasMap.emplace(alias, otype);
@@ -417,8 +397,7 @@ static void ParseHordeDef(const int lump, const OLumpName& name)
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer = fmt::sprintf("Unknown Token \"%s\".", os.getToken());
-			os.error(buffer);
+			os.error("Unknown Token \"{}\".", os.getToken());
 		}
 	}
 }

--- a/common/oscanner.h
+++ b/common/oscanner.h
@@ -85,16 +85,16 @@ class OScanner
 	[[nodiscard]] bool compareTokenNoCase(const char* string) const;
 
 	template <typename... ARGS>
-	void warning(const fmt::string_view format, const ARGS&... args) const
+	void warning(fmt::format_string<ARGS...> format, ARGS&&... args) const
 	{
 		PrintFmt(PRINT_WARNING, "Parse Warning: {}:{}: {}\n", m_config.lumpName,
-		       m_lineNumber, fmt::format(format, args...));
+		       m_lineNumber, fmt::format(format, std::forward<ARGS>(args)...));
 	}
 
 	template <typename... ARGS>
-	void error(const fmt::string_view format, const ARGS&... args) const
+	void error(fmt::format_string<ARGS...> format, ARGS&&... args) const
 	{
 		I_Error("Parse Error: {}:{}: {}", m_config.lumpName, m_lineNumber,
-		        fmt::format(format, args...));
+		        fmt::format(format, std::forward<ARGS>(args)...));
 	}
 };

--- a/server/src/i_system.h
+++ b/server/src/i_system.h
@@ -82,15 +82,15 @@ void I_BaseError(const std::string& errortext);
 [[noreturn]] void I_BaseFatalError(const std::string& errortext);
 
 template <typename... ARGS>
-void I_Error(const fmt::string_view format, const ARGS&... args)
+void I_Error(fmt::format_string<ARGS...>format, ARGS&&... args)
 {
-	I_BaseError(fmt::format(format, args...));
+	I_BaseError(fmt::format(format, std::forward<ARGS>(args)...));
 }
 
 template <typename... ARGS>
-[[noreturn]] void I_FatalError(const fmt::string_view format, const ARGS&... args)
+[[noreturn]] void I_FatalError(fmt::format_string<ARGS...> format, ARGS&&... args)
 {
-	I_BaseFatalError(fmt::format(format, args...));
+	I_BaseFatalError(fmt::format(format, std::forward<ARGS>(args)...));
 }
 
 void addterm (void (STACK_ARGS *func)(void), const char *name);

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -56,24 +56,24 @@ void SV_BasePrint(client_t* cl, const int printlevel, const std::string& str);
 
 // Print directly to a specific client.
 template <typename... ARGS>
-void SV_ClientPrintFmt(client_t *cl, int level, const fmt::string_view format, const ARGS&... args)
+void SV_ClientPrintFmt(client_t *cl, int level, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
-	SV_BasePrint(cl, level, fmt::format(format, args...));
+	SV_BasePrint(cl, level, fmt::format(format, std::forward<ARGS>(args)...));
 }
 
 // Print directly to a specific player.
 template <typename... ARGS>
-void SV_PlayerPrintFmt(int level, int player_id, const fmt::string_view format, const ARGS&... args)
+void SV_PlayerPrintFmt(int level, int player_id, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	client_t* cl = &idplayer(player_id).client;
-	SV_ClientPrintFmt(cl, level, format, args...);
+	SV_ClientPrintFmt(cl, level, format, std::forward<ARGS>(args)...);
 }
 
 // Print to all spectators
 template <typename... ARGS>
-void SV_SpectatorPrintFmt(int level, const fmt::string_view format, const ARGS&... args)
+void SV_SpectatorPrintFmt(int level, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
-	std::string string = fmt::format(format, args...);
+	std::string string = fmt::format(format, std::forward<ARGS>(args)...);
 	PrintFmt(level, "{}", string);  // print to the console
 
 	for (auto& player : players)
@@ -89,12 +89,12 @@ void SV_SpectatorPrintFmt(int level, const fmt::string_view format, const ARGS&.
 }
 
 template <typename... ARGS>
-void SV_TeamPrintFmt(int level, int who, const fmt::string_view format, const ARGS&... args)
+void SV_TeamPrintFmt(int level, int who, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	if (sv_gametype != GM_TEAMDM && sv_gametype != GM_CTF)
 		return;
 
-	std::string string = fmt::format(format, args...);
+	std::string string = fmt::format(format, std::forward<ARGS>(args)...);
 	PrintFmt(level, "{}", string);  // print to the console
 
 	const team_t& team = idplayer(who).userinfo.team;


### PR DESCRIPTION
{fmt} introduced compile-time format string checking when the library is used with C++20 or later. This PR reworks Odamex's formatting functions to be compatible with this and fixes all the related errors found by compiling Odamex as C++20.