### PR TITLE
Prevent unnecessary szp unlink and relink from/to same object

### DIFF
--- a/common/szp.h
+++ b/common/szp.h
@@ -123,7 +123,7 @@ public:
 	inline szp &operator =(szp other)
 	{
 		// itself?
-		if(&other == this)
+		if(&other == this || other.naive == naive)
 			return *this;
 
 		unlink();


### PR DESCRIPTION
No need to unlink and relink an szp if it's going to wind up pointing right back at the same thing.

This greatly helps debugging if we need to put a watchpoint on an szp's pointer to some data object.  Without this commit, we often see the `naive` pointer get set to nullptr and then right back to whatever it had already been pointing at.