### PR TITLE
Fix:  CPU spin and stop streaming console input when server (or client) is pushed to a terminal background

### DIFF
--- a/common/m_consolecommandstream.cpp
+++ b/common/m_consolecommandstream.cpp
@@ -23,6 +23,7 @@
 #include "m_consolecommandstream.h"
 
 #include <condition_variable>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -43,7 +44,6 @@
 
 #elif defined UNIX
 
-#include <filesystem>
 #include <signal.h>
 
 #endif

--- a/common/m_consolecommandstream.cpp
+++ b/common/m_consolecommandstream.cpp
@@ -41,6 +41,11 @@
 //  destructed.  On Debug builds, this raises an Abort signal.  By switching to
 //  SRW Locks, which don't even have a destructor, we can destruct at any time.
 
+#elif defined UNIX
+
+#include <filesystem>
+#include <signal.h>
+
 #endif
 
 namespace {
@@ -143,6 +148,18 @@ namespace {
 #ifdef _WIN32
 				InitializeSRWLock(& m_srwLock);
 				InitializeConditionVariable(& m_commandIsReleasedCondition);
+#elif defined UNIX
+				// In the event that we get pushed into the background of a terminal, yet still
+				// try to read from std::cin / stdin, and someone actually supplies input, we
+				// get a SIGTTIN, which causes the process to suspend because STOP is the default
+				// action for that signal.
+				//
+				// If we do get launched in or pushed to the background, we want to avoid being
+				// suspended, so we tell the process to ignore the signal.
+				//
+				// Please note that it means that our read operation will error out, in which
+				// case we have to let the thread exit because we can't just simply re-open cin.
+				signal(SIGTTIN, SIG_IGN);
 #endif
 				m_thread = std::thread(&CommandStreamReader::ThreadMain, this);
 			}
@@ -178,7 +195,12 @@ namespace {
 			void ThreadMain()
 			{
 				AcquireSRWLockExclusive(& m_srwLock);
-				while(true)
+
+				// Please note that we only allow the file to be reopened if we've been
+				// directed to read a fifo / named pipe.  We don't want to reopen text files
+				// or any other kind of file, and certainly not std::cin if it went bad.
+				for (bool reopenIsAllowed = true; reopenIsAllowed; reopenIsAllowed = not s_streamFilename.empty()
+                                                                                     and std::filesystem::is_fifo(s_streamFilename))
 				{
 					std::unique_ptr<std::ifstream> filePtr { s_streamFilename.empty() ? nullptr : std::make_unique<std::ifstream>(s_streamFilename) };
 					std::istream&                  streamRef = filePtr ? *filePtr : std::cin;
@@ -200,7 +222,12 @@ namespace {
 			void ThreadMain()
 			{
 				std::unique_lock lock(m_mutex);
-				while(true)
+
+				// Please note that we only allow the file to be reopened if we've been
+				// directed to read a fifo / named pipe.  We don't want to reopen text files
+				// or any other kind of file, and certainly not std::cin if it went bad.
+				for (bool reopenIsAllowed = true; reopenIsAllowed; reopenIsAllowed = not s_streamFilename.empty()
+                                                                                     and std::filesystem::is_fifo(s_streamFilename))
 				{
 					std::unique_ptr<std::ifstream> filePtr { s_streamFilename.empty() ? nullptr : std::make_unique<std::ifstream>(s_streamFilename) };
 					std::istream&                  streamRef = filePtr ? *filePtr : std::cin;


### PR DESCRIPTION
There are two parts to this fix:

1. Ignore `SIGTTIN`.  This signal is sent to background processes by the terminal when input becomes available for reading.  Unfortunately, the input is not actually supplied to the program until it's brought to the foreground, so the default POSIX action is to completely suspend the background process and wait for the user to decide to bring it to the foreground.  Since that suspension is a tremendous disruption to Odamex, we change the action from Stop to Ignore.  When this happens, the program-side input read operations fail, and stdin / std::cin are marked as failed.
2.  Update the input-reader thread's main loop to allow the thread to exit if the file or input stream goes EOF, bad, or failed.  The only exception to this is FIFOs / named pipes, which we intentionally want to allow to be reopened to work with successive opens+writes from a user perspective.

### Testing

On my RHEL 10 box, launched odasrv in a terminal under the various conditions, and verified that the CPU usage remains "normal" in all cases:

- `./odasrv` (input normal)
- `./odasrv` + ctrl-z + `bg`  (input terminates)
- `./odasrv &` (input terminates)
- `./odasrv -confile cmds.txt`  (runs commands from text file, then input terminates)
- `./odasrv -confile ./thinger-fifo`  + `cat version > ./thinger-fifo` in another terminal, along with other commands up to `quit`
- `./odasrv -confile ./thinger-fifo &`  `cat version > ./thinger-fifo` in same terminal, along with other commands up to `quit`
- `./odasrv -confile ./thinger-fifo` + ctrl-z + `bg`  (input works via `cat` to fifo as shown above)