### PR TITLE
[BUGFIX] `-warp` and `+map` don't work on server

### DIFF
--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -178,8 +178,7 @@ EXTERN_CVAR(sv_shufflemaplist)
 
 bool isLastMap()
 {
-	return level.nextmap.empty() ||
-		std::any_of(
+	return std::any_of(
 			forcedlastmaps.entries.begin(), forcedlastmaps.entries.end(),
 			[&](const auto& entry) {
 				return entry.first == level.mapname && (entry.second.empty() || entry.second == level.nextmap);


### PR DESCRIPTION
An issue I missed in my cleanup of the original lastmap PR, `isLastMap` would always end up true at startup, overriding whatever was set on the command line. The case of no nextmap is already handled elsewhere and shouldn't have been mixed into lastmap.