### PR TITLE
Use segment heap on Windows

### DIFF
--- a/client/sdl/manifest.xml
+++ b/client/sdl/manifest.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
-
-  <!-- Declare app as DPI aware, so that Windows Vista and later will not
-       apply DPI virtualization. -->
-
   <asmv3:application>
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">
+    <!-- Declare app as DPI aware, so that Windows Vista and later will not
+       apply DPI virtualization. -->
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
       <dpiAware>true</dpiAware>
+    </asmv3:windowsSettings>
+    <!-- Enable newer Segment Heap instead of the older NT Heap. It improves
+       memory footprint and performance. -->
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">
       <heapType>SegmentHeap</heapType>
     </asmv3:windowsSettings>
   </asmv3:application>

--- a/client/sdl/manifest.xml
+++ b/client/sdl/manifest.xml
@@ -5,8 +5,9 @@
        apply DPI virtualization. -->
 
   <asmv3:application>
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">
       <dpiAware>true</dpiAware>
+      <heapType>SegmentHeap</heapType>
     </asmv3:windowsSettings>
   </asmv3:application>
 

--- a/client/sdl/manifest.xml
+++ b/client/sdl/manifest.xml
@@ -21,5 +21,5 @@
             language="*"
         />
     </dependentAssembly>
-  `</dependency>
+  </dependency>
 </assembly>

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -48,6 +48,9 @@ if(WIN32)
   # but the API itself doesn't exist until Windows 8.  Here we set the minimum
   # Windows version to 8.  (Windows Server 2012, BTW)
   target_compile_definitions(odasrv PRIVATE _WIN32_WINNT=0x0602)
+
+  # We supply our own manifest, don't use the default one.
+  set_target_properties(odasrv PROPERTIES LINK_FLAGS "/MANIFEST:NO")
 endif()
 
 target_link_libraries(odasrv fmt::fmt tinylibs ZLIB::ZLIB odamex-common odaproto minilzo cpptrace::cpptrace)

--- a/server/win32/manifest.xml
+++ b/server/win32/manifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <!-- This section copied from default manifest -->
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"></requestedExecutionLevel>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <asmv3:application>
+    <!-- Enable newer Segment Heap instead of the older NT Heap. It improves
+       memory footprint and performance. -->
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">
+      <heapType>SegmentHeap</heapType>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/server/win32/server.rc.in
+++ b/server/win32/server.rc.in
@@ -1,5 +1,7 @@
 // This file is encoded as Windows 1252 to ensure the copyright symbol appears
 
+#include <winuser.h>
+
 #define VFT_APP 0x00000001L
 #define VOS_NT  0x00040000L
 #define VS_FF_DEBUG 0x00000001L
@@ -10,6 +12,8 @@
 #define ODASRV_NAME "Odamex Server"
 
 1 ICON "@CMAKE_SOURCE_DIR@/server/win32/odaserv.ico"
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "@CMAKE_SOURCE_DIR@/server/win32/manifest.xml"
 
 1 VERSIONINFO
 FILEVERSION @PROJECT_RC_VERSION@
@@ -33,7 +37,7 @@ FILESUBTYPE 0
       VALUE "FileDescription", ODASRV_DESC
       VALUE "FileVersion", "@PROJECT_VERSION@"
       VALUE "InternalName", ODASRV_INTERNAL
-      VALUE "LegalCopyright", "ODAMEX and its likeness are Copyright © @PROJECT_COPYRIGHT@ by @PROJECT_COMPANY@."
+      VALUE "LegalCopyright", "ODAMEX and its likeness are Copyright ï¿½ @PROJECT_COPYRIGHT@ by @PROJECT_COMPANY@."
       VALUE "OriginalFilename", ODASRV_EXE
       VALUE "ProductName", ODASRV_NAME
       VALUE "ProductVersion", "@PROJECT_VERSION@"


### PR DESCRIPTION
On Windows 10 (version 2004 and newer) and 11, this will make the client and server use the newer segment heap implementation. This is a newer, more efficient implementation that reduces memory footprint and fragmentation. It was [recently made the default for new Visual Studio projects](https://devblogs.microsoft.com/cppblog/segment-heap-support-for-c-projects-in-visual-studio/), and is now the recommended heap type for new/actively maintained applications. It is also supposed to be stricter about detecting memory corruption and terminating sooner, to make it easier to debug.

Clear documentation on all of this is a bit hard to find, so I believe, but am not 100% sure, that this should cause no issues for older Windows versions and that they will just ignore the new manifest elements.

I have not yet done any real benchmarking, but in a quick test, I observed small performance improvements in Eviternity II, with map01 loading faster and map11's framerate being about 5fps higher.