### PR TITLE
Replace uses of __FILE__ and __LINE__ with std::source_location and M_GetStacktrace

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -360,7 +360,7 @@ void Host_EndGame(const char *msg)
 	CL_QuitNetGame(NQ_SILENT);
 }
 
-void CL_QuitNetGame2(const netQuitReason_e reason, const char* file, const int line)
+void CL_QuitNetGame(const netQuitReason_e reason)
 {
 	if(connected)
 	{
@@ -446,7 +446,7 @@ void CL_QuitNetGame2(const netQuitReason_e reason, const char* file, const int l
 	}
 
 	if (::debug_disconnect)
-		PrintFmt("  ({}:{})\n", file, line);
+		PrintFmt("{}\n", M_GetStacktrace("Disconnect location:", false));
 }
 
 
@@ -836,7 +836,7 @@ BEGIN_COMMAND (playerinfo)
 		       GetTeamInfo(player->userinfo.team)->ColorizedTeamName());
 	}
 	PrintFmt(PRINT_HIGH, " userinfo.aimdist     - {:d} \n",		player->userinfo.aimdist >> FRACBITS);
-	PrintFmt(PRINT_HIGH, " userinfo.colorpreset - {:d} \n",		player->userinfo.colorpreset); 
+	PrintFmt(PRINT_HIGH, " userinfo.colorpreset - {:d} \n",		player->userinfo.colorpreset);
 	PrintFmt(PRINT_HIGH, " userinfo.color       - {:s} \n",		color);
 	PrintFmt(PRINT_HIGH, " userinfo.gender      - {:d} \n",		player->userinfo.gender);
 	PrintFmt(PRINT_HIGH, " time                 - {:d} \n",		player->GameTime);

--- a/client/src/cl_main.h
+++ b/client/src/cl_main.h
@@ -57,8 +57,7 @@ enum netQuitReason_e
 	NQ_PROTO,      // Encountered something unexpected in the protocol
 };
 
-#define CL_QuitNetGame(reason) CL_QuitNetGame2(reason, __FILE__, __LINE__)
-void CL_QuitNetGame2(const netQuitReason_e reason, const char* file, const int line);
+void CL_QuitNetGame(const netQuitReason_e reason);
 void CL_Reconnect();
 void CL_InitNetwork (void);
 void CL_RequestConnectInfo(void);

--- a/common/m_stacktrace.cpp
+++ b/common/m_stacktrace.cpp
@@ -28,7 +28,7 @@
 #include "cpptrace/cpptrace.hpp"
 #include "cpptrace/formatting.hpp"
 
-std::string M_GetStacktrace(std::string header)
+std::string M_GetStacktrace(std::string header, bool report_message)
 {
 	auto formatter = cpptrace::formatter{}
 		.header(header)
@@ -40,8 +40,15 @@ std::string M_GetStacktrace(std::string header)
 		.filter([](const auto& frame)
 			{ return frame.symbol.find("M_GetStacktrace") == std::string::npos; })
 		.filtered_frame_placeholders(false);
-	return fmt::format(
-		"{}\n\nPlease report this error to the Odamex Team at https://github.com/odamex/odamex/issues",
-		formatter.format(cpptrace::generate_trace())
-	);
+	if (report_message)
+	{
+		return fmt::format(
+			"{}\n\nPlease report this error to the Odamex Team at https://github.com/odamex/odamex/issues",
+			formatter.format(cpptrace::generate_trace())
+		);
+	}
+	else
+	{
+		return formatter.format(cpptrace::generate_trace());
+	}
 }

--- a/common/m_stacktrace.h
+++ b/common/m_stacktrace.h
@@ -23,4 +23,4 @@
 
 #pragma once
 
-std::string M_GetStacktrace(std::string header = "Stack trace:");
+std::string M_GetStacktrace(std::string header = "Stack trace:", bool report_message = true);

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -60,8 +60,6 @@ struct OFileLine
 	}
 };
 
-#define FILELINE OFileLine::create(__FILE__, __LINE__)
-
 #define CASE_STR(x) \
 	case x:         \
 		return #x
@@ -320,9 +318,9 @@ void Z_Init()
 //
 // Z_Free2
 //
-void Z_Free2(void* ptr, const char* file, int line)
+void Z_Free(void* ptr, const std::source_location location)
 {
-	g_zone.deallocPtr(ptr, OFileLine::create(file, line));
+	g_zone.deallocPtr(ptr, OFileLine::create(location.file_name(), location.line()));
 }
 
 
@@ -333,16 +331,14 @@ void Z_Free2(void* ptr, const char* file, int line)
 #define MINFRAGMENT	64
 #define ALIGN		8
 
-void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,
-                const int line)
+void* Z_Malloc(size_t size, const zoneTag_e tag, void* user, const std::source_location location)
 {
-	return g_zone.alloc(size, tag, user, OFileLine::create(file, line));
+	return g_zone.alloc(size, tag, user, OFileLine::create(location.file_name(), location.line()));
 }
 
-void* Z_Realloc2(void* ptr, size_t size, const zoneTag_e tag, void* user, const char* file,
-                const int line)
+void* Z_Realloc(void* ptr, size_t size, const zoneTag_e tag, void* user, const std::source_location location)
 {
-	return g_zone.realloc(ptr, size, tag, user, OFileLine::create(file, line));
+	return g_zone.realloc(ptr, size, tag, user, OFileLine::create(location.file_name(), location.line()));
 }
 
 //
@@ -356,26 +352,26 @@ void Z_FreeTags(const zoneTag_e lowtag, const zoneTag_e hightag)
 //
 // Z_ChangeTag
 //
-void Z_ChangeTag2(void* ptr, const zoneTag_e tag, const char* file, int line)
+void Z_ChangeTag(void* ptr, const zoneTag_e tag, const std::source_location location)
 {
-	return ::g_zone.changeTag(ptr, tag, OFileLine::create(file, line));
+	return ::g_zone.changeTag(ptr, tag, OFileLine::create(location.file_name(), location.line()));
 }
 
 //
 // Z_ChangeOwner
 //
-void Z_ChangeOwner2(void* ptr, void* user, const char* file, int line)
+void Z_ChangeOwner(void* ptr, void* user, const std::source_location location)
 {
-	return ::g_zone.changeOwner(ptr, user, OFileLine::create(file, line));
+	return ::g_zone.changeOwner(ptr, user, OFileLine::create(location.file_name(), location.line()));
 }
 
 //
 // Z_StrDup
 //
-char* Z_StrDup2(const char* s, const zoneTag_e tag, const char* file, int line)
+char* Z_StrDup(const char* s, const zoneTag_e tag, const std::source_location location)
 {
 	size_t len = strlen(s);
-	char* output = (char*)Z_Malloc2(len + 1, tag, NULL, file, line);
+	char* output = (char*)Z_Malloc(len + 1, tag, NULL, location);
 	strncpy(output, s, len);
 	output[len] = '\0';
 	return output;

--- a/common/z_zone.h
+++ b/common/z_zone.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <source_location>
 
 //
 // ZONE MEMORY
@@ -50,16 +51,18 @@ void Z_Close();
 void Z_FreeTags(const zoneTag_e lowtag, const zoneTag_e hightag);
 void Z_DumpHeap(const zoneTag_e lowtag, const zoneTag_e hightag);
 
+#define SOURCELOC const std::source_location location = std::source_location::current()
+
 // Don't use these, use the macros instead!
-void* Z_Malloc2(size_t size, const zoneTag_e tag, void* user, const char* file,
-                const int line);
-void* Z_Realloc2(void* ptr, size_t size, const zoneTag_e tag, void* user, const char* file,
-                 const int line);
-void Z_Free2(void* ptr, const char* file, int line);
-void Z_Discard2(void** ptr, const char* file, int line);
-void Z_ChangeTag2(void* ptr, const zoneTag_e tag, const char* file, int line);
-void Z_ChangeOwner2(void* ptr, void* user, const char* file, int line);
-char* Z_StrDup2(const char* s, const zoneTag_e tag, const char* file, int line);
+void* Z_Malloc(size_t size, const zoneTag_e tag, void* user, SOURCELOC);
+void* Z_Realloc(void* ptr, size_t size, const zoneTag_e tag, void* user, SOURCELOC);
+void Z_Free(void* ptr, SOURCELOC);
+void Z_Discard(void** ptr, SOURCELOC);
+void Z_ChangeTag(void* ptr, const zoneTag_e tag, SOURCELOC);
+void Z_ChangeOwner(void* ptr, void* user, SOURCELOC);
+char* Z_StrDup(const char* s, const zoneTag_e tag, SOURCELOC);
+
+#undef SOURCELOC
 
 typedef struct memblock_s
 {
@@ -71,9 +74,9 @@ typedef struct memblock_s
 	struct memblock_s*	prev;
 } memblock_t;
 
-inline void Z_ChangeTag2(const void* ptr, const zoneTag_e tag, const char* file, int line)
+inline void Z_ChangeTag(const void* ptr, const zoneTag_e tag, const std::source_location location = std::source_location::current())
 {
-	Z_ChangeTag2(const_cast<void *>(ptr), tag, file, line);
+	Z_ChangeTag(const_cast<void *>(ptr), tag, location);
 }
 
 /**
@@ -86,14 +89,14 @@ inline void Z_ChangeTag2(const void* ptr, const zoneTag_e tag, const char* file,
  * @param line Line number passed in from __LINE__ macro.
  */
 template <typename P>
-inline void Z_Discard2(P ptr, const char* file, int line)
+inline void Z_Discard(P ptr, const std::source_location location = std::source_location::current())
 {
 	if (*ptr == NULL)
 	{
 		return;
 	}
 
-	Z_ChangeTag2(*ptr, PU_CACHE, file, line);
+	Z_ChangeTag(*ptr, PU_CACHE, location);
 	*ptr = NULL;
 }
 
@@ -106,11 +109,3 @@ inline void Z_Discard2(P ptr, const char* file, int line)
       if (( (memblock_t *)( (char *)(p) - sizeof(memblock_t)))->tag > t) \
       Z_ChangeTag (p,t); \
 }
-
-#define Z_Malloc(s,t,p) Z_Malloc2(s,t,p,__FILE__,__LINE__)
-#define Z_Realloc(p,s,t,u) Z_Realloc2(p,s,t,u,__FILE__,__LINE__)
-#define Z_Free(p) Z_Free2(p,__FILE__,__LINE__)
-#define Z_Discard(p) Z_Discard2(p,__FILE__,__LINE__)
-#define Z_ChangeTag(p,t) Z_ChangeTag2(p,t,__FILE__,__LINE__)
-#define Z_ChangeOwner(p,u) Z_ChangeOwner2(p,u,__FILE__,__LINE__)
-#define Z_StrDup(s, t) Z_StrDup2(s,t, __FILE__,__LINE__)

--- a/common/z_zone.h
+++ b/common/z_zone.h
@@ -85,8 +85,7 @@ inline void Z_ChangeTag(const void* ptr, const zoneTag_e tag, const std::source_
  * @param ptr A pointer to the pointer we want to discard.  The pointer must
  *            point to something, but the pointed-to-pointer can be null,
  *            in which case nothing happens.
- * @param file Filename passed in from __FILE__ macro.
- * @param line Line number passed in from __LINE__ macro.
+ * @param location Location in the source code that this function was called
  */
 template <typename P>
 inline void Z_Discard(P ptr, const std::source_location location = std::source_location::current())

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -2272,7 +2272,7 @@ void SV_DisconnectClient(player_t &who)
 // SV_DropClient
 // Called when the player is leaving the server unwillingly.
 //
-void SV_DropClient2(player_t &who, const char* file, const int line)
+void SV_DropClient(player_t &who)
 {
 	client_t *cl = &who.client;
 
@@ -2283,7 +2283,7 @@ void SV_DropClient2(player_t &who, const char* file, const int line)
 	SV_DisconnectClient(who);
 
 	if (::debug_disconnect)
-		PrintFmt("  ({}:{})\n", file, line);
+		PrintFmt("{}\n", M_GetStacktrace("Disconnect location:", false));
 }
 
 //

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -135,8 +135,7 @@ void SV_ParseCommands(player_t &player);
 void SV_HandleReliableRetransmissions();
 void SV_UpdateFrags (const player_t &player);
 void SV_RemoveCorpses (void);
-#define SV_DropClient(who) SV_DropClient2(who, __FILE__, __LINE__)
-void SV_DropClient2(player_t& who, const char* file, const int line);
+void SV_DropClient(player_t& who);
 void SV_PlayerTriedToCheat(player_t &player);
 void SV_ActorTarget(const AActor *actor);
 void SV_ActorTracer(const AActor *actor);


### PR DESCRIPTION
This allows all the Z_* allocation functions to not need wrapper macros, and gives more useful output for `debug_disconnect`.