### PR TITLE
[BUGFIX] Serverchat only printing blank lines on clients

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1443,7 +1443,7 @@ static void CL_Print(const odaproto::svc::Print* msg)
 	else if (level == PRINT_TEAMCHAT)
 		PrintFmt(level, "{:c}!{}", TEXTCOLOR_ESCAPE, str);
 	else if (level == PRINT_SERVERCHAT)
-		PrintFmt(level, "{}", TEXTCOLOR_YELLOW, str);
+		PrintFmt(level, "{:c}{}", TEXTCOLOR_YELLOW, str);
 	else
 		PrintFmt(level, "{}", str);
 


### PR DESCRIPTION
Unfortunately compile time format string checking doesn't catch when there's more arguments than format specifiers...