### PR TITLE
[BUGFIX] Odalaunch start singleplayer menu option not working

### DIFF
--- a/odalaunch/res/gui_project.fbp
+++ b/odalaunch/res/gui_project.fbp
@@ -107,7 +107,7 @@
             <property name="id">wxID_ANY</property>
             <property name="kind">wxITEM_NORMAL</property>
             <property name="label">Start Odamex (Single Player)</property>
-            <property name="name">Id_MnuItmRunOffline1</property>
+            <property name="name">Id_MnuItmRunOffline</property>
             <property name="permission">none</property>
             <property name="shortcut"></property>
             <property name="unchecked_bitmap"></property>

--- a/odalaunch/res/xrc_resource.xrc
+++ b/odalaunch/res/xrc_resource.xrc
@@ -13,7 +13,7 @@
           <accel></accel>
           <help>Manually connect to a server by specifying Address:Port</help>
         </object>
-        <object class="wxMenuItem" name="Id_MnuItmRunOffline1">
+        <object class="wxMenuItem" name="Id_MnuItmRunOffline">
           <label>Start Odamex (Single Player)</label>
           <accel></accel>
           <help>Runs the Odamex Client without connecting to a server</help>


### PR DESCRIPTION
Looks like an extra 1 got added to its ID by accident when trying to fix the xrc and fbp being out of sync.