### PR TITLE
Fix (workaround?) spy angle interpolation

### DIFF
--- a/client/src/cl_pred.cpp
+++ b/client/src/cl_pred.cpp
@@ -192,17 +192,11 @@ static void CL_PredictSpying()
 	// Save and restore the prevangle and prevpitch so that the client viewangle interpolation
 	// actually works when spying.
 	//
-	// Details:
-	// As part of normal operations, P_PlayerThink overwrites prevangle and prevpitch with
-	// current angle and pitch, assuming that a newer angle and pitch are coming in P_MovePlayer
-	// under control of player->cmd.yaw and player->cmd.pitch.  The end result would be fresh
-	// previous and current values, which can be interpolated for nice smooth animation.
-	//
-	// Spying adds a wrinkle in that angle and pitch are *already* as up-to-date as can be,
-	// thanks to CL_SimulatePlayers, so P_PlayerThink's assumption that newer angle values are
-	// incoming doesn't hold.  However, prevangle and prevpitch genuinely have the previous
-	// snapshot's values, so hold onto them and write them back.  The end result will be the
-	// current and the previous snapshots' values reflected in their respective attributes.
+	// This is needed because the spy target's prevangle and prevpitch are already accurate
+	// thanks to CL_SimulatePlayers, but P_PlayerThink overwrites them, assuming that it's
+	// ultimately responsible for moving players.  That just isn't the case for spied remote
+	// players.  We can simply restore the overwritten states to allow interpolation to work.
+
 	const auto prevangle = player->mo->prevangle;
 	const auto prevpitch = player->mo->prevpitch;
 

--- a/client/src/cl_pred.cpp
+++ b/client/src/cl_pred.cpp
@@ -189,10 +189,30 @@ static void CL_PredictSpying()
 	if (consoleplayer_id == displayplayer_id)
 		return;
 
+	// Save and restore the prevangle and prevpitch so that the client viewangle interpolation
+	// actually works when spying.
+	//
+	// Details:
+	// As part of normal operations, P_PlayerThink overwrites prevangle and prevpitch with
+	// current angle and pitch, assuming that a newer angle and pitch are coming in P_MovePlayer
+	// under control of player->cmd.yaw and player->cmd.pitch.  The end result would be fresh
+	// previous and current values, which can be interpolated for nice smooth animation.
+	//
+	// Spying adds a wrinkle in that angle and pitch are *already* as up-to-date as can be,
+	// thanks to CL_SimulatePlayers, so P_PlayerThink's assumption that newer angle values are
+	// incoming doesn't hold.  However, prevangle and prevpitch genuinely have the previous
+	// snapshot's values, so hold onto them and write them back.  The end result will be the
+	// current and the previous snapshots' values reflected in their respective attributes.
+	const auto prevangle = player->mo->prevangle;
+	const auto prevpitch = player->mo->prevpitch;
+
 	predicting = false;
 
 	P_PlayerThink(player);
 	P_CalcHeight(player);
+
+	player->mo->prevangle = prevangle;
+	player->mo->prevpitch = prevpitch;
 }
 
 //


### PR DESCRIPTION
### Background

While spying another player, camera position is interpolated but angles are not.  The cause is that the `prevangle` and `prevpitch` have the same values as `angle` and `pitch`, so the interpolation calculation comes out as a no-op.

This makes watching Acts 19 Quiz tear things up in Horde mode really jarring at times, because positional motion is smooth, but view rotations are harsh.

This is caused by the `P_PlayerThink` call in `CL_PredictSpying`, which assumes that the player's current angles are going to be updated immediately by the player's `cmd`.  However, spied players don't have a `cmd` - the previous and current angles are already as up-to-date as can be thanks to `CL_SimulatePlayer`.  So when `P_PlayerThink` records the "current" values to "previous," the actual previous values are overwritten, forcing "previous" and "current" to always be the same.

### Fix / workaround

Save off the (accurate) "previous" values before calling `P_PlayerThink` and then restore them immediately afterwards.

Arguably a better solution might be to update `P_PlayerThink` to accept flags specifying what "thoughts" it's allowed to have / states it's allowed to update...  Something to consider for later probably.