### PR TITLE
[BUGFIX] Momentum continues to accumulate when walls blocking movement

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -36,6 +36,7 @@ EXTERN_CVAR(co_helpfriends)
 EXTERN_CVAR(co_monsterbacking)
 EXTERN_CVAR(co_avoidhazards)
 EXTERN_CVAR(co_monstersclimbsteep)
+EXTERN_CVAR(co_mbfphys)
 
 //
 // P_CrossCompatibleSpecialLine - Walkover Trigger Dispatcher
@@ -3601,5 +3602,5 @@ void P_PostProcessCompatibleLinedefSpecial(line_t* line)
 bool P_IsMBFCompatMode()
 {
 	return P_AllowDropOff() || co_pursuit || co_helpfriends || co_monsterbacking ||
-	       co_avoidhazards || co_monstersclimbsteep;
+	       co_avoidhazards || co_monstersclimbsteep || co_mbfphys;
 }

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1170,7 +1170,13 @@ static void P_WallBouncy(AActor* mo)
 			}
 		}
 		else
+		{
 			mo->momx = mo->momy = 0;
+		}
+	}
+	else
+	{
+		mo->momx = mo->momy = 0;
 	}
 }
 


### PR DESCRIPTION
Fixes the bfg in gaiaaura.wad and the red skulls on map10 of Skulltiverse II. Should fully resolve #1187

Just a minor error made when copying all the nested if conditions from mbf