### PR TITLE
Add support for mouse wheel tilt

### DIFF
--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -202,6 +202,8 @@ static void I_InitializeKeyNameTable()
 	key_names[OKEY_MOUSE5] = "mouse5";
 	key_names[OKEY_MWHEELDOWN] = "mwheeldown";
 	key_names[OKEY_MWHEELUP] = "mwheelup";
+	key_names[OKEY_MWHEELLEFT] = "mwheelleft";
+	key_names[OKEY_MWHEELRIGHT] = "mwheelright";
 	key_names[OKEY_JOY1] = "joy1";
 	key_names[OKEY_JOY2] = "joy2";
 	key_names[OKEY_JOY3] = "joy3";

--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -511,8 +511,7 @@ void ISDL20MouseInputDevice::gatherEvents()
 					ev.data1 = OKEY_MWHEELUP;
 				else if (direction * sdl_ev.wheel.y < 0)
 					ev.data1 = OKEY_MWHEELDOWN;
-
-				if (direction * sdl_ev.wheel.x > 0)
+				else if (direction * sdl_ev.wheel.x > 0)
 					ev.data1 = OKEY_MWHEELRIGHT;
 				else if (direction * sdl_ev.wheel.x < 0)
 					ev.data1 = OKEY_MWHEELLEFT;

--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -502,7 +502,7 @@ void ISDL20MouseInputDevice::gatherEvents()
 			{
 				ev.type = ev_keydown;
 				int direction = 1;
-				#if (SDL_VERSION >= SDL_VERSIONNUM(2, 0, 4))
+				#if SDL_VERSION_ATLEAST(2, 0, 4)
 				if (sdl_ev.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
 					direction = -1;
 				#endif

--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -511,6 +511,11 @@ void ISDL20MouseInputDevice::gatherEvents()
 					ev.data1 = OKEY_MWHEELUP;
 				else if (direction * sdl_ev.wheel.y < 0)
 					ev.data1 = OKEY_MWHEELDOWN;
+
+				if (direction * sdl_ev.wheel.x > 0)
+					ev.data1 = OKEY_MWHEELRIGHT;
+				else if (direction * sdl_ev.wheel.x < 0)
+					ev.data1 = OKEY_MWHEELLEFT;
 			}
 			else if (sdl_ev.type == SDL_MOUSEBUTTONDOWN || sdl_ev.type == SDL_MOUSEBUTTONUP)
 			{

--- a/client/sdl/i_sdl.h
+++ b/client/sdl/i_sdl.h
@@ -36,6 +36,6 @@
 	#define SDL12
 #endif
 
-#if (SDL_VERSION > SDL_VERSIONNUM(1, 2, 7))
+#if SDL_VERSION_ATLEAST(1, 2, 7)
 	#include "SDL_cpuinfo.h"
 #endif

--- a/common/doomkeys.h
+++ b/common/doomkeys.h
@@ -126,6 +126,8 @@
 #define OKEY_MOUSE5          0x20000004
 #define OKEY_MWHEELDOWN      0x20000005
 #define OKEY_MWHEELUP        0x20000006
+#define OKEY_MWHEELLEFT      0x20000007
+#define OKEY_MWHEELRIGHT     0x20000008
 #define OKEY_JOY1            0x20000010
 #define OKEY_JOY2            0x20000011
 #define OKEY_JOY3            0x20000012


### PR DESCRIPTION
For mouse with horizontal scroll wheels or tiltable scroll wheels, mouse wheel left and right are now recognized as inputs.