### PR TITLE
Odasrv: Win 11 power throttle fix; retire Windows 7 support for odasrv

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -44,6 +44,11 @@ odamex_target_settings(odasrv)
 target_include_directories(odasrv PRIVATE src)
 if(WIN32)
   target_include_directories(odasrv PRIVATE win32)
+
+  # We need to call SetProcessInformation to disable power throttling,
+  # but the API itself doesn't exist until Windows 8.  Here we set the minimum
+  # Windows version to 8.  (Windows Server 2012, BTW)
+  target_compile_definitions(odasrv PRIVATE _WIN32_WINNT=0x0602)
 endif()
 
 target_link_libraries(odasrv fmt::fmt tinylibs ZLIB::ZLIB odamex-common odaproto minilzo cpptrace::cpptrace)

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -21,13 +21,17 @@
 //
 //-----------------------------------------------------------------------------
 
+// We need to call SetProcessInformation to disable power throttling,
+// but the API itself doesn't exist until Windows 8.  Here we set the minimum
+// Windows version to 8.  (Windows Server 2012, BTW)
+#define _WIN32_WINNT 0x0602 // _WIN32_WINNT_WIN8
+#include "win32inc.h"
 
 #include "odamex.h"
 
 #include <stack>
 #include <iostream>
 
-#include "win32inc.h"
 #ifdef _WIN32
     #include "resource.h"
 	#include "mmsystem.h"
@@ -88,12 +92,57 @@ BOOL WINAPI ConsoleHandlerRoutine(DWORD dwCtrlType)
     return true;
 }
 
+class PowerThrottleController
+{
+    public:
+        void Disable(ULONG flag)
+        {
+            PROCESS_POWER_THROTTLING_STATE throttleCommand{};
+            throttleCommand.Version     = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
+            throttleCommand.ControlMask = m_toggledFlags | flag;
+            throttleCommand.StateMask   = 0;
+
+            if (SetProcessInformation(GetCurrentProcess(),
+                                      ProcessPowerThrottling,
+                                      & throttleCommand,
+                                      sizeof(throttleCommand)))
+            {
+                m_toggledFlags |= flag;
+            }
+        }
+
+    protected:
+        // Record the successfully-toggled flags so that we can support successive calls
+        // to SetProcessInformation with a potential mixture of successes and failures,
+        // which is to be expected on Windows versions prior to 11.
+        ULONG m_toggledFlags = 0;
+};
+
+static void DisablePowerThrottling()
+{
+    // Sometime during 2022, Windows 11 was updated to throttle processes' access to
+    // the high-resolution timer, even if processes explicitly requested it.  Throttling
+    // occurs when the process is no longer in the foreground, including when being
+    // obscured by other windows.  When this happens, the server spends excessive time
+    // sleeping in various system API calls, such as kbhit() in the console code and/or
+    // sendto() in the network code.
+    //
+    // Fortunately we can disable this behavior via the SetProcessInformation API.
+
+    PowerThrottleController throttler;
+
+    throttler.Disable(PROCESS_POWER_THROTTLING_EXECUTION_SPEED);
+    throttler.Disable(PROCESS_POWER_THROTTLING_IGNORE_TIMER_RESOLUTION);
+}
+
 int __cdecl main(int argc, char *argv[])
 {
 	// [AM] Set crash callbacks, so we get something useful from crashes.
 #ifdef NDEBUG
 	I_SetCrashCallbacks();
 #endif
+
+    DisablePowerThrottling();
 
     try
     {

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -83,56 +83,56 @@ static HANDLE hEvent;
 
 int ShutdownNow()
 {
-    return (WaitForSingleObject(hEvent, 1) == WAIT_OBJECT_0);
+	return (WaitForSingleObject(hEvent, 1) == WAIT_OBJECT_0);
 }
 
 BOOL WINAPI ConsoleHandlerRoutine(DWORD dwCtrlType)
 {
-    SetEvent(hEvent);
-    return true;
+	SetEvent(hEvent);
+	return true;
 }
 
 class PowerThrottleController
 {
-    public:
-        void Disable(ULONG flag)
-        {
-            PROCESS_POWER_THROTTLING_STATE throttleCommand{};
-            throttleCommand.Version     = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
-            throttleCommand.ControlMask = m_toggledFlags | flag;
-            throttleCommand.StateMask   = 0;
+	public:
+		void Disable(ULONG flag)
+		{
+			PROCESS_POWER_THROTTLING_STATE throttleCommand{};
+			throttleCommand.Version     = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
+			throttleCommand.ControlMask = m_toggledFlags | flag;
+			throttleCommand.StateMask   = 0;
 
-            if (SetProcessInformation(GetCurrentProcess(),
-                                      ProcessPowerThrottling,
-                                      & throttleCommand,
-                                      sizeof(throttleCommand)))
-            {
-                m_toggledFlags |= flag;
-            }
-        }
+			if (SetProcessInformation(GetCurrentProcess(),
+			                          ProcessPowerThrottling,
+			                          & throttleCommand,
+			                          sizeof(throttleCommand)))
+			{
+				m_toggledFlags |= flag;
+			}
+		}
 
-    protected:
-        // Record the successfully-toggled flags so that we can support successive calls
-        // to SetProcessInformation with a potential mixture of successes and failures,
-        // which is to be expected on Windows versions prior to 11.
-        ULONG m_toggledFlags = 0;
+	protected:
+		// Record the successfully-toggled flags so that we can support successive calls
+		// to SetProcessInformation with a potential mixture of successes and failures,
+		// which is to be expected on Windows versions prior to 11.
+		ULONG m_toggledFlags = 0;
 };
 
 static void DisablePowerThrottling()
 {
-    // Sometime during 2022, Windows 11 was updated to throttle processes' access to
-    // the high-resolution timer, even if processes explicitly requested it.  Throttling
-    // occurs when the process is no longer in the foreground, including when being
-    // obscured by other windows.  When this happens, the server spends excessive time
-    // sleeping in various system API calls, such as kbhit() in the console code and/or
-    // sendto() in the network code.
-    //
-    // Fortunately we can disable this behavior via the SetProcessInformation API.
+	// Sometime during 2022, Windows 11 was updated to throttle processes' access to
+	// the high-resolution timer, even if processes explicitly requested it.  Throttling
+	// occurs when the process is no longer in the foreground, including when being
+	// obscured by other windows.  When this happens, the server spends excessive time
+	// sleeping in various system API calls, such as kbhit() in the console code and/or
+	// sendto() in the network code.
+	//
+	// Fortunately we can disable this behavior via the SetProcessInformation API.
 
-    PowerThrottleController throttler;
+	PowerThrottleController throttler;
 
-    throttler.Disable(PROCESS_POWER_THROTTLING_EXECUTION_SPEED);
-    throttler.Disable(PROCESS_POWER_THROTTLING_IGNORE_TIMER_RESOLUTION);
+	throttler.Disable(PROCESS_POWER_THROTTLING_EXECUTION_SPEED);
+	throttler.Disable(PROCESS_POWER_THROTTLING_IGNORE_TIMER_RESOLUTION);
 }
 
 int __cdecl main(int argc, char *argv[])
@@ -142,34 +142,34 @@ int __cdecl main(int argc, char *argv[])
 	I_SetCrashCallbacks();
 #endif
 
-    DisablePowerThrottling();
+	DisablePowerThrottling();
 
-    try
-    {
-        // Handle close box, shutdown and logoff events
-        if (!(hEvent = CreateEvent(NULL, false, false, NULL)))
-            throw CDoomError("Could not create console control event!\n");
+	try
+	{
+		// Handle close box, shutdown and logoff events
+		if (!(hEvent = CreateEvent(NULL, false, false, NULL)))
+			throw CDoomError("Could not create console control event!\n");
 
-        if (!SetConsoleCtrlHandler(ConsoleHandlerRoutine, true))
-            throw CDoomError("Could not set console control handler!\n");
+		if (!SetConsoleCtrlHandler(ConsoleHandlerRoutine, true))
+			throw CDoomError("Could not set console control handler!\n");
 
-        // Disable QuickEdit mode as any text selection will cause all functions
-        // that use stdout (printf etc) to block
-        DWORD lpMode = ENABLE_EXTENDED_FLAGS;
+		// Disable QuickEdit mode as any text selection will cause all functions
+		// that use stdout (printf etc) to block
+		DWORD lpMode = ENABLE_EXTENDED_FLAGS;
 
-        if (!SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), lpMode))
-            throw CDoomError("SetConsoleMode failed!\n");
+		if (!SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), lpMode))
+			throw CDoomError("SetConsoleMode failed!\n");
 
-        // Fixes icon not showing in titlebar and alt-tab menu under windows 7
-        HANDLE hIcon;
+		// Fixes icon not showing in titlebar and alt-tab menu under windows 7
+		HANDLE hIcon;
 
-        hIcon = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_ICON1));
+		hIcon = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_ICON1));
 
-        if(hIcon)
-        {
-            SendMessage(GetConsoleWindow(), WM_SETICON, ICON_SMALL, (LPARAM)hIcon);
-            SendMessage(GetConsoleWindow(), WM_SETICON, ICON_BIG, (LPARAM)hIcon);
-        }
+		if(hIcon)
+		{
+			SendMessage(GetConsoleWindow(), WM_SETICON, ICON_SMALL, (LPARAM)hIcon);
+			SendMessage(GetConsoleWindow(), WM_SETICON, ICON_BIG, (LPARAM)hIcon);
+		}
 
 		// [ML] 2007/9/3: From Eternity (originally chocolate Doom) Thanks SoM & fraggle!
 		::Args.SetArgs(argc, argv);
@@ -197,13 +197,13 @@ int __cdecl main(int argc, char *argv[])
 		// Set the timer to be as accurate as possible
 		TIMECAPS tc;
 		if (timeGetDevCaps (&tc, sizeof(tc) != TIMERR_NOERROR))
-			TimerPeriod = 1;	// Assume minimum resolution of 1 ms
+			TimerPeriod = 1;    // Assume minimum resolution of 1 ms
 		else
 			TimerPeriod = tc.wPeriodMin;
 
 		timeBeginPeriod (TimerPeriod);
 
-        // Don't call this on windows!
+		// Don't call this on windows!
 		//atexit (call_terms);
 
 		Z_Init();

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -21,17 +21,12 @@
 //
 //-----------------------------------------------------------------------------
 
-// We need to call SetProcessInformation to disable power throttling,
-// but the API itself doesn't exist until Windows 8.  Here we set the minimum
-// Windows version to 8.  (Windows Server 2012, BTW)
-#define _WIN32_WINNT 0x0602 // _WIN32_WINNT_WIN8
-#include "win32inc.h"
-
 #include "odamex.h"
 
 #include <stack>
 #include <iostream>
 
+#include "win32inc.h"
 #ifdef _WIN32
     #include "resource.h"
 	#include "mmsystem.h"


### PR DESCRIPTION
As of sometime in 2022, Windows 11 began throttling processes' access to the high-resolution timer by default.  The throttle also makes a heuristic decision about whether or not to slow down the process's execution regardless of whether or not the process requested a high-res timer.

Please see [the Remarks section of the `timeBeginPeriod` API documentation](https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod#remarks) and the [`SetProcessInformation` API docs](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setprocessinformation)

When odasrv gets auto-throttled on my Windows 11 rig, it causes `kbhit()` and `sendto()` to sleep for excessive lengths of time:

<img width="846" height="171" alt="Screenshot 2025-12-19 082857" src="https://github.com/user-attachments/assets/8ef0b1bd-2771-443d-8576-963ab2d26caa" />

(The following two images are from a different session from above)

<img width="1001" height="349" alt="Screenshot 2025-12-22 164052" src="https://github.com/user-attachments/assets/0951b0d1-9efe-4a5e-a127-1db6ffb38846" />

<img width="552" height="250" alt="Screenshot 2025-12-22 164105" src="https://github.com/user-attachments/assets/edcc7136-d6d8-4029-ac56-a92555b40618" />

The fix is to call `SetProcessInformation` to disable the throttling states.  Because this API didn't exist until Windows 8 (or Windows Server 2012), these become the new minimum Windows versions for running odasrv.  Please note that this is *only* for odasrv - The odamex client is unaffected.

With throttling disabled, the odasrv profile becomes:

<img width="769" height="406" alt="Screenshot 2025-12-19 093343" src="https://github.com/user-attachments/assets/9d12749e-bc66-4458-a6fb-961a02fa4e6d" />

(The following two images are from a different session from above)

<img width="962" height="342" alt="Screenshot 2025-12-22 163541" src="https://github.com/user-attachments/assets/c633f1ce-1f5b-4d5f-9a8e-dd065e0e0cbd" />

<img width="528" height="214" alt="Screenshot 2025-12-22 163517" src="https://github.com/user-attachments/assets/eeeafeac-a423-4abc-a470-e9e43d10f06e" />

Note the reduction in time spent running ConsoleInput and SendPackets.