### PR TITLE
Quadruple state cycle limit

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1044,7 +1044,7 @@ int P_ThingInfoHeight(mobjinfo_t *mi)
 // [AM] Taken from Crispy Doom, with a smaller limit - 10,000 iterations
 //      still seems like a lot to me.
 
-#define MOBJ_CYCLE_LIMIT 128
+#define MOBJ_CYCLE_LIMIT 512
 
 // P_SetMobjState
 //

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -163,10 +163,10 @@ AActor::AActor(const AActor& other)
       translucency(other.translucency), waterlevel(other.waterlevel), gear(other.gear),
       onground(other.onground), touching_sectorlist(other.touching_sectorlist),
       deadtic(other.deadtic), oldframe(other.oldframe), rndindex(other.rndindex),
-      netid(other.netid), tid(other.tid),
       friend_playerid(other.friend_playerid),
       friend_teamid(other.friend_teamid), pursuecount(other.pursuecount),
       strafecount(other.strafecount),
+      netid(other.netid), tid(other.tid),
       baseline_set(false), bmapnode(other.bmapnode)
 {
 	memcpy(args, other.args, sizeof(args));


### PR DESCRIPTION
What it says on the tin, fixes Eviternity II map36. Just doubling the limit was enough, but even 512 is still much lower than some ports with limits in the thousands.