### PR TITLE
[BUGFIX] Crash on maps using DeePBSP nodes

### DIFF
--- a/common/doomfunc.h
+++ b/common/doomfunc.h
@@ -166,4 +166,11 @@ struct visitor : Ts... { using Ts::operator()...; };
 template<class... Ts>
 visitor(Ts...) -> visitor<Ts...>;
 
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+// requires std::is_integral_v<T>
+constexpr auto to_unsigned(T x)
+{
+	return static_cast<std::make_unsigned_t<T>>(x);
+}
+
 }

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -470,7 +470,7 @@ void P_LoadNodes(int lump)
 	static constexpr size_t headerSize =
 		std::is_same_v<MapNodeType, mapnode_deepbsp_t> ? 8 : 0;
 
-	numnodes = W_LumpLength(lump - headerSize) / sizeof(MapNodeType);
+	numnodes = (W_LumpLength(lump) - headerSize) / sizeof(MapNodeType);
 	nodes = (node_t*) Z_Malloc(numnodes * sizeof(node_t), PU_LEVEL, 0);
 	byte* data = (byte*) W_CacheLumpNum(lump, PU_STATIC);
 

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -305,8 +305,8 @@ void P_LoadSubsectors(int lump)
 
 	for (int i = 0; i < numsubsectors; i++)
 	{
-		subsectors[i].numlines = LESWAP<decltype(MapSubsectorType::numsegs)>(data[i].numsegs);
-		subsectors[i].firstline = LESWAP<decltype(MapSubsectorType::firstseg)>(data[i].firstseg);
+		subsectors[i].numlines = LESWAP(data[i].numsegs);
+		subsectors[i].firstline = LESWAP(data[i].firstseg);
 	}
 
 	Z_Free(data);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -265,7 +265,7 @@ void P_LoadSegs (int lump)
 	{
 		seg_t* const li = segs + i;
 		const MapSegType *ml = (MapSegType*) data + i;
-		auto v = LESWAP(ml->v1);
+		auto v = OUtil::to_unsigned(LESWAP(ml->v1));
 
 		if(v >= numvertexes)
 			I_Error("P_LoadSegs: invalid vertex {}", v);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -577,7 +577,7 @@ byte* P_LoadSegs_XNOD(byte* p) {
 			seg->backsector = sides[line->sidenum[side^1]].sector;
 		else
 		{
-			seg->backsector = NULL;
+			seg->backsector = nullptr;
 			line->flags &= ~ML_TWOSIDED;
 		}
 

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -467,11 +467,14 @@ void P_LoadNodes(int lump)
 		    "P_LoadNodes: NODES lump is empty - levels without nodes are not supported.");
 	}
 
-	numnodes = W_LumpLength(lump) / sizeof(MapNodeType);
+	static constexpr size_t headerSize =
+		std::is_same_v<MapNodeType, mapnode_deepbsp_t> ? 8 : 0;
+
+	numnodes = W_LumpLength(lump - headerSize) / sizeof(MapNodeType);
 	nodes = (node_t*) Z_Malloc(numnodes * sizeof(node_t), PU_LEVEL, 0);
 	byte* data = (byte*) W_CacheLumpNum(lump, PU_STATIC);
 
-	const MapNodeType* mn = (MapNodeType *)data;
+	const MapNodeType* mn = (MapNodeType *)(data + headerSize);
 	node_t* no = nodes;
 
 	for (int i = 0; i < numnodes; i++, no++, mn++)
@@ -500,7 +503,7 @@ void P_LoadNodes(int lump)
 		}
 	}
 
-	Z_Free (data);
+	Z_Free(data);
 }
 
 byte* P_DecompressNodes(byte* data, size_t len) {


### PR DESCRIPTION
When deduplicating the code, I accidentally made it stop skipping the 8 byte header.