### PR TITLE
[BUGFIX] COMPLVL cvar overrides not getting applied in singleplayer

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -765,7 +765,7 @@ CVAR(			r_flashhom, "0", "Draws flashing colors where there is HOM",
 CVAR(			r_drawflat, "0", "Disables all texturing of walls, floors and ceilings",
 				CVARTYPE_BOOL, CVAR_NULL)
 
-CVAR(			r_clipmaskedspecial, "1", "Vertically clip masked midtextures when surrounding sectors have differing specials (mimics Hexen and DSDA-Doom behavior)",
+CVAR(			r_clipmaskedspecial, "0", "Vertically clip masked midtextures when surrounding sectors have differing specials (mimics Hexen and DSDA-Doom behavior)",
 				CVARTYPE_BOOL, CVAR_NULL)
 
 CVAR(			r_thingsectorlight, "0", "Things are lit according to the average of the transfered light levels (mimics MBF behavior)",

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -612,7 +612,8 @@ void G_ReadCOMPLVL()
 	char* complvl = static_cast<char*>(W_CacheLumpNum(lumpnum, PU_STATIC));
 	auto guard = nonstd::make_scope_exit([&]{ Z_Free(complvl); });
 
-	if (!serverside)
+	// don't use !serverside here, it doesn't get set early enough
+	if (multiplayer)
 	{
 		if (iequals("mbf", complvl))
 			r_thingsectorlight.Set(1.0f);


### PR DESCRIPTION
Fixes #1611

Turns out that `serverside` doesn't get set to true until after the wad loading process has completed, so it's too early to check it here.

Also sets r_clipmaskedspecial to 0 by default, as that is vanilla behavior, and it should only get changed for mbf21 wads. It was just a typo that had it as 1 by default.