### PR TITLE
Fix crashes due to corrupted `touching_thinglist` resulting from being in contact with sectorless linedef while exiting a sector

### DIFF
--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3478,7 +3478,7 @@ void P_PutSecnode (msecnode_t *node)
 msecnode_t *P_AddSecnode (sector_t *s, AActor *thing, msecnode_t *nextnode)
 {
 	if (!s)
-		return NULL;
+		return nextnode;
 
 	msecnode_t *node;
 

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3480,9 +3480,7 @@ msecnode_t *P_AddSecnode (sector_t *s, AActor *thing, msecnode_t *nextnode)
 	if (s == nullptr)
 		return nextnode;
 
-	msecnode_t *node;
-
-	node = nextnode;
+	msecnode_t *node = nextnode;
 	while (node)
 	{
 		if (node->m_sector == s)	// Already have a node for this sector?

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3477,13 +3477,10 @@ void P_PutSecnode (msecnode_t *node)
 
 msecnode_t *P_AddSecnode (sector_t *s, AActor *thing, msecnode_t *nextnode)
 {
-	if (!s)
+	if (s == nullptr)
 		return nextnode;
 
 	msecnode_t *node;
-
-	if (s == NULL)
-		I_FatalError("AddSecnode of 0 for {}\n", thing->_StaticType.Name);
 
 	node = nextnode;
 	while (node)


### PR DESCRIPTION
### Overview

When in contact with an orphaned linedef that's completely "out in the void" while exiting a sector, the sector's `touching_thinglist` can be corrupted, ultimately yielding a crash.

This PR fixes it by ensuring that when updating the list, we do not modify the list at all if the line's relevant front-side sector is null (i.e. it's orphaned).

### Testing

1. Load paintitdoom.wad, map16.
2. `noclip` and `notarget`
3. Run to sector 644, a monster and voodoo doll hall.
4. Exit the sector through its south wall.  An orphaned special linedef is directly outside of the sector along that wall.
5. Verify that no crash occurs.

<img width="417" height="402" alt="Screenshot 2026-05-31 123009" src="https://github.com/user-attachments/assets/b594d4c3-26fe-4a41-8d39-eba319f2e0f7" />
