### PR TITLE
Pad reject table with 0s instead of ignoring it when too small

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -2126,7 +2126,7 @@ void P_SetupLevel (const char *lumpname, int position)
 			rejectpad[0] = ((totallines * 4 + 3) & ~3) + 24;
 			byte* dest = rejectmatrix + rejectsize;
 
-			for (int i = 0; i < (minrejectsize - rejectsize); i++)
+			for (int i = 0; i < (minrejectsize - rejectsize) && i < sizeof(rejectpad); i++)
 			{
 				uint32_t byte_num = i % 4;
 				*dest = (rejectpad[i / 4] >> (byte_num * 8)) & 0xff;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -2110,7 +2110,7 @@ void P_SetupLevel (const char *lumpname, int position)
 	if (rejectsize < minrejectsize)
 	{
 		DPrintFmt("Reject matrix is not valid and will be ignored.\n");
-		rejectempty = true;
+		// rejectempty = true;
 		rejectmatrix = static_cast<byte*>(Z_Malloc(minrejectsize, PU_LEVEL, nullptr));
 		W_ReadLump(lumpnum + ML_REJECT, rejectmatrix);
 		memset(rejectmatrix + rejectsize, 0, minrejectsize - rejectsize);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1970,14 +1970,14 @@ void P_SetupSlopes()
 void P_LoadReject(int lumpnum, int totallines)
 {
 	// [SL] 2011-07-01 - Check to see if the reject table is of the proper size
-	// If it's missing, the reject table should be ignored when
+	// If it's empty, the reject table should be ignored when
 	// calling P_CheckSight
 	// [EB] and if exists, but is too small, pad it with 0s until its the right size
 	const auto lumpsize = W_LumpLength(lumpnum);
 	const uint32_t correctsize = (numsectors * numsectors + 7) / 8;
 	// TODO: if we end up using reject to optimize netcodea and it makes a significant difference,
-	// build reject lumps when its completely missing
-	if (lumpsize == 0)
+	// build reject lumps when its completely empty
+	if (!demoplayback && lumpsize == 0)
 	{
 		DPrintFmt("Reject matrix is empty and will be ignored.\n");
 		rejectempty = true;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1641,7 +1641,7 @@ void P_GenerateUniqueMapFingerPrint(int maplumpnum)
 // Builds sector line lists and subsector sector numbers.
 // Finds block bounding boxes for sectors.
 //
-void P_GroupLines (void)
+int P_GroupLines()
 {
 	// look up sector number for each subsector
 	for (int i = 0; i < numsubsectors; i++)
@@ -1717,7 +1717,7 @@ void P_GroupLines (void)
 		block = block < 0 ? 0 : block;
 		sector->blockbox[BOXLEFT]=block;
 	}
-
+	return total;
 }
 
 //
@@ -2100,18 +2100,44 @@ void P_SetupLevel (const char *lumpname, int position)
 			P_LoadSegs<mapseg_t>(lumpnum+ML_SEGS);
 	}
 
-	rejectmatrix = (byte *)W_CacheLumpNum (lumpnum+ML_REJECT, PU_LEVEL);
+	const auto totallines = P_GroupLines();
+
+	// [SL] 2011-07-01 - Check to see if the reject table is of the proper size
+	// If it's too short, the reject table should be ignored when
+	// calling P_CheckSight
+	const auto rejectsize = W_LumpLength(lumpnum + ML_REJECT);
+	const uint32_t minrejectsize = (numsectors * numsectors + 7) / 8;
+	if (rejectsize < minrejectsize)
 	{
-		// [SL] 2011-07-01 - Check to see if the reject table is of the proper size
-		// If it's too short, the reject table should be ignored when
-		// calling P_CheckSight
-		if (W_LumpLength(lumpnum + ML_REJECT) < ((unsigned int)ceil((float)(numsectors * numsectors / 8))))
-		{
-			DPrintFmt("Reject matrix is not valid and will be ignored.\n");
-			rejectempty = true;
+		DPrintFmt("Reject matrix is not valid and will be ignored.\n");
+		rejectempty = true;
+		rejectmatrix = static_cast<byte*>(Z_Malloc(minrejectsize, PU_LEVEL, nullptr));
+		W_ReadLump(lumpnum + ML_REJECT, rejectmatrix);
+		memset(rejectmatrix + rejectsize, 0, minrejectsize - rejectsize);
+		if (demoplayback) {
+			uint32_t rejectpad[4] =
+			{
+				0,       // Size
+				0,       // Part of z_zone block header
+				50,      // PU_LEVEL
+				0x1d4a11 // DOOM_CONST_ZONEID
+			};
+
+			rejectpad[0] = ((totallines * 4 + 3) & ~3) + 24;
+			byte* dest = rejectmatrix + rejectsize;
+
+			for (int i = 0; i < (minrejectsize - rejectsize); i++)
+			{
+				uint32_t byte_num = i % 4;
+				*dest = (rejectpad[i / 4] >> (byte_num * 8)) & 0xff;
+				dest++;
+			}
 		}
 	}
-	P_GroupLines ();
+	else
+	{
+		rejectmatrix = static_cast<byte*>(W_CacheLumpNum(lumpnum + ML_REJECT, PU_LEVEL));
+	}
 
 	// [SL] don't move seg vertices if compatibility is cruical
 	if (!demoplayback)

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1647,30 +1647,29 @@ int P_GroupLines()
 	for (int i = 0; i < numsubsectors; i++)
 	{
 		if (subsectors[i].firstline >= (unsigned int)numsegs)
-			I_Error("subsector[{}].firstline exceeds numsegs (%u)", i, numsegs);
+			I_Error("subsector[{}].firstline exceeds numsegs ({})", i, numsegs);
 		subsectors[i].sector = segs[subsectors[i].firstline].sidedef->sector;
 	}
 
 	// count number of lines in each sector
-	line_t* li = lines;
 	int total = 0;
-	for (int i = 0; i < numlines; i++, li++)
+	for (auto& line : R_GetLines())
 	{
 		total++;
-		if (!li->frontsector && li->backsector)
+		if (!line.frontsector && line.backsector)
 		{
 			// swap front and backsectors if a one-sided linedef
 			// does not have a front sector
-			li->frontsector = li->backsector;
-			li->backsector = NULL;
+			line.frontsector = line.backsector;
+			line.backsector = nullptr;
 		}
 
-        if (li->frontsector)
-            li->frontsector->linecount++;
+        if (line.frontsector)
+            line.frontsector->linecount++;
 
-		if (li->backsector && li->backsector != li->frontsector)
+		if (line.backsector && line.backsector != line.frontsector)
 		{
-			li->backsector->linecount++;
+			line.backsector->linecount++;
 			total++;
 		}
 	}
@@ -1683,14 +1682,13 @@ int P_GroupLines()
 	{
 		bbox.ClearBox ();
 		sector->lines = linebuffer;
-		li = lines;
-		for (int j = 0 ; j < numlines ; j++, li++)
+		for (auto& line : R_GetLines())
 		{
-			if (li->frontsector == sector || li->backsector == sector)
+			if (line.frontsector == sector || line.backsector == sector)
 			{
-				*linebuffer++ = li;
-				bbox.AddToBox (li->v1->x, li->v1->y);
-				bbox.AddToBox (li->v2->x, li->v2->y);
+				*linebuffer++ = &line;
+				bbox.AddToBox (line.v1->x, line.v1->y);
+				bbox.AddToBox (line.v2->x, line.v2->y);
 			}
 		}
 		if (linebuffer - sector->lines != sector->linecount)

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1967,6 +1967,56 @@ void P_SetupSlopes()
 	}
 }
 
+void P_LoadReject(int lumpnum, int totallines)
+{
+	// [SL] 2011-07-01 - Check to see if the reject table is of the proper size
+	// If it's missing, the reject table should be ignored when
+	// calling P_CheckSight
+	// [EB] and if exists, but is too small, pad it with 0s until its the right size
+	const auto lumpsize = W_LumpLength(lumpnum);
+	const uint32_t correctsize = (numsectors * numsectors + 7) / 8;
+	// TODO: if we end up using reject to optimize netcodea and it makes a significant difference,
+	// build reject lumps when its completely missing
+	if (lumpsize == 0)
+	{
+		DPrintFmt("Reject matrix is empty and will be ignored.\n");
+		rejectempty = true;
+	}
+	else if (lumpsize < correctsize)
+	{
+		DPrintFmt("Reject matrix is not valid. It will be padded to the correct size.\n");
+		rejectmatrix = static_cast<byte*>(Z_Malloc(correctsize, PU_LEVEL, nullptr));
+		W_ReadLump(lumpnum, rejectmatrix);
+		memset(rejectmatrix + lumpsize, 0, correctsize - lumpsize);
+		// vanilla doom just reads pass the edge of the reject table if its too small
+		// so we replace the start of the padding with what would likely have been in memory
+		// when playing on MS-DOS
+		if (demoplayback) {
+			uint32_t rejectpad[4] =
+			{
+				((totallines * 4 + 3) & ~3) + 24, // Size
+				0,                                // Part of z_zone block header
+				50,                               // PU_LEVEL
+				0x1d4a11                          // DOOM_CONST_ZONEID
+			};
+
+			rejectpad[0] = ((totallines * 4 + 3) & ~3) + 24;
+			byte* dest = rejectmatrix + lumpsize;
+
+			for (uint32_t i = 0; i < (correctsize - lumpsize) && i < sizeof(rejectpad); i++)
+			{
+				uint32_t byte_num = i % 4;
+				*dest = (rejectpad[i / 4] >> (byte_num * 8)) & 0xff;
+				dest++;
+			}
+		}
+	}
+	else
+	{
+		rejectmatrix = static_cast<byte*>(W_CacheLumpNum(lumpnum, PU_LEVEL));
+	}
+}
+
 } // namespace
 
 //
@@ -2098,44 +2148,7 @@ void P_SetupLevel (const char *lumpname, int position)
 			P_LoadSegs<mapseg_t>(lumpnum+ML_SEGS);
 	}
 
-	const auto totallines = P_GroupLines();
-
-	// [SL] 2011-07-01 - Check to see if the reject table is of the proper size
-	// If it's too short, the reject table should be ignored when
-	// calling P_CheckSight
-	const auto rejectsize = W_LumpLength(lumpnum + ML_REJECT);
-	const uint32_t minrejectsize = (numsectors * numsectors + 7) / 8;
-	if (rejectsize < minrejectsize)
-	{
-		DPrintFmt("Reject matrix is not valid and will be ignored.\n");
-		// rejectempty = true;
-		rejectmatrix = static_cast<byte*>(Z_Malloc(minrejectsize, PU_LEVEL, nullptr));
-		W_ReadLump(lumpnum + ML_REJECT, rejectmatrix);
-		memset(rejectmatrix + rejectsize, 0, minrejectsize - rejectsize);
-		if (demoplayback) {
-			uint32_t rejectpad[4] =
-			{
-				0,       // Size
-				0,       // Part of z_zone block header
-				50,      // PU_LEVEL
-				0x1d4a11 // DOOM_CONST_ZONEID
-			};
-
-			rejectpad[0] = ((totallines * 4 + 3) & ~3) + 24;
-			byte* dest = rejectmatrix + rejectsize;
-
-			for (int i = 0; i < (minrejectsize - rejectsize) && i < sizeof(rejectpad); i++)
-			{
-				uint32_t byte_num = i % 4;
-				*dest = (rejectpad[i / 4] >> (byte_num * 8)) & 0xff;
-				dest++;
-			}
-		}
-	}
-	else
-	{
-		rejectmatrix = static_cast<byte*>(W_CacheLumpNum(lumpnum + ML_REJECT, PU_LEVEL));
-	}
+	P_LoadReject(lumpnum + ML_REJECT, P_GroupLines());
 
 	// [SL] don't move seg vertices if compatibility is cruical
 	if (!demoplayback)

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1994,10 +1994,10 @@ void P_LoadReject(int lumpnum, int totallines)
 		if (demoplayback) {
 			uint32_t rejectpad[4] =
 			{
-				((totallines * 4 + 3) & ~3) + 24, // Size
-				0,                                // Part of z_zone block header
-				50,                               // PU_LEVEL
-				0x1d4a11                          // DOOM_CONST_ZONEID
+				0,       // Size
+				0,       // Part of z_zone block header
+				50,      // PU_LEVEL
+				0x1d4a11 // DOOM_CONST_ZONEID
 			};
 
 			rejectpad[0] = ((totallines * 4 + 3) & ~3) + 24;


### PR DESCRIPTION
Addresses #1605

When playing back demos, the start of the padding is also replaced with a few bytes mirroring what would likely have been in that position in memory on MS-DOS. This should fix playback of *some* vanilla demos recorded on maps with empty or too small reject tables.
