### PR TITLE
[BUGFIX] FLZOFile compressing uninitialized memory.

### DIFF
--- a/common/farchive.cpp
+++ b/common/farchive.cpp
@@ -184,13 +184,13 @@ FFile& FLZOFile::Write(const void* mem, unsigned int len)
 		return *this;
 	}
 
-	if (m_Pos + len > m_BufferSize)
+	if (m_Pos + len > m_MaxBufferSize)
 	{
 		do {
-			m_BufferSize = m_MaxBufferSize = m_BufferSize ? m_BufferSize * 2 : 16384;
-		} while (m_Pos + len > m_BufferSize);
+			m_MaxBufferSize = m_MaxBufferSize ? m_MaxBufferSize * 2 : 16384;
+		} while (m_Pos + len > m_MaxBufferSize);
 
-		m_Buffer = (byte*)M_Realloc(m_Buffer, m_BufferSize);
+		m_Buffer = (byte*)M_Realloc(m_Buffer, m_MaxBufferSize);
 	}
 
 	if (len == 1)


### PR DESCRIPTION
Addresses many valgrind warnings in `FLZOFile::Implode`.
<details>
<summary>Full list of warnings:</summary>

```
==13998== Use of uninitialised value of size 8
==13998==    at 0x799E10: lzo1x_1_compress_core (minilzo.c:4993)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x799E43: lzo1x_1_compress_core (minilzo.c:4994)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x799E58: lzo1x_1_compress_core (minilzo.c:4995)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A03C: lzo1x_1_compress_core (minilzo.c:5057)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A085: lzo1x_1_compress_core (minilzo.c:5063)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A0BC: lzo1x_1_compress_core (minilzo.c:5153)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A12F: lzo1x_1_compress_core (minilzo.c:5167)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x799DDB: lzo1x_1_compress_core (minilzo.c:4989)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x799DE5: lzo1x_1_compress_core (minilzo.c:4991)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x799E89: lzo1x_1_compress_core (minilzo.c:5003)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A016: lzo1x_1_compress_core (minilzo.c:5056)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A04E: lzo1x_1_compress_core (minilzo.c:5060)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A07E: lzo1x_1_compress_core (minilzo.c:5061)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A11F: lzo1x_1_compress_core (minilzo.c:5164)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A38C: lzo1x_1_compress (minilzo.c:5229)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A3BC: lzo1x_1_compress (minilzo.c:5229)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x799D9D: lzo1x_1_compress_core (minilzo.c:4940)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x799E94: lzo1x_1_compress_core (minilzo.c:5005)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x799ED1: lzo1x_1_compress_core (minilzo.c:5016)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x799EEE: lzo1x_1_compress_core (minilzo.c:5019)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x799F08: lzo1x_1_compress_core (minilzo.c:5020)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A15E: lzo1x_1_compress_core (minilzo.c:5172)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A17D: lzo1x_1_compress_core (minilzo.c:5176)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A1A8: lzo1x_1_compress_core (minilzo.c:5179)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A1C3: lzo1x_1_compress_core (minilzo.c:5181)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A1DE: lzo1x_1_compress_core (minilzo.c:5182)
==13998==    by 0x79A3FF: lzo1x_1_compress (minilzo.c:5234)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x79A45B: lzo1x_1_compress (minilzo.c:5245)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A4E1: lzo1x_1_compress (minilzo.c:5255)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A51C: lzo1x_1_compress (minilzo.c:5263)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A543: lzo1x_1_compress (minilzo.c:5265)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A5A0: lzo1x_1_compress (minilzo.c:5265)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A5C2: lzo1x_1_compress (minilzo.c:5269)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A5D1: lzo1x_1_compress (minilzo.c:5270)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x79A5E0: lzo1x_1_compress (minilzo.c:5271)
==13998==    by 0x4D8B73: FLZOFile::Implode() (farchive.cpp:267)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x4D8B89: FLZOFile::Implode() (farchive.cpp:270)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998==    by 0x7084B4: SV_RunTics() (sv_main.cpp:4099)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x4D8C04: FLZOFile::Implode() (farchive.cpp:282)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998==    by 0x7084B4: SV_RunTics() (sv_main.cpp:4099)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x55AE03: Malloc(unsigned long) (m_alloc.cpp:35)
==13998==    by 0x4D8C72: FLZOFile::Implode() (farchive.cpp:287)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x4840AD0: malloc (vg_replace_malloc.c:447)
==13998==    by 0x55AE17: Malloc(unsigned long) (m_alloc.cpp:38)
==13998==    by 0x4D8C72: FLZOFile::Implode() (farchive.cpp:287)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x4D8CBC: FLZOFile::Implode() (farchive.cpp:293)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998==    by 0x7084B4: SV_RunTics() (sv_main.cpp:4099)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x484F237: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x484F277: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x484F613: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x484F3AD: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x484F3C6: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x484F407: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x484F29B: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x484F2F0: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Use of uninitialised value of size 8
==13998==    at 0x484F2F3: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
==13998== 
==13998== Conditional jump or move depends on uninitialised value(s)
==13998==    at 0x484F2FD: memmove (vg_replace_strmem.c:1415)
==13998==    by 0x4D8D38: FLZOFile::Implode() (farchive.cpp:296)
==13998==    by 0x4D9117: FLZOMemFile::Close() (farchive.cpp:410)
==13998==    by 0x4D9553: FArchive::Close() (farchive.cpp:552)
==13998==    by 0x40D8E9: FArchive::~FArchive() (farchive.cpp:527)
==13998==    by 0x6F7610: G_DoSaveResetState() (sv_level.cpp:670)
==13998==    by 0x6F82EA: G_DoLoadLevel(int) (sv_level.cpp:965)
==13998==    by 0x6F728E: G_InitNew(char const*) (sv_level.cpp:570)
==13998==    by 0x6F569F: G_InitNew(OLumpName const&) (g_level.h:449)
==13998==    by 0x6F6953: G_DoNewGame() (sv_level.cpp:410)
==13998==    by 0x6F3F55: G_Ticker() (sv_game.cpp:131)
==13998==    by 0x708310: SV_StepTics(unsigned long) (sv_main.cpp:4048)
```
</details>

It turns out that `FLZOFile::Write` was mixing up `m_MaxBufferSize` and `m_BufferSize`, sometimes treating `m_BufferSize` as the capacity, rather than the size. This would result in `m_BufferSize` being too large, and some uninitialized memory in the buffer's capacity would be seen as part of the file by later operations.