### PR TITLE
[BUGFIX] Wad downloader downloads html file from dogsoft

### DIFF
--- a/client/src/otransfer.cpp
+++ b/client/src/otransfer.cpp
@@ -255,7 +255,12 @@ bool OTransferCheck::tick()
 	}
 
 	// Make sure we didn't find an HTML file - those are only okay on redirects.
-	if (stricmp(info.contentType.c_str(), "text/html") == 0)
+	std::string_view contentType = info.contentType;
+	const auto semiPos = contentType.find(';');
+	if (semiPos != std::string_view::npos)
+		contentType = contentType.substr(0, semiPos);
+	contentType = TrimStringView(contentType);
+	if (iequals(contentType, "text/html"))
 	{
 		m_errorProc("Only found an HTML file");
 		return false;

--- a/client/src/otransfer.h
+++ b/client/src/otransfer.h
@@ -29,29 +29,22 @@
 
 struct OTransferProgress
 {
-	ptrdiff_t dltotal;
-	ptrdiff_t dlnow;
-
-	OTransferProgress() : dltotal(0), dlnow(0)
-	{
-	}
+	ptrdiff_t dltotal = 0;
+	ptrdiff_t dlnow   = 0;
 };
 
 struct OTransferInfo
 {
-	int code;
-	curl_off_t speed;
+	int code         = 0;
+	curl_off_t speed = 0;
 	std::string url;
 	std::string contentType;
 
-	OTransferInfo() : code(0), speed(0), url(""), contentType("")
-	{
-	}
 	bool hydrate(CURL* curl);
 };
 
-typedef void (*OTransferDoneProc)(const OTransferInfo& info);
-typedef void (*OTransferErrorProc)(const char* msg);
+using OTransferDoneProc  = void (*)(const OTransferInfo& info);
+using OTransferErrorProc = void (*)(const char* msg);
 
 /**
  * @brief Encapsulates an HTTP check to see if a specific remote file exists.

--- a/common/cmdlib.cpp
+++ b/common/cmdlib.cpp
@@ -502,14 +502,14 @@ void TicsToTime(OTimespan& span, int time, bool ceilsec)
 // Trim whitespace from the start of a string
 std::string &TrimStringStart(std::string &s)
 {
-	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not_fn( std::isspace )));
+	s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char c) { return !std::isspace(c); }));
 	return s;
 }
 
 // Trim whitespace from the end of a string
 std::string &TrimStringEnd(std::string &s)
 {
-	s.erase(std::find_if(s.rbegin(), s.rend(), std::not_fn( std::isspace )).base(), s.end());
+	s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char c) { return !std::isspace(c); }).base(), s.end());
 	return s;
 }
 

--- a/common/cmdlib.cpp
+++ b/common/cmdlib.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 
 #include <ctime>
+#include <cctype>
 #include <functional>
 #include <sstream>
 

--- a/common/cmdlib.cpp
+++ b/common/cmdlib.cpp
@@ -498,23 +498,17 @@ void TicsToTime(OTimespan& span, int time, bool ceilsec)
 	span.csecs = (span.tics * 100) / TICRATE;
 }
 
-// [SL] Reimplement std::isspace
-static int _isspace(int c)
-{
-	return (c == ' ' || c == '\n' || c == '\t' || c == '\v' || c == '\f' || c == '\r');
-}
-
 // Trim whitespace from the start of a string
 std::string &TrimStringStart(std::string &s)
 {
-	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not_fn( _isspace )));
+	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not_fn( std::isspace )));
 	return s;
 }
 
 // Trim whitespace from the end of a string
 std::string &TrimStringEnd(std::string &s)
 {
-	s.erase(std::find_if(s.rbegin(), s.rend(), std::not_fn( _isspace )).base(), s.end());
+	s.erase(std::find_if(s.rbegin(), s.rend(), std::not_fn( std::isspace )).base(), s.end());
 	return s;
 }
 
@@ -522,6 +516,34 @@ std::string &TrimStringEnd(std::string &s)
 std::string &TrimString(std::string &s)
 {
 	return TrimStringStart(TrimStringEnd(s));
+}
+
+// Trim whitespace from the start of a string_view
+std::string_view TrimStringViewStart(std::string_view str)
+{
+	const auto it = std::find_if(str.begin(), str.end(), [](unsigned char c){
+		return !std::isspace(c);
+	});
+
+    str.remove_prefix(std::distance(str.begin(), it));
+    return str;
+}
+
+// Trim whitespace from the end of a string_view
+std::string_view TrimStringViewEnd(std::string_view str)
+{
+	const auto it = std::find_if(str.rbegin(), str.rend(), [](unsigned char c){
+		return !std::isspace(c);
+	});
+
+    str.remove_suffix(std::distance(str.rbegin(), it));
+    return str;
+}
+
+// Trim whitespace from the start and end of a string
+std::string_view TrimStringView(std::string_view str)
+{
+	return TrimStringViewStart(TrimStringViewEnd(str));
 }
 
 // Ensure that a string only has valid viewable ASCII in it.

--- a/common/cmdlib.h
+++ b/common/cmdlib.h
@@ -96,6 +96,9 @@ std::string StdStringToUpper(const char*, size_t n = std::string::npos);
 std::string &TrimString(std::string &s);
 std::string &TrimStringStart(std::string &s);
 std::string &TrimStringEnd(std::string &s);
+std::string_view TrimStringView(std::string_view s);
+std::string_view TrimStringViewStart(std::string_view s);
+std::string_view TrimStringViewEnd(std::string_view s);
 
 bool ValidString(const std::string&);
 bool IsHexString(const std::string& str, const size_t len);


### PR DESCRIPTION
Fixes #1291

The Content-Type will often be something like `text/html; charset=UTF-8` instead of just `text/html`. So now if there's a semicolon found, we throw away everything after the semicolon (and strip whitespace too just in case).