### PR TITLE
Fix spyprev not working in survival game with more than 2 players

### DIFF
--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -815,7 +815,11 @@ bool P_AreTeammates(const player_t &a, const player_t &b)
 
 bool P_CanSpy(player_t &viewer, player_t &other, bool demo)
 {
-	// Viewers can always spy themselves.
+	// skip yourself if out of lives in survival
+	if (viewer.id == other.id && G_IsLivesGame() && viewer.lives < 1)
+		return false;
+
+	// otherwise viewers can always spy themselves.
 	if (viewer.id == other.id)
 		return true;
 


### PR DESCRIPTION
Noticed while playing hoarde mode that the spyprev would stop working when you run out of lives. spynext continued to work, however spyprev will cycle and then stop working. 

Turns out its because it would hit the (viewer.id == other.id) check and allow you to spy yourself (while you are PST_DEAD). Issue is P_SwitchSpyOnNoLives() runs every tic which manually adds the command spynext if you have died in survival mode. So in this situation you hit spyprev but then spynext happens immediately and theres no change. Fix is just to skip yourself if you are out of lives