### PR TITLE
[BUGFIX] Serious performance regression in monster targeting

### DIFF
--- a/common/actor.h
+++ b/common/actor.h
@@ -473,8 +473,6 @@ public:
 
 	DWORD			effects;			// [RH] see p_effect.h
 
-    // Interaction info, by BLOCKMAP.
-    // Links in blocks (if needed).
 	struct subsector_s		*subsector;
 
     // The closest interval over all contacted Sectors.
@@ -642,6 +640,8 @@ public:
 		AActor		**prev[BLOCKSX * BLOCKSY];
 	};
 
+	// Interaction info, by BLOCKMAP.
+    // Links in blocks (if needed).
 	ActorBlockMapListNode bmapnode;
 };
 

--- a/common/p_maputl.cpp
+++ b/common/p_maputl.cpp
@@ -1207,7 +1207,9 @@ bool P_ActorInFOV(const AActor* origin, const AActor* mo , float f, fixed_t dist
 
 AActor* RoughMonsterCheck(AActor* mo, int index, angle_t fov)
 {
-	for (AActor* link = blocklinks[index]; link != nullptr; link = link->bmapnode.Next(0, 0))
+	const int bx = index % bmapwidth;
+	const int by = index / bmapwidth;
+	for (AActor* link = blocklinks[index]; link != nullptr; link = link->bmapnode.Next(bx, by))
 	{
 		// skip non-shootable actors
 		if (!(link->flags & MF_SHOOTABLE))
@@ -1256,7 +1258,9 @@ AActor* RoughMonsterCheck(AActor* mo, int index, angle_t fov)
 
 AActor* RoughTracerCheck(AActor* mo, int index, angle_t fov)
 {
-	for (AActor* link = blocklinks[index]; link != nullptr; link = link->bmapnode.Next(0, 0))
+	const int bx = index % bmapwidth;
+	const int by = index / bmapwidth;
+	for (AActor* link = blocklinks[index]; link != nullptr; link = link->bmapnode.Next(bx, by))
 	{
 		// skip non-shootable actors
 		if (!(link->flags & MF_SHOOTABLE))

--- a/common/p_maputl.cpp
+++ b/common/p_maputl.cpp
@@ -1207,59 +1207,35 @@ bool P_ActorInFOV(const AActor* origin, const AActor* mo , float f, fixed_t dist
 
 AActor* RoughMonsterCheck(AActor* mo, int index, angle_t fov)
 {
-	AActor* link;
-
-	link = blocklinks[index];
-	while (link)
+	for (AActor* link = blocklinks[index]; link != nullptr; link = link->bmapnode.Next(0, 0))
 	{
 		// skip non-shootable actors
 		if (!(link->flags & MF_SHOOTABLE))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// skip yourself
 		if (link == mo)
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// skip barrels and other shootable but not alive things
 		if (!sentient(link))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// Don't target things friendly to you.
 		if (P_IsFriendlyThing(mo, link))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// Don't target players or spectators (done elsewhere)
 		if (link->player || (link->player && link->player->spectator))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// skip actors outside of specified FOV
 		if (fov > 0 && !P_CheckFov(mo, link, fov))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// skip actors not in line of sight
 		if (!P_CheckSight(mo, link))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// all good! return it.
 		return link;
@@ -1273,67 +1249,43 @@ AActor* RoughMonsterCheck(AActor* mo, int index, angle_t fov)
 // RoughTracerCheck
 // Searches though the surrounding mapblocks for monsters/players
 // based on Hexen's P_RoughMonsterSearch
-// 
+//
 // Special logic to handle tracers (actor->target is owner of tracer)
 //
 // distance is in MAPBLOCKUNITS
 
 AActor* RoughTracerCheck(AActor* mo, int index, angle_t fov)
 {
-	AActor* link;
-
-	link = blocklinks[index];
-	while (link)
+	for (AActor* link = blocklinks[index]; link != nullptr; link = link->bmapnode.Next(0, 0))
 	{
 		// skip non-shootable actors
 		if (!(link->flags & MF_SHOOTABLE))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// skip the projectile's owner
 		if (link == mo->target)
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// [Blair] Don't target friendlies
 		if (P_IsFriendlyThing(mo->target, link))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// [Blair] Don't target spectators
 		if (link->player && link->player->spectator)
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// [Blair] Don't target teammates
 		if (mo->target->player && link->player &&
 			P_AreTeammates(*mo->target->player, *link->player))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// skip actors outside of specified FOV
 		if (fov > 0 && !P_CheckFov(mo, link, fov))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// skip actors not in line of sight
 		if (!P_CheckSight(mo, link))
-		{
-			link = link->snext;
 			continue;
-		}
 
 		// all good! return it.
 		return link;


### PR DESCRIPTION
Addresses #1439

The new monster targeting code had a search based on Hexen's RoughBlockCheck. That function iterates over all the things in a blockmap block. It looks like when MBF21 was originally implemented for Odamex, a similar check was used for A_FindTracer, but because Odamex removed the `bnext` pointer used in the Hexen code years ago, `snext` was naively substituted, and this carried over to the friendlies implementation. This instead meant that these functions iterate over all things in a *sector*, causing serious performance issues on maps with high monster counts and large sectors.

Standing at the beginning of nuts.wad, on 11.2.0 I get 65-70fps on an i5-9300H at 1080p
On protobreak prior to this PR, the map is completely unplayable. Odamex completely locks up and I have to kill it from task manager.
With this PR, I now get about 50fps.