### PR TITLE
[BUGFIX] Crash when skybox `szp` tracking gets trashed

### DIFF
--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -330,13 +330,13 @@ visplane_t *R_FindPlane (const plane_t &secplane, int picnum, int lightlevel,
 				return check;
 			}
 		}
-		else if (P_IdenticalPlanes(&secplane, &check->secplane) && 
+		else if (P_IdenticalPlanes(&secplane, &check->secplane) &&
 				picnum == check->picnum &&
 				lightlevel == check->lightlevel &&
 				xoffs == check->xoffs && // killough 2/28/98: Add offset checks
 				yoffs == check->yoffs &&
 				basecolormap == check->colormap && // [RH] Add colormap check
-				xscale == check->xscale && 
+				xscale == check->xscale &&
 				yscale == check->yscale &&
 				angle == check->angle)
 		{
@@ -769,7 +769,7 @@ void R_DrawSkyBoxes()
 		if (pl->maxx < pl->minx)
 			continue;
 
-		AActor::AActorPtr sky = pl->skybox;
+		AActor* sky = pl->skybox;
 
 		viewx = sky->x;
 		viewy = sky->y;
@@ -795,7 +795,7 @@ void R_DrawSkyBoxes()
 				floorclip[i] = pl->bottom[i];
 			}
 		}
-		
+
 		// Create a drawseg to clip sprites to the sky plane.
 		R_ReallocDrawSegs();
 		ds_p->x1 = 0;
@@ -811,7 +811,7 @@ void R_DrawSkyBoxes()
 		// [RK] Copy visplane clip values into the arrays.
 		memcpy(ds_p->sprbottomclip, floorclip, viewwidth * sizeof(*ds_p->sprbottomclip));
 		memcpy(ds_p->sprtopclip, ceilingclip, viewwidth * sizeof(*ds_p->sprtopclip));
-		
+
 		firstvissprite = vissprite_p;
 		firstdrawseg = ds_p++;
 

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -769,7 +769,7 @@ struct visplane_s
 	shaderef_t	colormap;			// [RH] Support multiple colormaps
 	fixed_t		xscale, yscale;		// [RH] Support flat scaling
 	angle_t		angle;				// [RH] Support flat rotation
-	AActor::AActorPtr skybox;
+	AActor*		skybox;
 
 	unsigned int *bottom;			// [RH] bottom and top arrays are dynamically
 	unsigned int pad;				//		allocated immediately after the


### PR DESCRIPTION
Fixes #1526

Visplanes are managed with M_Calloc and M_Free, so storing an szp inside them will end up breaking the linked list in the szp.

Since visplanes only live for a frame, it's safe to use a raw pointer instead of an szp here.