### PR TITLE
Fix crashes or corruption due to out-of-bounds accesses for very large custom actors

### DIFF
--- a/common/actor.h
+++ b/common/actor.h
@@ -613,7 +613,7 @@ public:
 	class ActorBlockMapListNode
 	{
 	public:
-		ActorBlockMapListNode(AActor *mo);
+		explicit ActorBlockMapListNode(AActor* mo);
 		void Link();
 		void Unlink();
 		AActor* Next(int bmx, int bmy);
@@ -622,26 +622,23 @@ public:
 		void clear();
 		size_t getIndex(int bmx, int bmy);
 
-		static constexpr size_t BLOCKSX = 3;
-		static constexpr size_t BLOCKSY = 3;
-
-		AActor		*actor;
+		AActor* m_actor;
 
 		// the top-left blockmap the actor is in
-		int			originx;
-		int			originy;
+		int m_originx;
+		int m_originy;
 		// the number of blocks the actor occupies
-		int			blockcntx;
-		int			blockcnty;
+		int m_blockcntx;
+		int m_blockcnty;
 
 		// the next and previous actors in each of the possible blockmaps
 		// this actor can inhabit
-		AActor		*next[BLOCKSX * BLOCKSY];
-		AActor		**prev[BLOCKSX * BLOCKSY];
+		std::vector<AActor*>  m_next;
+		std::vector<AActor**> m_prev;
 	};
 
 	// Interaction info, by BLOCKMAP.
-    // Links in blocks (if needed).
+	// Links in blocks (if needed).
 	ActorBlockMapListNode bmapnode;
 };
 

--- a/common/p_maputl.cpp
+++ b/common/p_maputl.cpp
@@ -99,24 +99,26 @@ subsector_t* P_PointInSubsector(fixed_t x, fixed_t y)
 
 
 AActor::ActorBlockMapListNode::ActorBlockMapListNode(AActor *mo) :
-	actor(mo)
+	m_actor (mo),
+	m_next  (1, nullptr), // Always at least 1 element so that an index calculation of 0 results in valid access.
+	m_prev  (1, nullptr)  // Always at least 1 element so that an index calculation of 0 results in valid access.
 {
 	clear();
 }
 
 void AActor::ActorBlockMapListNode::Link()
 {
-	int left    = (actor->x - actor->radius - bmaporgx) >> MAPBLOCKSHIFT;
-	int right   = (actor->x + actor->radius - bmaporgx) >> MAPBLOCKSHIFT;
-	int top     = (actor->y - actor->radius - bmaporgy) >> MAPBLOCKSHIFT;
-	int bottom  = (actor->y + actor->radius - bmaporgy) >> MAPBLOCKSHIFT;
+	int left    = (m_actor->x - m_actor->radius - bmaporgx) >> MAPBLOCKSHIFT;
+	int right   = (m_actor->x + m_actor->radius - bmaporgx) >> MAPBLOCKSHIFT;
+	int top     = (m_actor->y - m_actor->radius - bmaporgy) >> MAPBLOCKSHIFT;
+	int bottom  = (m_actor->y + m_actor->radius - bmaporgy) >> MAPBLOCKSHIFT;
 
 	if (!co_blockmapfix)
 	{
 		// originally Doom only used the block containing the center point
 		// of the actor even if the actor overlapped into other blocks
-		top = bottom = (actor->y - bmaporgy) >> MAPBLOCKSHIFT;
-		left = right = (actor->x - bmaporgx) >> MAPBLOCKSHIFT;
+		top = bottom = (m_actor->y - bmaporgy) >> MAPBLOCKSHIFT;
+		left = right = (m_actor->x - bmaporgx) >> MAPBLOCKSHIFT;
 	}
 
 	// do not ignore actors only *partially* outside blockmap
@@ -130,10 +132,13 @@ void AActor::ActorBlockMapListNode::Link()
 		if (top < 0) top = 0;
 		if (bottom >= bmapheight) bottom = bmapheight - 1;
 
-		originx = left;
-		originy = top;
-		blockcntx = right - left + 1;
-		blockcnty = bottom - top + 1;
+		m_originx = left;
+		m_originy = top;
+		m_blockcntx = right - left + 1;
+		m_blockcnty = bottom - top + 1;
+
+		m_next.resize(m_blockcntx * m_blockcnty);
+		m_prev.resize(m_blockcntx * m_blockcnty);
 
 		// [SL] 2012-05-15 - Add the actor to the blocklinks list for all of the
 		// blockmaps it overlaps, not just the blockmap for the actor's center point.
@@ -144,19 +149,19 @@ void AActor::ActorBlockMapListNode::Link()
 				// killough 8/11/98: simpler scheme using pointer-to-pointer prev
 				// pointers, allows head nodes to be treated like everything else
 
-				AActor **headptr = &blocklinks[bmy * bmapwidth + bmx];
-				AActor *headactor = *headptr;
+				AActor** headptr   = &blocklinks[bmy * bmapwidth + bmx];
+				AActor*  headactor = *headptr;
 
 				size_t thisidx = getIndex(bmx, bmy);
 
-		        if ((next[thisidx] = headactor))
-		        {
-		        	size_t nextidx = headactor->bmapnode.getIndex(bmx, bmy);
-					headactor->bmapnode.prev[nextidx] = &next[thisidx];
+				if ((m_next[thisidx] = headactor))
+				{
+					size_t nextidx = headactor->bmapnode.getIndex(bmx, bmy);
+					headactor->bmapnode.m_prev[nextidx] = & m_next[thisidx];
 				}
 
-		        prev[thisidx] = headptr;
-		        *headptr = actor;
+				m_prev[thisidx] = headptr;
+				*headptr = m_actor;
 			}
 		}
 	}
@@ -168,9 +173,9 @@ void AActor::ActorBlockMapListNode::Link()
 
 void AActor::ActorBlockMapListNode::Unlink()
 {
-	for (int bmy = originy; bmy < originy + blockcnty; bmy++)
+	for (int bmy = m_originy; bmy < m_originy + m_blockcnty; bmy++)
 	{
-		for (int bmx = originx; bmx < originx + blockcntx; bmx++)
+		for (int bmx = m_originx; bmx < m_originx + m_blockcntx; bmx++)
 		{
 			// killough 8/11/98: simpler scheme using pointers-to-pointers for prev
 			// pointers, allows head node pointers to be treated like everything else
@@ -182,13 +187,13 @@ void AActor::ActorBlockMapListNode::Unlink()
 
 			size_t thisidx = getIndex(bmx, bmy);
 
-			AActor *nextactor = next[thisidx];
-			AActor **prevactor = prev[thisidx];
+			AActor*  nextactor = m_next[thisidx];
+			AActor** prevactor = m_prev[thisidx];
 
 			if (prevactor && (*prevactor = nextactor))
 			{
 				size_t nextidx = nextactor->bmapnode.getIndex(bmx, bmy);
-				nextactor->bmapnode.prev[nextidx] = prevactor;
+				nextactor->bmapnode.m_prev[nextidx] = prevactor;
 			}
 		}
 	}
@@ -197,17 +202,19 @@ void AActor::ActorBlockMapListNode::Unlink()
 AActor* AActor::ActorBlockMapListNode::Next(int bmx, int bmy)
 {
 	if (bmx < 0 || bmx >= bmapwidth || bmy < 0 || bmy >= bmapheight)
-		return NULL;
+		return nullptr;
 
-	return next[getIndex(bmx, bmy)];
+	return m_next[getIndex(bmx, bmy)];
 }
 
 void AActor::ActorBlockMapListNode::clear()
 {
-	originx = originy = 0;
-	blockcntx = blockcnty = 0;
-	memset(prev, 0, sizeof(prev));
-	memset(next, 0, sizeof(next));
+	m_originx = 0;
+	m_originy = 0;
+	m_blockcntx = 0;
+	m_blockcnty = 0;
+	std::fill(m_next.begin(), m_next.end(), nullptr);
+	std::fill(m_prev.begin(), m_prev.end(), nullptr);
 }
 
 size_t AActor::ActorBlockMapListNode::getIndex(int bmx, int bmy)
@@ -216,11 +223,11 @@ size_t AActor::ActorBlockMapListNode::getIndex(int bmx, int bmy)
 		return 0;
 
 	// range check
-	if (bmx < originx || bmx > originx + blockcntx - 1 ||
-		bmy < originy || bmy > originy + blockcnty - 1)
+	if (bmx < m_originx || bmx > m_originx + m_blockcntx - 1 ||
+		bmy < m_originy || bmy > m_originy + m_blockcnty - 1)
 		return 0;
 
-	return (bmy - originy) * BLOCKSX + bmx - originx;
+	return (bmy - m_originy) * m_blockcntx + bmx - m_originx;
 }
 
 


### PR DESCRIPTION
### Overview

When `co_blockmapfix` is enabled, actors are allowed to occupy more than one blockmap block.  They do this with their `bmapnode`s, which contain `next` and `prev` tables for walking through lists of actors that are co-located in blockmap blocks.  These tables have been fixed-size at 9 blocks, which doesn't work for exceptionally large custom actors.

This PR allows the tables to grow in size so that very large actors can fit.

### Details

This counts on `vector::resize`'s guarantee that nothing happens if the requested size is the same as the vector's actual size.

### Testing

1. Enable `co_blockmapfix`.
2. Load Crimson Horror (CRIMHOR.wad), map01.
3. Disconnect and quit
4. Verify that a crash did not occur.

### Additional context

From gobolt's playtesting thread:

Point of Interest #2

Crimson Horror crashes the server on map01 shortly after a client connects. This also causes a client crash if you don't relaunch the client before reconnecting to the server after relaunching it with any other wad, or even the same one.

Furthermore, running the provided netdemos seems to generate more client crash dumps. Opening the wad in singleplayer and alt-f4 closing it also seems to generate new crash dumps.

wad: Crimson Horror

VoD timestamp: <https://www.twitch.tv/videos/2783841327?t=1h6m27s>

Crash dumps: Server: <https://www.dropbox.com/scl/fi/0sbf3ed81amxlkya5b8md/crimhor_server_crash_dumps.7z?rlkey=u0a124679h5q9mqhr18j5fbyk&dl=0>
Client: <https://www.dropbox.com/scl/fi/mej0c4e66rujxxf24n1yj/crimhor_client_crash_dumps.7z?rlkey=w4pjooj89i8olyjnqmij4ncd0&dl=0>

Netdemos: Odamex_COOP_20260529_222440_crimhor.wad_MAP01, Odamex_COOP_20260529_222517_crimhor.wad_MAP01