### PR TITLE
Fix protobreak compilation errors

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -122,7 +122,7 @@ void P_SetButtonTexture(line_t* line, short texture);
 /**
  * @brief Unpack a bitfield into an array of booleans.
  */
-static void UnpackBoolArray(nonstd::span<bool> bools, size_t count, uint32_t in)
+static void UnpackBoolArray(std::span<bool> bools, size_t count, uint32_t in)
 {
 	for (size_t i = 0; i < count; i++)
 	{
@@ -1193,7 +1193,7 @@ static void CL_SpawnPlayer(const odaproto::svc::SpawnPlayer* msg)
 
 	SpreeManager::getInstance().erasePoints(p.id);
 	MultiKillManager::getInstance().eraseMultiKills(p.id);
-	
+
 	p.mo = p.camera = mobj->ptr();
 	p.fov = 90.0f;
 	p.playerstate = PST_LIVE;

--- a/common/c_cvars.h
+++ b/common/c_cvars.h
@@ -146,18 +146,20 @@ public:
 	[[nodiscard]] int asInt() const { return static_cast<int>(std::round(m_Value)); }
 	[[nodiscard]] bool asBool() const { return m_Value != 0; }
 
-	[[nodiscard]]
-	auto operator<=>(auto e) const
-	requires std::is_enum_v<decltype(e)> || std::is_integral_v<decltype(e)>
+
+	template <typename E>
+		requires std::is_enum_v<E> || std::is_integral_v<E>
+	[[nodiscard]] auto operator<=>(E e) const
 	{
-		return static_cast<decltype(e)>(asInt()) <=> e;
+		return static_cast<E>(asInt()) <=> e;
 	}
 
-	[[nodiscard]]
-	bool operator==(auto e) const
-	requires std::is_enum_v<decltype(e)> || std::is_integral_v<decltype(e)>
+
+	template <typename E>
+		requires std::is_enum_v<E> || std::is_integral_v<E>
+	[[nodiscard]] bool operator==(auto e) const
 	{
-		return static_cast<decltype(e)>(asInt()) == e;
+		return static_cast<E>(asInt()) == e;
 	}
 
 	inline void Callback (){ if (m_Callback) m_Callback (*this); }

--- a/common/c_cvars.h
+++ b/common/c_cvars.h
@@ -146,6 +146,20 @@ public:
 	[[nodiscard]] int asInt() const { return static_cast<int>(std::round(m_Value)); }
 	[[nodiscard]] bool asBool() const { return m_Value != 0; }
 
+	[[nodiscard]]
+	auto operator<=>(auto e) const
+	requires std::is_enum_v<decltype(e)> || std::is_integral_v<decltype(e)>
+	{
+		return static_cast<decltype(e)>(asInt()) <=> e;
+	}
+
+	[[nodiscard]]
+	bool operator==(auto e) const
+	requires std::is_enum_v<decltype(e)> || std::is_integral_v<decltype(e)>
+	{
+		return static_cast<decltype(e)>(asInt()) == e;
+	}
+
 	inline void Callback (){ if (m_Callback) m_Callback (*this); }
 
 	void SetDefault (const char *value);

--- a/common/doomfunc.h
+++ b/common/doomfunc.h
@@ -166,8 +166,5 @@ inline drop_wrapper<T> drop(T&& iterable, std::size_t count) { return { iterable
 // Helper for use of std::visit with lambdas
 template<class... Ts>
 struct visitor : Ts... { using Ts::operator()...; };
-// TODO: remove deduction guide in C++20
-template<class... Ts>
-visitor(Ts...) -> visitor<Ts...>;
 
 }

--- a/common/doomfunc.h
+++ b/common/doomfunc.h
@@ -166,5 +166,8 @@ inline drop_wrapper<T> drop(T&& iterable, std::size_t count) { return { iterable
 // Helper for use of std::visit with lambdas
 template<class... Ts>
 struct visitor : Ts... { using Ts::operator()...; };
+// This shouldn't be needed in C++20, but for some reason macOS builds fail without it
+template<class... Ts>
+visitor(Ts...) -> visitor<Ts...>;
 
 }

--- a/common/g_level.h
+++ b/common/g_level.h
@@ -32,6 +32,7 @@
 
 #include <assert.h>
 #include <unordered_map>
+#include <array>
 
 #define NUM_MAPVARS				128
 #define NUM_WORLDVARS			256

--- a/common/g_spreedef.cpp
+++ b/common/g_spreedef.cpp
@@ -273,8 +273,7 @@ static void ParseSpreeDef(const int lump, const OLumpName name)
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer = fmt::sprintf("Unknown Token \"%s\".", os.getToken());
-			os.error(buffer);
+			os.error("Unknown Token \"{:s}\".", os.getToken());
 		}
 	}
 

--- a/common/g_spreedef.cpp
+++ b/common/g_spreedef.cpp
@@ -128,8 +128,7 @@ static void ParseSpree(OScanner& os, std::vector<Spree_s>& spreeLevels)
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer = fmt::sprintf("Unknown Spree Token \"%s\".", os.getToken());
-			os.warning(buffer);
+			os.warning("Unknown Spree Token \"{:s}\".", os.getToken());
 		}
 		os.mustScan();
 	}
@@ -181,9 +180,7 @@ static void ParseMulti(OScanner& os, std::vector<MultiKillLevel_s>& multiKillLev
 		else
 		{
 			// We don't know what this token is.
-			std::string buffer =
-			    fmt::sprintf("Unknown Multi Kill Token \"%s\".", os.getToken());
-			os.warning(buffer);
+			os.warning("Unknown Multi Kill Token \"{:s}\".", os.getToken());
 		}
 		os.mustScan();
 	}

--- a/common/p_compdb.cpp
+++ b/common/p_compdb.cpp
@@ -49,15 +49,14 @@ static const std::unordered_map<fhfprint_t, levelcompdata_t> compdata = {
 		// Congestion 1024 MAP23
 		fhfprint_t::fromString("b0b0b3a99c2ed6780a5a79b325dcc5ca"),
 		{
-			// TODO C++20: use designated initializers for readability here
-			true // reservedLineFlag
+			.reservedLineFlag = true
 		}
 	},
 	{
 		// UDMX MAP32
 		fhfprint_t::fromString("c13f47bbcca3fc2d5013c17a604af645"),
 		{
-			true // reservedLineFlag
+			.reservedLineFlag = true
 		}
 	},
 };

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -103,7 +103,7 @@ weaponstate_t P_GetWeaponState(const player_t& player);
 //
 void P_FallingDamage (AActor *ent);
 void P_PlayerThink (player_t& player);
-void P_SetPlayerPowerupStatuses(player_t& player, nonstd::span<const int, NUMPOWERS> powers);
+void P_SetPlayerPowerupStatuses(player_t& player, std::span<const int, NUMPOWERS> powers);
 bool P_AreTeammates(const player_t& a, const player_t& b);
 bool P_CanSpy(player_t &viewer, player_t &other, bool demo = false);
 

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -46,7 +46,7 @@
 #include "p_mapformat.h"
 #include "g_multikill.h"
 
-#include <nonstd/span.hpp>
+#include <span>
 
 //
 // Movement.
@@ -872,7 +872,7 @@ bool P_CanSpy(player_t &viewer, player_t &other, bool demo)
 
 void SV_SendPlayerInfo(player_t &);
 
-void P_SetPlayerInvulnBleed(player_t& player, nonstd::span<const int, NUMPOWERS> powers)
+void P_SetPlayerInvulnBleed(player_t& player, std::span<const int, NUMPOWERS> powers)
 {
 	if (sv_showplayerpowerups)
 	{
@@ -902,7 +902,7 @@ void P_SwitchSpyOnNoLives(const player_t& player)
 	}
 }
 
-void P_SetPlayerPowerupStatuses(player_t& player, nonstd::span<const int, NUMPOWERS> powers)
+void P_SetPlayerPowerupStatuses(player_t& player, std::span<const int, NUMPOWERS> powers)
 {
 	if (!player.mo)
 		return;
@@ -1561,7 +1561,7 @@ player_s &player_s::operator =(const player_s &other)
 
 	doreborn = other.doreborn;
 	QueuePosition = other.QueuePosition;
-	
+
 	hazardcount = other.hazardcount;
 	hazardinterval = other.hazardinterval;
 

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -45,7 +45,7 @@
 /**
  * @brief Pack an array of booleans into a bitfield.
  */
-static uint32_t PackBoolArray(nonstd::span<const bool> bools)
+static uint32_t PackBoolArray(std::span<const bool> bools)
 {
 	uint32_t out = 0;
 	for (size_t i = 0; i < bools.size(); i++)


### PR DESCRIPTION
C++20 PR was out of date so it hadn't replaced some of the more recent uses of nonstd::span with std::span