### PR TITLE
Fix `PlayerInput` angles being one tic behind the other fields

### DIFF
--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -542,13 +542,10 @@ void P_MovePlayer (player_t& player)
 	}
 
 	// Look left/right
-	if(clientside || step_mode)
-	{
-		mo->angle += player.cmd.yaw << 16;
+	mo->angle += player.cmd.yaw << 16;
 
-		// Look up/down stuff
-		P_PlayerLookUpDown(player);
-	}
+	// Look up/down stuff
+	P_PlayerLookUpDown(player);
 
 	// killough 10/98:
 	//


### PR DESCRIPTION
### Overview

Ensure that MovePlayer makes the same delta-angles adjustment on the server that it does on the client

### Details

The client proceeds into a tic with a set of starting angles, delta-yaw, and delta-pitch values. Before the client proceeds with predicting the world and local client, it sends those values to the server in `PlayerInput`.  When the client does a PlayerThink before simulating the world, the delta angles are added to the starting angles as part of MovePlayer.  All subsequent thinking and prediction in the tic is done using those calculated values.

When the server receives those values as part of the Player Input command, and it eventually processes that command, it also runs PlayerThink before heading into the rest of the tic. Unfortunately, the code that applied the delta angles was enclosed in a check that prevented it from happening on the server.  So the server proceeded into the tic with DIFFERENT angle values than the client.

Because the starting angle values are actually the result of the previous tic's adjusted outcomes, this creates the situation where the angles that the server actually uses are one tic behind all other fields in the Player Input messages - Use, Shoot, Move, Impulse, and Change Weapons.

This can naturally cause minute differences in the results between client and server.  In rare cases, particularly ones where the player has commanded some severe yaw motion, there could be major enough differences in prediction outcomes that switches aren't hit or shots miss.

### Testing

Fired up a local server, connected to it and tested taking slow and quick-turn shots at monsters with significant delta-yaw.  Verified that hits looked good.

Tested with both low ping and induced ~200 msec ping using Clumsy.