### PR TITLE
[BUGFIX] - Read access error on nullptr within P_SmartMove

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -486,7 +486,7 @@ bool P_SmartMove(AActor* actor)
 	int dropoff = 0;
 
 	/* killough 9/12/98: Stay on a lift if target is on one */
-	bool on_lift = co_staylift && target && target->health > 0 &&
+	bool on_lift = co_staylift && target && target->health > 0 && target->subsector &&
 	               target->subsector->sector->tag == actor->subsector->sector->tag &&
 	               P_IsOnLift(actor);
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -485,7 +485,7 @@ bool P_SmartMove(AActor* actor)
 	AActor* target = actor->target;
 	int dropoff = 0;
 
-	if (target->WasDestroyed())
+	if (target && target->WasDestroyed())
 	{
 		return false;
 	}

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -485,8 +485,13 @@ bool P_SmartMove(AActor* actor)
 	AActor* target = actor->target;
 	int dropoff = 0;
 
+	if (target->WasDestroyed())
+	{
+		return false;
+	}
+
 	/* killough 9/12/98: Stay on a lift if target is on one */
-	bool on_lift = co_staylift && target && target->health > 0 && target->subsector &&
+	bool on_lift = co_staylift && target && target->health > 0 &&
 	               target->subsector->sector->tag == actor->subsector->sector->tag &&
 	               P_IsOnLift(actor);
 


### PR DESCRIPTION
This bug was found from one of @nikovaan dmp files from a testing session. The crash happened immediately after a CL_LoadMap or CL_ResetMap. Not sure if more research needs to be done as to why target->subsector was null here. But this would at least fix the read violation

<img width="941" height="299" alt="image" src="https://github.com/user-attachments/assets/a7d04e27-26ff-4a8f-8382-907e25f9884a" />
