### PR TITLE
[BUGFIX] Blockmap 0th element being skipped unconditionally when co_blockmapfix enabled

### DIFF
--- a/common/p_local.h
+++ b/common/p_local.h
@@ -23,9 +23,7 @@
 
 #pragma once
 
-#ifndef __R_LOCAL__
 #include "r_local.h"
-#endif
 
 #include <set>
 

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -329,6 +329,7 @@ extern int				bmapheight; 	// in mapblocks
 extern fixed_t			bmaporgx;
 extern fixed_t			bmaporgy;		// origin of block map
 extern AActor** 		blocklinks; 	// for thing chains
+inline bool skipblstart; // should the first element of blocklists be skipped
 
 extern std::set<short>	movable_sectors;
 

--- a/common/p_maputl.cpp
+++ b/common/p_maputl.cpp
@@ -691,7 +691,7 @@ bool P_BlockLinesIterator (int x, int y, bool(*func)(line_t*))
 	// referencing linedef 0). Using this first entry (as vanilla Doom does) can
 	// cause hitscan weapons to erroneously hit the first linedef entry regardless
 	// of where that linedef is located in relation to the block.
-	if (co_blockmapfix)
+	if (!demoplayback && skipblstart)
 		++list;
 
 	for (; *list != -1; list++)

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1547,6 +1547,27 @@ void P_CreateBlockMap()
 // jff 10/6/98
 // End new code added to speed up calculation of internal blockmap
 
+void P_SetSkipBlockStart()
+{
+	skipblstart = true;
+
+	for (int y = 0; y < bmapheight; y++)
+	{
+		for (int x = 0; x < bmapwidth; x++)
+		{
+			int32_t* blockoffset = blockmaplump + y * bmapwidth + x + 4;
+
+			int32_t* list = blockmaplump + *blockoffset;
+
+			if (*list != 0)
+			{
+				skipblstart = false;
+				return;
+			}
+		}
+	}
+}
+
 //
 // P_LoadBlockMap
 //
@@ -1593,6 +1614,8 @@ void P_LoadBlockMap (int lump)
 	blocklinks = (AActor **)Z_Malloc (count, PU_LEVEL, 0);
 	memset (blocklinks, 0, count);
 	blockmap = blockmaplump+4;
+
+	P_SetSkipBlockStart();
 }
 
 /*


### PR DESCRIPTION
Some maps now actually have blockmaps without the extra 0 elements in each list, so these would be broken when `co_blockmapfix` is enabled. Now, Odamex will not skip if it finds any blocklist that starts with a non-zero element. Unless playing back a demo, in which case it will never be skipped.