### PR TITLE
Fix jitter when playing a demo and changing cl_movebob

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2958,10 +2958,13 @@ static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)
 	player_t* clientPlayer = &consoleplayer();
 	fixed_t x, y, z;
 	fixed_t momx, momy, momz;
-	fixed_t pitch, viewheight, deltaviewheight; // ,viewz
+	fixed_t pitch, viewheight, deltaviewheight;
 	angle_t angle;
 	int jumpTics, reactiontime;
 	byte waterlevel;
+
+	// Note clientPlayer->viewz should not be set with the value from the demo here
+	// it is an aggregate value and will be set correctly later
 
 	clientPlayer->cmd.clear();
 	clientPlayer->cmd.unserialize(msg->player_cmd());
@@ -2975,7 +2978,6 @@ static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)
 	momz = msg->actor().mom().z();
 	angle = msg->actor().angle();
 	pitch = msg->actor().pitch();
-	//viewz = msg->player().viewz();
 	viewheight = msg->player().viewheight();
 	deltaviewheight = msg->player().deltaviewheight();
 	jumpTics = msg->player().jumptics();
@@ -2994,10 +2996,6 @@ static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)
 		clientPlayer->mo->momz = momz;
 		clientPlayer->mo->angle = angle;
 		clientPlayer->mo->pitch = pitch;
-    
-		//fix jitter when demo's cl_movebob is dif than user's, viewz will set in P_CalcHeight()
-		//clientPlayer->viewz = viewz;
-
 		clientPlayer->viewheight = viewheight;
 		clientPlayer->deltaviewheight = deltaviewheight;
 		clientPlayer->jumpTics = jumpTics;

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2995,7 +2995,7 @@ static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)
 		clientPlayer->mo->angle = angle;
 		clientPlayer->mo->pitch = pitch;
     
-    //fix jitter when demo's cl_movebob is dif than user's, viewz will set in P_CalcHeight()
+		//fix jitter when demo's cl_movebob is dif than user's, viewz will set in P_CalcHeight()
 		//clientPlayer->viewz = viewz;
 
 		clientPlayer->viewheight = viewheight;

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2958,7 +2958,7 @@ static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)
 	player_t* clientPlayer = &consoleplayer();
 	fixed_t x, y, z;
 	fixed_t momx, momy, momz;
-	fixed_t pitch, viewz, viewheight, deltaviewheight;
+	fixed_t pitch, viewheight, deltaviewheight; // ,viewz
 	angle_t angle;
 	int jumpTics, reactiontime;
 	byte waterlevel;
@@ -2975,7 +2975,7 @@ static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)
 	momz = msg->actor().mom().z();
 	angle = msg->actor().angle();
 	pitch = msg->actor().pitch();
-	viewz = msg->player().viewz();
+	//viewz = msg->player().viewz();
 	viewheight = msg->player().viewheight();
 	deltaviewheight = msg->player().deltaviewheight();
 	jumpTics = msg->player().jumptics();
@@ -2994,7 +2994,10 @@ static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)
 		clientPlayer->mo->momz = momz;
 		clientPlayer->mo->angle = angle;
 		clientPlayer->mo->pitch = pitch;
-		clientPlayer->viewz = viewz;
+    
+    //fix jitter when demo's cl_movebob is dif than user's, viewz will set in P_CalcHeight()
+		//clientPlayer->viewz = viewz;
+
 		clientPlayer->viewheight = viewheight;
 		clientPlayer->deltaviewheight = deltaviewheight;
 		clientPlayer->jumpTics = jumpTics;


### PR DESCRIPTION
Long story short but setting viewz here is not necessary. At this point viewz has the bob value from the demo built into it. Prevviewz is set with this viewz but then viewz is overwritten in P_CalcHeight (using user's bob value). Now when there was a large discrepency between prevviewz (demo) and viewz (user) the jitter would happen in interpolateCamera(). That large discrepency would happen when user's bob setting is different than the demo's. 

Solution is removing the intial set of viewz by the demo so that prevviewz will bet set with the viewz made in P_CalcHeight.  Also pretty sure its not necessary to write viewz at all to demos, didnt want to do that without permission though.

Fixes #527 