### PR TITLE
[BUGFIX] WDLStats: Don't count disconnects from struggling connections as a logged event

### DIFF
--- a/common/m_wdlstats.cpp
+++ b/common/m_wdlstats.cpp
@@ -926,6 +926,17 @@ int M_GetPlayerId(const player_t& player, team_t team)
 	return 0;
 }
 
+bool M_CheckIfPlayerInLogs(const int playerid)
+{
+	if (!::wdlstate.recording)
+		return false;
+
+	auto it = std::find_if(::wdlplayers.begin(), ::wdlplayers.end(),
+	                       [playerid](const auto& wp) { return wp.id == playerid; });
+
+	return it != ::wdlplayers.end();
+}
+
 void M_CommitWDLLog()
 {
 	if (!::wdlstate.recording || wdlevents.empty() ||

--- a/common/m_wdlstats.h
+++ b/common/m_wdlstats.h
@@ -132,6 +132,7 @@ void M_LogActorWDLEvent(
 	int arg0, int arg1, int arg2, int arg3
 );
 int M_GetPlayerId(const player_t& player, team_t team);
+bool M_CheckIfPlayerInLogs(const int playerid);
 void M_LogWDLPlayerSpawn(const mapthing2_t& mthing);
 void M_RemoveWDLPlayerSpawn(const mapthing2_t& mthing);
 void M_LogWDLItemRespawnEvent(AActor* activator);

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -2556,17 +2556,23 @@ void P_PlayerLeavesGame(player_s* player)
 				}
 			}
 		}
-	}
 
-	if (targethasflag)
-	{
-		M_LogWDLEvent(WDL_EVENT_CARRIERKILL, player, player, f, 0, MOD_EXIT, 0);
+		// We need to check if the player already exists here
+		// Because some clients can disconnect before they fully join the game, and we
+		// don't want to log disconnects for players that never fully joined.
+		if (M_CheckIfPlayerInLogs(player->id))
+		{
+			if (targethasflag)
+			{
+				M_LogWDLEvent(WDL_EVENT_CARRIERKILL, player, player, f, 0, MOD_EXIT, 0);
+			}
+			else
+			{
+				M_LogWDLEvent(WDL_EVENT_KILL, player, player, 0, 0, MOD_EXIT, 0);
+			}
+			M_LogWDLEvent(WDL_EVENT_DISCONNECT, player, NULL, current, 0, 0, 0);
+		}
 	}
-	else
-	{
-		M_LogWDLEvent(WDL_EVENT_KILL, player, player, 0, 0, MOD_EXIT, 0);
-	}
-	M_LogWDLEvent(WDL_EVENT_DISCONNECT, player, NULL, current, 0, 0, 0);
 
 	// Playercount changes can cause end-of-game conditions.
 	G_AssertValidPlayerCount();


### PR DESCRIPTION
When a new player_s is minted on client connect, it sets spectator = false. Because of this, when a client doesn't fully connect (by not acking the first packet after connect which sets spectate = true) functions designed for in-game players get run when this player is dropped, including logging a WDL log event, but since this player never joined, no log entry should've been created at all.

This fixes that.