### PR TITLE
Create GitHub prerelease for prereleases

### DIFF
--- a/.github/actions/update-prerelease/action.yml
+++ b/.github/actions/update-prerelease/action.yml
@@ -1,0 +1,83 @@
+name: Update Prerelease
+
+inputs:
+  files:
+    description: "Files to upload to release artifacts"
+    required: true
+  build_number:
+    description: "Prerelease build number"
+    required: true
+  new_version:
+    description: "Version number of the upcoming release"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check if prerelease is outdated
+      id: check
+      shell: bash
+      run: |
+        if git fetch --quiet origin refs/tags/prerelease:refs/tags/prerelease; then
+          TAG_COMMIT=$(git rev-list -n 1 refs/tags/prerelease)
+
+          if [ "$TAG_COMMIT" != "${{ github.sha }}" ]; then
+            echo "should_delete=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_delete=false" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          echo "should_delete=false" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Delete old prerelease
+      if: steps.check.outputs.should_delete == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release delete prerelease --yes || true
+        git push origin :prerelease || true
+    - name: Find last release tag
+      id: get_tag
+      shell: bash
+      run: |
+        latest_tag=$(git tag -l --sort=version:refname "[0-9]*.[0-9]*.[0-9]*" | tail -n 1)
+        echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
+    - name: Create prerelease
+      uses: softprops/action-gh-release@v2.3.4
+      id: create_prerelease
+      with:
+        tag_name: prerelease
+        target_commitish: ${{ github.sha }}
+        name: "Odamex ${{ inputs.new_version }} Prerelease ${{ inputs.build_number }}"
+        prerelease: true
+        make_latest: false
+        draft: false
+        overwrite_files: true
+        generate_release_notes: false
+        body: ""
+        files: ${{ inputs.files }}
+    - name: Generate release notes
+      id: build_changelog
+      uses: actions/github-script@v8
+      env:
+        latest_tag: ${{ steps.get_tag.outputs.latest_tag }}
+        release_id: ${{ steps.create_prerelease.outputs.id }}
+      with:
+        script: |
+          const notes = await github.rest.repos.generateReleaseNotes({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: "prerelease",
+            previous_tag_name: process.env.latest_tag,
+          });
+          const releases = await github.rest.repos.listReleases({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          await github.rest.repos.updateRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            release_id: process.env.release_id,
+            body: notes.data.body,
+          });

--- a/.github/workflows/linux-rc.yml
+++ b/.github/workflows/linux-rc.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - 'release/[0-9]+.[0-9]+.[0-9]+' # Only run on major.minor.patch releases
 
+permissions:
+  contents: write
+
 jobs:
   pre_job:
     name: Build Preparation
@@ -204,13 +207,13 @@ jobs:
         --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
     - name: Pack flatpak
       run: |
-        flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
-        --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+        flatpak build-bundle repo odamex-linux-x86_64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak \
+        net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: Odamex-Flatpak-x86_64
-        path: odamex.flatpak
+        path: odamex-linux-x86_64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak
   build-flatpak-arm:
     name: Build Flatpak (Ubuntu 24.04 ARM)
     needs: pre_job
@@ -253,10 +256,39 @@ jobs:
         --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
     - name: Pack flatpak
       run: |
-        flatpak build-bundle repo odamex.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
-        --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+        flatpak build-bundle repo odamex-linux-arm64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak \
+        net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
         name: Odamex-Flatpak-ARM64
-        path: odamex.flatpak
+        path: odamex-linux-arm64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak
+  package-and-upload:
+    name: Package and Upload Artifacts
+    runs-on: windows-latest
+    needs: [pre_job, build-flatpak, build-flatpak-arm]
+    env:
+      build_number: ${{ needs.pre_job.outputs.build_number }}
+      new_version: ${{ needs.pre_job.outputs.new_version }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+    - name: Download x86_64 Flatpak
+      uses: actions/download-artifact@v4
+      with:
+        name: Odamex-Flatpak-x86_64
+    - name: Download Arm Flatpak
+      uses: actions/download-artifact@v4
+      with:
+        name: Odamex-Flatpak-ARM64
+    - name: Create or update prerelease
+      uses: ./.github/actions/update-prerelease
+      env:
+        build_number: ${{ needs.pre_job.outputs.build_number }}
+        new_version: ${{ needs.pre_job.outputs.new_version }}
+      with:
+        build_number: ${{ env.build_number }}
+        new_version: ${{ env.new_version }}
+        files: |
+          ./*.flatpak

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   pre_job:
     name: Build Preparation

--- a/.github/workflows/windows-rc.yml
+++ b/.github/workflows/windows-rc.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - 'release/[0-9]+.[0-9]+.[0-9]+' # Only run on major.minor.patch releases
 
+permissions:
+  contents: write
+
 jobs:
   pre_job:
     name: Build Preparation
@@ -167,6 +170,8 @@ jobs:
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
     - name: Run Upversion
       id:   upversion
       shell: pwsh
@@ -201,3 +206,23 @@ jobs:
       with:
         name: Odamex-Installer
         path: 'Output/*.exe'
+    - name: Download x86 pdb
+      uses: actions/download-artifact@v4
+      with:
+        name: Odamex-Win-x86-pdb
+    - name: Download x64 pdb
+      uses: actions/download-artifact@v4
+      with:
+        name: Odamex-Win-x64-pdb
+    - name: Create or update prerelease
+      uses: ./.github/actions/update-prerelease
+      env:
+        build_number: ${{ needs.pre_job.outputs.build_number }}
+        new_version: ${{ needs.pre_job.outputs.new_version }}
+      with:
+        build_number: ${{ env.build_number }}
+        new_version: ${{ env.new_version }}
+        files: |
+          ./odamex-win*.zip
+          ./odamex-debug-*.zip
+          ./Output/*.exe

--- a/ci/win-release-x64.ps1
+++ b/ci/win-release-x64.ps1
@@ -170,16 +170,16 @@ function ZipDebugX64 {
     # Copy pdb files into zip.  DO NOT THROW THESE AWAY!
     Copy-Item -Force -Path `
         "${CurrentDir}\BuildX64\client\RelWithDebInfo\odamex.pdb" `
-        -Destination "${OutputDir}\odamex-x64-${OdamexVersion}.pdb"
+        -Destination "${OutputDir}\odamex-x64-${OdamexVersion}${OdamexTestSuffix}.pdb"
     Copy-Item -Force -Path `
         "${CurrentDir}\BuildX64\server\RelWithDebInfo\odasrv.pdb" `
-        -Destination "${OutputDir}\odasrv-x64-${OdamexVersion}.pdb"
+        -Destination "${OutputDir}\odasrv-x64-${OdamexVersion}${OdamexTestSuffix}.pdb"
     Copy-Item -Force -Path `
         "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\odalaunch.pdb" `
-        -Destination "${OutputDir}\odalaunch-x64-${OdamexVersion}.pdb"
+        -Destination "${OutputDir}\odalaunch-x64-${OdamexVersion}${OdamexTestSuffix}.pdb"
 
     7z.exe a `
-        "${PdbDir}\odamex-debug-pdb-${OdamexVersion}-x64.zip" `
+        "${PdbDir}\odamex-debug-pdb-${OdamexVersion}${OdamexTestSuffix}-x64.zip" `
         "${OutputDir}\*.pdb"
 
     Remove-Item -Force -Path "${OutputDir}\*.pdb"

--- a/ci/win-release-x86.ps1
+++ b/ci/win-release-x86.ps1
@@ -168,16 +168,16 @@ function ZipDebugX86 {
     # Copy pdb files into zip.  DO NOT THROW THESE AWAY!
     Copy-Item -Force -Path `
         "${CurrentDir}\BuildX86\client\RelWithDebInfo\odamex.pdb" `
-        -Destination "${OutputDir}\odamex-x86-${OdamexVersion}.pdb"
+        -Destination "${OutputDir}\odamex-x86-${OdamexVersion}${OdamexTestSuffix}.pdb"
     Copy-Item -Force -Path `
         "${CurrentDir}\BuildX86\server\RelWithDebInfo\odasrv.pdb" `
-        -Destination "${OutputDir}\odasrv-x86-${OdamexVersion}.pdb"
+        -Destination "${OutputDir}\odasrv-x86-${OdamexVersion}${OdamexTestSuffix}.pdb"
     Copy-Item -Force -Path `
         "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\odalaunch.pdb" `
-        -Destination "${OutputDir}\odalaunch-x86-${OdamexVersion}.pdb"
+        -Destination "${OutputDir}\odalaunch-x86-${OdamexVersion}${OdamexTestSuffix}.pdb"
 
     7z.exe a `
-        "${PdbDir}\odamex-debug-pdb-${OdamexVersion}-x86.zip" `
+        "${PdbDir}\odamex-debug-pdb-${OdamexVersion}${OdamexTestSuffix}-x86.zip" `
         "${OutputDir}\*.pdb"
 
     Remove-Item -Force -Path "${OutputDir}\*.pdb"


### PR DESCRIPTION
This PR makes it so that commits to `release/x.x.x` branches create a GitHub prerelease. To prevent lots of prereleases building up, the previous prerelease, if it exists, is deleted and the `prerelease` tag is moved to the new commit.

It also seems that GitHub is getting more strict about actions permissions. I had to explicitly list write permissions for the actions despite repo settings allowing writing from actions. It appears without this change, the existing release workflow may not work either.

PDB filenames now also include the prerelease suffix, this appears to have been an oversight when originally adding it to the other prerelease artifacts.

https://github.com/electricbrass/odamex/releases/tag/prerelease