### PR TITLE
Fix out-of-bounds write while parsing defaultskill in the mapinfo lump..

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1088,9 +1088,9 @@ void MIType_MapKey(OScanner& os, bool newStyleMapInfo, void* data, unsigned int 
 	}
 }
 
-void MIType_SetInt(OScanner& os, bool newStyleMapInfo, void* data, uint32_t flags, uint32_t flags2)
+void MIType_SetByte(OScanner& os, bool newStyleMapInfo, void* data, uint32_t flags, uint32_t flags2)
 {
-	*static_cast<int32_t*>(data) = flags;
+	*static_cast<byte*>(data) = static_cast<byte>(flags);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1571,7 +1571,7 @@ struct MapInfoDataSetter<SkillInfo>
 			{ "noinfighting", &MIType_SCFlags, &ref.flags, SKILL_NOINFIGHTING, ~SKILL_TOTALINFIGHTING },
 			{ "totalinfighting", &MIType_SCFlags, &ref.flags, SKILL_TOTALINFIGHTING, ~SKILL_NOINFIGHTING },
 			{ "playerrespawn", &MIType_Bool, &ref.player_respawn, true },
-			{ "defaultskill", &MIType_SetInt, &defaultskillmenu, skillnum }
+			{ "defaultskill", &MIType_SetByte, &defaultskillmenu, skillnum }
 		};
 	}
 };

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1088,9 +1088,10 @@ void MIType_MapKey(OScanner& os, bool newStyleMapInfo, void* data, unsigned int 
 	}
 }
 
-void MIType_SetByte(OScanner& os, bool newStyleMapInfo, void* data, uint32_t flags, uint32_t flags2)
+template <typename DataType>
+void MIType_SetInt(OScanner& os, bool newStyleMapInfo, void* data, uint32_t flags, uint32_t flags2)
 {
-	*static_cast<byte*>(data) = static_cast<byte>(flags);
+	*static_cast<DataType*>(data) = static_cast<DataType>(flags);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1571,7 +1572,7 @@ struct MapInfoDataSetter<SkillInfo>
 			{ "noinfighting", &MIType_SCFlags, &ref.flags, SKILL_NOINFIGHTING, ~SKILL_TOTALINFIGHTING },
 			{ "totalinfighting", &MIType_SCFlags, &ref.flags, SKILL_TOTALINFIGHTING, ~SKILL_NOINFIGHTING },
 			{ "playerrespawn", &MIType_Bool, &ref.player_respawn, true },
-			{ "defaultskill", &MIType_SetByte, &defaultskillmenu, skillnum }
+			{ "defaultskill", &MIType_SetInt<decltype(defaultskillmenu)>, &defaultskillmenu, skillnum }
 		};
 	}
 };


### PR DESCRIPTION
On my particular machine, the overwrite just happened to blow away skillnum, causing only 3 skills to be listed in the New Game menu for Doom2, as well as preventing basically anything from spawning in during demo playback.

As an OOB write, who knows what other side effects there were in other builds.

This is just an immediate triage fix.  The *real* answer is to make the mapinfo setters type-safe.