### PR TITLE
[BUGFIX] Voodoo dolls spin when using IDDT

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -698,7 +698,7 @@ void AActor::RunThink ()
 	prevy = y;
 	prevz = z;
 
-	if (!player || player->mo != this)
+	if (!player || P_IsVoodooDoll(this))
 	{
 		prevangle = angle;
 		prevpitch = pitch;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -698,7 +698,7 @@ void AActor::RunThink ()
 	prevy = y;
 	prevz = z;
 
-	if (!player)
+	if (!player || player->mo != this)
 	{
 		prevangle = angle;
 		prevpitch = pitch;


### PR DESCRIPTION
Fixes #1717

Since singleplayer voodoo dolls do have a player pointer, the check in AActor::RunThink was preventing prevangle and prevpitch from ever getting set, so they would just always be 0, resulting in bad interpolation.