### PR TITLE
[BUGFIX] A few Doom format map compat issues

### DIFF
--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -397,7 +397,7 @@ bool P_IsTeleportLine(const short special)
 	return special == 39 || special == 97 || special == 125 || special == 126 ||
 	       special == 174 || special == 195 || special == 207 || special == 208 ||
 	       special == 209 || special == 210 || special == 243 || special == 244 ||
-		   (262 <= special && special <= 269);
+	       (262 <= special && special <= 269);
 }
 
 bool P_IsThingTeleportLine(const short special)
@@ -406,7 +406,8 @@ bool P_IsThingTeleportLine(const short special)
 		return false;
 
 	return special == 39 || special == 97 || special == 125 || special == 126 ||
-	       special == 174 || special == 195 || special == 208 || special == 243;
+	       special == 174 || special == 195 || special == 207 || special == 208 ||
+	       special == 209 || special == 210 || special == 268 || special == 269;
 }
 
 bool P_IsThingNoFogTeleportLine(const short special)

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -424,7 +424,8 @@ bool P_IsCompatibleLockedDoorLine(const short special)
 		return false;
 
 	return special == 26 || special == 27 || special == 28 || special == 32 ||
-	       special == 33 || special == 34;
+	       special == 33 || special == 34 || special == 99 || special == 133 ||
+		   special == 134 || special == 135 || special == 136 || special == 137;
 }
 
 bool P_IsCompatibleBlueDoorLine(const short special)
@@ -432,13 +433,10 @@ bool P_IsCompatibleBlueDoorLine(const short special)
 	if (map_format.getZDoom())
 		return false;
 
-	int lock = (special & LockedKey) >> LockedKeyShift;
-	bool genericlock = false;
+	const int lock = (special & LockedKey) >> LockedKeyShift;
+	const bool genericlock = lock == BCard || lock == BSkull;
 
-	if (lock == BCard || lock == BSkull)
-		genericlock = true;
-
-	return special == 26 || special == 32 || genericlock;
+	return special == 26 || special == 32 || special == 99 || special == 133 || genericlock;
 }
 
 bool P_IsCompatibleRedDoorLine(const short special)
@@ -446,13 +444,10 @@ bool P_IsCompatibleRedDoorLine(const short special)
 	if (map_format.getZDoom())
 		return false;
 
-	int lock = (special & LockedKey) >> LockedKeyShift;
-	bool genericlock = false;
+	const int lock = (special & LockedKey) >> LockedKeyShift;
+	const bool genericlock = lock == RCard || lock == RSkull;
 
-	if (lock == RCard || lock == RSkull)
-		genericlock = true;
-
-	return special == 28 || special == 33 || genericlock;
+	return special == 28 || special == 33 || special == 134 || special == 135 || genericlock;
 }
 
 bool P_IsCompatibleYellowDoorLine(const short special)
@@ -460,13 +455,10 @@ bool P_IsCompatibleYellowDoorLine(const short special)
 	if (map_format.getZDoom())
 		return false;
 
-	int lock = (special & LockedKey) >> LockedKeyShift;
-	bool genericlock = false;
+	const int lock = (special & LockedKey) >> LockedKeyShift;
+	const bool genericlock = lock == YCard || lock == YSkull;
 
-	if (lock == YCard || lock == YSkull)
-		genericlock = true;
-
-	return special == 27 || special == 34 || genericlock;
+	return special == 27 || special == 34 || special == 136 || special == 137 || genericlock;
 }
 
 bool P_IsLightTagDoorType(const short special)

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -396,8 +396,8 @@ bool P_IsTeleportLine(const short special)
 
 	return special == 39 || special == 97 || special == 125 || special == 126 ||
 	       special == 174 || special == 195 || special == 207 || special == 208 ||
-	       special == 209 || special == 210 || special == 244 || special == 268 ||
-	       special == 269;
+	       special == 209 || special == 210 || special == 243 || special == 244 ||
+		   (262 <= special && special <= 269);
 }
 
 bool P_IsThingTeleportLine(const short special)


### PR DESCRIPTION
This fixes a few issues with locked doors and teleports on Doom format maps

Automap fixes:
- The fast variants of locked doors (types 99 and 133-137) now glow their colors, matching the other locked door types
- Teleport to same tag lines (243 and 262-267, 244 was already correct) are now colored as teleport lines

Gameplay fixes:
- Teleport to same tag lines (243 and 262-267, 244 was already correct) now cannot be activated from the wrong side
- Player position interpolation in multiplayer works better for teleport to same tag lines (243 and 262-267, 244 was already correct)