### PR TITLE
[BUGFIX] Dormant monsters wake up in multiplayer

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -678,12 +678,17 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 		mo->flags = msg->current().flags();
 	}
 
+	if (msg->spawn_flags() & SVC_SM_FLAGS2)
+	{
+		mo->flags2 = msg->current().flags2();
+	}
+
 	if (msg->spawn_flags() & SVC_SM_OFLAGS)
 	{
 		mo->oflags = msg->current().oflags();
 
 		// [AM] HACK! Assume that any monster with a flag is a boss.
-		if (mo->oflags)
+		if (mo->oflags & hordeBossModMask)
 		{
 			mo->effects = FX_YELLOWFOUNTAIN;
 			mo->translation = translationref_t(&::bosstable[0]);

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -112,6 +112,11 @@ enum clientBuf_e
 #define SVC_SM_OFLAGS BIT(2)
 
 /**
+ * @brief svc_spawnmobj: ZDoom/Heretic flags.
+ */
+#define SVC_SM_FLAGS2 BIT(3)
+
+/**
  * @brief svc_updatemobj: Supply mobj position and random index.
  */
 #define SVC_UM_POS_RND BIT(0)

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -89,6 +89,7 @@ void SV_SocketTouch(player_t &player, team_t f);
 void SV_SendKillMobj(AActor *source, AActor *target, AActor *inflictor, bool joinkill);
 void SV_SendDamagePlayer(player_t *player, AActor* inflictor, int healthDamage, int armorDamage);
 void SV_SendDamageMobj(AActor *target, int pain);
+void SV_UpdateMobj(AActor* mo);
 void SV_ActorTarget(AActor *actor);
 void PickupMessage(AActor *toucher, const char *message);
 void WeaponPickupMessage(AActor *toucher, weapontype_t &Weapon);
@@ -2436,7 +2437,7 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
 	if (source && player && co_helpfriends)
 		target->target = source->ptr();
 
-  if (!(target->flags2 & MF2_DORMANT))
+	if (!(target->flags2 & MF2_DORMANT))
 	{
 		int pain = P_Random(target);
 
@@ -2500,6 +2501,10 @@ void P_DamageMobj(AActor *target, AActor *inflictor, AActor *source, int damage,
             }
             SV_ActorTarget(target);
 		}
+	}
+	else
+	{
+		SV_UpdateMobj(target);
 	}
 }
 

--- a/common/p_mobj.h
+++ b/common/p_mobj.h
@@ -128,8 +128,8 @@ inline static fixed_t DegToSlope(fixed_t a)
 extern NetIDHandler ServerNetID;
 
 // All oflag mods that are sent to horde bosses.
-const uint32_t hordeBossModMask = MFO_INFIGHTINVUL | MFO_UNFLINCHING | MFO_ARMOR |
-                                  MFO_QUICK | MFO_NORAISE | MFO_FULLBRIGHT;
+inline constexpr uint32_t hordeBossModMask = MFO_INFIGHTINVUL | MFO_UNFLINCHING | MFO_ARMOR |
+                                             MFO_QUICK | MFO_NORAISE | MFO_FULLBRIGHT;
 
 void P_ClearAllNetIds();
 AActor* P_FindThingById(uint32_t id);

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -368,6 +368,12 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(AActor* mo)
 		cur->set_flags(mo->flags);
 	}
 
+	if (mo->flags2 & MF2_DORMANT)
+	{
+		spawnFlags |= SVC_SM_FLAGS2;
+		cur->set_flags2(mo->flags2);
+	}
+
 	// odamex flags - only monster flags for now
 	if (mo->oflags & hordeBossModMask)
 	{

--- a/odaproto/common.proto
+++ b/odaproto/common.proto
@@ -47,6 +47,7 @@ message Actor
 	uint32 tracerid = 16;
 	int32 waterlevel = 17;
 	uint32 rndindex = 18;
+	fixed32 flags2 = 19;
 }
 
 message Player


### PR DESCRIPTION
Addresses #1411

After further investigating, it turns out this only affect monsters that were tagged as dormant in the map, but not monsters that were defined as dormant in dehacked. This is because when the server tells the client to spawn a thing, it wasn't sending `flags2`. Since the dormant flag can be set per-thing instead of as part of the type, this resulted in the client not knowing such things were dormant.