### PR TITLE
[BUGFIX] Episode select skull appearing past the end of the list

### DIFF
--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -952,6 +952,9 @@ namespace
 {
 	void SetupEpisodeList()
 	{
+		if (EpiDef.lastOn >= episodenum)
+			EpiDef.lastOn = episodenum - 1;
+
 		for (int i = 0; i < episodenum; ++i)
 		{
 			if (EpisodeInfos[i].fulltext)


### PR DESCRIPTION
This fixes a bug where when switching from a wad with more episodes to one with fewer episodes, it was possible for lastOn to place the menu selector past the end of the current episode list:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/0e7297ba-bbc5-473c-b27d-62a8745983cf" />

Now when populating the episode list for the menu, the lastOn is clamped to the current episode list length.