### PR TITLE
[CHANGE] Add more Spree and Multi Kill controls

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -448,6 +448,10 @@ CVAR(cl_showsprees, "1", "Show killing sprees for the display player.", CVARTYPE
 
 CVAR(cl_showmultikills, "1", "Show multi kills for the display player.", CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
+CVAR(cl_showofflinesprees, "0", "Show killing sprees during single player games and vanilla demo playback. Netdemos are unaffected. Does not supercede cl_showsprees.", CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
+CVAR(cl_showofflinemultikills, "0", "Show multi kills during single player games and vanilla demo playback. Netdemos are unaffected. Does not supercede cl_showmultikills", CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+
 // Netdemo Preferences
 // --------------------
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -90,6 +90,7 @@ EXTERN_CVAR(show_messages)
 EXTERN_CVAR(co_novileghosts)
 EXTERN_CVAR(sv_sharekeys)
 EXTERN_CVAR(cl_showsprees)
+EXTERN_CVAR(sv_showsprees)
 
 extern std::string digest;
 extern bool forcenetdemosplit;
@@ -2932,7 +2933,7 @@ static void CL_Spree(const odaproto::svc::Spree* msg)
 	bool update = SpreeManager::getInstance().setRawSpree(playerId, spreeLevel);
 
 	// No need to check cl_showofflinesprees here since this will only fire online or during a netdemo.
-	if (cl_showsprees && displayplayer_id == playerId && update)
+	if (cl_showsprees && sv_showsprees && displayplayer_id == playerId && update)
 	{
 		// Play the sound for the new multi kill
 		// S_Sound(CHAN_ANNOUNCER, '', 1, ATTN_NONE);

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2931,6 +2931,7 @@ static void CL_Spree(const odaproto::svc::Spree* msg)
 
 	bool update = SpreeManager::getInstance().setRawSpree(playerId, spreeLevel);
 
+	// No need to check cl_showofflinesprees here since this will only fire online or during a netdemo.
 	if (cl_showsprees && displayplayer_id == playerId && update)
 	{
 		// Play the sound for the new multi kill

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -209,6 +209,8 @@ EXTERN_CVAR(cl_autorecord_horde)
 // Spree options
 EXTERN_CVAR(cl_showsprees)
 EXTERN_CVAR(cl_showmultikills)
+EXTERN_CVAR(cl_showofflinesprees)
+EXTERN_CVAR(cl_showofflinemultikills)
 
 // Weapon Preferences
 EXTERN_CVAR (cl_switchweapon)
@@ -918,6 +920,8 @@ static menuitem_t VideoItems[] = {
 	{ discrete, "Center weapon when firing",{&cl_centerbobonfire},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Show Killing Sprees",		{&cl_showsprees},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ discrete, "Show Multi Kills",		{&cl_showmultikills},	{2.0}, {0.0},	{0.0},	{OnOff} },
+	{ discrete, "Show Sprees in Offline Games",	{&cl_showofflinesprees},{2.0}, {0.0},	{0.0},	{OnOff} },
+	{ discrete, "Show Multi Kills in Offline Games",	{&cl_showofflinemultikills},{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ redtext,	" ",					    {NULL},				    {0.0}, {0.0},	{0.0},  {NULL} },
 	{ discrete, "Force Team Color",			{&r_forceteamcolor},	{2.0}, {0.0},	{0.0},	{OnOff} },
 	{ redslider,   "Team Color Red",        {&r_teamcolor},  {0.0}, {0.0},   {0.0},  {NULL} },

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -136,6 +136,7 @@ EXTERN_CVAR(g_roundlimit)
 EXTERN_CVAR(hud_hordeinfo_debug)
 EXTERN_CVAR(g_preroundreset)
 EXTERN_CVAR(cl_showsprees)
+EXTERN_CVAR(cl_showofflinesprees)
 
 void ST_unloadNew()
 {
@@ -1167,7 +1168,7 @@ void DrawToasts()
 		x += icon->width() + 1;
 
 			// Draw spree point badge if any
-		if (toast.active_spree && cl_showsprees)
+		if (toast.active_spree && cl_showsprees && (cl_showofflinesprees || network_game))
 		{
 			// Draw the arrow
 			const patch_t* arrow = W_ResolvePatchHandle(ToastSpreeArrow);
@@ -1578,7 +1579,7 @@ void DisplaySmallSpree(const SpreeRecord_t& record)
 
 void SpreeHud()
 {
-	if (!validplayer(displayplayer()) || !cl_showsprees)
+	if (!validplayer(displayplayer()) || !cl_showsprees || (!cl_showofflinesprees && !network_game))
 		return;
 
 	static SpreeManager& manager = SpreeManager::getInstance();

--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -137,6 +137,7 @@ EXTERN_CVAR(hud_hordeinfo_debug)
 EXTERN_CVAR(g_preroundreset)
 EXTERN_CVAR(cl_showsprees)
 EXTERN_CVAR(cl_showofflinesprees)
+EXTERN_CVAR(sv_showsprees)
 
 void ST_unloadNew()
 {
@@ -1168,7 +1169,7 @@ void DrawToasts()
 		x += icon->width() + 1;
 
 			// Draw spree point badge if any
-		if (toast.active_spree && cl_showsprees && (cl_showofflinesprees || network_game))
+		if (toast.active_spree && cl_showsprees && ((network_game && sv_showsprees) || (!network_game && cl_showofflinesprees)))
 		{
 			// Draw the arrow
 			const patch_t* arrow = W_ResolvePatchHandle(ToastSpreeArrow);
@@ -1579,7 +1580,7 @@ void DisplaySmallSpree(const SpreeRecord_t& record)
 
 void SpreeHud()
 {
-	if (!validplayer(displayplayer()) || !cl_showsprees || (!cl_showofflinesprees && !network_game))
+	if (!validplayer(displayplayer()) || !cl_showsprees || (!cl_showofflinesprees && !network_game) || (!sv_showsprees && network_game))
 		return;
 
 	static SpreeManager& manager = SpreeManager::getInstance();

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -193,6 +193,12 @@ CVAR(				sv_hostname, "Untitled Odamex Server", "Server name to appear on master
 CVAR(				sv_showplayerpowerups, "0", "Show which powerup each player has. (1 = Show all powerups to clients. 0 = Only show Invisibility (vanilla)",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 
+CVAR(				sv_showsprees, "1", "Enable killing spree announcements. When disabled, clients will not display or announce sprees.",
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
+
+CVAR(				sv_showmultikills, "1", "Enable multi kill announcements. When disabled, clients will not display or announce multi kills.",
+					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
+
 CVAR(sv_downloadsites, "",
      "A list of websites to download WAD files from, separated by spaces",
      CVARTYPE_STRING, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_NOENABLEDISABLE)

--- a/common/c_cvarlist.cpp
+++ b/common/c_cvarlist.cpp
@@ -193,10 +193,10 @@ CVAR(				sv_hostname, "Untitled Odamex Server", "Server name to appear on master
 CVAR(				sv_showplayerpowerups, "0", "Show which powerup each player has. (1 = Show all powerups to clients. 0 = Only show Invisibility (vanilla)",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO | CVAR_LATCH)
 
-CVAR(				sv_showsprees, "1", "Enable killing spree announcements. When disabled, clients will not display or announce sprees.",
+CVAR(				sv_showsprees, "0", "Enable killing spree announcements. When disabled, clients will not display or announce sprees.",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
 
-CVAR(				sv_showmultikills, "1", "Enable multi kill announcements. When disabled, clients will not display or announce multi kills.",
+CVAR(				sv_showmultikills, "0", "Enable multi kill announcements. When disabled, clients will not display or announce multi kills.",
 					CVARTYPE_BOOL, CVAR_SERVERARCHIVE | CVAR_SERVERINFO)
 
 CVAR(sv_downloadsites, "",

--- a/common/g_multikill.cpp
+++ b/common/g_multikill.cpp
@@ -200,6 +200,8 @@ EXTERN_CVAR(cl_showmultikills)
 EXTERN_CVAR(cl_showofflinemultikills)
 #endif
 
+EXTERN_CVAR(sv_showmultikills)
+
 void P_ProcessMultiKills(const AActor* source, const player_t* target)
 {
 	MultiKillManager& manager = MultiKillManager::getInstance();
@@ -220,7 +222,7 @@ void P_ProcessMultiKills(const AActor* source, const player_t* target)
 
 	#ifdef CLIENT_APP
 	// Don't announce multi kills if the client has showing them disabled
-	if (!cl_showmultikills || (!cl_showofflinemultikills && !network_game))
+	if (!cl_showmultikills || (!cl_showofflinemultikills && !network_game) || (!sv_showmultikills && network_game))
 		return;
 	#endif
 

--- a/common/g_multikill.cpp
+++ b/common/g_multikill.cpp
@@ -197,6 +197,7 @@ void MultiKillManager::clearMultiTics()
 
 #ifdef CLIENT_APP
 EXTERN_CVAR(cl_showmultikills)
+EXTERN_CVAR(cl_showofflinemultikills)
 #endif
 
 void P_ProcessMultiKills(const AActor* source, const player_t* target)
@@ -219,7 +220,7 @@ void P_ProcessMultiKills(const AActor* source, const player_t* target)
 
 	#ifdef CLIENT_APP
 	// Don't announce multi kills if the client has showing them disabled
-	if (!cl_showmultikills)
+	if (!cl_showmultikills || (!cl_showofflinemultikills && !network_game))
 		return;
 	#endif
 

--- a/common/g_spree.cpp
+++ b/common/g_spree.cpp
@@ -614,6 +614,7 @@ void SpreeManager::clearPoints()
 
 #ifdef CLIENT_APP
 EXTERN_CVAR(cl_showsprees)
+EXTERN_CVAR(cl_showofflinesprees)
 #endif
 
 void P_ProcessSpreeKill(const AActor* source, const player_t* target)
@@ -647,7 +648,7 @@ void P_ProcessSpreeKill(const AActor* source, const player_t* target)
 
 #ifdef CLIENT_APP
 	// Don't announce sprees if the client has showing them disabled
-	if (!cl_showsprees)
+	if (!cl_showsprees || (!cl_showofflinesprees && !network_game))
 		return;
 #endif
 
@@ -684,7 +685,7 @@ void P_ProcessSpreeDamage(const player_t* source, const int totalDamage)
 
 #ifdef CLIENT_APP
 	// Don't announce sprees if the client has showing them disabled
-	if (!cl_showsprees)
+	if (!cl_showsprees || (!cl_showofflinesprees && !network_game))
 		return;
 #endif
 

--- a/common/g_spree.cpp
+++ b/common/g_spree.cpp
@@ -191,6 +191,8 @@ void SpreeManager::setRawSpreeBreaker(const SpreeBreaker_t& breaker, const int l
 	spreeBreaker = newbreaker;
 }
 
+EXTERN_CVAR(sv_showsprees)
+
 void SpreeManager::setSpreeBreaker(const AActor* source, const player_t* target)
 {
 	if (clientside && network_game)
@@ -270,8 +272,11 @@ void SpreeManager::setSpreeBreaker(const AActor* source, const player_t* target)
 	                         ::gametic};
 
 	#ifdef SERVER_APP
-	// Broadcast to all clients
-	MSG_BroadcastSVC(CLBUF_NET, SVC_SpreeBreaker(breaker, level, type), -1);
+	if (!sv_showsprees)
+	{
+		// Broadcast to all clients
+		MSG_BroadcastSVC(CLBUF_NET, SVC_SpreeBreaker(breaker, level, type), -1);
+	}
 	#endif
 
 	setBreakerLanguage(breaker, type);
@@ -376,8 +381,11 @@ bool SpreeManager::checkForSpreeUpdates(const int playerId, const std::string pl
 
 		spreeRecord[playerId] = newRecord;
 #ifdef SERVER_APP
-		// Broadcast to all clients
-		MSG_BroadcastSVC(CLBUF_NET, SVC_Spree(newRecord), -1);
+		if (sv_showsprees)
+		{
+			// Broadcast to all clients
+			MSG_BroadcastSVC(CLBUF_NET, SVC_Spree(newRecord), -1);
+		}
 #endif
 		return true;
 	}
@@ -402,8 +410,11 @@ bool SpreeManager::checkForSpreeUpdates(const int playerId, const std::string pl
 			// Apply sexmessage to the broadcast text
 			setSpreeRecordLanguage(record, playerId);
 #ifdef SERVER_APP
-			// Broadcast to all clients
-			MSG_BroadcastSVC(CLBUF_NET, SVC_Spree(record), -1);
+			if (!sv_showsprees)
+			{
+				// Broadcast to all clients
+				MSG_BroadcastSVC(CLBUF_NET, SVC_Spree(record), -1);
+			}
 #endif
 			return true;
 		}
@@ -648,7 +659,8 @@ void P_ProcessSpreeKill(const AActor* source, const player_t* target)
 
 #ifdef CLIENT_APP
 	// Don't announce sprees if the client has showing them disabled
-	if (!cl_showsprees || (!cl_showofflinesprees && !network_game))
+	if (!cl_showsprees || (!cl_showofflinesprees && !network_game) ||
+	    (!sv_showsprees && network_game))
 		return;
 #endif
 
@@ -685,7 +697,8 @@ void P_ProcessSpreeDamage(const player_t* source, const int totalDamage)
 
 #ifdef CLIENT_APP
 	// Don't announce sprees if the client has showing them disabled
-	if (!cl_showsprees || (!cl_showofflinesprees && !network_game))
+	if (!cl_showsprees || (!cl_showofflinesprees && !network_game) ||
+	    (!sv_showsprees && network_game))
 		return;
 #endif
 

--- a/common/g_spree.cpp
+++ b/common/g_spree.cpp
@@ -272,7 +272,7 @@ void SpreeManager::setSpreeBreaker(const AActor* source, const player_t* target)
 	                         ::gametic};
 
 	#ifdef SERVER_APP
-	if (!sv_showsprees)
+	if (sv_showsprees)
 	{
 		// Broadcast to all clients
 		MSG_BroadcastSVC(CLBUF_NET, SVC_SpreeBreaker(breaker, level, type), -1);
@@ -410,7 +410,7 @@ bool SpreeManager::checkForSpreeUpdates(const int playerId, const std::string pl
 			// Apply sexmessage to the broadcast text
 			setSpreeRecordLanguage(record, playerId);
 #ifdef SERVER_APP
-			if (!sv_showsprees)
+			if (sv_showsprees)
 			{
 				// Broadcast to all clients
 				MSG_BroadcastSVC(CLBUF_NET, SVC_Spree(record), -1);

--- a/config-samples/coop-all-official-wads.cfg
+++ b/config-samples/coop-all-official-wads.cfg
@@ -221,6 +221,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript "if sv_curpwad eq id1.wad set co_boomphys 1; if sv_curpwad ne id1.wad set co_boomphys 0"
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/coop-doom.cfg
+++ b/config-samples/coop-doom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/coop-masterlevels.cfg
+++ b/config-samples/coop-masterlevels.cfg
@@ -222,6 +222,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/coop-modern.cfg
+++ b/config-samples/coop-modern.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/coop-zdoom.cfg
+++ b/config-samples/coop-zdoom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/ctf-attackdefend.cfg
+++ b/config-samples/ctf-attackdefend.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/ctf-doom.cfg
+++ b/config-samples/ctf-doom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/ctf-pub.cfg
+++ b/config-samples/ctf-pub.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/ctf-wdl.cfg
+++ b/config-samples/ctf-wdl.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/dm-doom.cfg
+++ b/config-samples/dm-doom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/dm-iddm1.cfg
+++ b/config-samples/dm-iddm1.cfg
@@ -225,6 +225,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/dm-modern.cfg
+++ b/config-samples/dm-modern.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/dm-zdoom.cfg
+++ b/config-samples/dm-zdoom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/duel-altdeath.cfg
+++ b/config-samples/duel-altdeath.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/duel-ddl.cfg
+++ b/config-samples/duel-ddl.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/duel-doom.cfg
+++ b/config-samples/duel-doom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/duel-zddl.cfg
+++ b/config-samples/duel-zddl.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/duel-zdoom.cfg
+++ b/config-samples/duel-zdoom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/horde-doom.cfg
+++ b/config-samples/horde-doom.cfg
@@ -200,6 +200,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/horde-modern.cfg
+++ b/config-samples/horde-modern.cfg
@@ -200,6 +200,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/horde-zdoom.cfg
+++ b/config-samples/horde-zdoom.cfg
@@ -200,6 +200,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/lms-2team.cfg
+++ b/config-samples/lms-2team.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/lms-3team.cfg
+++ b/config-samples/lms-3team.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/lms-ffa.cfg
+++ b/config-samples/lms-ffa.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/survival-modern.cfg
+++ b/config-samples/survival-modern.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "0"
+set sv_showmultikills "0"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/tdm-doom.cfg
+++ b/config-samples/tdm-doom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/tdm-modern.cfg
+++ b/config-samples/tdm-modern.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"

--- a/config-samples/tdm-zdoom.cfg
+++ b/config-samples/tdm-zdoom.cfg
@@ -198,6 +198,11 @@ set sv_endmapscript ""
 set sv_startmapscript ""
 set sv_startwadscript ""
 
+// -- Sprees & Multi Kills --
+
+set sv_showsprees "1"
+set sv_showmultikills "1"
+
 // --- Aliases ---
 
 alias "?" "help"


### PR DESCRIPTION
Added 4 vars, 2 clientside and 2 serverside:

### Client
`cl_showofflinesprees` - Show sprees in non-network games, like in single player or vanilla demos. Is superseded by `cl_showsprees`. Defaults to 0.

`cl_showofflinemultikills` - Shows multi kills in non-network games, like in single player or vanilla demos. In fact, multi kills aren't really viewable outside of vanilla demos due to Odamex's inability to play deathmatch offline. Is superseded by `cl_showmultikills`. Defaults to 0.

### Server
`sv_showsprees` - Configures the server-wide disablement of Sprees. If this is 0, sprees aren't shown to any player, even if the player enabled them in the client -- because not only is it disabled in the client, sprees aren't broadcasted at all. Defaults to 0.

`sv_showmultikills` - Configures the server-wide disablement of Multi Kills. If this is 0, multi kills aren't shown to any player, even if the player enabled them in the client. Defaults to 0.

Addresses #1729