### PR TITLE
Make sure we go through the complete-disconnect phase if user commands a `disconnect` while not connected.

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -363,12 +363,17 @@ void Host_EndGame(const char *msg)
 
 void CL_QuitNetGame(const netQuitReason_e reason)
 {
-	if(connected)
+	if (connected)
 	{
 		CL_CompleteDisconnect(reason);
 
 		sv_gametype = GM_COOP;
 		ClientReplay::getInstance().reset();
+	}
+	else
+	{
+		// Make sure we do a proper silent disconnect in single player.
+		CL_CompleteDisconnect(NQ_SILENT);
 	}
 
 	if (paused)


### PR DESCRIPTION
This comes from testing the case where the user issues a `disconnect` while playing single-player.  In my previous PR, I focused so much on server/client disconnect that I overlooked testing the "not connected but still playing" case.