### PR TITLE
Make sure that a request for the actor with netid == 0 yields nullptr

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -372,12 +372,16 @@ void P_ClearAllNetIds()
 //
 AActor* P_FindThingById(uint32_t id)
 {
-	netid_map_t::iterator i = actor_by_netid.find(id);
+	if (id)
+	{
+		netid_map_t::iterator i = actor_by_netid.find(id);
 
-	if(i == actor_by_netid.end())
-		return AActor::AActorPtr();
-	else
-		return i->second;
+		if(i != actor_by_netid.end())
+		{
+			return i->second;
+		}
+	}
+	return nullptr;
 }
 
 //
@@ -386,7 +390,10 @@ AActor* P_FindThingById(uint32_t id)
 void P_SetThingId(AActor *mo, uint32_t newnetid)
 {
 	mo->netid = newnetid;
-	actor_by_netid[newnetid] = mo->ptr();
+	if (newnetid)
+	{
+		actor_by_netid[newnetid] = mo->ptr();
+	}
 }
 
 


### PR DESCRIPTION
NetIDs start at 1, and 0 is used to mean "no NetID," so make sure that we don't let it map to anything.

This addresses an issue where when the server tells clients that a mobj no longer has a target, the clients wind up just picking something that doesn't have a NetId, leading to a nonsensical state and potentially odd effects, especially if used as a mobj's target.