### PR TITLE
[BUGFIX] Crash while switching wads when using sdl mixer

### DIFF
--- a/client/sdl/i_musicsystem_sdl.cpp
+++ b/client/sdl/i_musicsystem_sdl.cpp
@@ -92,7 +92,7 @@ void SdlMixerMusicSystem::startSong(byte* data, size_t length, bool loop, int or
 //
 void SdlMixerMusicSystem::_StopSong()
 {
-	if (!isInitialized() || !isPlaying())
+	if (!isInitialized())
 		return;
 
 	if (isPaused())

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -254,7 +254,7 @@ class OZone
 		if (it == m_heap.end())
 		{
 			I_Error("{}: Address 0x{:p} is not tracked by zone at {}:{}.\n{}", __FUNCTION__,
-			        it->first, info.shortFile(), info.line, M_GetStacktrace());
+			        ptr, info.shortFile(), info.line, M_GetStacktrace());
 		}
 
 		dealloc(it);

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -201,7 +201,7 @@ class OZone
 		if (it == m_heap.end())
 		{
 			I_Error("{}: Address 0x{:p} is not tracked by zone at {}:{}.\n{}", __FUNCTION__,
-			        it->first, info.shortFile(), info.line, M_GetStacktrace());
+			        ptr, info.shortFile(), info.line, M_GetStacktrace());
 		}
 
 		const size_t copySize = std::min(size, static_cast<size_t>(it->second.size));
@@ -225,7 +225,7 @@ class OZone
 		if (it == m_heap.end())
 		{
 			I_Error("{}: Address 0x{:p} is not tracked by zone at {}:{}.\n{}", __FUNCTION__,
-			        it->first, info.shortFile(), info.line, M_GetStacktrace());
+			        ptr, info.shortFile(), info.line, M_GetStacktrace());
 		}
 
 		if (tag >= PU_PURGELEVEL && it->second.user == NULL)


### PR DESCRIPTION
`m_registeredSong.Mem` wouldn't get freed and nulled when calling `_StopSong` if music was not actively playing. This would lead to the pointer still being held after clearing `OZone` on a wad switch. The memfile would then be freed the next time music was started, but Z_Free would throw an error because the pointer was no longer being tracked by `OZone`. It would then crash when trying to format the error due to dereferencing an end iterator.