### PR TITLE
[BUGFIX] Missing tag 0 check for Boom generalized specials

### DIFF
--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -105,14 +105,17 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if ((line->special & FloorChange) || !(line->special & FloorModel))
 					return false; // FloorModel is "Allow Monsters" if FloorChange is 0
+			if (!line->id) //jff 2/27/98 all walk generalized types require tag
+				return false;
 			linefunc = EV_DoGenFloor;
 		}
 		else if ((unsigned)line->special >= GenCeilingBase)
 		{
 			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if ((line->special & CeilingChange) || !(line->special & CeilingModel))
-					return false; // CeilingModel is "Allow Monsters" if CeilingChange is
-					               // 0
+					return false; // CeilingModel is "Allow Monsters" if CeilingChange is 0
+			if (!line->id) //jff 2/27/98 all walk generalized types require tag
+				return false;
 			linefunc = EV_DoGenCeiling;
 		}
 		else if ((unsigned)line->special >= GenDoorBase)
@@ -124,6 +127,8 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 				if (line->flags & ML_SECRET) // they can't open secret doors either
 					return false;
 			}
+			if (!line->id) //3/2/98 move outside the monster check
+				return false;
 			linefunc = EV_DoGenDoor;
 		}
 		else if ((unsigned)line->special >= GenLockedBase)
@@ -146,6 +151,8 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if (!(line->special & LiftMonster))
 					return false; // monsters disallowed
+			if (!line->id) //jff 2/27/98 all walk generalized types require tag
+				return false;
 			linefunc = EV_DoGenLift;
 		}
 		else if ((unsigned)line->special >= GenStairsBase)
@@ -153,6 +160,8 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if (!(line->special & StairMonster))
 					return false; // monsters disallowed
+			if (!line->id) //jff 2/27/98 all walk generalized types require tag
+				return false;
 			linefunc = EV_DoGenStairs;
 		}
 		else if ((unsigned)line->special >= GenCrusherBase)
@@ -162,6 +171,8 @@ bool P_CrossCompatibleSpecialLine(line_t* line, int side, AActor* thing,
 			if (!P_IsPlayerOrAvatar(*thing) && !bossaction)
 				if (!(line->special & StairMonster))
 					return false; // monsters disallowed
+			if (!line->id) //jff 2/27/98 all walk generalized types require tag
+				return false;
 			linefunc = EV_DoGenCrusher;
 		}
 

--- a/common/p_boomfspec.cpp
+++ b/common/p_boomfspec.cpp
@@ -3406,6 +3406,8 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		if (!P_IsPlayerOrAvatar(*thing))
 			if ((line->special & FloorChange) || !(line->special & FloorModel))
 				return false; // FloorModel is "Allow Monsters" if FloorChange is 0
+		if (!line->id) //jff 2/27/98 all gun generalized types require tag
+			return false;
 		linefunc = EV_DoGenFloor;
 	}
 	else if ((unsigned)line->special >= GenCeilingBase)
@@ -3413,6 +3415,8 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		if (!P_IsPlayerOrAvatar(*thing))
 			if ((line->special & CeilingChange) || !(line->special & CeilingModel))
 				return false; // CeilingModel is "Allow Monsters" if CeilingChange is 0
+		if (!line->id) //jff 2/27/98 all gun generalized types require tag
+			return false;
 		linefunc = EV_DoGenCeiling;
 	}
 	else if ((unsigned)line->special >= GenDoorBase)
@@ -3424,6 +3428,8 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 			if (line->flags & ML_SECRET) // they can't open secret doors either
 				return false;
 		}
+		if (!line->id) //jff 2/27/98 all gun generalized types require tag
+			return false;
 		linefunc = EV_DoGenDoor;
 	}
 	else if ((unsigned)line->special >= GenLockedBase)
@@ -3437,6 +3443,8 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 				return false;
 		}
 		else
+			return false;
+		if (!line->id) //jff 2/27/98 all gun generalized types require tag
 			return false;
 		linefunc = EV_DoGenLockedDoor;
 	}
@@ -3452,6 +3460,8 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		if (!P_IsPlayerOrAvatar(*thing))
 			if (!(line->special & StairMonster))
 				return false; // monsters disallowed
+		if (!line->id) //jff 2/27/98 all gun generalized types require tag
+			return false;
 		linefunc = EV_DoGenStairs;
 	}
 	else if ((unsigned)line->special >= GenCrusherBase)
@@ -3459,6 +3469,8 @@ bool P_ShootCompatibleSpecialLine(AActor* thing, line_t* line)
 		if (!P_IsPlayerOrAvatar(*thing))
 			if (!(line->special & StairMonster))
 				return false; // monsters disallowed
+		if (!line->id) //jff 2/27/98 all gun generalized types require tag
+			return false;
 		linefunc = EV_DoGenCrusher;
 	}
 


### PR DESCRIPTION
`P_CrossCompatibleSpecialLine` and `P_ShootSpecialLine` should return early if a Boom generalized special has a tag of 0. Strangely, locked doors skip this check when crossing them, and lifts skip it when shooting them. The checks are left out here too for compatibility.