### PR TITLE
Chex Quest 3 IWAD support

### DIFF
--- a/client/src/r_draw.cpp
+++ b/client/src/r_draw.cpp
@@ -234,7 +234,7 @@ static void R_BuildFontTranslation(int color_num, argb_t start_color, argb_t end
 
 	palindex_t* dest = (palindex_t*)Ranges + color_num * 256;
 
-	if (gamemode == retail_chex)
+	if (IsChexMission(gamemission))
 	{
 		for (int index = 0; index < chexstart_index; index++)
 			dest[index] = index;
@@ -263,7 +263,7 @@ static void R_BuildFontTranslation(int color_num, argb_t start_color, argb_t end
 	int b_diff = end_color.getb() - start_color.getb();
 	int hacxtrack;
 
-	if (gamemode == retail_chex)
+	if (IsChexMission(gamemission))
 	{
 		for (palindex_t index = chexstart_index; index <= chexend_index; index++)
 		{

--- a/client/src/v_palette.cpp
+++ b/client/src/v_palette.cpp
@@ -1106,7 +1106,7 @@ void V_DoPaletteEffects()
 		{
 			palette_num = ((int)red_count + 7) >> 3;
 
-			if (gamemode == retail_chex)
+			if (IsChexMission(gamemission))
 				palette_num = RADIATIONPAL;
 			else
 			{
@@ -1170,8 +1170,8 @@ void V_DoPaletteEffects()
 				red_amount = MIN(red_amount, 56.0f);
 				float alpha = (red_amount + 8.0f) / 72.0f;
 
-				const float red = gamemode == retail_chex ? 0.0f : 1.0f;
-				const float green = gamemode == retail_chex ? 1.0f : 0.0f;
+				const float red = IsChexMission(gamemission) ? 0.0f : 1.0f;
+				const float green = IsChexMission(gamemission) ? 1.0f : 0.0f;
 				static constexpr float blue = 0.0f;
 				V_AddBlend(blend, fargb_t(alpha, red, green, blue));
 			}

--- a/common/doomdef.h
+++ b/common/doomdef.h
@@ -134,7 +134,8 @@ enum GameMission_t
   pack_tnt, 			// TNT mission pack
   pack_plut,			// Plutonia pack
   chex,					// Chex Quest
-  chex3,				// Chex Quest 3
+  chex3,				// Chex Quest 3 v2.0
+  chex3v,				// Chex Quest 3 Vanilla Edition
   chex3d2,              // Chex Quest 3 Vanilla Edition Modding Version
   retail_freedoom,
   commercial_freedoom,	// FreeDoom
@@ -144,7 +145,10 @@ enum GameMission_t
 
 inline bool IsChexMission(GameMission_t mission)
 {
-	return mission == chex || mission == chex3 || mission == chex3d2;
+	return mission == chex ||
+	       mission == chex3 ||
+	       mission == chex3v ||
+	       mission == chex3d2;
 }
 
 // If rangecheck is undefined,

--- a/common/doomdef.h
+++ b/common/doomdef.h
@@ -134,11 +134,18 @@ enum GameMission_t
   pack_tnt, 			// TNT mission pack
   pack_plut,			// Plutonia pack
   chex,					// Chex Quest
+  chex3,				// Chex Quest 3
+  chex3d2,              // Chex Quest 3 Vanilla Edition Modding Version
   retail_freedoom,
   commercial_freedoom,	// FreeDoom
   commercial_hacx,		// HACX
   none
 };
+
+inline bool IsChexMission(GameMission_t mission)
+{
+	return mission == chex || mission == chex3 || mission == chex3d2;
+}
 
 // If rangecheck is undefined,
 // most parameter validation debugging code will not be compiled

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1952,6 +1952,12 @@ void G_ParseMapInfo()
 	case chex:
 		baseinfoname = "_CHEXNFO";
 		break;
+	case chex3:
+		baseinfoname = "_CHX3NFO";
+		break;
+	case chex3d2:
+		baseinfoname = "_CHXDNFO";
+		break;
 	case none:
 	default:
 		I_Error("{}: This IWAD is unknown to Odamex", __FUNCTION__);

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1923,6 +1923,7 @@ void G_ParseMapInfo()
 	switch (gamemission)
 	{
 	case doom:
+	case chex3v:
 	case retail_freedoom:
 		baseinfoname = "_D1NFO";
 		if (gamemode == shareware)
@@ -1933,6 +1934,7 @@ void G_ParseMapInfo()
 		}
 		break;
 	case doom2:
+	case chex3d2:
 	case commercial_freedoom:
 	case commercial_hacx:
 		baseinfoname = "_D2NFO";
@@ -1950,13 +1952,8 @@ void G_ParseMapInfo()
 		baseinfoname = "_PLUTNFO";
 		break;
 	case chex:
-		baseinfoname = "_CHEXNFO";
-		break;
 	case chex3:
-		baseinfoname = "_CHX3NFO";
-		break;
-	case chex3d2:
-		baseinfoname = "_CHXDNFO";
+		baseinfoname = "_CHEXNFO";
 		break;
 	case none:
 	default:

--- a/common/p_teleport.cpp
+++ b/common/p_teleport.cpp
@@ -144,6 +144,13 @@ static AActor* SelectTeleDest(int tid, int tag)
 	return NULL;
 }
 
+static bool UseFinalDoomTeleportZBug()
+{
+	EXTERN_CVAR(co_boomphys);
+	return ((demoplayback || !co_boomphys) &&
+	        (gamemission == pack_tnt || gamemission == pack_plut));
+}
+
 //
 // TELEPORTATION
 //
@@ -183,7 +190,7 @@ bool EV_Teleport(int tid, int tag, int arg0, int side, AActor *thing, int nostop
 	// it does not have this quirk.
 	// [AM] For z-teleports, the destination sets the height, don't
 	//      override it here.
-	if (m->type == MT_TELEPORTMAN && (gamemission != pack_tnt && gamemission != pack_plut))
+	if (m->type == MT_TELEPORTMAN && !UseFinalDoomTeleportZBug())
 		thing->z = thing->floorz;
 
 	if (player)
@@ -281,7 +288,7 @@ bool EV_LineTeleport (line_t *line, int side, AActor *thing)
 
 				fixed_t destz;
 
-				if (demoplayback && (gamemission == pack_tnt || gamemission == pack_plut))
+				if (UseFinalDoomTeleportZBug())
 					destz = m->z;	// Make sure we have the original Z-Height bug on Final Doom.
 				else
 					destz = (m->type == MT_TELEPORTMAN) ? P_FloorHeight(m) : m->z;
@@ -293,7 +300,7 @@ bool EV_LineTeleport (line_t *line, int side, AActor *thing)
 				// problem between normal doom2 1.9 and final doom
 				// Note that although chex.exe is based on Final Doom,
 				// it does not have this quirk.
-				if (gamemission != pack_tnt && gamemission != pack_plut)
+				if (!UseFinalDoomTeleportZBug())
 						thing->z = thing->floorz;
 
 				if (player)

--- a/common/p_teleport.cpp
+++ b/common/p_teleport.cpp
@@ -183,7 +183,7 @@ bool EV_Teleport(int tid, int tag, int arg0, int side, AActor *thing, int nostop
 	// it does not have this quirk.
 	// [AM] For z-teleports, the destination sets the height, don't
 	//      override it here.
-	if (m->type == MT_TELEPORTMAN && (gamemission < pack_tnt || gamemission == chex))
+	if (m->type == MT_TELEPORTMAN && (gamemission != pack_tnt && gamemission != pack_plut))
 		thing->z = thing->floorz;
 
 	if (player)
@@ -281,7 +281,7 @@ bool EV_LineTeleport (line_t *line, int side, AActor *thing)
 
 				fixed_t destz;
 
-				if (demoplayback && (gamemission == pack_tnt || gamemission == pack_plut || gamemission == chex))
+				if (demoplayback && (gamemission == pack_tnt || gamemission == pack_plut))
 					destz = m->z;	// Make sure we have the original Z-Height bug on Final Doom.
 				else
 					destz = (m->type == MT_TELEPORTMAN) ? P_FloorHeight(m) : m->z;
@@ -293,7 +293,7 @@ bool EV_LineTeleport (line_t *line, int side, AActor *thing)
 				// problem between normal doom2 1.9 and final doom
 				// Note that although chex.exe is based on Final Doom,
 				// it does not have this quirk.
-				if (gamemission < pack_tnt || gamemission == chex)
+				if (gamemission != pack_tnt && gamemission != pack_plut)
 						thing->z = thing->floorz;
 
 				if (player)

--- a/common/stringtable.cpp
+++ b/common/stringtable.cpp
@@ -42,13 +42,20 @@
  */
 static bool IfGameZDoom(const std::string& str)
 {
-	if (!stricmp(str.c_str(), "doom") && ::gamemode != retail_chex &&
-	    ::gamemode != undetermined)
+	// TODO: should this account for rekkr too? uzdoom seems to just have
+	// doom, strife, heretic, hexen, and chex here
+	if (!stricmp(str.c_str(), "doom") && !IsChexMission(::gamemission) &&
+	    ::gamemode != undetermined && ::gamemission != commercial_hacx)
 	{
 		return true;
 	}
 
-	if (!stricmp(str.c_str(), "chex") && ::gamemode == retail_chex)
+	if (!stricmp(str.c_str(), "chex") && IsChexMission(::gamemission))
+	{
+		return true;
+	}
+
+	if (!stricmp(str.c_str(), "hacx") && ::gamemission == commercial_hacx)
 	{
 		return true;
 	}

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -1507,7 +1507,7 @@ void W_ConfigureGameInfo(const OResFile& iwad)
 	}
     else if (idname.find(OStringToUpper(OString(CHEX3_PREFIX))) == 0)
 	{
-		gamemission = chex3;
+		gamemission = idname.find("VANILLA") != std::string::npos ? chex3v : chex3;
 		gamemode = registered;
 		gameinfo.flags = GI_MENUHACK_RETAIL;
 		gameinfo.maxSwitch = 2;

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -64,6 +64,7 @@ struct identData_t
 #define FREEDM_PREFIX "FreeDM"
 #define NERVE_PREFIX "No Rest for the Living"
 #define MASTERLV_PREFIX "Master Levels"
+#define CHEX3_PREFIX "Chex Quest 3"
 
 #define PWAD_NO_WEIGHT 0
 
@@ -1006,6 +1007,45 @@ static constexpr identData_t identdata[] = {
     },
 
     // ------------------------------------------------------------------------
+    // CHEX3ODX-RCD4.WAD
+    // ------------------------------------------------------------------------
+    {
+        CHEX3_PREFIX " v2.0 RC4",           // mIdName
+        "CHEX3ODX-RC4.WAD",                 // mFilename
+        "D85A48E2",                         // mCRC32Sum
+        "D7FF45AD937D8F26D0723D70349E38CC", // mMd5Sum
+        "chex3v2",                          // mGroupName
+        IDENT_IWAD,                         // flags
+        600,                                // weight
+    },
+
+    // ------------------------------------------------------------------------
+    // CHEX3V.WAD
+    // ------------------------------------------------------------------------
+    {
+        CHEX3_PREFIX " Vanilla Edition",    // mIdName
+        "CHEX3V.WAD",                       // mFilename
+        "C57A9F82",                         // mCRC32Sum
+        "99325880D3D91EE1F8B47BFD9665A887", // mMd5Sum
+        "chex3vanilla",                     // mGroupName
+        IDENT_IWAD,                         // flags
+        600,                                // weight
+    },
+
+    // ------------------------------------------------------------------------
+    // CHEX3D2.WAD
+    // ------------------------------------------------------------------------
+    {
+        CHEX3_PREFIX "V Modding Version",   // mIdName
+        "CHEX3D2.WAD",                      // mFilename
+        "67EA7CD5",                         // mCRC32Sum
+        "B43DB49801C6C9577B89810A8650CF1D", // mMd5Sum
+        "chex3vanillad2",                   // mGroupName
+        IDENT_IWAD,                         // flags
+        600,                                // weight
+    },
+
+    // ------------------------------------------------------------------------
     // HACX.WAD
     // ------------------------------------------------------------------------
     {
@@ -1457,11 +1497,27 @@ void W_ConfigureGameInfo(const OResFile& iwad)
 		gameinfo.maxSwitch = 3;
 		gameinfo.titleString = "DOOM 2: TNT - Evilution";
 	}
+    else if (idname.find("CHEX QUEST 3V MODDING") == 0)
+	{
+		gamemission = chex3d2;
+		gamemode = commercial;
+		gameinfo.flags = GI_MAPxx | GI_MENUHACK_COMMERCIAL;
+		gameinfo.maxSwitch = 3;
+		gameinfo.titleString = "Chex Quest 3 Modding Version";
+	}
+    else if (idname.find(OStringToUpper(OString(CHEX3_PREFIX))) == 0)
+	{
+		gamemission = chex3;
+		gamemode = registered;
+		gameinfo.flags = GI_MENUHACK_RETAIL;
+		gameinfo.maxSwitch = 2;
+		gameinfo.titleString = "Chex Quest 3";
+	}
 	else if (idname.find("CHEX QUEST") == 0)
 	{
 		gamemission = chex;
 		gamemode = retail_chex;
-		gameinfo.flags = GI_MENUHACK_RETAIL | GI_NOCRAZYDEATH;
+		gameinfo.flags = GI_MENUHACK_RETAIL;
 		gameinfo.maxSwitch = 2;
 		gameinfo.titleString = "Chex Quest";
 	}
@@ -1510,7 +1566,7 @@ void W_ConfigureGameInfo(const OResFile& iwad)
 	{
 		gamemode = retail_bfg;
 		gamemission = doom;
-		gameinfo.flags = GI_MENUHACK_RETAIL | GI_NOCRAZYDEATH;
+		gameinfo.flags = GI_MENUHACK_RETAIL;
 		gameinfo.maxSwitch = 2;
 		gameinfo.titleString = "The Ultimate DOOM (BFG Edition)";
 	}
@@ -1518,7 +1574,7 @@ void W_ConfigureGameInfo(const OResFile& iwad)
 	{
 		gamemode = retail;
 		gamemission = doom;
-		gameinfo.flags = GI_MENUHACK_RETAIL | GI_NOCRAZYDEATH;
+		gameinfo.flags = GI_MENUHACK_RETAIL;
 		gameinfo.maxSwitch = 2;
 		gameinfo.titleString = "The Ultimate DOOM";
 	}
@@ -1542,7 +1598,7 @@ void W_ConfigureGameInfo(const OResFile& iwad)
 	{
 		gamemode = registered;
 		gamemission = doom;
-		gameinfo.flags = GI_NOCRAZYDEATH;
+		gameinfo.flags = 0;
 		gameinfo.maxSwitch = 2;
 		gameinfo.titleString = "DOOM Registered";
 	}

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -214,6 +214,7 @@ OLumpName G_NextMap()
 			(((gamemode == registered && level.cluster == 3) ||
 			((gameinfo.flags & GI_MENUHACK_RETAIL) && level.cluster == 4))))
 		{
+			// FIXME: this doesn't play nicely with umapinfo defined episodes
 			next = CalcMapName(1, 1);
 		}
 		else


### PR DESCRIPTION
This PR adds three Chex Quest 3 wads as recognized iwads: Chex Quest 3 Vanilla Edition, Chex Quest 3 Vanilla Edition Modding Version, and Chex Quest 3 v2.0 Odamex/ZDaemon version RC4.