### PR TITLE
Make sure to print helpful messages to the console involving the starting and stopping of timer recordings

### DIFF
--- a/common/StopwatchManager.cpp
+++ b/common/StopwatchManager.cpp
@@ -116,6 +116,7 @@ bool StopwatchManager::StartRecording(const std::string& i_filepath)
 
 	if (m_outFile->good())
 	{
+		m_outFilename = i_filepath;
 		const std::string headingLine = std::accumulate(m_activeRecordingWatches.begin(),
 		                                                m_activeRecordingWatches.end(),
 		                                                std::string("gametic"),
@@ -147,8 +148,14 @@ void StopwatchManager::RecordSamples(int i_gametic)
 	}
 }
 
-void StopwatchManager::StopRecording()
+bool StopwatchManager::StopRecording()
 {
-	m_outFile.reset();
-	m_activeRecordingWatches.clear();
+	if (m_outFile)
+	{
+		m_outFile.reset();
+		m_outFilename.clear();
+		m_activeRecordingWatches.clear();
+		return true;
+	}
+	return false;
 }

--- a/common/StopwatchManager.h
+++ b/common/StopwatchManager.h
@@ -66,12 +66,16 @@ class StopwatchManager
 		/// enabled, recorded stopwatches.
 		void RecordSamples(int i_tic);
 
-		/// Close the recording file.
-		void StopRecording();
+		/// Close the recording file.  Returns true if there was a recording
+		/// in progress that is now stopped, false otherwise.
+		bool StopRecording();
+
+		const std::string& GetFilename() { return m_outFilename; }
 
 	protected:
 
 		WatchMap                                m_watches;
 		std::unique_ptr<std::ofstream>          m_outFile;
+		std::string                             m_outFilename;
 		std::vector<std::shared_ptr<Stopwatch>> m_activeRecordingWatches;
 };

--- a/common/m_instrumentation.cpp
+++ b/common/m_instrumentation.cpp
@@ -47,15 +47,28 @@ BEGIN_COMMAND(instrecord)
 
     const std::string filepath = path + argv[1];
 
-    TimingInstr::Get().StartRecording(path + argv[1]);
-
-    PrintFmt(PRINT_HIGH, "Recording stopwatches to {}\n", filepath);
+    if (TimingInstr::Get().StartRecording(path + argv[1]))
+    {
+        PrintFmt(PRINT_HIGH, "Recording stopwatches to {}\n", filepath);
+    }
+    else
+    {
+        PrintFmt(PRINT_WARNING, "Cannot open file for recording: {}\n", filepath);
+    }
 }
 END_COMMAND(instrecord)
 
 BEGIN_COMMAND(inststop)
 {
-    TimingInstr::Get().StopRecording();
+    const std::string filepath = TimingInstr::Get().GetFilename();
+    if (TimingInstr::Get().StopRecording())
+    {
+        PrintFmt(PRINT_HIGH, "Stopped recording to {}\n", filepath);
+    }
+    else
+    {
+        PrintFmt(PRINT_HIGH, "No recording to stop.\n");
+    }
 }
 END_COMMAND(inststop)
 
@@ -96,8 +109,12 @@ void TimingInstr::ManageRecording(int i_tic)
     m_manager.RecordSamples(i_tic);
 }
 
-void TimingInstr::StopRecording()
+bool TimingInstr::StopRecording()
 {
-    m_manager.StopRecording();
+    return m_manager.StopRecording();
 }
 
+const std::string& TimingInstr::GetFilename()
+{
+    return m_manager.GetFilename();
+}

--- a/common/m_instrumentation.h
+++ b/common/m_instrumentation.h
@@ -20,7 +20,9 @@ class TimingInstr
 
         bool StartRecording(const std::string& i_filename);
         void ManageRecording(int i_tic);
-        void StopRecording();
+        bool StopRecording();
+
+        const std::string& GetFilename();
 
     protected:
         TimingInstr() = default;


### PR DESCRIPTION
The silent `inststop` command was kind of unsettling.  It gave no indication of success or failure, but as of this PR, it reports its status back to the console.  Similarly, the `instrecord` command now tells the user if it failed to open the recording file.