### PR TITLE
Remove invalid packet constructor

### DIFF
--- a/common/SequenceQueueEntryType.h
+++ b/common/SequenceQueueEntryType.h
@@ -37,14 +37,6 @@ struct SequenceQueueEntryType
 	int   lastRetransmitTic;///< The tic number on which this packet was last retransmitted.
 	bool  isAwaiting;       ///< True if this packet needs yet to be acked.
 
-	SequenceQueueEntryType() :
-		buf           (),
-		sequence      (-1),
-		originatingTic(-1),
-		lastRetransmitTic(-1),
-		isAwaiting    (false)
-	{}
-
 	explicit SequenceQueueEntryType(size_t length) :
 		buf           (length),
 		sequence      (-1),

--- a/common/SequenceQueueEntryType.h
+++ b/common/SequenceQueueEntryType.h
@@ -21,6 +21,8 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
+#include <cassert>
+
 #include "i_net.h"
 
 // This is sized with a theoretical max tolerance assuming a client with about
@@ -43,5 +45,13 @@ struct SequenceQueueEntryType
 		originatingTic(-1),
 		lastRetransmitTic(-1),
 		isAwaiting    (false)
-	{}
+	{
+		// We do it this way so that MSVC has a place to drop a breakpoint in the event of a failure.
+		// This is only a concern with MSVC because it does NOT trigger a breakpoint automatically
+		// when an assert fails in a console application!
+		if (buf.maxsize() == 0)
+		{
+			assert(buf.maxsize() > 0);
+		}
+	}
 };

--- a/tests/unit-tests/test/t_SequenceReceiver.cpp
+++ b/tests/unit-tests/test/t_SequenceReceiver.cpp
@@ -8,7 +8,7 @@
 
 struct ReliableSequenceReceiverData
 {
-    SequenceQueueEntryType packet;
+    SequenceQueueEntryType packet {16};
 };
 
 struct ReliableSequenceReceiver : ReliableSequenceReceiverData, testing::Test

--- a/tests/unit-tests/test/t_SequenceReceiver.cpp
+++ b/tests/unit-tests/test/t_SequenceReceiver.cpp
@@ -8,7 +8,7 @@
 
 struct ReliableSequenceReceiverData
 {
-    SequenceQueueEntryType packet {16};
+    SequenceQueueEntryType packet {16}; // The 16 byte packet buffer is an arbitrary size.  Just as long as it's > 0.
 };
 
 struct ReliableSequenceReceiver : ReliableSequenceReceiverData, testing::Test


### PR DESCRIPTION
This ultimately addresses an out-of-bounds vector read seen in the unit tests where I originally wrote them to use 0-sized packet buffers.

In RelWithDebInfo builds, this didn't actually trigger a read because the offending line was optimized from a full read to an address calculation, and the read itself wouldn't take place because the ultimate `memcpy` knows to not access data in 0-byte copy operations.

In Debug builds, the `std::vector` bounds check would fail in the address calculation, which made use of `operator[]`.