### PR TITLE
Make sure descriptions are commented out in odamex.cfg for co_friend_helpertype and co_friend_playerhelpers

### DIFF
--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -368,7 +368,7 @@ CVAR_RANGE(sv_countdown, "5",
 	//------------------------------
 
 	CVAR(			co_pursuit, "0",
-					"Use MBF comp_pursuit behavior -- monsters will change targets " 
+					"Use MBF comp_pursuit behavior -- monsters will change targets "
 					"if their current target is out of sight and a new valid target is in sight.",
 					CVARTYPE_BOOL, CVAR_ARCHIVE | CVAR_SERVERINFO)
 
@@ -407,15 +407,15 @@ CVAR_RANGE(sv_countdown, "5",
 
 	CVAR_RANGE(co_friend_playerhelpers, "0",
 					"Use MBF player_helpers behavior -- amount of friendly things to spawn at map start.\n" \
-					"If in an online game, dogs spawn only once on map start per helper per player.\n" \
-					"The helper type is defined in BEX or through the cvar co_friend_helpertype.",
+					"// If in an online game, dogs spawn only once on map start per helper per player.\n" \
+					"// The helper type is defined in BEX or through the cvar co_friend_helpertype.",
 					CVARTYPE_INT, CVAR_ARCHIVE | CVAR_SERVERINFO | CVAR_LATCH | CVAR_NOENABLEDISABLE, 0.0f, 64.0f)
 
-	CVAR(			co_friend_helpertype, "", 
+	CVAR(			co_friend_helpertype, "",
 					"Name of the actor type to spawn as a helper.\n" \
-					"Spawnable actors can be found using the ccmd `dumpactors`\n" \
-					"If empty, it uses the defined default friend in Dehacked (BEX).\n" \
-					"If the actor name can't be found, an MBF helper dog will be spawned\n",
+					"// Spawnable actors can be found using the ccmd `dumpactors`\n" \
+					"// If empty, it uses the defined default friend in Dehacked (BEX).\n" \
+					"// If the actor name can't be found, an MBF helper dog will be spawned\n",
 					CVARTYPE_STRING, CVAR_ARCHIVE | CVAR_NOENABLEDISABLE)
 
 	CVAR(			co_mbfphys, "0", "Use MBF's movement code. Fixes mancubus fireball clipping and linedef skips.",


### PR DESCRIPTION
Multiline cvar help messages need the lines after the first to start with `//` so that they won't be interpreted as commands in odamex.cfg. In the future having these added automatically would probably be ideal, so that issues like this don't happen again, and it wouldn't then affect the formatting in the game console, but for now this is consistent with how other cvars with multiline descriptions are handled.

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/ec13b0df-8fbb-44cf-804e-6d03ec90712e" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/cb408f7a-ba23-4cd4-9dd2-e1afb716debd" />
