### PR TITLE
[BUGFIX] Textures and flats affected by multiple scrollers are interpolated multiple times per frame

### DIFF
--- a/client/src/r_interp.cpp
+++ b/client/src/r_interp.cpp
@@ -38,6 +38,8 @@
 #include "p_local.h"
 #include "r_interp.h"
 
+#include <unordered_set>
+
 EXTERN_CVAR(sv_allowmovebob)
 EXTERN_CVAR(cl_movebob)
 
@@ -156,6 +158,9 @@ void OInterpolation::ticGameInterpolation()
 	prev_linescrollingtex.clear();
 	prev_sectorceilingscrollingflat.clear();
 	prev_sectorfloorscrollingflat.clear();
+	seen_wallnums.clear();
+	seen_ceilingsectornums.clear();
+	seen_floorsectornums.clear();
 	prev_sky2offset = 0;
 	prev_camerax = 0;
 	prev_cameray = 0;
@@ -187,8 +192,9 @@ void OInterpolation::ticGameInterpolation()
 			{
 				int wallnum = scroller->GetWallNum();
 
-				if (wallnum >= 0) // huh?!?
+				if (wallnum >= 0 && !seen_wallnums.count(wallnum)) // huh?!?
 				{
+					seen_wallnums.insert(wallnum);
 					prev_linescrollingtex.emplace_back(
 						std::make_pair(
 							sides[wallnum].textureoffset,
@@ -198,6 +204,9 @@ void OInterpolation::ticGameInterpolation()
 			}
 			else if (P_CeilingScrollType(type))
 			{
+				if (seen_ceilingsectornums.count(affectee))
+					continue;
+
 				prev_sectorceilingscrollingflat.emplace_back(
 						std::make_pair(
 							sectors[affectee].ceiling_xoffs,
@@ -206,6 +215,9 @@ void OInterpolation::ticGameInterpolation()
 			}
 			else if (P_FloorScrollType(type))
 			{
+				if (seen_floorsectornums.count(affectee))
+					continue;
+
 				prev_sectorfloorscrollingflat.emplace_back(
 						std::make_pair(
 							sectors[affectee].floor_xoffs,

--- a/client/src/r_interp.cpp
+++ b/client/src/r_interp.cpp
@@ -207,6 +207,7 @@ void OInterpolation::ticGameInterpolation()
 				if (seen_ceilingsectornums.count(affectee))
 					continue;
 
+				seen_ceilingsectornums.insert(affectee);
 				prev_sectorceilingscrollingflat.emplace_back(
 						std::make_pair(
 							sectors[affectee].ceiling_xoffs,
@@ -218,6 +219,7 @@ void OInterpolation::ticGameInterpolation()
 				if (seen_floorsectornums.count(affectee))
 					continue;
 
+				seen_floorsectornums.insert(affectee);
 				prev_sectorfloorscrollingflat.emplace_back(
 						std::make_pair(
 							sectors[affectee].floor_xoffs,

--- a/client/src/r_interp.cpp
+++ b/client/src/r_interp.cpp
@@ -158,9 +158,6 @@ void OInterpolation::ticGameInterpolation()
 	prev_linescrollingtex.clear();
 	prev_sectorceilingscrollingflat.clear();
 	prev_sectorfloorscrollingflat.clear();
-	seen_wallnums.clear();
-	seen_ceilingsectornums.clear();
-	seen_floorsectornums.clear();
 	prev_sky2offset = 0;
 	prev_camerax = 0;
 	prev_cameray = 0;
@@ -192,39 +189,33 @@ void OInterpolation::ticGameInterpolation()
 			{
 				int wallnum = scroller->GetWallNum();
 
-				if (wallnum >= 0 && !seen_wallnums.count(wallnum)) // huh?!?
+				if (wallnum >= 0) // huh?!?
 				{
-					seen_wallnums.insert(wallnum);
-					prev_linescrollingtex.emplace_back(
+					prev_linescrollingtex.emplace(
+						wallnum,
 						std::make_pair(
 							sides[wallnum].textureoffset,
-							sides[wallnum].rowoffset),
-								wallnum);
+							sides[wallnum].rowoffset)
+					);
 				}
 			}
 			else if (P_CeilingScrollType(type))
 			{
-				if (seen_ceilingsectornums.count(affectee))
-					continue;
-
-				seen_ceilingsectornums.insert(affectee);
-				prev_sectorceilingscrollingflat.emplace_back(
-						std::make_pair(
-							sectors[affectee].ceiling_xoffs,
-							sectors[affectee].ceiling_yoffs),
-								affectee);
+				prev_sectorceilingscrollingflat.emplace(
+					affectee,
+					std::make_pair(
+						sectors[affectee].ceiling_xoffs,
+						sectors[affectee].ceiling_yoffs)
+				);
 			}
 			else if (P_FloorScrollType(type))
 			{
-				if (seen_floorsectornums.count(affectee))
-					continue;
-
-				seen_floorsectornums.insert(affectee);
-				prev_sectorfloorscrollingflat.emplace_back(
-						std::make_pair(
-							sectors[affectee].floor_xoffs,
-							sectors[affectee].floor_yoffs),
-								affectee);
+				prev_sectorfloorscrollingflat.emplace(
+					affectee,
+					std::make_pair(
+						sectors[affectee].floor_xoffs,
+						sectors[affectee].floor_yoffs)
+				);
 			}
 		}
 
@@ -258,7 +249,7 @@ void OInterpolation::interpolateCeilings(fixed_t amount)
 		P_SetCeilingHeight(sector, new_value);
 	}
 
-	for (const auto& [offs, secnum] : prev_sectorceilingscrollingflat)
+	for (const auto& [secnum, offs] : prev_sectorceilingscrollingflat)
 	{
 		const sector_t* sector = &sectors[secnum];
 
@@ -291,7 +282,7 @@ void OInterpolation::interpolateFloors(fixed_t amount)
 		P_SetFloorHeight(sector, new_value);
 	}
 
-	for (const auto& [offs, secnum] : prev_sectorfloorscrollingflat)
+	for (const auto& [secnum, offs] : prev_sectorfloorscrollingflat)
 	{
 		const sector_t* sector = &sectors[secnum];
 
@@ -312,7 +303,7 @@ void OInterpolation::interpolateFloors(fixed_t amount)
 
 void OInterpolation::interpolateWalls(fixed_t amount)
 {
-	for (const auto& [offs, sidenum] : prev_linescrollingtex)
+	for (const auto& [sidenum, offs] : prev_linescrollingtex)
 	{
 		const side_t* side = &sides[sidenum];
 

--- a/client/src/r_interp.h
+++ b/client/src/r_interp.h
@@ -30,13 +30,10 @@
 
 #pragma once
 
-#include <unordered_set>
+#include <unordered_map>
 
 #include "m_fixed.h"
 #include "r_defs.h"
-
-typedef std::pair<fixed_t, unsigned int> fixed_uint_pair;
-typedef std::pair<std::pair<fixed_t, fixed_t>, unsigned int> fixed_fixed_uint_pair;
 
 class OInterpolation
 {
@@ -76,6 +73,10 @@ private:
 	// camera interpolation
 	void interpolateCamera(fixed_t amount, bool use_localview, bool chasecam);
 
+	using fixed_uint_pair = std::pair<fixed_t, uint32_t>;
+	using fixed_fixed_uint_pair = std::pair<std::pair<fixed_t, fixed_t>, uint32_t>;
+	using fixed_fixed_pair = std::pair<fixed_t, fixed_t>;
+
 	// private interpolation state variables
 	// Sector heights
 	std::vector<fixed_uint_pair> prev_ceilingheight;
@@ -84,17 +85,14 @@ private:
 	std::vector<fixed_uint_pair> saved_floorheight;
 
 	// Line scrolling
-	std::vector<fixed_fixed_uint_pair> prev_linescrollingtex; // <x offs, yoffs>, linenum
+	std::unordered_map<uint32_t, fixed_fixed_pair> prev_linescrollingtex; // linenum, <x offs, yoffs>
 	std::vector<fixed_fixed_uint_pair> saved_linescrollingtex;
-	std::unordered_set<int> seen_wallnums;
 
 	// Floor/Ceiling scrolling
-	std::vector<fixed_fixed_uint_pair> prev_sectorceilingscrollingflat; // <x offs, yoffs>, sectornum
+	std::unordered_map<uint32_t, fixed_fixed_pair> prev_sectorceilingscrollingflat; // sectornum, <x offs, yoffs>
 	std::vector<fixed_fixed_uint_pair> saved_sectorceilingscrollingflat;
-	std::unordered_set<int> seen_ceilingsectornums;
-	std::vector<fixed_fixed_uint_pair> prev_sectorfloorscrollingflat; // <x offs, yoffs>, sectornum
+	std::unordered_map<uint32_t, fixed_fixed_pair> prev_sectorfloorscrollingflat; // sectornum, <x offs, yoffs>
 	std::vector<fixed_fixed_uint_pair> saved_sectorfloorscrollingflat;
-	std::unordered_set<int> seen_floorsectornums;
 
 	// Skies
 	fixed_t saved_sky2offset;

--- a/client/src/r_interp.h
+++ b/client/src/r_interp.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "m_fixed.h"
 #include "r_defs.h"
 
@@ -84,12 +86,15 @@ private:
 	// Line scrolling
 	std::vector<fixed_fixed_uint_pair> prev_linescrollingtex; // <x offs, yoffs>, linenum
 	std::vector<fixed_fixed_uint_pair> saved_linescrollingtex;
+	std::unordered_set<int> seen_wallnums;
 
 	// Floor/Ceiling scrolling
 	std::vector<fixed_fixed_uint_pair> prev_sectorceilingscrollingflat; // <x offs, yoffs>, sectornum
 	std::vector<fixed_fixed_uint_pair> saved_sectorceilingscrollingflat;
+	std::unordered_set<int> seen_ceilingsectornums;
 	std::vector<fixed_fixed_uint_pair> prev_sectorfloorscrollingflat; // <x offs, yoffs>, sectornum
 	std::vector<fixed_fixed_uint_pair> saved_sectorfloorscrollingflat;
+	std::unordered_set<int> seen_floorsectornums;
 
 	// Skies
 	fixed_t saved_sky2offset;


### PR DESCRIPTION
Addresses #1610

Sometimes multiple scrollers will have the same affectee, and currently, that means each one gets processed separately by OInterpolation. This causes repeated interpolation of the old position and the already-interpolated new position, slowing down the scrolling.