### PR TITLE
[BUGFIX] `am_showlocked` doesn't work for generalized doors or ZDoom format

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -1462,23 +1462,49 @@ void AM_drawWalls()
 					if (line.special == Door_LockedRaise || line.special == Generic_Door)
 					{
 						const short lock = line.special == Door_LockedRaise ? line.args[3] : line.args[4];
-						if (lock == (zk_blue_card | zk_blue))
+						switch (lock)
 						{
-							r = doorColors.bluedoor[0];
-							g = doorColors.bluedoor[1];
-							b = doorColors.bluedoor[2];
-						}
-						else if (lock == (zk_yellow_card | zk_yellow))
-						{
-							r = doorColors.yellowdoor[0];
-							g = doorColors.yellowdoor[1];
-							b = doorColors.yellowdoor[2];
-						}
-						else
-						{
-							r = doorColors.reddoor[0];
-							g = doorColors.reddoor[1];
-							b = doorColors.reddoor[2];
+							case zk_blue_card:
+							case zk_blue:
+							case zk_blue_skull:
+							case zk_bluex:
+								r = doorColors.bluedoor[0];
+								g = doorColors.bluedoor[1];
+								b = doorColors.bluedoor[2];
+								break;
+							case zk_yellow_card:
+							case zk_yellow:
+							case zk_yellow_skull:
+							case zk_yellowx:
+								r = doorColors.yellowdoor[0];
+								g = doorColors.yellowdoor[1];
+								b = doorColors.yellowdoor[2];
+								break;
+							case zk_red_card:
+							case zk_red:
+							case zk_red_skull:
+							case zk_redx:
+								r = doorColors.reddoor[0];
+								g = doorColors.reddoor[1];
+								b = doorColors.reddoor[2];
+								break;
+							case zk_all:
+							case zk_any:
+							case zk_each_color:
+								r = doorColors.multidoor[0];
+								g = doorColors.multidoor[1];
+								b = doorColors.multidoor[2];
+								break;
+							case zk_none:
+								r = gameinfo.currentAutomapColors.CDWallColor.rgb.getr();
+								g = gameinfo.currentAutomapColors.CDWallColor.rgb.getg();
+								b = gameinfo.currentAutomapColors.CDWallColor.rgb.getb();
+								break;
+							default:
+								r = gameinfo.currentAutomapColors.LockedColor.rgb.getr();
+								g = gameinfo.currentAutomapColors.LockedColor.rgb.getg();
+								b = gameinfo.currentAutomapColors.LockedColor.rgb.getb();
+								break;
 						}
 
 						AM_drawMline(&l, AM_BestColor(pal->basecolors, r, g, b));

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -424,9 +424,22 @@ bool P_IsCompatibleLockedDoorLine(const short special)
 	if (map_format.getZDoom())
 		return false;
 
+	if (special >= GenLockedBase && special < GenDoorBase)
+		return true;
+
 	return special == 26 || special == 27 || special == 28 || special == 32 ||
 	       special == 33 || special == 34 || special == 99 || special == 133 ||
-		   special == 134 || special == 135 || special == 136 || special == 137;
+	       special == 134 || special == 135 || special == 136 || special == 137;
+}
+
+bool P_IsCompatibleMultiKeyDoorLine(const short special)
+{
+	if (map_format.getZDoom())
+		return false;
+
+	const int lock = (special & LockedKey) >> LockedKeyShift;
+
+	return lock == 0 || lock == 7;
 }
 
 bool P_IsCompatibleBlueDoorLine(const short special)

--- a/common/p_mapformat.h
+++ b/common/p_mapformat.h
@@ -98,6 +98,8 @@ bool P_IsTeleportLine(const short special);
 bool P_IsThingTeleportLine(const short special);
 bool P_IsThingNoFogTeleportLine(const short special);
 bool P_IsCompatibleLockedDoorLine(const short special);
+// true if generalized door can be opened with either all or any key
+bool P_IsCompatibleMultiKeyDoorLine(const short special);
 bool P_IsCompatibleBlueDoorLine(const short special);
 bool P_IsCompatibleRedDoorLine(const short special);
 bool P_IsCompatibleYellowDoorLine(const short special);


### PR DESCRIPTION
With `am_showlocked` enabled, Boom generalized doors did not use the correct colors for most types. The same applied to ZDoom format doors, despite actually being checked for, unlike the Boom doors.

Now all generalized doors pulse their colors, and doors that require all 3/6 keys or a key of any color now cycle through all three colors.

Addresses #1487
