### PR TITLE
Fix broken frag/death/kill count calculation on client side...

### DIFF
--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -539,7 +539,7 @@ static void GiveWins(player_t& player, int wins)
 	{
 		if (!it->ingame())
 			continue;
-		MSG_WriteSVC(it->client.messenger.NetBuf(), SVC_PlayerMembers(player, SVC_PM_SCORE));
+		MSG_WriteSVC(it->client.messenger.ReliableBuf(), SVC_PlayerMembers(player, SVC_PM_SCORE));
 	}
 }
 

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -106,7 +106,7 @@ static void PersistPlayerDamage(const player_t& p)
 		if (!player.ingame())
 			continue;
 
-		MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_PlayerMembers(p, SVC_PM_DAMAGE));
+		MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_PlayerMembers(p, SVC_PM_DAMAGE));
 	}
 }
 
@@ -133,7 +133,7 @@ static void PersistPlayerScore(player_t& p, const bool lives, const bool score)
 		if (!player.ingame())
 			continue;
 
-		MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_PlayerMembers(p, flags));
+		MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_PlayerMembers(p, flags));
 	}
 }
 


### PR DESCRIPTION
Force PlayerMembers to be sent always reliably.  There is an assumption about order of operations on the client side that the KillMobj message will be received before PlayerMembers, so sending both reliably is the way to ensure the intended order.