### PR TITLE
[BUGFIX] Errors that cause an invalid level state get hidden by "Tried to tic unknown levelstate"

### DIFF
--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -376,6 +376,7 @@ void D_DoomLoop()
 			::players.clear();
 
 			::gameaction = ga_fullconsole;
+			::gamestate = GS_FULLCONSOLE;
 		}
 	}
 }

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -2075,6 +2075,27 @@ void P_LoadReject(int lumpnum, int totallines)
 	}
 }
 
+void P_ValidateMap(const int lumpnum)
+{
+	// TODO: this will need to be updated for UDMF and/or an internal nodebuilder
+	// UDMF has a different set of lumps, and a nodebuilder could create some of the missing lumps
+	auto checkMapLump = [&](int offset, const char* name) {
+		if (!W_CheckLumpName(lumpnum + offset, name))
+			I_Error("{} lump is missing for map {}\n", name, level.mapname);
+	};
+
+	checkMapLump(ML_THINGS,   "THINGS"  );
+	checkMapLump(ML_LINEDEFS, "LINEDEFS");
+	checkMapLump(ML_SIDEDEFS, "SIDEDEFS");
+	checkMapLump(ML_VERTEXES, "VERTEXES");
+	checkMapLump(ML_SEGS,     "SEGS"    );
+	checkMapLump(ML_SSECTORS, "SSECTORS");
+	checkMapLump(ML_NODES,    "NODES"   );
+	checkMapLump(ML_SECTORS,  "SECTORS" );
+	checkMapLump(ML_REJECT,   "REJECT"  );
+	checkMapLump(ML_BLOCKMAP, "BLOCKMAP");
+}
+
 } // namespace
 
 //
@@ -2151,6 +2172,10 @@ void P_SetupLevel (const char *lumpname, int position)
 
 	// [Blair] Create map fingerprint
 	P_GenerateUniqueMapFingerPrint(lumpnum);
+
+	// [EB] check that all lumps are present and in the correct order
+	// so we can give useful error messages
+	P_ValidateMap(lumpnum);
 
 	if (HasBehavior)
 	{

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -2079,7 +2079,7 @@ void P_ValidateMap(const int lumpnum)
 {
 	// TODO: this will need to be updated for UDMF and/or an internal nodebuilder
 	// UDMF has a different set of lumps, and a nodebuilder could create some of the missing lumps
-	auto checkMapLump = [&](int offset, const char* name) {
+	auto checkMapLump = [lumpnum](int offset, const char* name) {
 		if (!W_CheckLumpName(lumpnum + offset, name))
 			I_Error("{} lump is missing for map {}\n", name, level.mapname);
 	};


### PR DESCRIPTION
Fixes #1317

The gamestate just needed to be set to GS_FULLCONSOLE, so that there wouldn't be a single tic of GS_LEVEL before ga_fullconsole changed the state. Most other places set both of these.

Also adds validation of map lumps, checking that all are present and in the correct order. This makes error messages much more informative than before, when a missing or out of order lump would just mean loading the wrong lumps.