### PR TITLE
[BUGFIX] dont auto switch back to consoleplayer when watching a netdemo

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1408,7 +1408,10 @@ void CL_SpectatePlayer(player_t& player, bool spectate)
 		}
 		else
 		{
-			displayplayer_id = consoleplayer_id; // get out of spynext
+			if (!netdemo.isPlaying())
+			{
+				displayplayer_id = consoleplayer_id; // get out of spynext
+			}
 			player.cheats &= ~CF_FLY;	// remove flying ability
 		}
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -240,7 +240,7 @@ static void CL_PlayerInfo(const odaproto::svc::PlayerInfo* msg)
 	p.armorpoints = msg->player().armorpoints();
 	p.armortype = msg->player().armortype();
 
-	if (p.lives == 0 && msg->player().lives() > 0)
+	if ((p.lives == 0 && msg->player().lives() > 0) && !netdemo.isPlaying())
 	{
 		// Stop spying so you know you're back from the dead.
 		::displayplayer_id = ::consoleplayer_id;


### PR DESCRIPTION
While watching a netdemo, the displayplayer view would auto-switch back to the consoleplayer's view when

- Someone picked up the resurrect item in horde, and the consoleplayer was chosen
- The consoleplayer joins the game (goes from spec to unspec) 

This change stops switching back to the consoleplayer's view in those scenarios. 

There is another scenario when a new round begins, but fixing that seems to be much more involved. Partial fix for #542 