### PR TITLE
[BUGFIX] Client crash when printing serverchat

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1450,7 +1450,7 @@ static void CL_Print(const odaproto::svc::Print* msg)
 	else if (level == PRINT_TEAMCHAT)
 		PrintFmt(level, "{:c}!{}", TEXTCOLOR_ESCAPE, str);
 	else if (level == PRINT_SERVERCHAT)
-		PrintFmt(level, "{:c}{}", TEXTCOLOR_YELLOW, str);
+		PrintFmt(level, "{:s}{}", TEXTCOLOR_YELLOW, str);
 	else
 		PrintFmt(level, "{}", str);
 


### PR DESCRIPTION
The fix to make it not invisible was slightly wrong, yet for some reason worked on Windows, but crashes on Linux.