### PR TITLE
[BUGFIX] MT_UNKNOWNTHING is invisible

### DIFF
--- a/common/odainfo.cpp
+++ b/common/odainfo.cpp
@@ -487,7 +487,7 @@ mobjinfo_t odamobjinfo[] = {
         MF_NOGRAVITY,   // flags
         0,              // flags2
         S_NULL,         // raisestate
-        0,
+        0x10000,
         "MT_UNKNOWNTHING",
         NO_ALTSPEED,   // altspeed
         64 * FRACUNIT, // meleerange
@@ -528,7 +528,7 @@ mobjinfo_t odamobjinfo[] = {
         MF_NOBLOCKMAP, // flags
         MF2_DONTDRAW,  // flags2
         S_NULL,        // raisestate
-        0,
+        0x10000,
         "MT_PATHNODE -- used for monster patrols",
         NO_ALTSPEED,   // altspeed
         64 * FRACUNIT, // meleerange

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3067,6 +3067,7 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 		         mthing->type,
 		         mthing->x, mthing->y);
 		info = &mobjinfo[MT_UNKNOWNTHING]; // [CMB] odamex specific MT_UNKNOWNTHING
+		type = MT_UNKNOWNTHING;
 	}
 	// [RH] If the thing's corresponding sprite has no frames, also map
 	//		it to the unknown thing.
@@ -3074,6 +3075,7 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 	{
 		PrintFmt(PRINT_WARNING, "P_SpawnMapThing: Type {} at {}, {} has no frames\n",
 		         mthing->type, mthing->x, mthing->y);
+		info = &mobjinfo[MT_UNKNOWNTHING];
 		type = MT_UNKNOWNTHING;
 	}
 


### PR DESCRIPTION
Addresses #1530

For some reason the translucency on this got set to 0 when info.cpp was split into 2 files.