### PR TITLE
Clean up friendly effects code a bit

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -424,8 +424,8 @@ CVAR(in_autosr50, "1", "+strafe activates automatic SR50", CVARTYPE_BOOL,
 CVAR(				cl_showspawns, "0", "Show spawn points as particle fountains",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE | CVAR_LATCH)
 
-CVAR(				cl_showfriends, "0", "Show an indicator on friendly monsters.",
-					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE | CVAR_LATCH)
+CVAR_FUNC_DECL(		cl_showfriends, "0", "Show an indicator on friendly monsters.",
+					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
 // Netdemo Preferences
 // --------------------

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -152,7 +152,6 @@ EXTERN_CVAR (mute_enemies)
 EXTERN_CVAR (cl_autoaim)
 
 EXTERN_CVAR (cl_interp)
-EXTERN_CVAR (cl_showfriends)
 EXTERN_CVAR (cl_serverdownload)
 EXTERN_CVAR (cl_forcedownload)
 
@@ -586,8 +585,7 @@ void CL_SpyCycle(Iterator begin, Iterator end)
 				ST_ForceRefresh();
 			}
 
-			if (cl_showfriends)
-				P_FriendlyEffects(); // Mark any new friendly monsters with an effect
+			P_FriendlyEffects(); // Mark any new friendly monsters with an effect
 
 			return;
 		}
@@ -1410,8 +1408,7 @@ void CL_SpectatePlayer(player_t& player, bool spectate)
 	{
 		R_ForceViewWindowResize();		// toggline spectator mode affects status bar visibility
 
-		if (cl_showfriends)
-			P_FriendlyEffects(); // Mark any new friendly monsters with an effect
+		P_FriendlyEffects(); // Mark any new friendly monsters with an effect
 
 		if (player.spectator)
 		{

--- a/client/src/cl_mobj.cpp
+++ b/client/src/cl_mobj.cpp
@@ -39,7 +39,6 @@
 
 EXTERN_CVAR(sv_nomonsters)
 EXTERN_CVAR(cl_showspawns)
-EXTERN_CVAR(cl_showfriends)
 EXTERN_CVAR(chasedemo)
 
 void G_PlayerReborn(player_t &player);
@@ -160,8 +159,7 @@ void P_SpawnPlayer(player_t& player, mapthing2_t* mthing)
 			level.behavior->StartTypedScripts(SCRIPT_Respawn, player.mo);
 	}
 
-	if (cl_showfriends)
-		P_FriendlyEffects(); // Mark any new friendly monsters with an effect
+	P_FriendlyEffects(); // Mark any new friendly monsters with an effect
 }
 
 std::vector<AActor*> spawnfountains;

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -81,7 +81,6 @@ EXTERN_CVAR(cl_disconnectalert)
 EXTERN_CVAR(cl_netdemoname)
 EXTERN_CVAR(cl_splitnetdemos)
 EXTERN_CVAR(cl_team)
-EXTERN_CVAR(cl_showfriends)
 EXTERN_CVAR(hud_revealsecrets)
 EXTERN_CVAR(mute_enemies)
 EXTERN_CVAR(mute_spectators)
@@ -587,16 +586,11 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 	    (mo->target->oflags & hordeBossModMask))
 	{
 		mo->oflags |= MFO_FULLBRIGHT;
-		mo->effects = FX_YELLOWFOUNTAIN;
+		mo->effects |= FX_YELLOWFOUNTAIN;
 		mo->translation = translationref_t(&::bosstable[0]);
 	}
 
-	if (cl_showfriends && validplayer(displayplayer()) && displayplayer().mo &&
-	    P_IsFriendlyThing(displayplayer().mo, mo))
-	{
-		mo->effects = FX_FRIENDHEARTS;
-		mo->translation = translationref_t(&friendtable[0]);
-	}
+	P_FriendlyEffects(mo);
 
 	AActor* tracer = NULL;
 	if (bflags & baseline_t::TRACER)

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -869,6 +869,7 @@ EXTERN_CVAR (r_painintensity)
 EXTERN_CVAR (cl_movebob)
 EXTERN_CVAR (cl_centerbobonfire)
 EXTERN_CVAR (cl_showspawns)
+EXTERN_CVAR (cl_showfriends)
 EXTERN_CVAR (hud_show_scoreboard_ondeath)
 EXTERN_CVAR (hud_demobar)
 EXTERN_CVAR(hud_targetnames)
@@ -944,6 +945,7 @@ static menuitem_t VideoItems[] = {
 	{ discrete, "Linear Skies",			    {&r_linearsky},	   		{2.0}, {0.0},	{0.0},  {OnOff} },
 	{ discrete, "Invuln changes skies",		{&r_skypalette},		{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Use softer invuln effect", {&r_softinvulneffect},	{2.0}, {0.0},	{0.0},	{OnOff} },
+	{ discrete, "Heart effect on friendlies", {&cl_showfriends},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Screen wipe style",	    {&r_wipetype},			{4.0}, {0.0},	{0.0},  {Wipes} },
 	{ discrete, "Multiplayer Intermissions",{&wi_oldintermission},	{2.0}, {0.0},	{0.0},  {DoomOrOdamex} },
 	{ discrete, "Show loading disk icon",	{&r_loadicon},			{2.0}, {0.0},	{0.0},	{OnOff} },

--- a/common/m_cheat.cpp
+++ b/common/m_cheat.cpp
@@ -45,7 +45,6 @@ EXTERN_CVAR(sv_allowcheats)
 #include "cl_main.h"
 #include "c_dispatch.h"
 extern bool automapactive;
-EXTERN_CVAR(cl_showfriends)
 #endif
 
 void C_DoCommand(std::string_view cmd, uint32_t key = 0);
@@ -541,14 +540,7 @@ AActor* CHEAT_Summon(player_s* player, const std::string& sum, bool friendly)
 		entity->flags |= MF_FRIEND;
 		cheatname = "summonfriend";
 		P_GiveFriendlyOwnerInfo(entity, player->mo);
-#ifdef CLIENT_APP
-		if (cl_showfriends && validplayer(displayplayer()) && displayplayer().mo &&
-			  P_IsFriendlyThing(displayplayer().mo, entity))
-		{
-		entity->effects = FX_FRIENDHEARTS;
-		entity->translation = translationref_t(&friendtable[0]);
-		}
-#endif
+		P_FriendlyEffects(entity);
 	}
 
 	if (multiplayer)

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -3241,7 +3241,7 @@ CLIENT_ONLY(
 		else
 		{
 			other->effects &= ~FX_FRIENDHEARTS;
-			other->translation = 0;
+			other->translation = nullptr;
 		}
 	}
 )
@@ -3272,7 +3272,7 @@ CLIENT_ONLY(
 	else
 	{
 		mo->effects &= ~FX_FRIENDHEARTS;
-		mo->translation = 0;
+		mo->translation = nullptr;
 	}
 )
 }
@@ -3295,7 +3295,7 @@ CVAR_FUNC_IMPL(cl_showfriends)
 			if (other->flags & MF_FRIEND)
 			{
 				other->effects &= ~FX_FRIENDHEARTS;
-				other->translation = 0;
+				other->translation = nullptr;
 			}
 		}
 	}

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -3277,6 +3277,31 @@ CLIENT_ONLY(
 )
 }
 
+#ifdef CLIENT_APP
+CVAR_FUNC_IMPL(cl_showfriends)
+{
+	if (var)
+	{
+		P_FriendlyEffects();
+	}
+	else
+	{
+		// Clear all friendly effects
+		TThinkerIterator<AActor> iterator;
+		AActor* other;
+
+		while ((other = iterator.Next()))
+		{
+			if (other->flags & MF_FRIEND)
+			{
+				other->effects &= ~FX_FRIENDHEARTS;
+				other->translation = 0;
+			}
+		}
+	}
+}
+#endif
+
 // P_RemoveSoulLimit
 bool P_RemoveSoulLimit()
 {

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -1020,14 +1020,7 @@ AActor::AActorPtr SpawnHelper(const MapThing SpawnPoint, mobjtype_t SpawnType, c
 
 			P_GiveFriendlyOwnerInfo(mo, origin);
 
-#ifdef CLIENT_APP
-			if (cl_showfriends && validplayer(displayplayer()) && displayplayer().mo &&
-			    P_IsFriendlyThing(displayplayer().mo, mo))
-			{
-				mo->effects = FX_FRIENDHEARTS;
-				mo->translation = translationref_t(&friendtable[0]);
-			}
-#endif
+			P_FriendlyEffects(mo);
 
 			SV_SpawnMobj(mo);
 
@@ -2640,14 +2633,7 @@ void A_SpawnObject(AActor* actor)
 
 	P_GiveFriendlyOwnerInfo(mo, actor);
 
-	CLIENT_ONLY(
-		if (cl_showfriends && validplayer(displayplayer()) && displayplayer().mo &&
-		    P_IsFriendlyThing(displayplayer().mo, mo))
-		{
-			mo->effects = FX_FRIENDHEARTS;
-			mo->translation = translationref_t(&friendtable[0]);
-		}
-	)
+	P_FriendlyEffects(mo);
 
 	SV_UpdateMobj(mo);
 }
@@ -3166,7 +3152,7 @@ void A_AddFlags(AActor* actor)
 	const int flags2 = actor->state->args[1];
 	const int flags3 = actor->state->args[2];
 
-	const bool update_blockmap = 
+	const bool update_blockmap =
 		((flags & MF_NOBLOCKMAP) && !(actor->flags & MF_NOBLOCKMAP)) ||
 		((flags & MF_NOSECTOR)   && !(actor->flags & MF_NOSECTOR));
 
@@ -3201,7 +3187,7 @@ void A_RemoveFlags(AActor* actor)
 	const int flags2 = actor->state->args[1];
 	const int flags3 = actor->state->args[2];
 
-	const bool update_blockmap = 
+	const bool update_blockmap =
 		((flags & MF_NOBLOCKMAP) && (actor->flags & MF_NOBLOCKMAP)) ||
 		((flags & MF_NOSECTOR)   && (actor->flags & MF_NOSECTOR));
 
@@ -3227,6 +3213,10 @@ void A_Stop(AActor* actor)
 // P_FriendlyEffects
 void P_FriendlyEffects()
 {
+CLIENT_ONLY(
+	if (!cl_showfriends)
+		return;
+
 	TThinkerIterator<AActor> iterator;
 	AActor* other;
 
@@ -3234,26 +3224,57 @@ void P_FriendlyEffects()
 	{
 		if (other->health <= 0)
 		{
-			other->effects = 0;
+			other->effects &= ~FX_FRIENDHEARTS;
 			continue;
 		}
 
-		if (other->player || !(other->flags & MF_FRIEND) || other->health <= 0 ||
+		if (other->player || !(other->flags & MF_FRIEND) ||
 		    (other->oflags & MFO_BOSSPOOL))
 			continue;
 
 		if (validplayer(displayplayer()) && displayplayer().mo &&
-		    P_IsFriendlyThing(displayplayer().mo, other))
+		    P_IsFriendlyThing(displayplayer().mo, other) && sentient(other))
 		{
-			other->effects = FX_FRIENDHEARTS;
+			other->effects |= FX_FRIENDHEARTS;
 			other->translation = translationref_t(&friendtable[0]);
 		}
 		else
 		{
-			other->effects = 0;
+			other->effects &= ~FX_FRIENDHEARTS;
 			other->translation = 0;
 		}
 	}
+)
+}
+
+void P_FriendlyEffects(AActor* mo)
+{
+CLIENT_ONLY(
+	if (!cl_showfriends)
+		return;
+
+	if (mo->health <= 0)
+	{
+		mo->effects &= ~FX_FRIENDHEARTS;
+		return;
+	}
+
+	if (mo->player || !(mo->flags & MF_FRIEND) ||
+	    (mo->oflags & MFO_BOSSPOOL))
+		return;
+
+	if (validplayer(displayplayer()) && displayplayer().mo &&
+	    P_IsFriendlyThing(displayplayer().mo, mo) && sentient(mo))
+	{
+		mo->effects |= FX_FRIENDHEARTS;
+		mo->translation = translationref_t(&friendtable[0]);
+	}
+	else
+	{
+		mo->effects &= ~FX_FRIENDHEARTS;
+		mo->translation = 0;
+	}
+)
 }
 
 // P_RemoveSoulLimit
@@ -3875,15 +3896,7 @@ void A_Spawn(AActor* mo)
 		newmobj->flags = (newmobj->flags & ~MF_FRIEND) | (mo->flags & MF_FRIEND);
 
 		P_GiveFriendlyOwnerInfo(newmobj, mo);
-
-		CLIENT_ONLY (
-			if (cl_showfriends && validplayer(displayplayer()) && displayplayer().mo &&
-			    P_IsFriendlyThing(displayplayer().mo, newmobj))
-			{
-				newmobj->effects = FX_FRIENDHEARTS;
-				newmobj->translation = translationref_t(&friendtable[0]);
-			}
-		)
+		P_FriendlyEffects(newmobj);
 	}
 }
 

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -505,6 +505,7 @@ bool P_CheckFov(AActor* t1, AActor* t2, angle_t fov);
 bool P_IsFriendlyThing(AActor* actor, AActor* friendshiptest);
 bool P_IsVoodooDoll(const AActor* mo);
 void P_FriendlyEffects();
+void P_FriendlyEffects(AActor* mo);
 void P_GiveFriendlyOwnerInfo(AActor* friendly, const AActor* origin);
 bool P_ProjectileImmune(AActor* target, AActor* source);
 void P_SetupHelpers();

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2427,7 +2427,7 @@ AActor* P_SpawnMissile (AActor *source, AActor *dest, mobjtype_t type)
 	if (source->oflags & MFO_BOSSPOOL)
 	{
 		th->oflags |= MFO_FULLBRIGHT;
-		th->effects = FX_YELLOWFOUNTAIN;
+		th->effects |= FX_YELLOWFOUNTAIN;
 		th->translation = translationref_t(&bosstable[0]);
 	}
 	else if (source->flags & MF_FRIEND)

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -74,10 +74,6 @@ EXTERN_CVAR(sv_allowexit)
 EXTERN_CVAR(sv_fragexitswitch)
 EXTERN_CVAR(co_boomphys)
 
-#ifdef CLIENT_APP
-EXTERN_CVAR(cl_showfriends)
-#endif
-
 std::list<movingsector_t> movingsectors;
 std::list<sector_t*> specialdoors;
 bool s_SpecialFromServer;
@@ -2372,10 +2368,7 @@ void P_SetupWorldState(void)
 		level.behavior->StartTypedScripts(SCRIPT_Open, NULL, 0, 0, 0, false);
 	}
 
-#ifdef CLIENT_APP
-	if (cl_showfriends)
-		P_FriendlyEffects(); // Mark any new friendly monsters with an effect
-#endif
+	P_FriendlyEffects(); // Mark any new friendly monsters with an effect
 }
 
 void P_AddSectorSecret(sector_t* sector)


### PR DESCRIPTION
Now there's less risk of forgetting to check cl_showfriends, and its all in one place.
Also adds a sentience check, so that wads using friendly flag for tricks with decorations don't have pillars and candlesticks that love you.