### PR TITLE
Properly refresh player sprite when jumping from online to offline.

### DIFF
--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -203,7 +203,7 @@ void D_SetupUserInfo(void)
 
 	// update color translation
 	if (!demoplayback && !connected)
-		R_BuildPlayerTranslation(consoleplayer_id, color, coninfo->colorpreset);
+		R_BuildPlayerTranslation(0, color, coninfo->colorpreset);
 }
 
 void D_UserInfoChanged (cvar_t *cvar)


### PR DESCRIPTION
Made to address #1623

The call to `R_BuildPlayerTranslation` in d_netinfo.cpp is the only call that occurs upon every start of a single-player game. For whatever reason, `consoleplayer_id` isn't properly catching the player id when going from mutliplayer to single-player.

The condition check before ensures that this never impacts online games or netdemos, and just concerns single-player.

Protobreak due to the fix needing to account for the indexed player skins.