### PR TITLE
Fix potential out-of-bounds read in strbin

### DIFF
--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -4078,7 +4078,7 @@ void strbin (char *str)
 	while ( (c = *p++) ) {
 		if (c != '\\') {
 			*str++ = c;
-		} else {
+		} else if (*p) {
 			switch (*p) {
 				case 'c':
 					*str++ = '\034';	// TEXTCOLOR_ESCAPE
@@ -4136,6 +4136,10 @@ void strbin (char *str)
 					break;
 			}
 			p++;
+		}
+		else
+		{
+			// Trainling backlash
 		}
 	}
 	*str = 0;


### PR DESCRIPTION
Brought to our attention here: https://github.com/fabiangreffrath/woof/pull/2521
Related fix: https://github.com/kraflab/dsda-doom/pull/823

This is already fixed in G/UZDoom, but wasn't in ZDoom, even as late as 2.8.1