### PR TITLE
[BUGFIX] Ednum conflicts favoring internal things over dehacked things

### DIFF
--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -1294,9 +1294,7 @@ static void PatchThing(int thingNum, DehScanner& scanner)
 		{
 			info->doomednum = (SDWORD)val;
 			// update spawn map
-			auto spawn_map_it = spawn_map.find(info->doomednum);
-			if (spawn_map_it == spawn_map.end())
-				spawn_map.insert(info, info->doomednum);
+			spawn_map.insert(info, info->doomednum);
 		}
 		else if (iequals(key, "Mass"))
 		{

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3008,24 +3008,22 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 		type = MT_MUSICSOURCE;
 	}
 
-	// [RH] Check if it's a particle fountain
-	if (mthing->type >= 9027 && mthing->type <= 9033)
-	{
-		mthing->args[0] = mthing->type - 9026;
-		type = MT_FOUNTAIN;
-	}
-
 	// [CMB] find the value in the mobjinfo table if we asked for a specific type; otherwise check the spawn table
 	mobjinfo_t* info = nullptr;
 	if (type == -1)
 	{
-		int32_t spawn_idx = type == -1 ? mthing->type : type;
-		auto spawn_it = spawn_map.find(spawn_idx);
+		auto spawn_it = spawn_map.find(mthing->type);
 		if (spawn_it != spawn_map.end())
 		{
 			info = spawn_it->second;
 			// set this for further down
 			type = info->type;
+		}
+		// [RH] Check if it's a particle fountain
+		if (type == -1 && mthing->type >= 9027 && mthing->type <= 9033)
+		{
+			mthing->args[0] = mthing->type - 9026;
+			type = MT_FOUNTAIN;
 		}
 	}
 	else

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3024,6 +3024,7 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 		{
 			mthing->args[0] = mthing->type - 9026;
 			type = MT_FOUNTAIN;
+			info = &mobjinfo[type]; // mt_fountain guaranteed to exist
 		}
 	}
 	else


### PR DESCRIPTION
In the case of a dehacked thing using the same ednum as a zdoom thing like a map spot or particle fountain, we should always use the dehacked thing. Fixes all the toilets in twogers.