### PR TITLE
[BUGFIX] Allow specifying `-waddir` with Odalaunch gui again

### DIFF
--- a/odalaunch/res/gui_project.fbp
+++ b/odalaunch/res/gui_project.fbp
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <wxFormBuilder_Project>
   <FileVersion major="1" minor="18"/>
-  <object class="Project" expanded="true">
+  <object class="Project" expanded="false">
     <property name="code_generation">XRC</property>
     <property name="cpp_class_decoration"></property>
     <property name="cpp_disconnect_events">1</property>
@@ -31,7 +31,7 @@
     <property name="relative_path">1</property>
     <property name="use_microsoft_bom">0</property>
     <property name="use_native_eol">0</property>
-    <object class="Frame" expanded="true">
+    <object class="Frame" expanded="false">
       <property name="aui_managed">0</property>
       <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
       <property name="bg"></property>
@@ -4188,6 +4188,686 @@
                             </object>
                           </object>
                         </object>
+                        <object class="sizeritem" expanded="false">
+                          <property name="border">5</property>
+                          <property name="flag">wxALL|wxEXPAND</property>
+                          <property name="proportion">1</property>
+                          <object class="wxStaticBoxSizer" expanded="false">
+                            <property name="id">wxID_ANY</property>
+                            <property name="label">WAD Directories (Only used if launching Odamex from within Odalaunch)</property>
+                            <property name="minimum_size"></property>
+                            <property name="name">11</property>
+                            <property name="orient">wxVERTICAL</property>
+                            <property name="parent">1</property>
+                            <property name="permission">none</property>
+                            <object class="sizeritem" expanded="false">
+                              <property name="border">0</property>
+                              <property name="flag">wxEXPAND</property>
+                              <property name="proportion">1</property>
+                              <object class="wxFlexGridSizer" expanded="false">
+                                <property name="cols">3</property>
+                                <property name="flexible_direction">wxBOTH</property>
+                                <property name="growablecols">0</property>
+                                <property name="growablerows">0</property>
+                                <property name="hgap">0</property>
+                                <property name="minimum_size"></property>
+                                <property name="name">fgSizer6</property>
+                                <property name="non_flexible_grow_mode">wxFLEX_GROWMODE_SPECIFIED</property>
+                                <property name="permission">none</property>
+                                <property name="rows">5</property>
+                                <property name="vgap">0</property>
+                                <object class="sizeritem" expanded="false">
+                                  <property name="border">5</property>
+                                  <property name="flag">wxEXPAND</property>
+                                  <property name="proportion">1</property>
+                                  <object class="wxBoxSizer" expanded="false">
+                                    <property name="minimum_size"></property>
+                                    <property name="name">bSizer31</property>
+                                    <property name="orient">wxVERTICAL</property>
+                                    <property name="permission">none</property>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxALL|wxEXPAND</property>
+                                      <property name="proportion">1</property>
+                                      <object class="wxListBox" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="choices"></property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">Id_LstCtrlWadDirectories</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos">0,190</property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style">wxLB_SINGLE</property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip"></property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                  </object>
+                                </object>
+                                <object class="sizeritem" expanded="false">
+                                  <property name="border">5</property>
+                                  <property name="flag">wxALIGN_CENTER</property>
+                                  <property name="proportion">0</property>
+                                  <object class="wxBoxSizer" expanded="false">
+                                    <property name="minimum_size"></property>
+                                    <property name="name">bSizer331</property>
+                                    <property name="orient">wxVERTICAL</property>
+                                    <property name="permission">none</property>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxALL</property>
+                                      <property name="proportion">0</property>
+                                      <object class="wxBitmapButton" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="auth_needed">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="bitmap">Load From Art Provider; wxART_HELP_SIDE_PANEL; wxART_BUTTON</property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="current"></property>
+                                        <property name="default">0</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="disabled"></property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="focus"></property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">MyButton</property>
+                                        <property name="margins"></property>
+                                        <property name="markup">0</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">Id_BtnCtrlGetEnvironment</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="position"></property>
+                                        <property name="pressed"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Import environment variables containing paths to Doom wad files (DOOMWADPATH and DOOMWADDIR)</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxEXPAND | wxALL</property>
+                                      <property name="proportion">0</property>
+                                      <object class="wxStaticLine" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">161</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style">wxLI_VERTICAL</property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxALL</property>
+                                      <property name="proportion">0</property>
+                                      <object class="wxBitmapButton" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="auth_needed">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="bitmap">Load From Art Provider; wxART_NEW; wxART_BUTTON</property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="current"></property>
+                                        <property name="default">0</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="disabled"></property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="focus"></property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">MyButton</property>
+                                        <property name="margins"></property>
+                                        <property name="markup">0</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">Id_BtnCtrlAddDir</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="position"></property>
+                                        <property name="pressed"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Add path to list</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxALL</property>
+                                      <property name="proportion">0</property>
+                                      <object class="wxBitmapButton" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="auth_needed">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="bitmap">Load From Art Provider; wxART_EDIT; wxART_BUTTON</property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="current"></property>
+                                        <property name="default">0</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="disabled"></property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="focus"></property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">MyButton</property>
+                                        <property name="margins"></property>
+                                        <property name="markup">0</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">Id_BtnCtrlReplaceDir</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="position"></property>
+                                        <property name="pressed"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Replace selected path in list</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxALL</property>
+                                      <property name="proportion">0</property>
+                                      <object class="wxBitmapButton" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="auth_needed">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="bitmap">Load From Art Provider; wxART_DELETE; wxART_BUTTON</property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="current"></property>
+                                        <property name="default">0</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="disabled"></property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="focus"></property>
+                                        <property name="font">,90,400,-1,70,0</property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">MyButton</property>
+                                        <property name="margins"></property>
+                                        <property name="markup">0</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">Id_BtnCtrlDeleteDir</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="position"></property>
+                                        <property name="pressed"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Delete path from list</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxEXPAND | wxALL</property>
+                                      <property name="proportion">0</property>
+                                      <object class="wxStaticLine" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="font"></property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">16</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style">wxLI_VERTICAL</property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxALL</property>
+                                      <property name="proportion">0</property>
+                                      <object class="wxBitmapButton" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="auth_needed">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="bitmap">Load From Art Provider; wxART_GO_UP; wxART_BUTTON</property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="current"></property>
+                                        <property name="default">0</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="disabled"></property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="focus"></property>
+                                        <property name="font">,90,400,-1,70,0</property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">MyButton</property>
+                                        <property name="margins"></property>
+                                        <property name="markup">0</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">Id_BtnCtrlMoveDirUp</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="position"></property>
+                                        <property name="pressed"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Move path up</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                    <object class="sizeritem" expanded="false">
+                                      <property name="border">5</property>
+                                      <property name="flag">wxALL</property>
+                                      <property name="proportion">0</property>
+                                      <object class="wxBitmapButton" expanded="false">
+                                        <property name="BottomDockable">1</property>
+                                        <property name="LeftDockable">1</property>
+                                        <property name="RightDockable">1</property>
+                                        <property name="TopDockable">1</property>
+                                        <property name="aui_layer">0</property>
+                                        <property name="aui_name"></property>
+                                        <property name="aui_position">0</property>
+                                        <property name="aui_row">0</property>
+                                        <property name="auth_needed">0</property>
+                                        <property name="best_size"></property>
+                                        <property name="bg"></property>
+                                        <property name="bitmap">Load From Art Provider; wxART_GO_DOWN; wxART_BUTTON</property>
+                                        <property name="caption"></property>
+                                        <property name="caption_visible">1</property>
+                                        <property name="center_pane">0</property>
+                                        <property name="close_button">1</property>
+                                        <property name="context_help"></property>
+                                        <property name="context_menu">1</property>
+                                        <property name="current"></property>
+                                        <property name="default">0</property>
+                                        <property name="default_pane">0</property>
+                                        <property name="disabled"></property>
+                                        <property name="dock">Dock</property>
+                                        <property name="dock_fixed">0</property>
+                                        <property name="docking">Left</property>
+                                        <property name="drag_accept_files">0</property>
+                                        <property name="enabled">1</property>
+                                        <property name="fg"></property>
+                                        <property name="floatable">1</property>
+                                        <property name="focus"></property>
+                                        <property name="font">,90,400,-1,70,0</property>
+                                        <property name="gripper">0</property>
+                                        <property name="hidden">0</property>
+                                        <property name="id">wxID_ANY</property>
+                                        <property name="label">MyButton</property>
+                                        <property name="margins"></property>
+                                        <property name="markup">0</property>
+                                        <property name="max_size"></property>
+                                        <property name="maximize_button">0</property>
+                                        <property name="maximum_size"></property>
+                                        <property name="min_size"></property>
+                                        <property name="minimize_button">0</property>
+                                        <property name="minimum_size"></property>
+                                        <property name="moveable">1</property>
+                                        <property name="name">Id_BtnCtrlMoveDirDown</property>
+                                        <property name="pane_border">1</property>
+                                        <property name="pane_position"></property>
+                                        <property name="pane_size"></property>
+                                        <property name="permission">protected</property>
+                                        <property name="pin_button">1</property>
+                                        <property name="pos"></property>
+                                        <property name="position"></property>
+                                        <property name="pressed"></property>
+                                        <property name="resize">Resizable</property>
+                                        <property name="show">1</property>
+                                        <property name="size"></property>
+                                        <property name="style"></property>
+                                        <property name="subclass">; ; forward_declare</property>
+                                        <property name="toolbar_pane">0</property>
+                                        <property name="tooltip">Move path down</property>
+                                        <property name="validator_data_type"></property>
+                                        <property name="validator_style">wxFILTER_NONE</property>
+                                        <property name="validator_type">wxDefaultValidator</property>
+                                        <property name="validator_variable"></property>
+                                        <property name="window_extra_style"></property>
+                                        <property name="window_name"></property>
+                                        <property name="window_style"></property>
+                                      </object>
+                                    </object>
+                                  </object>
+                                </object>
+                              </object>
+                            </object>
+                          </object>
+                        </object>
                       </object>
                     </object>
                   </object>
@@ -6102,7 +6782,7 @@
         </object>
       </object>
     </object>
-    <object class="Dialog" expanded="true">
+    <object class="Dialog" expanded="false">
       <property name="aui_managed">0</property>
       <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
       <property name="bg"></property>
@@ -6130,16 +6810,16 @@
       <property name="window_extra_style"></property>
       <property name="window_name"></property>
       <property name="window_style"></property>
-      <object class="wxBoxSizer" expanded="true">
+      <object class="wxBoxSizer" expanded="false">
         <property name="minimum_size"></property>
         <property name="name"></property>
         <property name="orient">wxVERTICAL</property>
         <property name="permission">none</property>
-        <object class="sizeritem" expanded="true">
+        <object class="sizeritem" expanded="false">
           <property name="border">5</property>
           <property name="flag">wxEXPAND | wxALL</property>
           <property name="proportion">1</property>
-          <object class="wxPanel" expanded="true">
+          <object class="wxPanel" expanded="false">
             <property name="BottomDockable">1</property>
             <property name="LeftDockable">1</property>
             <property name="RightDockable">1</property>
@@ -6191,7 +6871,7 @@
             <property name="window_extra_style"></property>
             <property name="window_name"></property>
             <property name="window_style">wxTAB_TRAVERSAL|wxBORDER_RAISED</property>
-            <object class="wxFlexGridSizer" expanded="true">
+            <object class="wxFlexGridSizer" expanded="false">
               <property name="cols">1</property>
               <property name="flexible_direction">wxBOTH</property>
               <property name="growablecols">0</property>
@@ -6534,11 +7214,11 @@
                   </object>
                 </object>
               </object>
-              <object class="sizeritem" expanded="true">
+              <object class="sizeritem" expanded="false">
                 <property name="border">5</property>
                 <property name="flag">wxALIGN_CENTER</property>
                 <property name="proportion">1</property>
-                <object class="wxBoxSizer" expanded="true">
+                <object class="wxBoxSizer" expanded="false">
                   <property name="minimum_size"></property>
                   <property name="name">bSizer341</property>
                   <property name="orient">wxHORIZONTAL</property>

--- a/odalaunch/res/xrc_resource.xrc
+++ b/odalaunch/res/xrc_resource.xrc
@@ -926,6 +926,154 @@
                           </object>
                         </object>
                       </object>
+                      <object class="sizeritem">
+                        <flag>wxALL|wxEXPAND</flag>
+                        <border>5</border>
+                        <option>1</option>
+                        <object class="wxStaticBoxSizer" name="11">
+                          <orient>wxVERTICAL</orient>
+                          <label>WAD Directories (Only used if launching Odamex from within Odalaunch)</label>
+                          <object class="sizeritem">
+                            <flag>wxEXPAND</flag>
+                            <border>0</border>
+                            <option>1</option>
+                            <object class="wxFlexGridSizer" name="fgSizer6">
+                              <vgap>0</vgap>
+                              <hgap>0</hgap>
+                              <growablerows>0</growablerows>
+                              <growablecols>0</growablecols>
+                              <rows>5</rows>
+                              <cols>3</cols>
+                              <object class="sizeritem">
+                                <flag>wxEXPAND</flag>
+                                <border>5</border>
+                                <option>1</option>
+                                <object class="wxBoxSizer" name="bSizer31">
+                                  <orient>wxVERTICAL</orient>
+                                  <object class="sizeritem">
+                                    <flag>wxALL|wxEXPAND</flag>
+                                    <border>5</border>
+                                    <option>1</option>
+                                    <object class="wxListBox" name="Id_LstCtrlWadDirectories">
+                                      <pos>0,190</pos>
+                                      <style>wxLB_SINGLE</style>
+                                      <content/>
+                                    </object>
+                                  </object>
+                                </object>
+                              </object>
+                              <object class="sizeritem">
+                                <flag>wxALIGN_CENTER</flag>
+                                <border>5</border>
+                                <option>0</option>
+                                <object class="wxBoxSizer" name="bSizer331">
+                                  <orient>wxVERTICAL</orient>
+                                  <object class="sizeritem">
+                                    <flag>wxALL</flag>
+                                    <border>5</border>
+                                    <option>0</option>
+                                    <object class="wxBitmapButton" name="Id_BtnCtrlGetEnvironment">
+                                      <tooltip>Import environment variables containing paths to Doom wad files (DOOMWADPATH and DOOMWADDIR)</tooltip>
+                                      <default>0</default>
+                                      <auth_needed>0</auth_needed>
+                                      <bitmap stock_id="wxART_HELP_SIDE_PANEL" stock_client="wxART_BUTTON">undefined.png</bitmap>
+                                    </object>
+                                  </object>
+                                  <object class="sizeritem">
+                                    <flag>wxEXPAND | wxALL</flag>
+                                    <border>5</border>
+                                    <option>0</option>
+                                    <object class="wxStaticLine" name="161">
+                                      <style>wxLI_VERTICAL</style>
+                                    </object>
+                                  </object>
+                                  <object class="sizeritem">
+                                    <flag>wxALL</flag>
+                                    <border>5</border>
+                                    <option>0</option>
+                                    <object class="wxBitmapButton" name="Id_BtnCtrlAddDir">
+                                      <tooltip>Add path to list</tooltip>
+                                      <default>0</default>
+                                      <auth_needed>0</auth_needed>
+                                      <bitmap stock_id="wxART_NEW" stock_client="wxART_BUTTON">undefined.png</bitmap>
+                                    </object>
+                                  </object>
+                                  <object class="sizeritem">
+                                    <flag>wxALL</flag>
+                                    <border>5</border>
+                                    <option>0</option>
+                                    <object class="wxBitmapButton" name="Id_BtnCtrlReplaceDir">
+                                      <tooltip>Replace selected path in list</tooltip>
+                                      <default>0</default>
+                                      <auth_needed>0</auth_needed>
+                                      <bitmap stock_id="wxART_EDIT" stock_client="wxART_BUTTON">undefined.png</bitmap>
+                                    </object>
+                                  </object>
+                                  <object class="sizeritem">
+                                    <flag>wxALL</flag>
+                                    <border>5</border>
+                                    <option>0</option>
+                                    <object class="wxBitmapButton" name="Id_BtnCtrlDeleteDir">
+                                      <tooltip>Delete path from list</tooltip>
+                                      <font>
+                                        <style>normal</style>
+                                        <weight>normal</weight>
+                                        <family>default</family>
+                                        <underlined>0</underlined>
+                                      </font>
+                                      <default>0</default>
+                                      <auth_needed>0</auth_needed>
+                                      <bitmap stock_id="wxART_DELETE" stock_client="wxART_BUTTON">undefined.png</bitmap>
+                                    </object>
+                                  </object>
+                                  <object class="sizeritem">
+                                    <flag>wxEXPAND | wxALL</flag>
+                                    <border>5</border>
+                                    <option>0</option>
+                                    <object class="wxStaticLine" name="16">
+                                      <style>wxLI_VERTICAL</style>
+                                    </object>
+                                  </object>
+                                  <object class="sizeritem">
+                                    <flag>wxALL</flag>
+                                    <border>5</border>
+                                    <option>0</option>
+                                    <object class="wxBitmapButton" name="Id_BtnCtrlMoveDirUp">
+                                      <tooltip>Move path up</tooltip>
+                                      <font>
+                                        <style>normal</style>
+                                        <weight>normal</weight>
+                                        <family>default</family>
+                                        <underlined>0</underlined>
+                                      </font>
+                                      <default>0</default>
+                                      <auth_needed>0</auth_needed>
+                                      <bitmap stock_id="wxART_GO_UP" stock_client="wxART_BUTTON">undefined.png</bitmap>
+                                    </object>
+                                  </object>
+                                  <object class="sizeritem">
+                                    <flag>wxALL</flag>
+                                    <border>5</border>
+                                    <option>0</option>
+                                    <object class="wxBitmapButton" name="Id_BtnCtrlMoveDirDown">
+                                      <tooltip>Move path down</tooltip>
+                                      <font>
+                                        <style>normal</style>
+                                        <weight>normal</weight>
+                                        <family>default</family>
+                                        <underlined>0</underlined>
+                                      </font>
+                                      <default>0</default>
+                                      <auth_needed>0</auth_needed>
+                                      <bitmap stock_id="wxART_GO_DOWN" stock_client="wxART_BUTTON">undefined.png</bitmap>
+                                    </object>
+                                  </object>
+                                </object>
+                              </object>
+                            </object>
+                          </object>
+                        </object>
+                      </object>
                     </object>
                   </object>
                 </object>

--- a/odalaunch/src/dlg_config.cpp
+++ b/odalaunch/src/dlg_config.cpp
@@ -34,6 +34,7 @@
 #include <wx/wfstream.h>
 #include <wx/tokenzr.h>
 #include <wx/recguard.h>
+#include <wx/dirdlg.h>
 
 #include "main.h"
 

--- a/odalaunch/src/dlg_config.cpp
+++ b/odalaunch/src/dlg_config.cpp
@@ -40,6 +40,15 @@
 // Event table for widgets
 BEGIN_EVENT_TABLE(dlgConfig,wxDialog)
 
+	// Button events
+	EVT_BUTTON(XRCID("Id_BtnCtrlAddDir"), dlgConfig::OnAddDir)
+	EVT_BUTTON(XRCID("Id_BtnCtrlReplaceDir"), dlgConfig::OnReplaceDir)
+	EVT_BUTTON(XRCID("Id_BtnCtrlDeleteDir"), dlgConfig::OnDeleteDir)
+	EVT_BUTTON(XRCID("Id_BtnCtrlMoveDirUp"), dlgConfig::OnUpClick)
+	EVT_BUTTON(XRCID("Id_BtnCtrlMoveDirDown"), dlgConfig::OnDownClick)
+
+	EVT_BUTTON(XRCID("Id_BtnCtrlGetEnvironment"), dlgConfig::OnGetEnvClick)
+
 	EVT_BUTTON(wxID_OK, dlgConfig::OnOK)
 
 	// Picker events
@@ -77,6 +86,7 @@ BEGIN_EVENT_TABLE(dlgConfig,wxDialog)
 
 	EVT_SPINCTRL(XRCID("Id_SpnRefreshInterval"), dlgConfig::OnSpinValChange)
 
+	EVT_LISTBOX_DCLICK(XRCID("Id_LstCtrlWadDirectories"), dlgConfig::OnReplaceDir)
 END_EVENT_TABLE()
 
 // Window constructor
@@ -95,6 +105,8 @@ dlgConfig::dlgConfig(wxWindow* parent, wxWindowID id) :
 	m_ChkCtrlHighlightServerLines = XRCCTRL(*this, "Id_ChkColorServerLine", wxCheckBox);
 	m_ChkCtrlHighlightCustomServers = XRCCTRL(*this, "Id_ChkColorCustomServers", wxCheckBox);
 	m_ChkCtrlkAutoServerRefresh = XRCCTRL(*this, "Id_ChkAutoRefresh", wxCheckBox);
+
+	m_LstCtrlWadDirectories = XRCCTRL(*this, "Id_LstCtrlWadDirectories", wxListBox);
 
 	m_DirCtrlChooseOdamexPath = XRCCTRL(*this, "Id_DirCtrlChooseOdamexPath", wxDirPickerCtrl);
 	m_FilePickCtrlSoundFile = XRCCTRL(*this, "Id_FilePickSoundFile", wxFilePickerCtrl);
@@ -224,6 +236,178 @@ void dlgConfig::OnTextChange(wxCommandEvent& event)
 	UserChangedSetting = true;
 }
 
+/*
+    WAD Directory stuff
+*/
+
+// Add a directory to the listbox
+void dlgConfig::OnAddDir(wxCommandEvent& event)
+{
+	wxString WadDirectory;
+
+	wxDirDialog ChooseWadDialog(this,
+	                            "Select a directory containing WAD files");
+
+	if(ChooseWadDialog.ShowModal() != wxID_OK)
+		return;
+
+	WadDirectory = ChooseWadDialog.GetPath();
+
+	// Check to see if the path exists on the system
+	if(wxDirExists(WadDirectory))
+	{
+		// Check if path already exists in box
+		if(m_LstCtrlWadDirectories->FindString(WadDirectory) == wxNOT_FOUND)
+		{
+			m_LstCtrlWadDirectories->Append(WadDirectory);
+
+			UserChangedSetting = true;
+		}
+	}
+	else
+		wxMessageBox(wxString::Format("Directory %s not found",
+		                              WadDirectory.c_str()));
+}
+
+// Replace a directory in the listbox
+void dlgConfig::OnReplaceDir(wxCommandEvent& event)
+{
+	wxInt32 i = m_LstCtrlWadDirectories->GetSelection();
+
+	wxString WadDirectory;
+
+	if(i == wxNOT_FOUND)
+	{
+		wxMessageBox("Select a directory from the list to replace");
+
+		return;
+	}
+
+	WadDirectory = m_LstCtrlWadDirectories->GetStringSelection();
+
+	wxDirDialog ChooseWadDialog(this,
+	                            "Replace selected directory with..",
+	                            WadDirectory);
+
+	if(ChooseWadDialog.ShowModal() != wxID_OK)
+		return;
+
+	WadDirectory = ChooseWadDialog.GetPath();
+
+	// Check to see if the path exists on the system
+	if(wxDirExists(WadDirectory))
+	{
+		// Get the selected item and replace it
+		m_LstCtrlWadDirectories->SetString(i, WadDirectory);
+
+		UserChangedSetting = true;
+	}
+	else
+		wxMessageBox(wxString::Format("Directory %s not found",
+		                              WadDirectory.c_str()));
+}
+
+// Delete a directory from the listbox
+void dlgConfig::OnDeleteDir(wxCommandEvent& event)
+{
+	// Get the selected item and delete it, if
+	// it is selected.
+	wxInt32 i = m_LstCtrlWadDirectories->GetSelection();
+
+	if(i != wxNOT_FOUND)
+	{
+		m_LstCtrlWadDirectories->Delete(i);
+
+		UserChangedSetting = true;
+	}
+	else
+		wxMessageBox("Select a directory from the list to delete");
+}
+
+// Move directory in list up 1 item
+void dlgConfig::OnUpClick(wxCommandEvent& event)
+{
+	// Get the selected item
+	wxInt32 i = m_LstCtrlWadDirectories->GetSelection();
+
+	if((i != wxNOT_FOUND) && (i > 0))
+	{
+		wxString str = m_LstCtrlWadDirectories->GetString(i);
+
+		m_LstCtrlWadDirectories->Delete(i);
+
+		m_LstCtrlWadDirectories->Insert(str, i - 1);
+
+		m_LstCtrlWadDirectories->SetSelection(i - 1);
+
+		UserChangedSetting = true;
+	}
+}
+
+// Move directory in list down 1 item
+void dlgConfig::OnDownClick(wxCommandEvent& event)
+{
+	// Get the selected item
+	wxInt32 i = m_LstCtrlWadDirectories->GetSelection();
+
+	if((i != wxNOT_FOUND) && (i + 1 < m_LstCtrlWadDirectories->GetCount()))
+	{
+		wxString str = m_LstCtrlWadDirectories->GetString(i);
+
+		m_LstCtrlWadDirectories->Delete(i);
+
+		m_LstCtrlWadDirectories->Insert(str, i + 1);
+
+		m_LstCtrlWadDirectories->SetSelection(i + 1);
+
+		UserChangedSetting = true;
+	}
+}
+
+// Get the environment variables
+void dlgConfig::OnGetEnvClick(wxCommandEvent& event)
+{
+	wxString doomwaddir = "";
+	wxString env_paths[NUM_ENVVARS];
+	wxInt32 i = 0;
+
+	// create a small list of paths
+	for(i = 0; i < NUM_ENVVARS; i++)
+	{
+		// only add paths if the variable exists and path isn't blank
+		if(wxGetEnv(env_vars[i], &env_paths[i]))
+			if(!env_paths[i].IsEmpty())
+				doomwaddir += env_paths[i] + PATH_DELIMITER;
+	}
+
+	wxInt32 path_count = 0;
+
+	wxStringTokenizer wadlist(doomwaddir, PATH_DELIMITER);
+
+	while(wadlist.HasMoreTokens())
+	{
+		wxString path = wadlist.GetNextToken();
+
+		// make sure the path doesn't already exist in the list box
+		if(m_LstCtrlWadDirectories->FindString(path) == wxNOT_FOUND)
+		{
+			m_LstCtrlWadDirectories->Append(path);
+
+			path_count++;
+		}
+	}
+
+	if(path_count)
+	{
+		wxMessageBox("Environment variables import successful");
+
+		UserChangedSetting = true;
+	}
+	else
+		wxMessageBox("Environment variables contains paths that have been already imported.");
+
+}
+
 void dlgConfig::OnNotebookPageChanged(wxBookCtrlEvent& event)
 {
 	// This is a workaround for notebook layout issues on some platforms
@@ -261,7 +445,7 @@ void dlgConfig::LoadSettings()
 	bool AutoServerRefresh;
 	int ThreadMul, ThreadMax, MasterTimeout, ServerTimeout, RetryCount;
     int RefreshInterval;
-	wxString OdamexDirectory, ExtraCmdLineArgs;
+	wxString DelimWadPaths, OdamexDirectory, ExtraCmdLineArgs;
 	wxString SoundFile, HighlightColour, CustomServerColour;
 	wxInt32 PQGood, PQPlayable, PQLaggy;
 
@@ -271,6 +455,7 @@ void dlgConfig::LoadSettings()
 	                ODA_UISHOWBLOCKEDSERVERS);
     ConfigInfo.Read(CHECKFORUPDATES, &CheckForUpdates,
 	                ODA_UIAUTOCHECKFORUPDATES);
+	ConfigInfo.Read(DELIMWADPATHS, &DelimWadPaths, OdaGetDataDir());
 	ConfigInfo.Read(ODAMEX_DIRECTORY, &OdamexDirectory, OdaGetInstallDir());
 	ConfigInfo.Read(MASTERTIMEOUT, &MasterTimeout, ODA_QRYMASTERTIMEOUT);
 	ConfigInfo.Read(SERVERTIMEOUT, &ServerTimeout, ODA_QRYSERVERTIMEOUT);
@@ -309,7 +494,25 @@ void dlgConfig::LoadSettings()
 	m_DirCtrlChooseOdamexPath->SetPath(OdamexDirectory);
 	m_FilePickCtrlSoundFile->SetPath(SoundFile);
 	m_ClrPickServerLineHighlighter->SetColour(HighlightColour);
-    m_ClrPickCustomServerHighlight->SetColour(CustomServerColour);
+	m_ClrPickCustomServerHighlight->SetColour(CustomServerColour);
+
+	// Load wad path list
+	m_LstCtrlWadDirectories->Clear();
+
+	wxStringTokenizer wadlist(DelimWadPaths, PATH_DELIMITER);
+
+	while(wadlist.HasMoreTokens())
+	{
+		wxString path = wadlist.GetNextToken();
+
+#ifdef __WXMSW__
+		path.Replace("\\\\","\\", true);
+#else
+		path.Replace("////","//", true);
+#endif
+
+		m_LstCtrlWadDirectories->AppendString(path);
+	}
 
     m_SpnCtrlThreadMul->SetValue(ThreadMul);
     m_SpnCtrlThreadMax->SetValue(ThreadMax);
@@ -335,12 +538,18 @@ void dlgConfig::SaveSettings()
 	// Allow $ in directory names
 	ConfigInfo.SetExpandEnvVars(false);
 
+	wxString DelimWadPaths;
+
+	for(unsigned int i = 0; i < m_LstCtrlWadDirectories->GetCount(); i++)
+		DelimWadPaths.Append(m_LstCtrlWadDirectories->GetString(i) + PATH_DELIMITER);
+
 	ConfigInfo.Write(MASTERTIMEOUT, m_SpnCtrlMasterTimeout->GetValue());
 	ConfigInfo.Write(SERVERTIMEOUT, m_SpnCtrlServerTimeout->GetValue());
 	ConfigInfo.Write(RETRYCOUNT, m_SpnCtrlRetry->GetValue());
 	ConfigInfo.Write(EXTRACMDLINEARGS, m_TxtCtrlExtraCmdLineArgs->GetValue());
 	ConfigInfo.Write(GETLISTONSTART, m_ChkCtrlGetListOnStart->GetValue());
 	ConfigInfo.Write(SHOWBLOCKEDSERVERS, m_ChkCtrlShowBlockedServers->GetValue());
+	ConfigInfo.Write(DELIMWADPATHS, DelimWadPaths);
 	ConfigInfo.Write(ODAMEX_DIRECTORY, m_DirCtrlChooseOdamexPath->GetPath());
 	ConfigInfo.Write(ICONPINGQGOOD, m_SpnCtrlPQGood->GetValue());
 	ConfigInfo.Write(ICONPINGQPLAYABLE, m_SpnCtrlPQPlayable->GetValue());

--- a/odalaunch/src/dlg_config.h
+++ b/odalaunch/src/dlg_config.h
@@ -61,6 +61,11 @@ public:
 protected:
 	void OnOK(wxCommandEvent& event);
 
+	void OnChooseDir(wxFileDirPickerEvent& event);
+	void OnAddDir(wxCommandEvent& event);
+	void OnReplaceDir(wxCommandEvent& event);
+	void OnDeleteDir(wxCommandEvent& event);
+
 	void OnUpClick(wxCommandEvent& event);
 	void OnDownClick(wxCommandEvent& event);
 
@@ -87,6 +92,8 @@ protected:
 	wxCheckBox* m_ChkCtrlHighlightServerLines;
 	wxCheckBox* m_ChkCtrlHighlightCustomServers;
 	wxCheckBox* m_ChkCtrlkAutoServerRefresh;
+
+	wxListBox* m_LstCtrlWadDirectories;
 
 	wxDirPickerCtrl* m_DirCtrlChooseOdamexPath;
 	wxFilePickerCtrl* m_FilePickCtrlSoundFile;

--- a/odalaunch/src/dlg_main.cpp
+++ b/odalaunch/src/dlg_main.cpp
@@ -681,10 +681,17 @@ void dlgMain::OnManualConnect(wxCommandEvent& event)
 		}
 	}
 
-	wxString OdamexDirectory;
-	ConfigInfo.Read(ODAMEX_DIRECTORY, &OdamexDirectory, OdaGetInstallDir());
 
-	LaunchGame(ted_result, OdamexDirectory, ped_result);
+	wxString OdamexDirectory, DelimWadPaths;
+
+	{
+		ConfigInfo.Read(ODAMEX_DIRECTORY, &OdamexDirectory,
+		                OdaGetInstallDir());
+
+		ConfigInfo.Read(DELIMWADPATHS, &DelimWadPaths, OdaGetDataDir());
+	}
+
+	LaunchGame(ted_result, OdamexDirectory, DelimWadPaths, ped_result);
 }
 
 // Various timers
@@ -1245,15 +1252,17 @@ void dlgMain::OnOpenSettingsDialog(wxCommandEvent& event)
 // Quick-Launch button click
 void dlgMain::OnQuickLaunch(wxCommandEvent& event)
 {
-	wxString OdamexDirectory;
+	wxString OdamexDirectory, DelimWadPaths;
 
 	{
 		wxFileConfig ConfigInfo;
 
-		ConfigInfo.Read(ODAMEX_DIRECTORY, &OdamexDirectory, OdaGetInstallDir());
+		ConfigInfo.Read(ODAMEX_DIRECTORY, &OdamexDirectory,
+		                OdaGetInstallDir());
+		ConfigInfo.Read(DELIMWADPATHS, &DelimWadPaths, OdaGetDataDir());
 	}
 
-	LaunchGame("", OdamexDirectory);
+	LaunchGame("", OdamexDirectory, DelimWadPaths);
 
 }
 
@@ -1318,17 +1327,18 @@ void dlgMain::OnLaunch(wxCommandEvent& event)
 		}
 	}
 
-	wxString OdamexDirectory;
+	wxString OdamexDirectory, DelimWadPaths;
 
 	{
 		wxFileConfig ConfigInfo;
 
 		ConfigInfo.Read(ODAMEX_DIRECTORY, &OdamexDirectory,
 		                OdaGetInstallDir());
+		ConfigInfo.Read(DELIMWADPATHS, &DelimWadPaths, OdaGetDataDir());
 	}
 
 	LaunchGame(stdstr_towxstr(QServer[i].GetAddress()), OdamexDirectory,
-	           Password);
+	           DelimWadPaths, Password);
 }
 
 // Update program state and get a new list of servers
@@ -1443,7 +1453,7 @@ void dlgMain::OnServerListClick(wxListEvent& event)
 }
 
 void dlgMain::LaunchGame(const wxString& Address, const wxString& ODX_Path,
-                         const wxString& Password)
+                         const wxString& waddirs, const wxString& Password)
 {
 	wxFileConfig ConfigInfo;
 
@@ -1484,6 +1494,13 @@ void dlgMain::LaunchGame(const wxString& Address, const wxString& ODX_Path,
 	{
 		CmdLine += " ";
 		CmdLine += Password;
+	}
+
+	if(!waddirs.IsEmpty())
+	{
+		CmdLine += " -waddir \"";
+		CmdLine += waddirs;
+		CmdLine += "\"";
 	}
 
 	// Check for any user command line arguments

--- a/odalaunch/src/dlg_main.h
+++ b/odalaunch/src/dlg_main.h
@@ -121,7 +121,7 @@ protected:
 	};
 
 	void LaunchGame(const wxString& Address, const wxString& ODX_Path,
-	                const wxString& Password = "");
+	                const wxString& waddirs, const wxString& Password = "");
 
 	LstOdaServerList* m_LstCtrlServers;
 	LstOdaPlayerList* m_LstCtrlPlayers;

--- a/odalaunch/src/plat_utils.cpp
+++ b/odalaunch/src/plat_utils.cpp
@@ -100,3 +100,17 @@ wxString OdaGetInstallDir()
 
 	return InstallDir;
 }
+
+wxString OdaGetDataDir()
+{
+	wxString DataDir;
+
+#if defined(ODAMEX_INSTALL_DATADIR)
+	const char* datadir_cstr = ODAMEX_INSTALL_DATADIR;
+	DataDir = wxString::FromAscii(datadir_cstr);
+#else
+	DataDir =  wxGetCwd();
+#endif
+
+	return DataDir;
+}

--- a/odalaunch/src/plat_utils.h
+++ b/odalaunch/src/plat_utils.h
@@ -37,6 +37,7 @@
 
 // All
 wxString OdaGetInstallDir();
+wxString OdaGetDataDir();
 
 // Windows
 void OdaMswFixTitlebarIcon(WXWidget Handle, wxIcon MainIcon);


### PR DESCRIPTION
This got removed in 12.2 as part of removing unused OdaGet code, but this part of it still partially functioned. It has been restored, with updated labels reflecting what it actually does.