### PR TITLE
[BUGFIX] Overflow when loading segs in maps with > 32,767 segs

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -256,10 +256,8 @@ void P_LoadSegs (int lump, bool isdeepbsp = false)
 		seg_t *li = segs+i;
 		if (isdeepbsp)
 		{
-			mapseg_deepbsp_t *ml = (mapseg_deepbsp_t*) data+i;
-			int v;
-
-			v = LELONG(ml->v1);
+			const mapseg_deepbsp_t *ml = (mapseg_deepbsp_t*) data+i;
+			uint32_t v = LELONG(ml->v1);
 
 			if(v >= numvertexes)
 				I_Error("P_LoadSegs: invalid vertex {}", v);
@@ -277,10 +275,8 @@ void P_LoadSegs (int lump, bool isdeepbsp = false)
 		}
 		else
 		{
-			mapseg_t *ml = (mapseg_t*) data+i;
-			short v;
-
-			v = LESHORT(ml->v1);
+			const mapseg_t *ml = (mapseg_t*) data+i;
+			uint16_t v = LESHORT(ml->v1);
 
 			if(v >= numvertexes)
 				I_Error("P_LoadSegs: invalid vertex {}", v);


### PR DESCRIPTION
To silence warnings after implementing support for deepbsp, v was made signed instead of unsigned, leading to reading out of bounds vertices. Fixes Amalgoom map15.