### PR TITLE
Add r_thingsectorlight cvar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /build*
+/.cache
 *.vscode
 *.zed
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -747,6 +747,9 @@ CVAR(			r_drawflat, "0", "Disables all texturing of walls, floors and ceilings",
 CVAR(			r_clipmaskedspecial, "1", "Vertically clip masked midtextures when surrounding sectors have differing specials (mimics Hexen and DSDA-Doom behavior)",
 				CVARTYPE_BOOL, CVAR_NULL)
 
+CVAR(			r_thingsectorlight, "0", "MObjs are lit according to the average of the transfered light levels (mimics MBF behavior)",
+				CVARTYPE_BOOL, CVAR_NULL)
+
 #if 0
 CVAR(			r_drawhitboxes, "0", "Draws a box outlining every actor's hitboxes",
 				CVARTYPE_BOOL, CVAR_NULL)

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -602,6 +602,7 @@ EXTERN_CVAR(co_novileghosts)
 EXTERN_CVAR(co_removesoullimit)
 EXTERN_CVAR(co_allowdropoff)
 EXTERN_CVAR(r_clipmaskedspecial)
+EXTERN_CVAR(r_thingsectorlight)
 
 void G_ReadCOMPLVL()
 {
@@ -624,6 +625,7 @@ void G_ReadCOMPLVL()
 			co_allowdropoff.Set(0.0f);
 			co_removesoullimit.Set(0.0f);
 			r_clipmaskedspecial.Set(0.0f);
+			r_thingsectorlight.Set(0.0f);
 		}
 		else if (iequals("boom", complvl))
 		{
@@ -633,6 +635,7 @@ void G_ReadCOMPLVL()
 			co_allowdropoff.Set(1.0f);
 			co_removesoullimit.Set(1.0f);
 			r_clipmaskedspecial.Set(0.0f);
+			r_thingsectorlight.Set(0.0f);
 		}
 		else if (iequals("mbf", complvl))
 		{
@@ -642,6 +645,7 @@ void G_ReadCOMPLVL()
 			co_allowdropoff.Set(1.0f);
 			co_removesoullimit.Set(1.0f);
 			r_clipmaskedspecial.Set(0.0f);
+			r_thingsectorlight.Set(1.0f);
 		}
 		else if (iequals("mbf21", complvl))
 		{
@@ -651,6 +655,7 @@ void G_ReadCOMPLVL()
 			co_allowdropoff.Set(1.0f);
 			co_removesoullimit.Set(1.0f);
 			r_clipmaskedspecial.Set(1.0f);
+			r_thingsectorlight.Set(0.0f);
 		}
 		else
 		{

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -73,6 +73,7 @@ fixed_t boby;
 EXTERN_CVAR (r_drawplayersprites)
 EXTERN_CVAR (r_softinvulneffect)
 EXTERN_CVAR (r_particles)
+EXTERN_CVAR (r_thingsectorlight);
 
 //
 // INITIALIZATION FUNCTIONS
@@ -689,7 +690,8 @@ void R_AddSprites (sector_t *sec, int lightlevel, int fakeside)
 	// Well, now it will be done.
 	sec->validcount = validcount;
 
-	int lightnum = (lightlevel >> LIGHTSEGSHIFT) + (foggy ? 0 : extralight);
+	int lightnum = r_thingsectorlight ? lightlevel : sec->lightlevel;
+	lightnum = (lightnum >> LIGHTSEGSHIFT) + (foggy ? 0 : extralight);
 
 	if (lightnum < 0)
 		spritelights = scalelight[0];


### PR DESCRIPTION
`Alongside the fake heights transfer (242), Boom also introduced two separate line specials that individually transfer floor and ceiling light levels (213 and 261) onto a tagged sector. Normally, in Boom and CL9, any Things present in said sector will be lit according to the sector's normal light level. MBF, however, changed this behavior to decide a Thing's light level using the average of the transferred floor and ceiling light levels, instead.`

Not only is the MBF behavior incredibly unpopular among mappers, the choice of which behavior is also widely inconsistent among ports. Some ports will only use the Boom behavior of defining a Thing's light level based on the true sector, some will only use the MBF behavior and others will only read the transferred floor light level, instead.

Relevant:
https://github.com/doom-cross-port-collab/issue-tracker/issues/1
https://github.com/kraflab/mbf21/pull/6
https://github.com/fabiangreffrath/woof/pull/2393
https://github.com/kraflab/dsda-doom/pull/820
https://github.com/team-eternity/eternity/pull/740