### PR TITLE
Add missing noblockmap flag to musinfo musicchanger things

### DIFF
--- a/common/info.cpp
+++ b/common/info.cpp
@@ -7049,7 +7049,7 @@ mobjinfo_t doom_mobjinfo[::NUMMOBJTYPES] = {
     100,           // mass
     0,             // damage
     NULL,          // activesound
-    0, // flags (MF_NOBLOCKMAP)
+    MF_NOBLOCKMAP, // flags
 	0,
     S_NULL,         // raisestate
     0x10000,   // translucency


### PR DESCRIPTION
Not sure why this flag wasn't set despite having a comment. I think it was just a remnant of an early partial implementation that DeathEgg and I built off of.