### PR TITLE
[BUGFIX] No need to increment gametic if netdemo is paused

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -627,7 +627,7 @@ void CL_StepTics(unsigned int count)
 
 		G_Ticker ();
 		
-		if (!paused && !netdemo.isPaused())
+		if (!netdemo.isPaused())
 			gametic++;
 
 		if (netdemo.isPlaying() && !netdemo.isPaused())

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -626,7 +626,10 @@ void CL_StepTics(unsigned int count)
 		OInterpolation::getInstance().ticGameInterpolation();
 
 		G_Ticker ();
-		gametic++;
+		
+		if (!paused && !netdemo.isPaused())
+			gametic++;
+
 		if (netdemo.isPlaying() && !netdemo.isPaused())
 			netdemo.ticker();
 	}


### PR DESCRIPTION
Noticed that gametic was still incrementing while the game is in a paused state. I cant see any reason why this should be happening? For netdemos the gametic is overwritten anyway each tic in netdemo.readMessages(). Fixes #1516