### PR TITLE
[BUGFIX] `SpecialAction_OpenDoor` uses incorrect linedef type

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1169,7 +1169,7 @@ struct MapInfoDataSetter<level_pwad_info_t>
 			{ "e4m6special", &MIType_Special<MT_NULL, MF3_E4M6BOSS>, &ref.bossactions },
 			{ "e4m8special", &MIType_Special<MT_NULL, MF3_E4M8BOSS>, &ref.bossactions },
 			{ "specialaction_exitlevel", &MIType_SpecialAction<11>, &ref.bossactions },
-			{ "specialaction_opendoor", &MIType_SpecialAction<29, 666>, &ref.bossactions },
+			{ "specialaction_opendoor", &MIType_SpecialAction<109, 666>, &ref.bossactions },
 			{ "specialaction_lowerfloor", &MIType_SpecialAction<23, 666>, &ref.bossactions },
 			{ "specialaction_killmonsters", &MIType_SpecialAction<280>, &ref.bossactions },
 			{ "lightning" },


### PR DESCRIPTION
Fixes: #1683

Seems the wrong linedef type was used when ZDoom SpecialActions, which don't actually pass through the linedef handling code, got reworked to be the same internally as UMAPINFO bossactions. Linedefs 29 and 109 are similar, but 29 is slower and automatically closes the door, which does not match the behavior of vanilla's E4M6 or ZDoom's `SpecialAction_OpenDoor`.