### PR TITLE
Fix misread of dehacked lumps when encountering C++-style comments or other unknown lines

### DIFF
--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -677,6 +677,7 @@ static void HandleMode(std::string_view header, DehScanner& scanner)
 
 	// Handle unknown or unimplemented data
 	DPrintFmt("Unknown chunk {} encountered. Skipping.\n", header);
+	while (scanner.getNextKeyValue());
 }
 
 static bool HandleKey(nonstd::span<const Key> keys, void* structure, std::string_view key, int value,

--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -677,8 +677,6 @@ static void HandleMode(std::string_view header, DehScanner& scanner)
 
 	// Handle unknown or unimplemented data
 	DPrintFmt("Unknown chunk {} encountered. Skipping.\n", header);
-	scanner.skipLine();
-	while (scanner.getNextKeyValue());
 }
 
 static bool HandleKey(nonstd::span<const Key> keys, void* structure, std::string_view key, int value,


### PR DESCRIPTION
### Overview

Don't do an extra line skip when encountering unknown dehacked lines - just let block processing continue normally.

### Testing

Load [mountaineer.wad](https://www.doomworld.com/idgames/levels/doom2/Ports/m-o/mountaineer), map05.

Verify that the green cyberdemons have the correct cyberdemon sounds and dimensions, but halved health.

### Additional context

From gobolt's writeup on discord:

Point of Interest #3

Custom monster that overrides spider mastermind to create a weaker cyberdemon with 1500 HP retains the spider mastermind collision box in Odamex, as well as a confused state of HP amounts. It triggers death state at 1500 HP, but if hit again it will trigger it over and over again until it has accumulated 3000 damage to die for good via the spider mastermind's death state. Furthermore, while the custom monster is meant to have cyberdemon's wake up sounds it instead keeps using the spider mastermind's wake up sounds.

In short, overriding a monster via dehacked (at least in mbf21) doesn't seem to always work properly.

wad: Mountaineer

VoD timestamp: <https://www.twitch.tv/videos/2783841327?t=1h35m5s>

Netdemo: Odamex_COOP_20260529_224956_mountaineer.wad_MAP05

At 3:22+