### PR TITLE
[BUGFIX] UDMX map32 teleporters blocking players

### DIFF
--- a/common/cmdlib.h
+++ b/common/cmdlib.h
@@ -60,10 +60,9 @@ bool	IsNum(std::string_view str);
 bool	IsRealNum(const char* str);
 
 template<typename T>
-std::optional<T> ParseNum(std::string_view str)
+std::optional<T> ParseNum(std::string_view str, int base = 10)
 {
     T out;
-	int base = 10;
 	while (!str.empty() && std::isspace(static_cast<unsigned char>(str.front())))
 		str.remove_prefix(1);
 	if (str[0] == '$')

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -102,12 +102,13 @@ struct fhfprint_t
 	std::array<byte, 16> fingerprint{};
 
 	[[nodiscard]]
-	bool operator==(const fhfprint_t& other)
+	bool operator==(const fhfprint_t& other) const
 	{
 		return fingerprint == other.fingerprint;
 	}
 
-	bool operator==(std::string_view other)
+	[[nodiscard]]
+	bool operator==(std::string_view other) const
 	{
 		return other == this->toString();
 	}
@@ -117,7 +118,8 @@ struct fhfprint_t
 		fingerprint.fill(0);
 	}
 
-	std::string toString()
+	[[nodiscard]]
+	std::string toString() const
 	{
 		// [Blair] Serialize the hashes before reading.
 		const uint64_t reconsthash1 = (uint64_t)(fingerprint[0]) |
@@ -139,6 +141,25 @@ struct fhfprint_t
 		                              (uint64_t)(fingerprint[15]) << 56;
 
 		return fmt::format("{:016x}{:016x}", reconsthash1, reconsthash2);
+	}
+
+	[[nodiscard]]
+	static fhfprint_t fromString(std::string_view hashstr)
+	{
+		const uint64_t hash1 = ParseNum<uint64_t>(hashstr.substr(0, 16), 16).value_or(0);
+		const uint64_t hash2 = ParseNum<uint64_t>(hashstr.substr(16), 16).value_or(0);
+
+		fhfprint_t fp{};
+
+		const auto unpack = [&fp](uint64_t hash, size_t index = 0){
+			for (int i = 0; i < 8; i++)
+				fp.fingerprint[i + index] = static_cast<byte>((hash >> (i * 8)) & 0xFF);
+		};
+
+		unpack(hash1);
+		unpack(hash2, 8);
+
+		return fp;
 	}
 };
 

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -3553,18 +3553,14 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 	return false;
 }
 
-unsigned int P_TranslateCompatibleLineFlags(const unsigned int flags, const bool reserved)
+uint32_t P_TranslateCompatibleLineFlags(const uint32_t flags, const bool reserved)
 {
-	/*
-	if (mbf21)
-		const unsigned int filter = (flags & ML_RESERVED && comp[comp_reservedlineflag]) ? 0x01ff : 0x3fff;
-	else
-		const unsigned int filter = 0x03ff;
-	*/
+	// no comp_reservedlineflag, it's only needed for playback of
+	// a small set of early mbf21 demos from before its introduction
 
-	unsigned int filter;
+	uint32_t filter;
 
-	if (demoplayback || reserved)
+	if (demoplayback || flags & ML_RESERVED || reserved)
 		filter = 0x01ff;
 	else
 		filter = 0x3fff;

--- a/common/p_compdb.cpp
+++ b/common/p_compdb.cpp
@@ -1,0 +1,75 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 1998-2006 by Randy Heit (ZDoom).
+// Copyright (C) 2006-2026 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	Compatibility hacks for older maps that won't be updated
+//
+//-----------------------------------------------------------------------------
+
+#include "odamex.h"
+
+#include "g_level.h"
+
+#include "p_compdb.h"
+
+template <>
+struct std::hash<fhfprint_t>
+{
+	constexpr size_t operator()(const fhfprint_t& f) const noexcept
+	{
+		const size_t halfhash = (size_t)(f.fingerprint[0]) |
+		                        (size_t)(f.fingerprint[1]) << 8 |
+		                        (size_t)(f.fingerprint[2]) << 16 |
+		                        (size_t)(f.fingerprint[3]) << 24 |
+		                        (size_t)(f.fingerprint[4]) << 32 |
+		                        (size_t)(f.fingerprint[5]) << 40 |
+		                        (size_t)(f.fingerprint[6]) << 48 |
+		                        (size_t)(f.fingerprint[7]) << 56;
+		return halfhash;
+	}
+};
+
+static const std::unordered_map<fhfprint_t, levelcompdata_t> compdata = {
+	{
+		// Congestion 1024 MAP23
+		fhfprint_t::fromString("b0b0b3a99c2ed6780a5a79b325dcc5ca"),
+		{
+			// TODO C++20: use designated initializers for readability here
+			true // reservedLineFlag
+		}
+	},
+	{
+		// UDMX MAP32
+		fhfprint_t::fromString("c13f47bbcca3fc2d5013c17a604af645"),
+		{
+			true // reservedLineFlag
+		}
+	},
+};
+
+const levelcompdata_t& P_GetLevelCompData(fhfprint_t fingerprint)
+{
+	const auto it = compdata.find(fingerprint);
+	if (it != compdata.end())
+		return it->second;
+
+	static constexpr levelcompdata_t defaultData{};
+	return defaultData;
+}
+
+VERSION_CONTROL (p_compdb_cpp, "$Id$")

--- a/common/p_compdb.h
+++ b/common/p_compdb.h
@@ -1,0 +1,33 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 1998-2006 by Randy Heit (ZDoom).
+// Copyright (C) 2006-2026 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	Compatibility hacks for older maps that won't be updated
+//
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#include "g_level.h"
+
+struct levelcompdata_t
+{
+    bool reservedLineFlag = false;
+};
+
+const levelcompdata_t& P_GetLevelCompData(fhfprint_t fingerprint);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -54,6 +54,7 @@
 #include "p_mapformat.h"
 #include "g_musinfo.h"
 #include "r_sky.h"
+#include "p_compdb.h"
 
 void SV_PreservePlayer(player_t &player);
 void P_SpawnMapThing (mapthing2_t *mthing, int position);
@@ -1168,25 +1169,16 @@ void P_FinishLoadingLineDefs (void)
 
 void P_LoadLineDefs (const int lump)
 {
-	byte *data;
-	int i;
-	line_t *ld;
-
 	numlines = W_LumpLength (lump) / sizeof(maplinedef_t);
 	lines = (line_t *)Z_Malloc (numlines*sizeof(line_t), PU_LEVEL, 0);
 	memset (lines, 0, numlines*sizeof(line_t));
-	data = (byte *)W_CacheLumpNum (lump, PU_STATIC);
+	byte* data = (byte *)W_CacheLumpNum (lump, PU_STATIC);
+	auto guard = nonstd::make_scope_exit([&]{ Z_Free(data); });
 
-	// [Blair] Don't mind me, just hackin'
-	// E2M7 has flags masked in that interfere with MBF21 flags.
-	// Boom fixes this with the comp flag comp_reservedlineflag
-	// We'll fix this for now by just checking for the E2M7 FarmHash
-	static constexpr std::string_view e2m7hash = "43ffa244f5ae923b7df59dbf511c0468";
+	const bool reservedLine = P_GetLevelCompData(::level.level_fingerprint).reservedLineFlag;
 
-	bool isE2M7 = (::level.level_fingerprint == e2m7hash);
-
-	ld = lines;
-	for (i=0 ; i<numlines ; i++, ld++)
+	line_t* ld = lines;
+	for (int i = 0; i < numlines; i++, ld++)
 	{
 		const maplinedef_t *mld = ((maplinedef_t *)data) + i;
 
@@ -1199,7 +1191,7 @@ void P_LoadLineDefs (const int lump)
 		ld->args[3] = 0;
 		ld->args[4] = 0;
 
-		ld->flags = P_TranslateCompatibleLineFlags(ld->flags, isE2M7);
+		ld->flags = P_TranslateCompatibleLineFlags(ld->flags, reservedLine);
 
 		unsigned short v = LESHORT(mld->v1);
 
@@ -1225,8 +1217,6 @@ void P_LoadLineDefs (const int lump)
 
 		P_AdjustLine (ld);
 	}
-
-	Z_Free (data);
 }
 
 // [RH] Same as P_LoadLineDefs() except it uses Hexen-style LineDefs.

--- a/common/w_ident.cpp
+++ b/common/w_ident.cpp
@@ -1413,9 +1413,8 @@ static FileIdentificationManager identtab;
 //
 void W_SetupFileIdentifiers()
 {
-	for (size_t i = 0; i < ARRAY_LENGTH(::identdata); i++)
+	for (const auto& data : ::identdata)
 	{
-		const identData_t& data = ::identdata[i];
 		::identtab.addFile(data.idName, data.filename, data.crc32Sum, data.md5Sum,
 		                   data.groupName, data.flags & IDENT_COMMERCIAL,
 		                   data.flags & IDENT_IWAD, data.flags & IDENT_DEPRECATED,


### PR DESCRIPTION
There are a few related changes here:

1. A minor memory leak in P_LoadLineDefs that occurred when loading linedefs with invalid vertices has been fixed.
2. MBF21 linedef flags in Doom format maps are now always cleared if `ML_RESERVED` is set. This matches the behavior of DSDA or Woof when `comp_reservedlineflag` is enabled. The actual comp option is only needed for playing back a small subset of early MBF21 demos, which we can't play back anyway.
3. E2M7 is now handled by 2, but `p_compdb.cpp` has been introduced, with a table of level hashes and corresponding compatibility options. Currently it only handles the block players flags in Congestion 1024 map23 and UDMX map32, but it's designed to easily add more as issues are discovered.