### PR TITLE
[BUGFIX] `fixed_t` to `fixed64_t` conversion losing upper 4 bits of the 32 bit value

### DIFF
--- a/common/doomfunc.h
+++ b/common/doomfunc.h
@@ -184,58 +184,66 @@ visitor(Ts...) -> visitor<Ts...>;
 
 // Literals for stdint types
 
+[[nodiscard]]
 consteval int8_t operator ""_i8(unsigned long long x)
 {
-	if (x >= std::numeric_limits<int8_t>::max())
+	if (x > std::numeric_limits<int8_t>::max())
 		throw "Literal out of range for type int8_t";
-    return static_cast<int8_t>(x);
+	return static_cast<int8_t>(x);
 }
 
+[[nodiscard]]
 consteval uint8_t operator ""_u8(unsigned long long x)
 {
 	if (x > std::numeric_limits<uint8_t>::max())
 		throw "Literal out of range for type uint8_t";
-    return static_cast<uint8_t>(x);
+	return static_cast<uint8_t>(x);
 }
 
+[[nodiscard]]
 consteval int16_t operator ""_i16(unsigned long long x)
 {
 	if (x > std::numeric_limits<int16_t>::max())
 		throw "Literal out of range for type int16_t";
-    return static_cast<int16_t>(x);
+	return static_cast<int16_t>(x);
 }
 
+[[nodiscard]]
 consteval uint16_t operator ""_u16(unsigned long long x)
 {
 	if (x > std::numeric_limits<uint16_t>::max())
 		throw "Literal out of range for type uint16_t";
-    return static_cast<uint16_t>(x);
+	return static_cast<uint16_t>(x);
 }
 
+[[nodiscard]]
 consteval int32_t operator ""_i32(unsigned long long x)
 {
 	if (x > std::numeric_limits<int32_t>::max())
 		throw "Literal out of range for type int32_t";
-    return static_cast<int32_t>(x);
+	return static_cast<int32_t>(x);
 }
 
+[[nodiscard]]
 consteval uint32_t operator ""_u32(unsigned long long x)
 {
 	if (x > std::numeric_limits<uint32_t>::max())
 		throw "Literal out of range for type uint32_t";
-    return static_cast<uint32_t>(x);
+	return static_cast<uint32_t>(x);
 }
 
+[[nodiscard]]
 consteval int64_t operator ""_i64(unsigned long long x)
 {
 	if (x > std::numeric_limits<int64_t>::max())
 		throw "Literal out of range for type int64_t";
-    return static_cast<int64_t>(x);
+	return static_cast<int64_t>(x);
 }
 
+[[nodiscard]]
 consteval uint64_t operator ""_u64(unsigned long long x)
 {
 	if (x > std::numeric_limits<uint64_t>::max())
 		throw "Literal out of range for type uint65_t";
-    return static_cast<uint64_t>(x);
+	return static_cast<uint64_t>(x);
 }

--- a/common/m_fixed.h
+++ b/common/m_fixed.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <stdlib.h>
+#include <stdint.h>
 
 //
 // Fixed point, 32bit as 16.16.
@@ -203,4 +204,48 @@ inline constexpr int32_t FixedDivN(int32_t a, int32_t b)
 {
 	static_assert(N >= 1 && N <= 32, "Shift out of range");
 	return static_cast<int32_t>((static_cast<int64_t>(a) << N) / b);
+}
+
+// fixed_t and fixed64_t literals
+
+[[nodiscard]]
+consteval fixed_t operator ""_fx(unsigned long long x)
+{
+	if (x > static_cast<unsigned long long>(std::numeric_limits<int32_t>::max() >> FRACBITS))
+		throw "Literal out of range for type fixed_t";
+	return INT2FIXED(x);
+}
+
+[[nodiscard]]
+consteval fixed64_t operator ""_fx64(unsigned long long x)
+{
+	if (x > static_cast<unsigned long long>(std::numeric_limits<int64_t>::max() >> FRACBITS64))
+		throw "Literal out of range for type fixed64_t";
+    return INT2FIXED64(x);
+}
+
+[[nodiscard]]
+consteval fixed_t operator ""_fx(long double x)
+{
+	constexpr long double max =
+		static_cast<long double>(std::numeric_limits<int32_t>::max()) / (1ULL << FRACBITS);
+	constexpr long double min =
+		static_cast<long double>(std::numeric_limits<int32_t>::min()) / (1ULL << FRACBITS);
+
+	if (x < min || x > max)
+		throw "Literal out of range for type fixed_t";
+    return DOUBLE2FIXED(x);
+}
+
+[[nodiscard]]
+consteval fixed64_t operator ""_fx64(long double x)
+{
+	constexpr long double max =
+		static_cast<long double>(std::numeric_limits<int64_t>::max()) / (1ULL << FRACBITS64);
+	constexpr long double min =
+		static_cast<long double>(std::numeric_limits<int64_t>::min()) / (1ULL << FRACBITS64);
+
+	if (x < min || x > max)
+		throw "Literal out of range for type fixed64_t";
+    return DOUBLE2FIXED64(x);
 }

--- a/common/m_fixed.h
+++ b/common/m_fixed.h
@@ -125,7 +125,7 @@ inline constexpr fixed_t FIXED642FIXED(fixed64_t x)
 [[nodiscard]]
 inline constexpr fixed64_t FIXED2FIXED64(fixed_t x)
 {
-	return static_cast<fixed64_t>(x << (FRACBITS64 - FRACBITS));
+	return static_cast<fixed64_t>(x) << (FRACBITS64 - FRACBITS);
 }
 
 //

--- a/common/m_fixed.h
+++ b/common/m_fixed.h
@@ -213,7 +213,7 @@ consteval fixed_t operator ""_fx(unsigned long long x)
 {
 	if (x > static_cast<unsigned long long>(std::numeric_limits<int32_t>::max() >> FRACBITS))
 		throw "Literal out of range for type fixed_t";
-	return INT2FIXED(x);
+	return INT2FIXED(static_cast<int32_t>(x));
 }
 
 [[nodiscard]]
@@ -221,7 +221,7 @@ consteval fixed64_t operator ""_fx64(unsigned long long x)
 {
 	if (x > static_cast<unsigned long long>(std::numeric_limits<int64_t>::max() >> FRACBITS64))
 		throw "Literal out of range for type fixed64_t";
-    return INT2FIXED64(x);
+    return INT2FIXED64(static_cast<int64_t>(x));
 }
 
 [[nodiscard]]
@@ -234,7 +234,7 @@ consteval fixed_t operator ""_fx(long double x)
 
 	if (x < min || x > max)
 		throw "Literal out of range for type fixed_t";
-    return DOUBLE2FIXED(x);
+    return DOUBLE2FIXED(static_cast<double>(x));
 }
 
 [[nodiscard]]
@@ -247,5 +247,5 @@ consteval fixed64_t operator ""_fx64(long double x)
 
 	if (x < min || x > max)
 		throw "Literal out of range for type fixed64_t";
-    return DOUBLE2FIXED64(x);
+    return DOUBLE2FIXED64(static_cast<double>(x));
 }

--- a/tests/unit-tests/test/t_fixed.cpp
+++ b/tests/unit-tests/test/t_fixed.cpp
@@ -133,6 +133,30 @@ TEST(FixedMath, NegativeFloatConversion) {
 	EXPECT_FLOAT_EQ(FIXED2FLOAT(FLOAT2FIXED(-1234.5f)), -1234.5f);
 }
 
+// -------------------------------------------------
+// ------- multiplication and division tests -------
+// -------------------------------------------------
+
+TEST(FixedMath, Multiplication) {
+	EXPECT_EQ(FixedMul(0_fx, 0_fx), 0_fx);
+	EXPECT_EQ(FixedMul(1_fx, 0_fx), 0_fx);
+	EXPECT_EQ(FixedMul(0_fx, 1_fx), 0_fx);
+	EXPECT_EQ(FixedMul(1_fx, 1_fx), 1_fx);
+	EXPECT_EQ(FixedMul(32767_fx, 1_fx), 32767_fx);
+	EXPECT_EQ(FixedMul(16_fx, 16_fx), 256_fx);
+	EXPECT_EQ(FixedMul(3_fx, 4_fx), 12_fx);
+	EXPECT_EQ(FixedMul(2_fx, 16383.5_fx), 32767_fx);
+}
+
+TEST(FixedMath, DISABLED_Division) {
+	EXPECT_EQ(FixedDiv(0_fx, 1_fx), 0_fx);
+	EXPECT_EQ(FixedDiv(1_fx, 1_fx), 1_fx);
+	EXPECT_EQ(FixedDiv(32767_fx, 2_fx), 16383.5_fx);
+	EXPECT_EQ(FixedDiv(256_fx, 16_fx), 16_fx);
+	EXPECT_EQ(FixedDiv(12_fx, 4_fx), 3_fx);
+	EXPECT_EQ(FixedDiv(32767_fx, 1_fx), 32767_fx);
+}
+
 // 44.20 fixed64_t
 
 // -------------------------------------
@@ -262,4 +286,48 @@ TEST(FixedMath64, NegativeFloatConversion) {
 	EXPECT_FLOAT_EQ(FIXED642FLOAT(FLOAT2FIXED64(-1.0f)), -1.0f);
 	EXPECT_FLOAT_EQ(FIXED642FLOAT(FLOAT2FIXED64(-1.25f)), -1.25f);
 	EXPECT_FLOAT_EQ(FIXED642FLOAT(FLOAT2FIXED64(-1234.5f)), -1234.5f);
+}
+
+// ------ fixed to fixed64 ------
+
+TEST(FixedMath64, FixedToFixed64Conversion) {
+	EXPECT_EQ(FIXED2FIXED64(0_fx), 0_fx64);
+	EXPECT_EQ(FIXED2FIXED64(1_fx), 1_fx64);
+	EXPECT_EQ(FIXED2FIXED64(2_fx), 2_fx64);
+	EXPECT_EQ(FIXED2FIXED64(10_fx), 10_fx64);
+	EXPECT_EQ(FIXED2FIXED64(1234_fx), 1234_fx64);
+	EXPECT_EQ(FIXED2FIXED64(32767_fx), 32767_fx64);
+}
+
+TEST(FixedMath64, Fixed64ToFixedConversion) {
+	EXPECT_EQ(FIXED642FIXED(0_fx64), 0_fx);
+	EXPECT_EQ(FIXED642FIXED(1_fx64), 1_fx);
+	EXPECT_EQ(FIXED642FIXED(2_fx64), 2_fx);
+	EXPECT_EQ(FIXED642FIXED(10_fx64), 10_fx);
+	EXPECT_EQ(FIXED642FIXED(1234_fx64), 1234_fx);
+	EXPECT_EQ(FIXED642FIXED(32767_fx64), 32767_fx);
+}
+
+// -------------------------------------------------
+// ------- multiplication and division tests -------
+// -------------------------------------------------
+
+TEST(FixedMath64, Multiplication) {
+	EXPECT_EQ(FixedMul64(0_fx64, 0_fx64), 0_fx64);
+	EXPECT_EQ(FixedMul64(1_fx64, 0_fx64), 0_fx64);
+	EXPECT_EQ(FixedMul64(0_fx64, 1_fx64), 0_fx64);
+	EXPECT_EQ(FixedMul64(1_fx64, 1_fx64), 1_fx64);
+	EXPECT_EQ(FixedMul64(32767_fx64, 1_fx64), 32767_fx64);
+	EXPECT_EQ(FixedMul64(16_fx64, 16_fx64), 256_fx64);
+	EXPECT_EQ(FixedMul64(3_fx64, 4_fx64), 12_fx64);
+	EXPECT_EQ(FixedMul64(2_fx64, 16383.5_fx64), 32767_fx64);
+}
+
+TEST(FixedMath64, DISABLED_Division) {
+	EXPECT_EQ(FixedDiv64(0_fx64, 1_fx64), 0_fx64);
+	EXPECT_EQ(FixedDiv64(1_fx64, 1_fx64), 1_fx64);
+	EXPECT_EQ(FixedDiv64(32767_fx64, 2_fx64), 16383.5_fx64);
+	EXPECT_EQ(FixedDiv64(256_fx64, 16_fx64), 16_fx64);
+	EXPECT_EQ(FixedDiv64(12_fx64, 4_fx64), 3_fx64);
+	EXPECT_EQ(FixedDiv64(32767_fx64, 1_fx64), 32767_fx64);
 }

--- a/tests/unit-tests/test/t_fixed.cpp
+++ b/tests/unit-tests/test/t_fixed.cpp
@@ -323,7 +323,7 @@ TEST(FixedMath64, Multiplication) {
 	EXPECT_EQ(FixedMul64(2_fx64, 16383.5_fx64), 32767_fx64);
 }
 
-TEST(FixedMath64, DISABLED_Division) {
+TEST(FixedMath64, Division) {
 	EXPECT_EQ(FixedDiv64(0_fx64, 1_fx64), 0_fx64);
 	EXPECT_EQ(FixedDiv64(1_fx64, 1_fx64), 1_fx64);
 	EXPECT_EQ(FixedDiv64(32767_fx64, 2_fx64), 16383.5_fx64);


### PR DESCRIPTION
It was being cast to 64 bit after shifting instead of before