### PR TITLE
Get rid of gross hack in `DoomObjectContainer` iterators

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -232,14 +232,14 @@ void G_InitNew (const char *mapname)
 	{
 		if (wantFast)
 		{
-			for (auto& [_, state] : states)
+			for (auto&& [_, state] : states)
 			{
 				if (state.flags & STATEF_SKILL5FAST &&
 				    (state.tics != 1 || demoplayback))
 					state.tics >>= 1; // don't change 1->0 since it causes cycles
 			}
 
-			for (auto& [_, minfo] : mobjinfo)
+			for (auto&& [_, minfo] : mobjinfo)
 			{
 				if (minfo.altspeed != NO_ALTSPEED)
 				{
@@ -251,13 +251,13 @@ void G_InitNew (const char *mapname)
 		}
 		else
 		{
-			for (auto& [_, state] : states)
+			for (auto&& [_, state] : states)
 			{
 				if (state.flags & STATEF_SKILL5FAST)
 					state.tics <<= 1; // don't change 1->0 since it causes cycles
 			}
 
-			for (auto& [_, minfo] : mobjinfo)
+			for (auto&& [_, minfo] : mobjinfo)
 			{
 				if (minfo.altspeed != NO_ALTSPEED)
 				{

--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -2080,7 +2080,7 @@ static void PatchText(int sizes, DehScanner& scanner)
 	DPrintFmt("Searching for text:\n{}\n", *oldStr);
 
 	// Search through sprite names
-	for (auto& [_, sprname] : sprnames)
+	for (auto&& [_, sprname] : sprnames)
 	{
 		if (sprname == *oldStr)
 		{
@@ -2448,7 +2448,7 @@ static void D_PostProcessDeh(const DehScanner::ParsedState& dp)
 		}
 	}
 
-	for (auto& [_, state] : states)
+	for (auto&& [_, state] : states)
 	{
 		const CodePtr* bexptr_match = &null_bexptr;
 

--- a/common/info.cpp
+++ b/common/info.cpp
@@ -7176,7 +7176,7 @@ mobjinfo_t doom_mobjinfo[::NUMMOBJTYPES] = {
 
 void D_BuildSpawnMap() {
 	spawn_map.clear();
-	for (auto& [_, mobj] : mobjinfo)
+	for (auto&& [_, mobj] : mobjinfo)
 	{
 		if (mobj.doomednum != -1)
 			spawn_map.insert(&mobj, mobj.type == MT_CAREPACK ? mobj.type : mobj.doomednum);

--- a/common/m_doomobjcontainer.h
+++ b/common/m_doomobjcontainer.h
@@ -65,24 +65,33 @@ class DoomObjectContainer
 
 public:
 	template <typename table_iterator>
-	class generic_iterator {
+	class generic_iterator
+	{
 	public:
 		using iterator_category = std::forward_iterator_tag;
-		using value_type        = std::pair<IdxType, ObjType&>;
+		using value_type        = std::pair<IdxType, ObjType>;
 		using difference_type   = std::ptrdiff_t;
-		using pointer           = value_type*;
-		using reference         = value_type&;
+		using reference         = std::pair<const IdxType&, ObjType&>;
+
+		struct arrow_proxy
+		{
+			reference r;
+			reference* operator->() { return &r; }
+		};
+
+		using pointer           = arrow_proxy;
+
 
 		generic_iterator(table_iterator it) : m_it(it) {}
 
-		reference operator*() const {
-			m_value.emplace(m_it->first, *m_it->second);
-			return *m_value;
+		reference operator*() const
+		{
+			return { m_it->first, *m_it->second };
 		}
 
-		pointer operator->() const {
-			m_value.emplace(m_it->first, *m_it->second);
-			return &*m_value;
+		pointer operator->() const
+		{
+			return pointer{ reference{ m_it->first, *m_it->second } };
 		}
 
 		generic_iterator& operator++() { ++m_it; return *this; }
@@ -93,7 +102,6 @@ public:
 
 	private:
 		table_iterator m_it;
-		mutable std::optional<value_type> m_value;
 	};
 
 	using iterator = generic_iterator<typename LookupTable::iterator>;
@@ -101,7 +109,8 @@ public:
 
 	// Construction and Destruction
 	explicit DoomObjectContainer() = default;
-	explicit DoomObjectContainer(size_t count)  : m_lookuptable(count), m_inordertable() {
+	explicit DoomObjectContainer(size_t count)  : m_lookuptable(count), m_inordertable()
+	{
 		m_inordertable.reserve(count);
 	}
 	~DoomObjectContainer() = default;

--- a/common/p_mapformat.cpp
+++ b/common/p_mapformat.cpp
@@ -57,7 +57,7 @@ void P_MigrateActorInfo(void)
 	// Set MF2_PASSMOBJ on dehacked monsters
 	// because we don't expose ZDoom's Bits2 BEX extension (yet...)
 	// which is the normal way MF2_PASSMOBJ gets set.
-	for (auto& [_, m] : mobjinfo)
+	for (auto&& [_, m] : mobjinfo)
 	{
 		if (m.flags & MF_COUNTKILL)
 		{
@@ -88,7 +88,7 @@ void P_MigrateActorInfo(void)
 	{
 		migrated = true;
 
-		for (auto& [_, m] : mobjinfo)
+		for (auto&& [_, m] : mobjinfo)
 		{
 			if (m.flags & MF_COUNTKILL)
 				m.flags2 |= MF2_MCROSS | MF2_PUSHWALL;
@@ -104,7 +104,7 @@ void P_MigrateActorInfo(void)
 	{
 		migrated = false;
 
-		for (auto& [idx, m] : mobjinfo)
+		for (auto&& [idx, m] : mobjinfo)
 		{
 			if (m.flags & MF_COUNTKILL)
 				m.flags2 &= ~(MF2_MCROSS | MF2_PUSHWALL);

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -477,14 +477,14 @@ void G_InitNew(const char *mapname)
 	{
 		if (wantFast)
 		{
-			for (auto& [_, state] : states)
+			for (auto&& [_, state] : states)
 			{
 				if (state.flags & STATEF_SKILL5FAST &&
 				    (state.tics != 1 || demoplayback))
 					state.tics >>= 1; // don't change 1->0 since it causes cycles
 			}
 
-			for (auto& [_, minfo] : mobjinfo)
+			for (auto&& [_, minfo] : mobjinfo)
 			{
 				if (minfo.altspeed != NO_ALTSPEED)
 				{
@@ -496,13 +496,13 @@ void G_InitNew(const char *mapname)
 		}
 		else
 		{
-			for (auto& [_, state] : states)
+			for (auto&& [_, state] : states)
 			{
 				if (state.flags & STATEF_SKILL5FAST)
 					state.tics <<= 1; // don't change 1->0 since it causes cycles
 			}
 
-			for (auto& [_, minfo] : mobjinfo)
+			for (auto&& [_, minfo] : mobjinfo)
 			{
 				if (minfo.altspeed != NO_ALTSPEED)
 				{

--- a/tests/unit-tests/test/t_doomobjcontainer.cpp
+++ b/tests/unit-tests/test/t_doomobjcontainer.cpp
@@ -1,0 +1,147 @@
+#include "gtest/gtest.h"
+#include "odamex.h"
+#include "m_doomobjcontainer.h"
+
+class DoomObjectContainerIterators : public ::testing::Test
+{
+protected:
+	DoomObjectContainer<int> c;
+
+	void SetUp() override
+	{
+		// 3 elements with indices 10, 11, 12, and values 1, 2, 3
+		int arr[] = {1, 2, 3};
+		c.insert(arr, 10);
+	}
+};
+
+TEST_F(DoomObjectContainerIterators, PostFixDerefReturnsEqualObject) {
+	auto it = c.begin();
+	auto v = *it;
+	EXPECT_EQ(v, *it++);
+}
+
+TEST_F(DoomObjectContainerIterators, DerefReturnsDistinctObjects)
+{
+	auto it = c.begin();
+	auto&& first = *it;
+	++it;
+	auto&& second = *it;
+
+	EXPECT_NE(&first, &second);
+}
+
+TEST_F(DoomObjectContainerIterators, StructuredBindingAliasing)
+{
+	auto it = c.begin();
+
+	auto [id1, obj1] = *it;
+	++it;
+	auto [id2, obj2] = *it;
+
+	EXPECT_NE(id1, id2);
+	EXPECT_NE(&id1, &id2);
+	EXPECT_NE(obj1, obj2);
+	EXPECT_NE(&obj1, &obj2);
+}
+
+TEST_F(DoomObjectContainerIterators, StructuredBindingAliasing2)
+{
+	auto it = c.begin();
+
+	auto&& [id1, obj1] = *it;
+	++it;
+	auto&& [id2, obj2] = *it;
+
+	EXPECT_NE(id1, id2);
+	EXPECT_NE(&id1, &id2);
+	EXPECT_NE(obj1, obj2);
+	EXPECT_NE(&obj1, &obj2);
+}
+
+TEST_F(DoomObjectContainerIterators, NestedIterationIsStable)
+{
+	int outer_count = 0;
+	int inner_total = 0;
+
+	for (auto&& outer : c)
+	{
+		++outer_count;
+
+		int inner_count = 0;
+		for (auto&& inner : c)
+			++inner_count;
+
+		EXPECT_EQ(inner_count, 3);
+		inner_total += inner_count;
+	}
+
+	EXPECT_EQ(outer_count, 3);
+	EXPECT_EQ(inner_total, 9);
+
+	for (auto&& [outer_idx, outer_obj] : c)
+	{
+		auto original_idx = outer_idx;
+		auto& original_obj = outer_obj;
+
+		for (auto&& inner : c)
+		{
+			std::ignore = inner.second;
+		}
+
+		EXPECT_EQ(outer_idx, original_idx);
+		EXPECT_EQ(outer_obj, original_obj);
+	}
+}
+
+TEST_F(DoomObjectContainerIterators, ReferenceSurvivesIncrement)
+{
+	auto it = c.begin();
+	auto& first = it->first;
+	auto firstcopy = first;
+
+	EXPECT_EQ(first, firstcopy);
+
+	++it;
+	*it;
+
+	EXPECT_EQ(first, firstcopy);
+}
+
+TEST_F(DoomObjectContainerIterators, IteratorsAreIndependent)
+{
+	auto it1 = c.begin();
+	auto it2 = c.begin();
+	++it2;
+
+	auto&& a = *it1;
+	auto&& b = *it2;
+
+	EXPECT_NE(&a, &b);
+}
+
+TEST_F(DoomObjectContainerIterators, IteratorCopyIndependent)
+{
+	auto it1 = c.begin();
+	auto it2 = it1;
+
+	auto&& a = *it1;
+	++it2;
+	auto&& b = *it2;
+
+	EXPECT_NE(&a, &b);
+}
+
+TEST_F(DoomObjectContainerIterators, RangeForStable)
+{
+	std::vector<int*> seen;
+
+	for (auto&& [id, obj] : c)
+		seen.push_back(&obj);
+
+	std::sort(seen.begin(), seen.end());
+	auto unique_end = std::unique(seen.begin(), seen.end());
+	EXPECT_EQ(unique_end, seen.end());
+}
+
+// TODO: Add a lot more tests. This is a very core part of the engine and we want to be sure it works as perfectly as possible


### PR DESCRIPTION
The iterator type for `DoomObjectContainer` wraps the iterator of the underlying `std::unordered_map`. This is done to hide the pointers used internally from the interface, to keep it more similar to the original static arrays and make sure there is no need for additional null checks. Unfortunately this means the iterator's `value_type`, `reference`, and `pointer` are not the same as those of the `unordered_map`, and so real references and pointers cannot be returned. To get around this originally, because it worked for all current uses and was quick to implement, I used a private mutable member of the iterator that the references and pointers could point to. This breaks many normal assumptions about how iterators work, which could lead to problems in the future as we expand our use of `DoomObjectContainer`. This PR updates it to be a proper proxy iterator to resolve these issues.