### PR TITLE
[stable] Prevent unnecessary szp unlink and relink from/to same object

### DIFF
--- a/common/szp.h
+++ b/common/szp.h
@@ -123,7 +123,7 @@ public:
 	inline szp &operator =(szp other)
 	{
 		// itself?
-		if(&other == this)
+		if(&other == this || other.naive == naive)
 			return *this;
 
 		unlink();


### PR DESCRIPTION
The same thing as https://github.com/odamex/odamex/pull/1662, except based on and targeting the `stable` branch.