### PR TITLE
Apply fix from #1520 to ReplaceSpecialChars

### DIFF
--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -799,7 +799,8 @@ static void ReplaceSpecialChars(std::string& str)
 		{
 			*write++ = c;
 		}
-		else
+		// don't read past a trailing backslash
+		else if (*read)
 		{
 			switch (*read)
 			{

--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -4078,7 +4078,7 @@ void strbin (char *str)
 	while ( (c = *p++) ) {
 		if (c != '\\') {
 			*str++ = c;
-		} else {
+		} else if (*p) {
 			switch (*p) {
 				case 'c':
 					*str++ = '\034';	// TEXTCOLOR_ESCAPE


### PR DESCRIPTION
ReplaceSpecialChars has the exact same issue as strbin since they're nearly identical. Also contains the fix for strbin since that went to protobreak instead of stable for some reason.