### PR TITLE
Make flatpak releases always use "release" as branch name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,11 +176,6 @@ jobs:
       run: git submodule update --init --recursive
     - name: Install flatpak
       run: sudo apt update && sudo apt install flatpak flatpak-builder
-    - name: Create escaped branch name
-      env:
-        name: "${{ github.ref_name }}"
-      run: |
-        echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
     - name: Remove .git folders
       shell: bash
       run: rm -rf .git
@@ -190,10 +185,10 @@ jobs:
       run: |
         flatpak-builder --force-clean --user --install-deps-from=flathub \
         --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-        --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
+        --default-branch=release -v
     - name: Pack flatpak
       run: |
-        flatpak build-bundle repo odamex-linux-x86_64-${{ env.new_version }}.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
+        flatpak build-bundle repo odamex-linux-x86_64-${{ env.new_version }}.flatpak net.odamex.Odamex release \
         --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -223,11 +218,6 @@ jobs:
       run: git submodule update --init --recursive
     - name: Install flatpak
       run: sudo apt update && sudo apt install flatpak flatpak-builder
-    - name: Create escaped branch name
-      env:
-        name: "${{ github.ref_name }}"
-      run: |
-        echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
     - name: Remove .git folders
       shell: bash
       run: rm -rf .git
@@ -237,10 +227,10 @@ jobs:
       run: |
         flatpak-builder --force-clean --user --install-deps-from=flathub \
         --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-        --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
+        --default-branch=release -v
     - name: Pack flatpak
       run: |
-        flatpak build-bundle repo odamex-linux-arm64-${{ env.new_version }}.flatpak net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} \
+        flatpak build-bundle repo odamex-linux-arm64-${{ env.new_version }}.flatpak net.odamex.Odamex release \
         --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
     - name: Upload artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Currently, the flatpak branch name for releases is the tag name. This means each release has a different branch name. Because of this, updating will always leave the old version installed. Most guis for flatpak management do not make it easy to manage multiple branches and see old versions, so for many users this will lead to multiple inaccessible installations piling up over time if they are installing from the .flatpak files on github releases and not from flathub.