### PR TITLE
[BUGFIX] Avatars spawning at wrong z in sectors with negative floor height

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3302,7 +3302,7 @@ void P_SpawnAvatars()
 
 	for (const auto& thing : ::voodoostarts)
 	{
-		new AActor(thing.x << FRACBITS, thing.y << FRACBITS, thing.z << FRACBITS, MT_AVATAR);
+		new AActor(thing.x << FRACBITS, thing.y << FRACBITS, ONFLOORZ, MT_AVATAR);
 	}
 }
 


### PR DESCRIPTION
Addresses #1584

Turns out the avatars were being spawned at height 0, but still getting forward momentum, so they fall over the walls. Players are always spawned with a z of ONFLOORZ, the mapthing height is ignored, so avatars now do the same.