### PR TITLE
[BUGFIX] Maplist `this_index` and `next_index` are swapped when sent to client

### DIFF
--- a/client/src/cl_maplist.cpp
+++ b/client/src/cl_maplist.cpp
@@ -387,7 +387,7 @@ void CMD_MaplistCallback(const maplist_qrows_t &result) {
 		} else if (index == next_index) {
 			flag = '+';
 		}
-		PrintFmt(PRINT_HIGH, "{}{}. {} {}{}\n", flag, index + 1,
+		PrintFmt(PRINT_HIGH, " {}{}. {} {}{}\n", flag, index + 1,
 			   JoinStrings(wads, " "), map,
 			   lastmap.empty() ? "" : fmt::format(" lastmap={}", lastmap));
 	}

--- a/client/src/cl_maplist.cpp
+++ b/client/src/cl_maplist.cpp
@@ -383,7 +383,7 @@ void CMD_MaplistCallback(const maplist_qrows_t &result) {
 		const auto& [map, lastmap, _, wads] = *entry;
 		char flag = ' ';
 		if (show_this_map && index == this_index) {
-			flag = '*';
+			flag = '>';
 		} else if (index == next_index) {
 			flag = '+';
 		}

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -265,6 +265,8 @@ void STACK_ARGS D_Shutdown()
 	NormalLight.next = NULL;
 }
 
+void G_ChangeMapStartup();
+
 //
 // D_DoomMain
 //
@@ -418,7 +420,7 @@ void D_DoomMain()
 
 	level.mapname = startmap;
 
-	G_ChangeMap();
+	G_ChangeMapStartup();
 
 	D_DoomLoop();	// never returns
 }

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -296,6 +296,50 @@ void G_ChangeMap(size_t index) {
 		AddCommandString(sv_endmapscript.str());
 }
 
+// Determine first map to load on startup
+void G_ChangeMapStartup()
+{
+	unnatural_level_progression = false;
+
+	maplist_entry_t lobby_entry = Maplist::instance().get_lobbymap();
+
+	if (!Maplist::instance().lobbyempty())
+	{
+		std::string wadstr = C_EscapeWadList(lobby_entry.wads);
+		G_LoadWadString(wadstr, lobby_entry.map);
+	}
+	else
+	{
+		if (Maplist::instance().empty())
+		{
+			// We don't have a maplist, so grab the next 'natural' map lump.
+			G_DeferedInitNew(G_NextMap());
+		}
+		else
+		{
+			size_t this_index = 0;
+			// if gotomap was run before this, stay on map set by that
+			// otherwise this_index is unmodified, and go to first maplist entry
+			Maplist::instance().get_this_index(this_index);
+			maplist_entry_t maplist_entry;
+			Maplist::instance().get_map_by_index(this_index, maplist_entry);
+
+			std::string wadstr = C_EscapeWadList(maplist_entry.wads);
+			G_LoadWadString(wadstr, maplist_entry.map, maplist_entry.lastmaps);
+
+			// Set the new map as the current map
+			Maplist::instance().set_index(this_index);
+		}
+	}
+
+	// run script at the end of each map
+	// [ML] 8/22/2010: There are examples in the wiki that outright don't work
+	// when onlcvars (addcommandstring's second param) is true.  Is there a
+	// reason why the mapscripts ahve to be safe mode?
+	if (!sv_endmapscript.str().empty())
+		AddCommandString(sv_endmapscript.str());
+}
+
 // Restart the current map.
 void G_RestartMap() {
 	// Restart the current map.

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -420,8 +420,8 @@ bool Maplist::set_index(const size_t &index) {
 		return false;
 	}
 
-	this->entered_once = true && gamestate != GS_STARTUP;
-	this->in_maplist = true && gamestate != GS_STARTUP;
+	this->entered_once = true;
+	this->in_maplist = true;
 	this->index = index;
 	this->update_shuffle_index();
 	return true;

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -527,7 +527,7 @@ void SV_MaplistIndex(player_t &player) {
 		}
 	}
 
-	MSG_WriteSVC(&cl->reliablebuf, SVC_MaplistIndex(count, next_index, this_index));
+	MSG_WriteSVC(&cl->reliablebuf, SVC_MaplistIndex(count, this_index, next_index));
 }
 
 // Send a full maplist update to a specific player

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -681,7 +681,7 @@ BEGIN_COMMAND (maplist) {
 		const auto& [map, _, lastmaps, wads] = *entry;
 		char flag = ' ';
 		if (show_this_map && index == this_index) {
-			flag = '*';
+			flag = '>';
 		} else if (index == next_index) {
 			flag = '+';
 		}


### PR DESCRIPTION
These indices were being sent in the wrong order, so when viewing the maplist on a client, the current entry would be displayed as the next index, and the next would be displayed as the current.

Also fixes a bug introduced by #1360, where the server would never enter the maplist on startup.