### PR TITLE
[BUGFIX] Musinfo things not spawning in multiplayer

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2797,13 +2797,17 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 	if (sv_allowshowspawns)
 		P_ShowSpawns(mthing);
 
+	const bool isTeleportDest = mthing->type == 14;
+	const bool isSecAct = (mthing->type >= 9982 && mthing->type <= 9983) ||
+	                      (mthing->type >= 9992 && mthing->type <= 9999);
+	const bool isSoundSource = (mthing->type >= 14001 && mthing->type <= 14065);
+	const bool isMusicChanger = (mthing->type >= 14100 && mthing->type <= 14165);
+
 	// only servers control spawning of items
 	// EXCEPT the client must spawn Type 14 (teleport exit).
 	// otherwise teleporters won't work well.
 	// Also spawn sector special things, fixes some other teleport issues.
-	if (!serverside && (mthing->type != 14)
-	                && !(mthing->type >= 9992 && mthing->type <= 9999)
-	                && !(mthing->type >= 9982 && mthing->type <= 9983))
+	if (!serverside && !(isTeleportDest || isSecAct || isSoundSource || isMusicChanger))
 	{
 		return;
 	}
@@ -2811,9 +2815,7 @@ void P_SpawnMapThing (mapthing2_t *mthing, int position)
 	//
 	// Clients also exclusively handle spawning of ambient sounds and music changers
 	//
-	if (!clientside &&
-	    ((mthing->type >= 14001 && mthing->type <= 14065) ||
-	     (mthing->type >= 14100 && mthing->type <= 14165)))
+	if (!clientside && (isSoundSource || isMusicChanger))
 	{
 		return;
 	}


### PR DESCRIPTION
Seems this got messed up when trying to clean up the hard to read nested ifs after sector action things got added to the checks.