### PR TITLE
Implement new UMAPINFO keys `jumping`, `crouching`, and `freeaim`.

### DIFF
--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -445,6 +445,11 @@ bool ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 			break;
 		}
 	}
+	else if (!stricmp(pname.c_str(), "crouching"))
+	{
+		if (ParsePlayerAction(os) == player_action_t::REQUIRE)
+			os.warning("Crouching is not supported in Odamex. Map {} may not work as intended.", mape->mapname);
+	}
 	else
 	{
 		do

--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -102,7 +102,7 @@ void MustGetIdentifier(OScanner& os)
 
 enum struct player_action_t
 {
-	DISABLE,
+	DISALLOW,
 	ALLOW,
 	REQUIRE,
 };
@@ -110,8 +110,8 @@ enum struct player_action_t
 player_action_t ParsePlayerAction(OScanner& os)
 {
 	MustGetIdentifier(os);
-	if (os.compareTokenNoCase("disable"))
-		return player_action_t::DISABLE;
+	if (os.compareTokenNoCase("disallow"))
+		return player_action_t::DISALLOW;
 
 	if (os.compareTokenNoCase("allow"))
 		return player_action_t::ALLOW;
@@ -415,7 +415,7 @@ bool ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 	{
 		switch (ParsePlayerAction(os))
 		{
-		case player_action_t::DISABLE:
+		case player_action_t::DISALLOW:
 			mape->flags |= LEVEL_JUMP_NO;
 			mape->flags &= ~LEVEL_JUMP_YES;
 			break;
@@ -432,7 +432,7 @@ bool ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 	{
 		switch (ParsePlayerAction(os))
 		{
-		case player_action_t::DISABLE:
+		case player_action_t::DISALLOW:
 			mape->flags |= LEVEL_FREELOOK_NO;
 			mape->flags &= ~LEVEL_FREELOOK_YES;
 			break;

--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -100,6 +100,28 @@ void MustGetIdentifier(OScanner& os)
 	}
 }
 
+enum struct player_action_t
+{
+	DISABLE,
+	ALLOW,
+	REQUIRE,
+};
+
+player_action_t ParsePlayerAction(OScanner& os)
+{
+	MustGetIdentifier(os);
+	if (os.compareTokenNoCase("disable"))
+		return player_action_t::DISABLE;
+
+	if (os.compareTokenNoCase("allow"))
+		return player_action_t::ALLOW;
+
+	if (os.compareTokenNoCase("require"))
+		return player_action_t::REQUIRE;
+
+	os.error("Expected 'disable', 'allow' or 'require', got '{}'.", os.getToken());
+}
+
 bool pnamemodified;
 
 bool ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
@@ -387,6 +409,40 @@ bool ParseStandardUmapInfoProperty(OScanner& os, level_pwad_info_t* mape)
 
 				mape->bossactions.push_back(new_bossaction);
 			}
+		}
+	}
+	else if (!stricmp(pname.c_str(), "jumping"))
+	{
+		switch (ParsePlayerAction(os))
+		{
+		case player_action_t::DISABLE:
+			mape->flags |= LEVEL_JUMP_NO;
+			mape->flags &= ~LEVEL_JUMP_YES;
+			break;
+		case player_action_t::ALLOW:
+			mape->flags &= ~(LEVEL_JUMP_NO | LEVEL_JUMP_YES);
+			break;
+		case player_action_t::REQUIRE:
+			mape->flags &= ~LEVEL_JUMP_NO;
+			mape->flags |= LEVEL_JUMP_YES;
+			break;
+		}
+	}
+	else if (!stricmp(pname.c_str(), "freeaim"))
+	{
+		switch (ParsePlayerAction(os))
+		{
+		case player_action_t::DISABLE:
+			mape->flags |= LEVEL_FREELOOK_NO;
+			mape->flags &= ~LEVEL_FREELOOK_YES;
+			break;
+		case player_action_t::ALLOW:
+			mape->flags &= ~(LEVEL_FREELOOK_NO | LEVEL_FREELOOK_YES);
+			break;
+		case player_action_t::REQUIRE:
+			mape->flags &= ~LEVEL_FREELOOK_NO;
+			mape->flags |= LEVEL_FREELOOK_YES;
+			break;
 		}
 	}
 	else


### PR DESCRIPTION
A frequent issue with projects using UMAPINFO, is that if they are designed with the intention that crouching, jumping, and freelook are unavailable or disabled, they end up having to redefine all their maps in ZDoom to disable these features or other similar workarounds. To remedy this, a proposal to add freeaim, jumping, and crouching keys to UMAPINFO has been made. The exact details of the specification haven't been worked out just yet, hence this being just a draft for now, but the current wording can be viewed at https://github.com/kraflab/umapinfo/pull/6