### PR TITLE
Segregate wad creation and dependent copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-# CMake 3.13 needed for -S and -B params in library compilation.
+# CMake >= 3.13 needed for -S and -B params in library compilation.
+# CMake >= 3.19 needed for policy CMP0112: target-dependent generator expressions
+#               do not implicitly add target-level dependencies.
 #
 # Note that if you are running Linux, there are many ways to get newer
 # versions of CMake.
@@ -12,7 +14,7 @@
 # - If you have Python installed, you can install CMake through pip.
 #
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.19)
 
 project(Odamex VERSION 12.2.0)
 

--- a/wad/CMakeLists.txt
+++ b/wad/CMakeLists.txt
@@ -23,6 +23,7 @@ macro(odamex_copy_wad _target)
       COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/odawad_${_target}.stamp"
       DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad" ${_target}
       VERBATIM
+      COMMENT "Copying $<TARGET_NAME:${_target}> odamex.wad if necessary..."
       )
   add_custom_target(odawad_${_target} ALL
       DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odawad_${_target}.stamp")

--- a/wad/CMakeLists.txt
+++ b/wad/CMakeLists.txt
@@ -17,17 +17,15 @@ file(GLOB_RECURSE ODAWAD_SOURCES
 macro(odamex_copy_wad _target)
 
   add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/odamex_${_target}.wad.stamp"
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/odawad_${_target}.stamp"
       COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${_target}>
       COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad" $<TARGET_FILE_DIR:${_target}>
-      COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/odamex_${_target}.wad.stamp"
-      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad"
+      COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/odawad_${_target}.stamp"
+      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad" ${_target}
       VERBATIM
       )
-  add_custom_target(odawad_${_target}
-      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex_${_target}.wad.stamp")
-
-  add_dependencies(${_target} odawad_${_target})   # Make sure a focused build of the executable also pulls in the wad.
+  add_custom_target(odawad_${_target} ALL
+      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odawad_${_target}.stamp")
 
 endmacro()
 

--- a/wad/CMakeLists.txt
+++ b/wad/CMakeLists.txt
@@ -15,12 +15,20 @@ file(GLOB_RECURSE ODAWAD_SOURCES
 # documentation.
 
 macro(odamex_copy_wad _target)
+
   add_custom_command(
-      APPEND
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad"
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/odamex_${_target}.wad.stamp"
+      COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${_target}>
       COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad" $<TARGET_FILE_DIR:${_target}>
+      COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/odamex_${_target}.wad.stamp"
+      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad"
+      VERBATIM
       )
-  add_dependencies(odawad ${_target}) # Ensure the target directory actually is created first!
+  add_custom_target(odawad_${_target}
+      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex_${_target}.wad.stamp")
+
+  add_dependencies(${_target} odawad_${_target})   # Make sure a focused build of the executable also pulls in the wad.
+
 endmacro()
 
 # If Python is available, use it to build the WAD.
@@ -37,10 +45,10 @@ if(Python_FOUND)
   add_custom_target(odawad ALL
     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad")
 
-  if (BUILD_CLIENT)
+  if (TARGET odamex)
     odamex_copy_wad(odamex)
   endif()
-  if (BUILD_SERVER)
+  if (TARGET odasrv)
     odamex_copy_wad(odasrv)
   endif()
 


### PR DESCRIPTION
### Summary

Rather than have the one odawad target that we conditionally update to copy, we now have three targets: odawad to create it, and one per executable to copy from the generated file to the executable target directory.  This allows for both per-executable post-build copying and wad rebuild AND copy if any of the wad's actual sources changed.

### Testing

1. Generate and build all executables, verify wad is copied.
2. Generate all, build only one executable, verify wad is copied.
3. Generate one, build it, verify wad is copied.
4. After executables are built, touch wad/wadinfo.txt, run build, verify wad is rapidly generated and then copied to the executable directories for the configured executables.