### PR TITLE
FIx spyprev for survival gametypes take 2

### DIFF
--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -815,8 +815,8 @@ bool P_AreTeammates(const player_t &a, const player_t &b)
 
 bool P_CanSpy(player_t &viewer, player_t &other, bool demo)
 {
-	// skip yourself if out of lives in survival
-	if (viewer.id == other.id && G_IsLivesGame() && viewer.lives < 1)
+	// skip if out of lives in survival
+	if (G_IsLivesGame() && other.lives < 1)
 		return false;
 
 	// otherwise viewers can always spy themselves.
@@ -860,10 +860,6 @@ bool P_CanSpy(player_t &viewer, player_t &other, bool demo)
 
 	if (isTeammate || viewer.spectator)
 	{
-		// If a player has no more lives, don't show him.
-		if (::g_lives && other.lives < 1)
-			return false;
-
 		return true;
 	}
 


### PR DESCRIPTION
Realized the bug from #1642 is still happening for survival when trying to spy any out of lives player (not just yourself). Looks like it's because P_SwitchSpyOnNoLives() uses displayplayer_id. The fix that seems to work is skipping any out of lives player in survival - and that check was already in there, just moving it to the top.