### PR TITLE
Add `NoiseAlert` message to propagate sector soundtarget state from server to client

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2983,6 +2983,20 @@ static void CL_SpreeBreaker(const odaproto::svc::SpreeBreaker* msg)
 	SpreeManager::getInstance().setRawSpreeBreaker(breaker, level, type);
 }
 
+static void CL_SectorSoundtarget(const odaproto::svc::SectorSoundtarget* msg)
+{
+    const uint32_t sectorIndex = msg->sectornum();
+
+    if (sectorIndex < static_cast<uint32_t>(::numsectors))
+    {
+        sector_t& sector = sectors[sectorIndex];
+
+        AActor* soundtarget = P_FindThingById(msg->soundtarget_netid());
+
+        sector.soundtarget = soundtarget->ptr();
+    }
+}
+
 static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)
 {
 	player_t* clientPlayer = &consoleplayer();
@@ -3206,6 +3220,7 @@ parseError_e CL_ProcessCommand(const ParseResultType& parsedCommand)
 		SV_MSG(svc_hordeinfo, CL_HordeInfo, odaproto::svc::HordeInfo);
 		SV_MSG(svc_spree, CL_Spree, odaproto::svc::Spree);
 		SV_MSG(svc_spreebreaker, CL_SpreeBreaker, odaproto::svc::SpreeBreaker);
+		SV_MSG(svc_sectorsoundtarget, CL_SectorSoundtarget, odaproto::svc::SectorSoundtarget);
 		SV_MSG(svc_netdemocap, CL_NetdemoCap, odaproto::svc::NetdemoCap);
 		SV_MSG(svc_netdemostop, CL_NetDemoStop, odaproto::svc::NetDemoStop);
 		SV_MSG(svc_netdemoloadsnap, CL_NetDemoLoadSnap, odaproto::svc::NetDemoLoadSnap);

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2985,19 +2985,19 @@ static void CL_SpreeBreaker(const odaproto::svc::SpreeBreaker* msg)
 
 static void CL_NoiseAlert(const odaproto::svc::NoiseAlert* msg)
 {
-    const uint32_t sectorIndex = msg->sectornum();
+	const uint32_t sectorIndex = msg->sectornum();
 
-    if (sectorIndex < static_cast<uint32_t>(::numsectors))
-    {
-        sector_t& sector = ::sectors[sectorIndex];
+	if (sectorIndex < static_cast<uint32_t>(::numsectors))
+	{
+		sector_t& sector = ::sectors[sectorIndex];
 
-        AActor* soundtarget = P_FindThingById(msg->soundtarget_netid());
+		AActor* soundtarget = P_FindThingById(msg->soundtarget_netid());
 
-        if (soundtarget)
-        {
-            P_NoiseAlert(*soundtarget, sector);
-        }
-    }
+		if (soundtarget)
+		{
+			P_NoiseAlert(*soundtarget, sector);
+		}
+	}
 }
 
 static void CL_NetdemoCap(const odaproto::svc::NetdemoCap* msg)

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2983,17 +2983,20 @@ static void CL_SpreeBreaker(const odaproto::svc::SpreeBreaker* msg)
 	SpreeManager::getInstance().setRawSpreeBreaker(breaker, level, type);
 }
 
-static void CL_SectorSoundtarget(const odaproto::svc::SectorSoundtarget* msg)
+static void CL_NoiseAlert(const odaproto::svc::NoiseAlert* msg)
 {
     const uint32_t sectorIndex = msg->sectornum();
 
     if (sectorIndex < static_cast<uint32_t>(::numsectors))
     {
-        sector_t& sector = sectors[sectorIndex];
+        sector_t& sector = ::sectors[sectorIndex];
 
         AActor* soundtarget = P_FindThingById(msg->soundtarget_netid());
 
-        sector.soundtarget = soundtarget->ptr();
+        if (soundtarget)
+        {
+            P_NoiseAlert(*soundtarget, sector);
+        }
     }
 }
 
@@ -3220,7 +3223,7 @@ parseError_e CL_ProcessCommand(const ParseResultType& parsedCommand)
 		SV_MSG(svc_hordeinfo, CL_HordeInfo, odaproto::svc::HordeInfo);
 		SV_MSG(svc_spree, CL_Spree, odaproto::svc::Spree);
 		SV_MSG(svc_spreebreaker, CL_SpreeBreaker, odaproto::svc::SpreeBreaker);
-		SV_MSG(svc_sectorsoundtarget, CL_SectorSoundtarget, odaproto::svc::SectorSoundtarget);
+		SV_MSG(svc_noisealert, CL_NoiseAlert, odaproto::svc::NoiseAlert);
 		SV_MSG(svc_netdemocap, CL_NetdemoCap, odaproto::svc::NetdemoCap);
 		SV_MSG(svc_netdemostop, CL_NetDemoStop, odaproto::svc::NetDemoStop);
 		SV_MSG(svc_netdemoloadsnap, CL_NetDemoLoadSnap, odaproto::svc::NetDemoLoadSnap);

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -71,6 +71,7 @@ void SV_SendExecuteLineSpecial(byte special, const line_t* line, const AActor* a
 
 void SV_UpdateMonsterRespawnCount() {}
 void SV_Sound(const AActor* mo, byte channel, const char* name, byte attenuation) {}
+void SV_BroadcastSectorSoundtargetUpdate(sector_t& , AActor& ) {}
 
 
 CVAR_FUNC_IMPL(sv_sharekeys) {}

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -71,8 +71,6 @@ void SV_SendExecuteLineSpecial(byte special, const line_t* line, const AActor* a
 
 void SV_UpdateMonsterRespawnCount() {}
 void SV_Sound(const AActor* mo, byte channel, const char* name, byte attenuation) {}
-void SV_BroadcastSectorSoundtargetUpdate(sector_t& , AActor& ) {}
-
 
 CVAR_FUNC_IMPL(sv_sharekeys) {}
 

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -72,6 +72,7 @@ void SV_SendExecuteLineSpecial(byte special, const line_t* line, const AActor* a
 void SV_UpdateMonsterRespawnCount() {}
 void SV_Sound(const AActor* mo, byte channel, const char* name, byte attenuation) {}
 
+
 CVAR_FUNC_IMPL(sv_sharekeys) {}
 
 VERSION_CONTROL (cl_stubs_cpp, "$Id$")

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -1072,6 +1072,7 @@ static void InitNetMessageFormats()
 	SVC_INFO(svc_maplist_index);
 	SVC_INFO(svc_toast);
 	SVC_INFO(svc_hordeinfo);
+	SVC_INFO(svc_sectorsoundtarget);
 	SVC_INFO(clc_playerinput);
 	SVC_INFO(svc_max);
 

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -1072,7 +1072,7 @@ static void InitNetMessageFormats()
 	SVC_INFO(svc_maplist_index);
 	SVC_INFO(svc_toast);
 	SVC_INFO(svc_hordeinfo);
-	SVC_INFO(svc_sectorsoundtarget);
+	SVC_INFO(svc_noisealert);
 	SVC_INFO(clc_playerinput);
 	SVC_INFO(svc_max);
 

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -257,8 +257,7 @@ enum svc_t
 	svc_resetmap,        // [AM] Server is resetting the map
 	svc_playerqueuepos,  // Notify clients of player queue postion
 	svc_fullupdatestart, // Inform client the full update has started
-	svc_lineupdate, // Sync client with any line property changes - e.g. SetLineTexture,
-	                // SetLineBlocking, SetLineSpecial, etc.
+	svc_lineupdate,      // Sync client with any line property changes - e.g. SetLineTexture, SetLineBlocking, SetLineSpecial, etc.
 	svc_sectorproperties,
 	svc_linesideupdate,
 	svc_mobjstate,
@@ -275,6 +274,7 @@ enum svc_t
 	svc_raisemobj,
 	svc_spree,
 	svc_spreebreaker,
+	svc_sectorsoundtarget,
 	clc_playerinput,        // SPECIAL KNOWLEDGE AND NOTE HERE: We're entering a transitory phase
 	                        // where client-originated messages are going to start transitioning
 	                        // to protobufs, and this svc enum is the basis for the unified message

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -274,7 +274,7 @@ enum svc_t
 	svc_raisemobj,
 	svc_spree,
 	svc_spreebreaker,
-	svc_sectorsoundtarget,
+	svc_noisealert,
 	clc_playerinput,        // SPECIAL KNOWLEDGE AND NOTE HERE: We're entering a transitory phase
 	                        // where client-originated messages are going to start transitioning
 	                        // to protobufs, and this svc enum is the basis for the unified message

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -116,6 +116,7 @@ void SV_SendRaiseMobj(const AActor* source, const AActor* corpse);
 void SV_UpdateMobj(const AActor* mo);
 void SV_Sound(const AActor* mo, byte channel, const char* name, byte attenuation);
 void SV_SpawnMobj(AActor* mobj);
+void SV_BroadcastSectorSoundtargetUpdate(sector_t& sector, AActor& soundtarget);
 
 extern bool isFast;
 
@@ -146,6 +147,14 @@ void P_RecursiveSound (sector_t *sec, int soundblocks, AActor *soundtarget)
 	{
 		return; 		// already flooded
 	}
+
+    SERVER_ONLY
+    (
+        if (sec->soundtarget != soundtarget)
+        {
+            SV_BroadcastSectorSoundtargetUpdate(*sec, *soundtarget);
+        }
+    )
 
 	sec->validcount = validcount;
 	sec->soundtraversed = soundblocks+1;

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -137,7 +137,6 @@ extern bool isFast;
 
 bool P_RecursiveSound (sector_t& sec, int soundblocks, AActor& soundtarget)
 {
-	int 		i;
 	line_t* 	check;
 	sector_t*	other;
 
@@ -145,7 +144,7 @@ bool P_RecursiveSound (sector_t& sec, int soundblocks, AActor& soundtarget)
 	if (sec.validcount == validcount
 		&& sec.soundtraversed <= soundblocks+1)
 	{
-		return false; 		// already flooded
+		return false;         // already flooded
 	}
 
 	bool soundtargetWasChanged = sec.soundtarget != soundtarget.ptr();
@@ -154,7 +153,7 @@ bool P_RecursiveSound (sector_t& sec, int soundblocks, AActor& soundtarget)
 	sec.soundtraversed = soundblocks+1;
 	sec.soundtarget = soundtarget.ptr();
 
-	for (i=0 ;i<sec.linecount ; i++)
+	for (int i = 0; i < sec. linecount; i++)
 	{
 		check = sec.lines[i];
 		if (! (check->flags & ML_TWOSIDED) )
@@ -196,6 +195,7 @@ bool P_RecursiveSound (sector_t& sec, int soundblocks, AActor& soundtarget)
 //
 // P_NoiseAlert
 // Propagates any sound that sets off monsters against the given target.
+// Returns true if any sector's soundtarget was actually changed as a result of the sound.
 //
 bool P_NoiseAlert (AActor& target, sector_t& sec)
 {
@@ -205,20 +205,20 @@ bool P_NoiseAlert (AActor& target, sector_t& sec)
 	validcount++;
 	const bool soundtargetWasChanged = P_RecursiveSound (sec, 0, target);
 
-    SERVER_ONLY
-    (
-        if (soundtargetWasChanged)
-        {
-            SV_BroadcastNoiseAlert(sec);
-        }
-    )
+	SERVER_ONLY
+	(
+		if (soundtargetWasChanged)
+		{
+			SV_BroadcastNoiseAlert(sec);
+		}
+	)
 
-    return soundtargetWasChanged;
+	return soundtargetWasChanged;
 }
 
 bool P_NoiseAlert (AActor *target, AActor *emmiter)
 {
-    return P_NoiseAlert(*target, *emmiter->subsector->sector);
+	return P_NoiseAlert(*target, *emmiter->subsector->sector);
 }
 
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -116,7 +116,7 @@ void SV_SendRaiseMobj(const AActor* source, const AActor* corpse);
 void SV_UpdateMobj(const AActor* mo);
 void SV_Sound(const AActor* mo, byte channel, const char* name, byte attenuation);
 void SV_SpawnMobj(AActor* mobj);
-void SV_BroadcastSectorSoundtargetUpdate(sector_t& sector, AActor& soundtarget);
+void SV_BroadcastNoiseAlert(const sector_t& sector);
 
 extern bool isFast;
 
@@ -135,38 +135,32 @@ extern bool isFast;
 // sound blocking lines cut off traversal.
 //
 
-void P_RecursiveSound (sector_t *sec, int soundblocks, AActor *soundtarget)
+bool P_RecursiveSound (sector_t& sec, int soundblocks, AActor& soundtarget)
 {
 	int 		i;
 	line_t* 	check;
 	sector_t*	other;
 
 	// wake up all monsters in this sector
-	if (sec->validcount == validcount
-		&& sec->soundtraversed <= soundblocks+1)
+	if (sec.validcount == validcount
+		&& sec.soundtraversed <= soundblocks+1)
 	{
-		return; 		// already flooded
+		return false; 		// already flooded
 	}
 
-    SERVER_ONLY
-    (
-        if (sec->soundtarget != soundtarget)
-        {
-            SV_BroadcastSectorSoundtargetUpdate(*sec, *soundtarget);
-        }
-    )
+	bool soundtargetWasChanged = sec.soundtarget != soundtarget.ptr();
 
-	sec->validcount = validcount;
-	sec->soundtraversed = soundblocks+1;
-	sec->soundtarget = soundtarget->ptr();
+	sec.validcount = validcount;
+	sec.soundtraversed = soundblocks+1;
+	sec.soundtarget = soundtarget.ptr();
 
-	for (i=0 ;i<sec->linecount ; i++)
+	for (i=0 ;i<sec.linecount ; i++)
 	{
-		check = sec->lines[i];
+		check = sec.lines[i];
 		if (! (check->flags & ML_TWOSIDED) )
 			continue;
 
-		if ( sides[ check->sidenum[0] ].sector == sec)
+		if ( sides[ check->sidenum[0] ].sector == &sec)
 			other = sides[ check->sidenum[1] ] .sector;
 		else
 			other = sides[ check->sidenum[0] ].sector;
@@ -175,7 +169,7 @@ void P_RecursiveSound (sector_t *sec, int soundblocks, AActor *soundtarget)
 		// midpoint of a sloped linedef.  P_RecursiveSound() in ZDoom 1.23 causes
 		// demo desyncs.
 		P_LineOpening(check, (check->v1->x >> 1) + (check->v2->x >> 1),
-							 (check->v1->y >> 1) + (check->v2->y >> 1));
+		                     (check->v1->y >> 1) + (check->v2->y >> 1));
 
 		if (openrange <= 0)
 			continue;	// closed door
@@ -183,27 +177,48 @@ void P_RecursiveSound (sector_t *sec, int soundblocks, AActor *soundtarget)
 		if (check->flags & ML_SOUNDBLOCK)
 		{
 			if (!soundblocks)
-				P_RecursiveSound (other, 1, soundtarget);
+			{
+				const bool propagatedSoundtargetWasChanged = P_RecursiveSound (*other, 1, soundtarget);
+				soundtargetWasChanged = soundtargetWasChanged or propagatedSoundtargetWasChanged;
+			}
 		}
 		else
-			P_RecursiveSound (other, soundblocks, soundtarget);
+		{
+			const bool propagatedSoundtargetWasChanged = P_RecursiveSound (*other, soundblocks, soundtarget);
+			soundtargetWasChanged = soundtargetWasChanged or propagatedSoundtargetWasChanged;
+		}
 	}
+	return soundtargetWasChanged;
 }
 
 
 
 //
 // P_NoiseAlert
-// If a monster yells at a player,
-// it will alert other monsters to the player.
+// Propagates any sound that sets off monsters against the given target.
 //
-void P_NoiseAlert (AActor *target, AActor *emmiter)
+bool P_NoiseAlert (AActor& target, sector_t& sec)
 {
-	if (target->player && (!multiplayer && (target->player->cheats & CF_NOTARGET)))
-		return;
+	if (target.player && (!multiplayer && (target.player->cheats & CF_NOTARGET)))
+		return false;
 
 	validcount++;
-	P_RecursiveSound (emmiter->subsector->sector, 0, target);
+	const bool soundtargetWasChanged = P_RecursiveSound (sec, 0, target);
+
+    SERVER_ONLY
+    (
+        if (soundtargetWasChanged)
+        {
+            SV_BroadcastNoiseAlert(sec);
+        }
+    )
+
+    return soundtargetWasChanged;
+}
+
+bool P_NoiseAlert (AActor *target, AActor *emmiter)
+{
+    return P_NoiseAlert(*target, *emmiter->subsector->sector);
 }
 
 

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -145,7 +145,9 @@ bool	P_DeactivateMobj (AActor *mobj);
 //
 // P_ENEMY
 //
-void	P_NoiseAlert (AActor* target, AActor* emmiter);
+bool P_NoiseAlert (AActor* target, AActor* emmiter);
+bool P_NoiseAlert (AActor& target, sector_t& sec);
+
 void	P_SpawnBrainTargets(void);	// killough 3/26/98: spawn icon landings
 
 extern struct brain_s {				// killough 3/26/98: global state of boss brain

--- a/common/svc_map.cpp
+++ b/common/svc_map.cpp
@@ -114,6 +114,7 @@ static void InitMap()
 	MapProto(svc_raisemobj, odaproto::svc::RaiseMobj::descriptor());
 	MapProto(svc_spree, odaproto::svc::Spree::descriptor());
 	MapProto(svc_spreebreaker, odaproto::svc::SpreeBreaker::descriptor());
+	MapProto(svc_sectorsoundtarget, odaproto::svc::SectorSoundtarget::descriptor());
 	MapProto(svc_netdemocap, odaproto::svc::NetdemoCap::descriptor());
 	MapProto(svc_netdemostop, odaproto::svc::NetDemoStop::descriptor());
 	MapProto(svc_netdemoloadsnap, odaproto::svc::NetDemoLoadSnap::descriptor());

--- a/common/svc_map.cpp
+++ b/common/svc_map.cpp
@@ -114,7 +114,7 @@ static void InitMap()
 	MapProto(svc_raisemobj, odaproto::svc::RaiseMobj::descriptor());
 	MapProto(svc_spree, odaproto::svc::Spree::descriptor());
 	MapProto(svc_spreebreaker, odaproto::svc::SpreeBreaker::descriptor());
-	MapProto(svc_sectorsoundtarget, odaproto::svc::SectorSoundtarget::descriptor());
+	MapProto(svc_noisealert, odaproto::svc::NoiseAlert::descriptor());
 	MapProto(svc_netdemocap, odaproto::svc::NetdemoCap::descriptor());
 	MapProto(svc_netdemostop, odaproto::svc::NetDemoStop::descriptor());
 	MapProto(svc_netdemoloadsnap, odaproto::svc::NetDemoLoadSnap::descriptor());

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1232,6 +1232,16 @@ odaproto::svc::LineUpdate SVC_LineUpdate(const line_t& line)
 	return msg;
 }
 
+odaproto::svc::SectorSoundtarget SVC_SectorSoundtarget(const sector_t& sector, AActor& soundtarget)
+{
+	odaproto::svc::SectorSoundtarget msg;
+
+	msg.set_sectornum(&sector - ::sectors);
+	msg.set_soundtarget_netid(soundtarget.netid);
+
+	return msg;
+}
+
 odaproto::svc::SectorProperties SVC_SectorProperties(const sector_t& sector)
 {
 	odaproto::svc::SectorProperties msg;

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1232,12 +1232,15 @@ odaproto::svc::LineUpdate SVC_LineUpdate(const line_t& line)
 	return msg;
 }
 
-odaproto::svc::SectorSoundtarget SVC_SectorSoundtarget(const sector_t& sector, AActor& soundtarget)
+odaproto::svc::NoiseAlert SVC_NoiseAlert(const sector_t& sector)
 {
-	odaproto::svc::SectorSoundtarget msg;
+	odaproto::svc::NoiseAlert msg;
 
 	msg.set_sectornum(&sector - ::sectors);
-	msg.set_soundtarget_netid(soundtarget.netid);
+	if (sector.soundtarget)
+	{
+	    msg.set_soundtarget_netid(sector.soundtarget->netid);
+	}
 
 	return msg;
 }

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1239,7 +1239,7 @@ odaproto::svc::NoiseAlert SVC_NoiseAlert(const sector_t& sector)
 	msg.set_sectornum(&sector - ::sectors);
 	if (sector.soundtarget)
 	{
-	    msg.set_soundtarget_netid(sector.soundtarget->netid);
+		msg.set_soundtarget_netid(sector.soundtarget->netid);
 	}
 
 	return msg;

--- a/common/svc_message.h
+++ b/common/svc_message.h
@@ -154,3 +154,4 @@ odaproto::svc::HordeInfo SVC_HordeInfo(const hordeInfo_t& horde);
 odaproto::svc::Spree SVC_Spree(const SpreeRecord_t& spree);
 odaproto::svc::SpreeBreaker SVC_SpreeBreaker(const SpreeBreaker_t& breaker, const int level, const SpreeBreakerType breakerType);
 odaproto::svc::NetdemoCap SVC_NetdemoCap(const player_t* player);
+odaproto::svc::SectorSoundtarget SVC_SectorSoundtarget(const sector_t& sector, AActor& soundtarget);

--- a/common/svc_message.h
+++ b/common/svc_message.h
@@ -154,4 +154,4 @@ odaproto::svc::HordeInfo SVC_HordeInfo(const hordeInfo_t& horde);
 odaproto::svc::Spree SVC_Spree(const SpreeRecord_t& spree);
 odaproto::svc::SpreeBreaker SVC_SpreeBreaker(const SpreeBreaker_t& breaker, const int level, const SpreeBreakerType breakerType);
 odaproto::svc::NetdemoCap SVC_NetdemoCap(const player_t* player);
-odaproto::svc::SectorSoundtarget SVC_SectorSoundtarget(const sector_t& sector, AActor& soundtarget);
+odaproto::svc::NoiseAlert SVC_NoiseAlert(const sector_t& sector);

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -489,6 +489,13 @@ message SectorProperties
 	Sector sector = 3;
 }
 
+// svc_sectorsoundtarget
+message SectorSoundtarget
+{
+	uint32 sectornum = 1;
+	uint32 soundtarget_netid = 2;
+}
+
 // svc_linesideupdate
 message LineSideUpdate
 {

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -489,8 +489,8 @@ message SectorProperties
 	Sector sector = 3;
 }
 
-// svc_sectorsoundtarget
-message SectorSoundtarget
+// svc_noisealert
+message NoiseAlert
 {
 	uint32 sectornum = 1;
 	uint32 soundtarget_netid = 2;

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1619,6 +1619,14 @@ bool SV_SendPacket(player_t &pl)
 	return pl.client.messenger.SendAll(gametic, pl.client.address) != MessageResultEnum::ABORT;
 }
 
+void SV_BroadcastSectorSoundtargetUpdate(sector_t& sector, AActor& soundtarget)
+{
+	for (auto& player : players)
+    {
+        MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_SectorSoundtarget(sector, soundtarget));
+    }
+}
+
 void SV_UpdateSector(client_t* cl, int sectornum)
 {
 	sector_t* sector = &sectors[sectornum];

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1621,6 +1621,11 @@ bool SV_SendPacket(player_t &pl)
 
 void SV_BroadcastNoiseAlert(const sector_t& sector)
 {
+	// Please note that we still send the noise alert back to the player that created it.
+	// This is intentional so that in the case that there's another player in a nearby sector
+	// also making a bunch of noise with overlapping areas of influence, the client plays back
+	// the same sequence of noise alerts, ultimately leading to the soundtarget states matching
+	// the server.
 	for (auto& player : players)
 	{
 		MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_NoiseAlert(sector));

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1619,12 +1619,12 @@ bool SV_SendPacket(player_t &pl)
 	return pl.client.messenger.SendAll(gametic, pl.client.address) != MessageResultEnum::ABORT;
 }
 
-void SV_BroadcastSectorSoundtargetUpdate(sector_t& sector, AActor& soundtarget)
+void SV_BroadcastNoiseAlert(const sector_t& sector)
 {
 	for (auto& player : players)
-    {
-        MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_SectorSoundtarget(sector, soundtarget));
-    }
+	{
+		MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_NoiseAlert(sector));
+	}
 }
 
 void SV_UpdateSector(client_t* cl, int sectornum)


### PR DESCRIPTION
### Overview

This addresses a rare ghost desync seen upon the following sequence of events:

1. Player 1 makes noise in a sector.
2. Player 2 arrives in sector and makes noise.
3. Player 2 is killed by monsters.
4. Those monsters are left in a position where they cannot see player 1.
5. Player 1 sees those monsters become ghosts.  Everyone else, including the server, sees the monsters go idle.

### Details

The key detail is that the monsters are reacting to the sector's soundtarget, and the client code doesn't locally set sector soundtarget when a remote player makes noise in a sector - only when the local player makes noise.  This results in the server and the client all disagreeing with each other about sector soundtargets, and can cause client-side monster prediction to incorrectly start chasing the local player.

The fix is for the server to inform clients when any client makes a noise that causes any sector's soundtarget to actually change.  This is done with a new reliable message, `NoiseAlert`.  By processing these messages in the order that the server generated them, the clients reproduce the server's sector soundtarget states.

With this change, the end result of the test case is that instead of chasing Player 1, the monsters go idle on the client-side.  This is because the server-originated NoiseAlert on step 2 caused Player 1's sector soundtarget to point to Player 2, and when Player 2 dropped dead, the sector's soundtarget continued to refer to a dead player, and the monsters cannot see Player 1.  This all matches the behavior on the server.

Discord discussion: https://discord.com/channels/236518337671200768/250157428455243777/1485729031172260006

### Alternatives considered

Also tested was an approach of sending fine-grained notifications of sector soundtarget updates.  It worked, but this becomes *a lot* of unnecessary network traffic in the real world.  That approach was discarded in favor of putting the burden on the clients to do the actual sound propagation from noise event to sectors.