### PR TITLE
Change build job name to Build instead of Build (Universal) so that i…

### DIFF
--- a/.github/workflows/macos-rc.yml
+++ b/.github/workflows/macos-rc.yml
@@ -64,7 +64,7 @@ jobs:
           echo "CommitDate: ${{ steps.gitversion.outputs.commitDate }}"
           echo "TotalCommits: ${{ steps.revlist.outputs.totalCommits }}"
   build-macos-universal:
-    name: Build (Universal)
+    name: Build
     needs: pre_job
     runs-on: macos-14
     env:


### PR DESCRIPTION
…t matches the non release branch names for branch protection purposes