### PR TITLE
[BUGFIX] Avatars aren't blocked by block players lines

### DIFF
--- a/common/d_player.h
+++ b/common/d_player.h
@@ -718,3 +718,13 @@ typedef struct wbstartstruct_s
 
 	std::vector<wbplayerstruct_s> plyr;
 } wbstartstruct_t;
+
+//
+// P_IsPlayerOrAvatar
+//
+// Returns true if thing is a player or an avatar
+//
+inline bool P_IsPlayerOrAvatar(const AActor& mo)
+{
+	return mo.player != nullptr || mo.type == MT_AVATAR;
+}

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -69,7 +69,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 	    }
 	}
 	*/
-	if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+	if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 	{
 		// Things that should NOT trigger specials...
 		switch (thing->type)
@@ -102,14 +102,14 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		}
 		else if ((unsigned)line->special >= GenFloorBase)
 		{
-			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if ((line->special & FloorChange) || !(line->special & FloorModel))
 					return false; // FloorModel is "Allow Monsters" if FloorChange is 0
 			linefunc = EV_DoGenFloor;
 		}
 		else if ((unsigned)line->special >= GenCeilingBase)
 		{
-			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if ((line->special & CeilingChange) || !(line->special & CeilingModel))
 					return false; // CeilingModel is "Allow Monsters" if CeilingChange is
 					               // 0
@@ -117,7 +117,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		}
 		else if ((unsigned)line->special >= GenDoorBase)
 		{
-			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 			{
 				if (!(line->special & DoorMonster))
 					return false;            // monsters disallowed from this door
@@ -128,7 +128,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		}
 		else if ((unsigned)line->special >= GenLockedBase)
 		{
-			if ((!thing->player && thing->type != MT_AVATAR) ||
+			if ((!P_IsPlayerOrAvatar(*thing)) ||
 			    bossaction)    // boss actions can't handle locked doors
 				return false;  // monsters disallowed from unlocking doors
 			if (((line->special & TriggerType) == WalkOnce) ||
@@ -143,14 +143,14 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		}
 		else if ((unsigned)line->special >= GenLiftBase)
 		{
-			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if (!(line->special & LiftMonster))
 					return false; // monsters disallowed
 			linefunc = EV_DoGenLift;
 		}
 		else if ((unsigned)line->special >= GenStairsBase)
 		{
-			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if (!(line->special & StairMonster))
 					return false; // monsters disallowed
 			linefunc = EV_DoGenStairs;
@@ -159,7 +159,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 		{
 			// haleyjd 06/09/09: This was completely forgotten in BOOM, disabling
 			// all generalized walk-over crusher types!
-			if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if (!(line->special & StairMonster))
 					return false; // monsters disallowed
 			linefunc = EV_DoGenCrusher;
@@ -181,7 +181,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			}
 	}
 
-	if ((!thing->player && thing->type != MT_AVATAR) || bossaction)
+	if ((!P_IsPlayerOrAvatar(*thing)) || bossaction)
 	{
 		ok = 0;
 		switch (line->special)
@@ -592,7 +592,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 
 	case 125:
 		// TELEPORT MonsterONLY
-		if (!thing->player && thing->type != MT_AVATAR &&
+		if (!P_IsPlayerOrAvatar(*thing) &&
 		    (EV_LineTeleport(line, side, thing)))
 		{
 			return true;
@@ -786,7 +786,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 
 	case 126:
 		// TELEPORT MonsterONLY.
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 		{
 			EV_LineTeleport(line, side, thing);
 			return true;
@@ -986,7 +986,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			break;
 
 		case 264: // jff 4/14/98 add monster-only silent line-line reversed
-			if (!thing->player && thing->type != MT_AVATAR &&
+			if (!P_IsPlayerOrAvatar(*thing) &&
 			    EV_SilentLineTeleport(line, side, thing, line->id, true))
 			{
 				return true;
@@ -995,7 +995,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			break;
 
 		case 266: // jff 4/14/98 add monster-only silent line-line
-			if (!thing->player && thing->type != MT_AVATAR &&
+			if (!P_IsPlayerOrAvatar(*thing) &&
 			    EV_SilentLineTeleport(line, side, thing, line->id, false))
 			{
 				return true;
@@ -1004,7 +1004,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			break;
 
 		case 268: // jff 4/14/98 add monster-only silent
-			if (!thing->player && thing->type != MT_AVATAR &&
+			if (!P_IsPlayerOrAvatar(*thing) &&
 			    EV_SilentTeleport(line->args[0], 0, line->args[2], 0, line, side, thing))
 			{
 				return true;
@@ -1181,7 +1181,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			break;
 
 		case 265: // jff 4/14/98 add monster-only silent line-line reversed
-			if (!thing->player && thing->type != MT_AVATAR)
+			if (!P_IsPlayerOrAvatar(*thing))
 			{
 				EV_SilentLineTeleport(line, side, thing, line->id, true);
 				return true;
@@ -1189,7 +1189,7 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			break;
 
 		case 267: // jff 4/14/98 add monster-only silent line-line
-			if (!thing->player && thing->type != MT_AVATAR)
+			if (!P_IsPlayerOrAvatar(*thing))
 			{
 				EV_SilentLineTeleport(line, side, thing, line->id, false);
 				return true;
@@ -1385,7 +1385,7 @@ bool P_ActorInCompatibleSector(AActor* actor)
 	sector_t* sector = actor->subsector->sector;
 
 	if (sector && sector->special & KILL_MONSTERS_MASK && actor->z == actor->floorz &&
-	    !actor->player && actor->type != MT_AVATAR && actor->flags & MF_SHOOTABLE && !(actor->flags & MF_FLOAT))
+	    !P_IsPlayerOrAvatar(*actor) && actor->flags & MF_SHOOTABLE && !(actor->flags & MF_FLOAT))
 	{
 		P_DamageMobj(actor, NULL, NULL, 10000);
 
@@ -1927,7 +1927,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 	}
 	else if ((unsigned)line->special >= GenFloorBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+		if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 			if ((line->special & FloorChange) || !(line->special & FloorModel))
 				return false; // FloorModel is "Allow Monsters" if FloorChange is 0
 		if (!line->id &&
@@ -1937,7 +1937,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 	}
 	else if ((unsigned)line->special >= GenCeilingBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+		if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 			if ((line->special & CeilingChange) || !(line->special & CeilingModel))
 				return false; // CeilingModel is "Allow Monsters" if CeilingChange is
 					            // 0
@@ -1948,7 +1948,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 	}
 	else if ((unsigned)line->special >= GenDoorBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+		if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 		{
 			if (!(line->special & DoorMonster))
 				return false;            // monsters disallowed from this door
@@ -1962,7 +1962,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 	}
 	else if ((unsigned)line->special >= GenLockedBase)
 	{
-		if ((!thing->player && thing->type != MT_AVATAR) || bossaction)
+		if ((!P_IsPlayerOrAvatar(*thing)) || bossaction)
 			return false; // monsters disallowed from unlocking doors
 		if (!P_CanUnlockGenDoor(line, thing->player))
 			return false;
@@ -1974,7 +1974,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 	}
 	else if ((unsigned)line->special >= GenLiftBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+		if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 			if (!(line->special & LiftMonster))
 				return false;                        // monsters disallowed
 		if (!line->id &&
@@ -1984,7 +1984,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 	}
 	else if ((unsigned)line->special >= GenStairsBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+		if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 			if (!(line->special & StairMonster))
 				return false;                        // monsters disallowed
 		if (!line->id &&
@@ -1994,7 +1994,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 	}
 	else if ((unsigned)line->special >= GenCrusherBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR && !bossaction)
+		if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 			if (!(line->special & CrusherMonster))
 				return false;                        // monsters disallowed
 		if (!line->id &&
@@ -2043,7 +2043,7 @@ bool P_UseCompatibleSpecialLine(AActor* thing, line_t* line, int side,
 		}
 
 	// Switches that other things can activate.
-	if (thing && !thing->player && thing->type != MT_AVATAR && !bossaction)
+	if (thing && !P_IsPlayerOrAvatar(*thing) && !bossaction)
 	{
 		// never open secret doors
 		if (line->flags & ML_SECRET)
@@ -3388,21 +3388,21 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 	}
 	else if ((unsigned)line->special >= GenFloorBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 			if ((line->special & FloorChange) || !(line->special & FloorModel))
 				return false; // FloorModel is "Allow Monsters" if FloorChange is 0
 		linefunc = EV_DoGenFloor;
 	}
 	else if ((unsigned)line->special >= GenCeilingBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 			if ((line->special & CeilingChange) || !(line->special & CeilingModel))
 				return false; // CeilingModel is "Allow Monsters" if CeilingChange is 0
 		linefunc = EV_DoGenCeiling;
 	}
 	else if ((unsigned)line->special >= GenDoorBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 		{
 			if (!(line->special & DoorMonster))
 				return false;            // monsters disallowed from this door
@@ -3413,7 +3413,7 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 	}
 	else if ((unsigned)line->special >= GenLockedBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 			return false; // monsters disallowed from unlocking doors
 		if (((line->special & TriggerType) == GunOnce) ||
 		    ((line->special & TriggerType) == GunMany))
@@ -3427,21 +3427,21 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 	}
 	else if ((unsigned)line->special >= GenLiftBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 			if (!(line->special & LiftMonster))
 				return false; // monsters disallowed
 		linefunc = EV_DoGenLift;
 	}
 	else if ((unsigned)line->special >= GenStairsBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 			if (!(line->special & StairMonster))
 				return false; // monsters disallowed
 		linefunc = EV_DoGenStairs;
 	}
 	else if ((unsigned)line->special >= GenCrusherBase)
 	{
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 			if (!(line->special & StairMonster))
 				return false; // monsters disallowed
 		linefunc = EV_DoGenCrusher;
@@ -3467,7 +3467,7 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		}
 
 	// Impacts that other things can activate.
-	if (thing && !thing->player && thing->type != MT_AVATAR)
+	if (thing && !P_IsPlayerOrAvatar(*thing))
 	{
 		int ok = 0;
 		switch (line->special)

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -1367,7 +1367,7 @@ void P_TouchSpecialThing(AActor *special, AActor *toucher)
 		return;
 
 	// Touchers that aren't players or avatars need not apply.
-	if (!toucher->player && toucher->type != MT_AVATAR)
+	if (!P_IsPlayerOrAvatar(*toucher))
 		return;
 
 	if (predicting)

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -243,7 +243,7 @@ bool P_TeleportMove (AActor *thing, fixed_t x, fixed_t y, fixed_t z, bool telefr
 	validcount++;
 	spechit.clear();
 
-	StompAlwaysFrags = tmthing->player || tmthing->type == MT_AVATAR ||
+	StompAlwaysFrags = P_IsPlayerOrAvatar(*tmthing) ||
 	                   (level.flags & LEVEL_MONSTERSTELEFRAG) || telefrag;
 
 	// stomp on any things contacted

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -437,10 +437,10 @@ bool PIT_CheckLine (line_t *ld)
     {
 		if ((ld->flags &
 		     (ML_BLOCKING | ML_BLOCKEVERYTHING)) || // explicitly blocking everything
-		    (!tmthing->player && tmthing->type != MT_AVATAR && !(tmthing->flags & MF_FRIEND) && (ld->flags & ML_BLOCKMONSTERS)) || // block monsters only
-		    (!tmthing->player && tmthing->type != MT_AVATAR && !(tmthing->flags & MF_FRIEND) && (ld->flags & ML_BLOCKLANDMONSTERS) &&
+		    (!P_IsPlayerOrAvatar(*tmthing) && !(tmthing->flags & MF_FRIEND) && (ld->flags & ML_BLOCKMONSTERS)) || // block monsters only
+		    (!P_IsPlayerOrAvatar(*tmthing) && !(tmthing->flags & MF_FRIEND) && (ld->flags & ML_BLOCKLANDMONSTERS) &&
 		     !(tmthing->flags & MF_FLOAT)) || // [Blair] Block land monsters.
-		    (tmthing->player &&
+		    (P_IsPlayerOrAvatar(*tmthing) &&
 		     (ld->flags & ML_BLOCKPLAYERS))) // [Blair] Block players only
 		{
 			CheckForPushSpecial(ld, 0, tmthing);

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2024,7 +2024,7 @@ void P_ShootSpecialLine(AActor*	thing, line_t* line)
 		if (thing->flags & MF_MISSILE)
 			return;
 
-		if (map_format.getZDoom() && !thing->player && thing->type != MT_AVATAR &&
+		if (map_format.getZDoom() && !P_IsPlayerOrAvatar(*thing) &&
 		    !(line->flags & ML_MONSTERSCANACTIVATE))
 			return;
 	}
@@ -2077,7 +2077,7 @@ bool P_UseSpecialLine(AActor* thing, line_t* line, int side, bool bossaction)
 	if(!bossaction && thing)
 	{
 		// Switches that other things can activate.
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 		{
 			// not for monsters?
 			if (map_format.getZDoom() && !(line->flags & ML_MONSTERSCANACTIVATE))
@@ -2150,7 +2150,7 @@ bool P_PushSpecialLine(AActor* thing, line_t* line, int side)
 			return false;
 
 		// Switches that other things can activate.
-		if (!thing->player && thing->type != MT_AVATAR)
+		if (!P_IsPlayerOrAvatar(*thing))
 		{
 			// not for monsters?
 			if (!(line->flags & ML_MONSTERSCANACTIVATE))

--- a/common/p_zdoomhexspec.cpp
+++ b/common/p_zdoomhexspec.cpp
@@ -148,7 +148,7 @@ bool P_TestActivateZDoomLine(line_t* line, AActor* mo, int side,
 		}
 	}
 
-	if (mo && !mo->player && mo->type != MT_AVATAR && !(mo->flags & MF_MISSILE) &&
+	if (mo && !P_IsPlayerOrAvatar(*mo) && !(mo->flags & MF_MISSILE) &&
 	    !(line->flags & ML_MONSTERSCANACTIVATE) &&
 	    (!(activationType & ML_SPAC_MCROSS) || !(lineActivation & ML_SPAC_MCROSS)))
 	{


### PR DESCRIPTION
Also adds P_IsPlayerOrAvatar to replace all the `thing->player || thing->type == MT_AVATAR`/`!thing->player && thing->type != MT_AVATAR` checks.