### PR TITLE
[BUGFIX] Lastmap with `->` doesn't work properly when exiting to secret maps

### DIFF
--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -177,10 +177,11 @@ EXTERN_CVAR(sv_shufflemaplist)
 
 bool isLastMap()
 {
+	const auto& next = secretexit ? level.secretmap : level.nextmap;
 	return std::any_of(
 			forcedlastmaps.entries.begin(), forcedlastmaps.entries.end(),
 			[&](const auto& entry) {
-				return entry.first == level.mapname && (entry.second.empty() || entry.second == level.nextmap);
+				return entry.first == level.mapname && (entry.second.empty() || entry.second == next);
 		});
 }
 


### PR DESCRIPTION
A maplist entry such as `addmap map15 doom2.wad lastmap=map15->map16,map31->map16,map32` did not work correctly, because upon exiting from map15 to map31, the nextmap of map15 would be checked instead of the secretmap, and the maplist would move onto the next entry too early.