### PR TITLE
[FEATURE] Colored server console output

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # ACS formatting changes
 caa159e47d0a4fc77c63aa4fd141b7b0946439e6
+
+# server i_main indentation update
+4b0fa19800182b0e94d01ca98ad2781aa0f368ea

--- a/client/sdl/i_system.cpp
+++ b/client/sdl/i_system.cpp
@@ -417,16 +417,6 @@ void I_BaseError(const std::string& errortext)
 	abort();
 }
 
-char DoomStartupTitle[256] = { 0 };
-
-void I_SetTitleString (const char *title)
-{
-	int i;
-
-	for (i = 0; title[i]; i++)
-		DoomStartupTitle[i] = title[i] | 0x80;
-}
-
 //
 // I_GetClipboardText
 //
@@ -455,39 +445,6 @@ std::string I_GetClipboardText()
 
 	return "";
 }
-
-void I_PrintStr (int xp, const char *cp, int count, bool scroll)
-{
-	// used in the DOS version
-}
-
-#ifdef _WIN32 // denis - fixme - make this work on POSIX
-
-long I_FindFirst (char *filespec, findstate_t *fileinfo)
-{
-	//return _findfirst (filespec, fileinfo);
-	return 0;
-}
-
-int I_FindNext (long handle, findstate_t *fileinfo)
-{
-	//return _findnext (handle, fileinfo);
-	return 0;
-}
-
-int I_FindClose (long handle)
-{
-	//return _findclose (handle);
-	return 0;
-}
-
-#else
-
-long I_FindFirst (char *filespec, findstate_t *fileinfo) {return 0;}
-int I_FindNext (long handle, findstate_t *fileinfo) {return 0;}
-int I_FindClose (long handle) {return 0;}
-
-#endif
 
 //
 // I_IsHeadless

--- a/client/sdl/i_system.h
+++ b/client/sdl/i_system.h
@@ -106,17 +106,8 @@ void addterm (void (STACK_ARGS *func)(void), const char *name);
 // Repaint the pre-game console
 void I_PaintConsole (void);
 
-// Print a console string
-void I_PrintStr (int x, const char *str, int count, bool scroll);
-
-// Set the title string of the startup window
-void I_SetTitleString (const char *title);
-
 // Returns true if there will be no application window
 bool I_IsHeadless();
-
-// [RH] Title string to display at bottom of console during startup
-extern char DoomStartupTitle[256];
 
 void I_FinishClockCalibration ();
 
@@ -128,20 +119,3 @@ std::string I_GetClipboardText();
  * @param message Contents of the message box.
  */
 void I_ErrorMessageBox(const char* message);
-
-// Directory searching routines
-
-typedef struct _finddata_t findstate_t;
-
-long I_FindFirst (char *filespec, findstate_t *fileinfo);
-int I_FindNext (long handle, findstate_t *fileinfo);
-int I_FindClose (long handle);
-
-#define I_FindName(a)	((a)->name)
-#define I_FindAttr(a)	((a)->attrib)
-
-#define FA_RDONLY	_A_RDONLY
-#define FA_HIDDEN	_A_HIDDEN
-#define FA_SYSTEM	_A_SYSTEM
-#define FA_DIREC	_A_SUBDIR
-#define FA_ARCH		_A_ARCH

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -601,9 +601,6 @@ static void LoadResolvedFiles(const OResFiles& newwadfiles,
 	// print info about the IWAD to the console
 	D_PrintIWADIdentity();
 
-	// set the window title based on which IWAD we're using
-	I_SetTitleString(D_GetTitleString().c_str());
-
 	::modifiedgame = (::wadfiles.size() > 2) ||
 	                 !::patchfiles.empty(); // more than odamex.wad and IWAD?
 

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -56,8 +56,6 @@ struct History
 // CmdLine[259]= offset from beginning of cmdline to display
 //static byte CmdLine[260];
 
-static byte printxormask;
-
 static struct History *HistTail = NULL;
 
 #define PRINTLEVELS 5

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -28,6 +28,8 @@
 
 #include <stdarg.h>
 
+#include "fmt/color.h"
+
 #include "m_fileio.h"
 #include "m_memio.h"
 #include "c_console.h"
@@ -99,16 +101,56 @@ char *TimeStamp()
 	return stamp;
 }
 
+EXTERN_CVAR(log_color)
+
 static size_t PrintString(int printlevel, std::string str)
 {
 	StripColorCodes(str);
 
-	fwrite(str.data(), 1, str.length(), stdout);
+	fmt::text_style style;
+	switch (printlevel)
+	{
+		case PRINT_CHAT:
+		case PRINT_FILTERCHAT:
+			style = fg(fmt::color::light_green);
+			break;
+		case PRINT_TEAMCHAT:
+			style = fg(fmt::color::orange);
+			break;
+		case PRINT_SERVERCHAT:
+			style = fg(fmt::color::dark_orange);
+			break;
+		case PRINT_WARNING:
+			style = fmt::emphasis::bold | fg(fmt::color::yellow);
+			break;
+		case PRINT_ERROR:
+			style = fmt::emphasis::bold | fg(fmt::color::red);
+			break;
+		case PRINT_PICKUP:
+			// do these even ever get printed serverside?
+			style = fg(fmt::color::red);
+			break;
+		case PRINT_OBITUARY:
+			style = fg(fmt::color::yellow);
+			break;
+		case PRINT_HIGH:
+		case PRINT_FILTERHIGH:
+		case PRINT_NORCON:
+			break;
+	}
+
+	if (log_color)
+		fmt::print(stdout, style, "{}", str);
+	else
+		fmt::print(stdout, "{}", str);
 	fflush(stdout);
 
 	if (LOG.is_open())
 	{
-		LOG << str;
+		if (log_color == 2)
+			LOG << fmt::format(style, "{}", str);
+		else
+			LOG << str;
 		LOG.flush();
 	}
 

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -137,7 +137,7 @@ static size_t PrintString(int printlevel, std::string str)
 			break;
 	}
 
-	if (log_color)
+	if (log_color && I_ConsoleUseColor())
 		fmt::print(stdout, style, "{}", str);
 	else
 		fmt::print(stdout, "{}", str);

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -109,7 +109,7 @@ void D_DoomLoop (void)
 		}
 		catch (CRecoverableError &error)
 		{
-			PrintFmt("ERROR: {}\n", error.GetMsg());
+			PrintFmt(PRINT_ERROR, "ERROR: {}\n", error.GetMsg());
 			PrintFmt("sleeping for 10 seconds before map reload...");
 
 			// denis - drop clients

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -39,6 +39,8 @@
 
 #include <stdlib.h>
 
+#include "fmt/color.h"
+
 #include "i_crash.h"
 #include "m_argv.h"
 #include "d_main.h"
@@ -69,6 +71,9 @@ void STACK_ARGS call_terms (void)
 	while (!TermFuncs.empty())
 		TermFuncs.top().first(), TermFuncs.pop();
 }
+
+EXTERN_CVAR(log_color)
+static constexpr auto ERROR_STYLE = fmt::emphasis::bold | fg(fmt::color::red);
 
 #ifdef _WIN32
 static HANDLE hEvent;
@@ -218,12 +223,32 @@ int __cdecl main(int argc, char *argv[])
 	}
 	catch (CDoomError& error)
 	{
+		// It's possible that the fatal error was encountered before
+		// loading the config file or setting cvars set from the command line
+		// so we should default to no color unless we know that we have already loaded that
 		if (LOG.is_open())
 		{
-			LOG << "=== ERROR: " << error.GetMsg() << " ===\n\n";
+			if (DefaultsLoaded && log_color == 2)
+				LOG << fmt::format(ERROR_STYLE, "=== ERROR: {} ===\n\n", error.GetMsg());
+			else
+				LOG << "=== ERROR: " << error.GetMsg() << " ===\n\n";
 		}
 
-		fmt::print(stderr, "=== ERROR: {} ===\n\n", error.GetMsg());
+		fmt::text_style style;
+		try
+		{
+			// I_ConsoleUseColor can throw on Windows
+			// but we've already gotten another fatal error,
+			// possibly even from another call to it
+			// so lets just ignore that exception since
+			// we're about to exit and log another one anyway
+			if (DefaultsLoaded && log_color && I_ConsoleUseColor())
+				style = ERROR_STYLE;
+		}
+		catch (CDoomError&)
+		{}
+
+		fmt::print(stderr, style, "=== ERROR: {} ===\n\n", error.GetMsg());
 
 		call_terms();
 		exit(EXIT_FAILURE);
@@ -349,12 +374,21 @@ int main(int argc, char **argv)
 	}
 	catch (CDoomError& error)
 	{
+		// It's possible that the fatal error was encountered before
+		// loading the config file or setting cvars set from the command line
+		// so we should default to no color unless we know that we have already loaded that
 		if (LOG.is_open())
 		{
-			LOG << "=== ERROR: " << error.GetMsg() << " ===\n\n";
+			if (DefaultsLoaded && log_color == 2)
+				LOG << fmt::format(ERROR_STYLE, "=== ERROR: {} ===\n\n", error.GetMsg());
+			else
+				LOG << "=== ERROR: " << error.GetMsg() << " ===\n\n";
 		}
 
-		fmt::print(stderr, "=== ERROR: {} ===\n\n", error.GetMsg());
+		if (DefaultsLoaded && log_color && I_ConsoleUseColor())
+			fmt::print(stderr, ERROR_STYLE, "=== ERROR: {} ===\n\n", error.GetMsg());
+		else
+			fmt::print(stderr, "=== ERROR: {} ===\n\n", error.GetMsg());
 
 		call_terms();
 		exit(EXIT_FAILURE);

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -152,15 +152,32 @@ int __cdecl main(int argc, char *argv[])
 
 		DWORD consoleMode = 0;
 
+		// TODO: don't just throw and exit if these fail,
+		// that prevents being able to pipe output
+		// and makes it so you can't start a server in github actions or vscode debugger
 		if (!GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &consoleMode))
-			throw CDoomError("GetConsoleMode failed!\n");
+			throw CDoomError("GetConsoleMode (input) failed!\n");
 
 		consoleMode &= ~ENABLE_QUICK_EDIT_MODE;
 		consoleMode |= ENABLE_EXTENDED_FLAGS;
-		consoleMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
 		if (!SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), consoleMode))
-			throw CDoomError("SetConsoleMode failed!\n");
+			throw CDoomError("SetConsoleMode (input) failed!\n");
+
+		// enable ansi color escape processing
+
+		if (!GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &consoleMode))
+			throw CDoomError("GetConsoleMode (output) failed!");
+
+		const DWORD originalOutputMode = consoleMode;
+		consoleMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+		if (!SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), consoleMode))
+		{
+			// we might just be on a version of windows before support was added, try setting mode back
+			if (!SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), originalOutputMode))
+				throw CDoomError("SetConsoleMode (OUTPUT) failed!");
+		}
 
 		// Fixes icon not showing in titlebar and alt-tab menu under windows 7
 		HANDLE hIcon;

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -157,6 +157,7 @@ int __cdecl main(int argc, char *argv[])
 
 		consoleMode &= ~ENABLE_QUICK_EDIT_MODE;
 		consoleMode |= ENABLE_EXTENDED_FLAGS;
+		consoleMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
 		if (!SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), consoleMode))
 			throw CDoomError("SetConsoleMode failed!\n");

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -278,7 +278,7 @@ void daemon_init(void)
     fclose(fpid);
 }
 
-void set_window_title()
+static void set_window_title()
 {
 	if (!isatty(STDOUT_FILENO))
 		return;

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -176,7 +176,7 @@ int __cdecl main(int argc, char *argv[])
 		{
 			// we might just be on a version of windows before support was added, try setting mode back
 			if (!SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), originalOutputMode))
-				throw CDoomError("SetConsoleMode (OUTPUT) failed!");
+				throw CDoomError("SetConsoleMode (output) failed!");
 		}
 
 		// Fixes icon not showing in titlebar and alt-tab menu under windows 7

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -147,34 +147,21 @@ int __cdecl main(int argc, char *argv[])
 
 		// Disable QuickEdit mode as any text selection will cause all functions
 		// that use stdout (printf etc) to block
-
-		DWORD consoleMode = 0;
-
-		// TODO: don't just throw and exit if these fail,
-		// that prevents being able to pipe output
-		// and makes it so you can't start a server in github actions or vscode debugger
-		if (!GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &consoleMode))
-			throw CDoomError("GetConsoleMode (input) failed!\n");
-
-		consoleMode &= ~ENABLE_QUICK_EDIT_MODE;
-		consoleMode |= ENABLE_EXTENDED_FLAGS;
-
-		if (!SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), consoleMode))
-			throw CDoomError("SetConsoleMode (input) failed!\n");
-
-		// enable ansi color escape processing
-
-		if (!GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &consoleMode))
-			throw CDoomError("GetConsoleMode (output) failed!");
-
-		const DWORD originalOutputMode = consoleMode;
-		consoleMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-
-		if (!SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), consoleMode))
+		// but only try to do so if stdin is actually a terminal
+		// otherwise this will prevent being able to pipe output
+		const auto hIn = GetStdHandle(STD_INPUT_HANDLE);
+		if (GetFileType(hIn) == FILE_TYPE_CHAR)
 		{
-			// we might just be on a version of windows before support was added, try setting mode back
-			if (!SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), originalOutputMode))
-				throw CDoomError("SetConsoleMode (output) failed!");
+			DWORD consoleMode = 0;
+
+			if (!GetConsoleMode(hIn, &consoleMode))
+				throw CDoomError("GetConsoleMode (input) failed!\n");
+
+			consoleMode &= ~ENABLE_QUICK_EDIT_MODE;
+			consoleMode |= ENABLE_EXTENDED_FLAGS;
+
+			if (!SetConsoleMode(hIn, consoleMode))
+				throw CDoomError("SetConsoleMode (input) failed!\n");
 		}
 
 		// Fixes icon not showing in titlebar and alt-tab menu under windows 7

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -278,7 +278,19 @@ void daemon_init(void)
     fclose(fpid);
 }
 
-int main (int argc, char **argv)
+void set_window_title()
+{
+	if (!isatty(STDOUT_FILENO))
+		return;
+
+	const char* term = getenv("TERM");
+	if (!term || strcmp(term, "dumb") == 0)
+		return;
+
+	fmt::print("\033]2;Odamex Server {}\033\\", NiceVersion());
+}
+
+int main(int argc, char **argv)
 {
 	// [AM] Set crash callbacks, so we get something useful from crashes.
 #ifdef NDEBUG
@@ -315,6 +327,8 @@ int main (int argc, char **argv)
 		}
 
 		M_InitConsoleInputFile(Args.CheckValue("-confile"));
+
+		set_window_title();
 
 		/*
 		  killough 1/98:

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -49,8 +49,6 @@
 #include "m_fileio.h"
 #include "m_consolecommandstream.h"
 
-using namespace std;
-
 void AddCommandString(std::string cmd);
 
 #ifdef _WIN32
@@ -257,27 +255,25 @@ int __cdecl main(int argc, char *argv[])
 //
 void daemon_init(void)
 {
-    int     pid;
-    FILE   *fpid;
-    string  pidfile;
-
     PrintFmt(PRINT_HIGH, "Launched into the background\n");
 
+	int pid;
     if ((pid = fork()) != 0)
     {
     	call_terms();
     	exit(EXIT_SUCCESS);
     }
 
+    std::string pidfile;
 	const char *forkargs = Args.CheckValue("-fork");
 	if (forkargs)
-		pidfile = string(forkargs);
+		pidfile = std::string(forkargs);
 
     if(!pidfile.size() || pidfile[0] == '-')
     	pidfile = "doomsv.pid";
 
     pid = getpid();
-    fpid = fopen(pidfile.c_str(), "w");
+    FILE* fpid = fopen(pidfile.c_str(), "w");
     fmt::print(fpid, "{}\n", pid);
     fclose(fpid);
 }

--- a/server/src/i_system.cpp
+++ b/server/src/i_system.cpp
@@ -273,7 +273,7 @@ bool I_ConsoleUseColor()
 		if (!isatty(STDOUT_FILENO))
 			return false;
 
-		if (getenv("NO_COLOR"));
+		if (getenv("NO_COLOR"))
 			return false;
 
 		const char* term = getenv("TERM");

--- a/server/src/i_system.cpp
+++ b/server/src/i_system.cpp
@@ -267,9 +267,31 @@ int ShutdownNow();
 bool I_ConsoleUseColor()
 {
 #ifdef _WIN32
+	static const bool usecolor = []{
+		const auto hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+		if (GetFileType(hOut) != FILE_TYPE_CHAR)
+			return false;
 
+		bool out = true;
+		// enable ansi color escape processing
+		DWORD consoleMode = 0;
+		if (!GetConsoleMode(hOut, &consoleMode))
+			throw CDoomError("GetConsoleMode (output) failed!");
+
+		const DWORD originalOutputMode = consoleMode;
+		consoleMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+		if (!SetConsoleMode(hOut, consoleMode))
+		{
+			out = consoleMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+			// we might just be on a version of windows before support was added, try setting mode back
+			if (!SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), originalOutputMode))
+				throw CDoomError("SetConsoleMode (output) failed!");
+		}
+		return out;
+	}();
 #else
-	static const bool usecolor = [](){
+	static const bool usecolor = []{
 		if (!isatty(STDOUT_FILENO))
 			return false;
 

--- a/server/src/i_system.cpp
+++ b/server/src/i_system.cpp
@@ -214,52 +214,6 @@ void I_BaseError(const std::string& errortext)
 	}
 }
 
-char DoomStartupTitle[256] = { 0 };
-
-void I_SetTitleString (const char *title)
-{
-    int i;
-
-    for (i = 0; title[i]; i++)
-                DoomStartupTitle[i] = title[i] | 0x80;
-}
-
-void I_PrintStr (int xp, const char *cp, int count, bool scroll)
-{
-        char string[4096];
-
-        memcpy (string, cp, count);
-        if (scroll)
-                string[count++] = '\n';
-        string[count] = 0;
-
-        fputs (string, stdout);
-        fflush (stdout);
-}
-
-//static const char *pattern; // [DL] todo - remove
-//static findstate_t *findstates[8]; // [DL] todo - remove
-
-long I_FindFirst (char *filespec, findstate_t *fileinfo)
-{
-    return 0;
-}
-
-int I_FindNext (long handle, findstate_t *fileinfo)
-{
-    return 0;
-}
-
-int I_FindClose (long handle)
-{
-    return 0;
-}
-
-int I_FindAttr (findstate_t *fileinfo)
-{
-    return 0;
-}
-
 #ifdef _WIN32
 int ShutdownNow();
 #endif

--- a/server/src/i_system.cpp
+++ b/server/src/i_system.cpp
@@ -264,7 +264,29 @@ int I_FindAttr (findstate_t *fileinfo)
 int ShutdownNow();
 #endif
 
-std::string I_ConsoleInput (void)
+bool I_ConsoleUseColor()
+{
+#ifdef _WIN32
+
+#else
+	static const bool usecolor = [](){
+		if (!isatty(STDOUT_FILENO))
+			return false;
+
+		if (getenv("NO_COLOR"));
+			return false;
+
+		const char* term = getenv("TERM");
+		if (!term || strcmp(term, "dumb") == 0)
+			return false;
+
+		return true;
+	}();
+#endif
+	return usecolor;
+}
+
+std::string I_ConsoleInput()
 {
 #ifdef _WIN32
     if (ShutdownNow())

--- a/server/src/i_system.h
+++ b/server/src/i_system.h
@@ -90,38 +90,7 @@ template <typename... ARGS>
 void addterm (void (STACK_ARGS *func)(void), const char *name);
 #define atterm(t) addterm (t, #t)
 
-// Print a console string
-void I_PrintStr (int x, const char *str, int count, bool scroll);
-
-// Set the title string of the startup window
-void I_SetTitleString (const char *title);
-
 bool I_ConsoleUseColor();
 std::string I_ConsoleInput();
 
-// [RH] Title string to display at bottom of console during startup
-extern char DoomStartupTitle[256];
-
 void I_FinishClockCalibration ();
-
-// Directory searching routines
-
-typedef struct
-{
-    int count;
-    struct dirent **namelist;
-    int current;
-} findstate_t;
-
-long I_FindFirst (char *filespec, findstate_t *fileinfo);
-int I_FindNext (long handle, findstate_t *fileinfo);
-int I_FindClose (long handle);
-int I_FindAttr (findstate_t *fileinfo);
-
-#define I_FindName(a)	((a)->namelist[(a)->current]->d_name)
-
-#define FA_RDONLY	1
-#define FA_HIDDEN	2
-#define FA_SYSTEM	4
-#define FA_DIREC	8
-#define FA_ARCH		16

--- a/server/src/i_system.h
+++ b/server/src/i_system.h
@@ -96,7 +96,8 @@ void I_PrintStr (int x, const char *str, int count, bool scroll);
 // Set the title string of the startup window
 void I_SetTitleString (const char *title);
 
-std::string I_ConsoleInput (void);
+bool I_ConsoleUseColor();
+std::string I_ConsoleInput();
 
 // [RH] Title string to display at bottom of console during startup
 extern char DoomStartupTitle[256];

--- a/server/src/sv_cvarlist.cpp
+++ b/server/src/sv_cvarlist.cpp
@@ -38,6 +38,12 @@ CVAR(			log_fulltimestamps, "0", "Extended timestamp info (dd/mm/yyyy hh:mm:ss)"
 CVAR(			log_packetdebug, "0", "Print debugging messages for each packet sent",
 				CVARTYPE_BOOL, CVAR_SERVERARCHIVE)
 
+CVAR_RANGE(		log_color, "1", "Print colored messages\n// " \
+				"0 - Disabled\n// " \
+				"1 - Enabled (terminal output only) \n//" \
+				"2 - Enabled (terminal and log files)",
+				CVARTYPE_BYTE, CVAR_SERVERARCHIVE | CVAR_NOENABLEDISABLE, 0.f, 2.f)
+
 // Server administrative settings
 // ------------------------------
 

--- a/tests/unit-tests/src/i_system.cpp
+++ b/tests/unit-tests/src/i_system.cpp
@@ -163,26 +163,6 @@ void I_BaseError(const std::string& errortext)
 	}
 }
 
-void I_SetTitleString (const char *title) { return; }
-
-void I_PrintStr (int xp, const char *cp, int count, bool scroll)
-{
-        char string[4096];
-
-        memcpy (string, cp, count);
-        if (scroll)
-                string[count++] = '\n';
-        string[count] = 0;
-
-        fputs (string, stdout);
-        fflush (stdout);
-}
-
-long I_FindFirst (char *filespec, findstate_t *fileinfo) { return 0; }
-int I_FindNext (long handle, findstate_t *fileinfo) { return 0; }
-int I_FindClose (long handle) { return 0; }
-int I_FindAttr (findstate_t *fileinfo) { return 0; }
-
 std::string I_ConsoleInput (void) { return ""; }
 
 VERSION_CONTROL (i_system_cpp, "$Id$")

--- a/tests/unit-tests/src/i_system.h
+++ b/tests/unit-tests/src/i_system.h
@@ -82,12 +82,6 @@ void I_FatalError(const fmt::string_view format, const ARGS&... args)
 void addterm (void (STACK_ARGS *func)(void), const char *name);
 #define atterm(t) addterm (t, #t)
 
-// Print a console string
-void I_PrintStr (int x, const char *str, int count, bool scroll);
-
-// Set the title string of the startup window
-void I_SetTitleString (const char *title);
-
 std::string I_ConsoleInput (void);
 
 // [RH] Returns millisecond-accurate time
@@ -96,25 +90,3 @@ dtime_t I_MSTime (void);
 void I_Yield(void);
 
 void I_FinishClockCalibration ();
-
-// Directory searching routines
-
-typedef struct
-{
-    int count;
-    struct dirent **namelist;
-    int current;
-} findstate_t;
-
-long I_FindFirst (char *filespec, findstate_t *fileinfo);
-int I_FindNext (long handle, findstate_t *fileinfo);
-int I_FindClose (long handle);
-int I_FindAttr (findstate_t *fileinfo);
-
-#define I_FindName(a)	((a)->namelist[(a)->current]->d_name)
-
-#define FA_RDONLY	1
-#define FA_HIDDEN	2
-#define FA_SYSTEM	4
-#define FA_DIREC	8
-#define FA_ARCH		16


### PR DESCRIPTION
This is a minimal version of what was requested by #1589

Server console output is now colored based on print level, similarly to the client console. In this PR, only the print level is considered, and the entire line, including the timestamp, gets that color. Odamex's ZDoom color escapes still get stripped before serverside printing, so there isn't yet any finer grain control over coloring only part of a line.
<img width="679" height="532" alt="image" src="https://github.com/user-attachments/assets/38e1dd75-9f9a-4625-b2d5-de164dfe51e3" />

Color printing is enabled by default and is controlled by the new `log_color` cvar. Setting this to 0 disables the color, and setting it to 2 enables color for the log file as well. 

Color is automatically disabled when:
- Output is being piped or redirected to a file
- Windows only:
  - Running on an older Windows version before support for ANSI color escapes was implemented
- Unix only:
  - The `NO_COLOR` environment variable is set
  - The `TERM` environment variable is not set or is set to `dumb`

Two additional changes have been made as well:
1. Disbling quick edit mode with `SetConsoleMode` now is only attempted if stdin is an actual console. This means Odasrv no longer fails to start on Windows when trying to pipe the output. This has been broken since 10.4.0.
2. Odasrv sets the window title on non-Windows systems now. This was previously Windows only.

Before:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/5d18a068-b13c-4265-ada9-792dd1bf4b20" />
After:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/55c4c77b-a5b8-4b32-82f0-910fb549fba3" />
