### PR TITLE
If an unsupported cvar comes from a .cfg file, make sure we keep it along with a comment about lack of support

### DIFF
--- a/common/c_cvars.cpp
+++ b/common/c_cvars.cpp
@@ -653,7 +653,14 @@ BEGIN_COMMAND (set)
 
 		var = cvar_t::FindCVar (argv[1], &prev);
 		if (!var)
-			var = new cvar_t(argv[1], NULL, "", CVARTYPE_NONE,  CVAR_AUTO | CVAR_UNSETTABLE | cvar_defflags);
+		{
+			const std::string description = "Unsupported in Odamex v" + std::string(NiceVersion());
+			var = new cvar_t(argv[1], argv[2], description.c_str(), CVARTYPE_NONE,
+			                 CVAR_NOENABLEDISABLE |         // If we got here due to LoadDefaults, make sure we save the value back out as-is.
+			                 CVAR_AUTO |
+			                 CVAR_UNSETTABLE |
+			                 cvar_defflags);
+		}
 
 		if (var->flags() & CVAR_NOSET)
 		{


### PR DESCRIPTION
This is so that we don't utterly confuse people as cvars are phased out, particularly the net buffer cvars going up to 13.x.

### Before

1. Edit your cfg file, adding:
   ```
   set "my_hot_cvar" "666"
   ```
2. Start the game, then exit.
3. Notice:
   ```
   //
   set "my_hot_cvar" "1"
   ```

### After

1. Go through the above process.  Notice it now saves off:
   ```
   // Unsupported in Odamex v12.1.0 (HEAD, gremotes/upstream/stable-0-g30016-11907)
   set "my_hot_cvar" "666"
   ```
