### PR TITLE
[BUGFIX] Thing lighting ignoring height transfers when r_thingsectorlight is disabled

### DIFF
--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -726,10 +726,9 @@ void R_Subsector (int num)
 	// killough 9/18/98: Fix underwater slowdown, by passing real sector
 	// instead of fake one. Improve sprite lighting by basing sprite
 	// lightlevels on floor & ceiling lightlevels in the surrounding area.
-	if (r_thingsectorlight)
-		R_AddSprites(sub.sector, (floorlightlevel + ceilinglightlevel) / 2, FakeSide);
-	else
-		R_AddSprites(sub.sector, frontsector->lightlevel, FakeSide);
+	const int lightlevel = r_thingsectorlight ?
+		(floorlightlevel + ceilinglightlevel) / 2 : frontsector->lightlevel;
+	R_AddSprites(sub.sector, lightlevel, FakeSide);
 
 	// [RH] Add particles
 	if (r_particles)

--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -42,7 +42,7 @@
 
 EXTERN_CVAR (r_particles)
 
-seg_t*			curline;
+const seg_t*	curline;
 side_t* 		sidedef;
 line_t* 		linedef;
 sector_t*		frontsector;
@@ -448,7 +448,7 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 // Clips the given segment
 // and adds any visible pieces to the line list.
 //
-void R_AddLine (seg_t *line)
+void R_AddLine (const seg_t *line)
 {
 	curline = line;
 
@@ -648,6 +648,8 @@ static bool R_CheckBBox(const fixed_t *bspcoord)
 	return false;
 }
 
+EXTERN_CVAR(r_thingsectorlight)
+
 //
 // R_Subsector
 // Determine floor/ceiling planes.
@@ -656,9 +658,6 @@ static bool R_CheckBBox(const fixed_t *bspcoord)
 //
 void R_Subsector (int num)
 {
-	int 		 count;
-	seg_t*		 line;
-	subsector_t *sub;
 	sector_t     tempsec;				// killough 3/7/98: deep water hack
 	int          floorlightlevel;		// killough 3/16/98: set floor lightlevel
 	int          ceilinglightlevel;		// killough 4/11/98
@@ -670,10 +669,10 @@ void R_Subsector (int num)
 				numsubsectors);
 #endif
 
-	sub = &subsectors[num];
-	frontsector = sub->sector;
-	count = sub->numlines;
-	line = &segs[sub->firstline];
+	const subsector_t& sub = subsectors[num];
+	frontsector = sub.sector;
+	int count = sub.numlines;
+	const seg_t* line = &segs[sub.firstline];
 
 	// killough 3/8/98, 4/4/98: Deep water / fake ceiling effect
 	frontsector = R_FakeFlat(frontsector, &tempsec, &floorlightlevel,
@@ -727,7 +726,10 @@ void R_Subsector (int num)
 	// killough 9/18/98: Fix underwater slowdown, by passing real sector
 	// instead of fake one. Improve sprite lighting by basing sprite
 	// lightlevels on floor & ceiling lightlevels in the surrounding area.
-	R_AddSprites (sub->sector, (floorlightlevel + ceilinglightlevel) / 2, FakeSide);
+	if (r_thingsectorlight)
+		R_AddSprites(sub.sector, (floorlightlevel + ceilinglightlevel) / 2, FakeSide);
+	else
+		R_AddSprites(sub.sector, frontsector->lightlevel, FakeSide);
 
 	// [RH] Add particles
 	if (r_particles)
@@ -736,10 +738,10 @@ void R_Subsector (int num)
 			R_ProjectParticle(Particles + i, subsectors[num].sector, FakeSide);
 	}
 
-	if (sub->poly)
+	if (sub.poly)
 	{ // Render the polyobj in the subsector first
-		int polyCount = sub->poly->numsegs;
-		seg_t **polySeg = sub->poly->segs;
+		int polyCount = sub.poly->numsegs;
+		const seg_t **polySeg = sub.poly->segs;
 		while (polyCount--)
 			R_AddLine (*polySeg++);
 	}

--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -741,7 +741,7 @@ void R_Subsector (int num)
 	if (sub.poly)
 	{ // Render the polyobj in the subsector first
 		int polyCount = sub.poly->numsegs;
-		const seg_t **polySeg = sub.poly->segs;
+		seg_t **polySeg = sub.poly->segs;
 		while (polyCount--)
 			R_AddLine (*polySeg++);
 	}

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -73,7 +73,6 @@ fixed_t boby;
 EXTERN_CVAR (r_drawplayersprites)
 EXTERN_CVAR (r_softinvulneffect)
 EXTERN_CVAR (r_particles)
-EXTERN_CVAR (r_thingsectorlight);
 
 //
 // INITIALIZATION FUNCTIONS
@@ -690,8 +689,7 @@ void R_AddSprites (sector_t *sec, int lightlevel, int fakeside)
 	// Well, now it will be done.
 	sec->validcount = validcount;
 
-	int lightnum = r_thingsectorlight ? lightlevel : sec->lightlevel;
-	lightnum = (lightnum >> LIGHTSEGSHIFT) + (foggy ? 0 : extralight);
+	int lightnum = (lightlevel >> LIGHTSEGSHIFT) + (foggy ? 0 : extralight);
 
 	if (lightnum < 0)
 		spritelights = scalelight[0];

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -834,7 +834,7 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 	R_DrawVisSprite (vis, vis->x1, vis->x2);
 }
 
-
+EXTERN_CVAR(r_thingsectorlight)
 
 //
 // R_DrawPlayerSprites
@@ -852,8 +852,8 @@ void R_DrawPlayerSprites()
 		(consoleplayer().cheats & CF_CHASECAM))
 		return;
 
-	sector_t* sec = R_FakeFlat(viewsector, &tempsec, &floorlight,
-	                           &ceilinglight, false);
+	const sector_t* sec = R_FakeFlat(viewsector, &tempsec, &floorlight,
+	                                 &ceilinglight, false);
 
 	// [RH] set foggy flag
 	foggy = level.fadeto_color[0] || level.fadeto_color[1] || level.fadeto_color[2] || level.fadeto_color[3]
@@ -863,7 +863,7 @@ void R_DrawPlayerSprites()
 	basecolormap = sec->colormap->maps;
 
 	// get light level
-	const int lightnum = ((floorlight + ceilinglight) >> (LIGHTSEGSHIFT + 1))
+	const int lightnum = ((r_thingsectorlight ? (floorlight + ceilinglight) / 2 : sec->lightlevel) >> LIGHTSEGSHIFT)
 	               + (foggy ? 0 : extralight);
 
 	if (lightnum < 0)

--- a/common/r_bsp.h
+++ b/common/r_bsp.h
@@ -25,7 +25,7 @@
 
 extern const fixed_t NEARCLIP;
 
-extern seg_t*		curline;
+extern const seg_t*		curline;
 extern side_t*		sidedef;
 extern line_t*		linedef;
 extern sector_t*	frontsector;

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -580,9 +580,9 @@ struct tallpost_t
 // OTHER TYPES
 //
 
-struct drawseg_s
+struct drawseg_t
 {
-	seg_t*			curline;
+	const seg_t*	curline;
 
     int				x1;
     int				x2;
@@ -602,7 +602,6 @@ struct drawseg_s
     int*			sprbottomclip;
 	tallpost_t**	midposts;
 };
-typedef drawseg_s drawseg_t;
 
 
 // Patches.


### PR DESCRIPTION
r_thingsectorlight didn't account for height transfers, always using the light level of the "real" sector. Now it should always account for height transfers.