### PR TITLE
Add "auto" option to hud_scaletext

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -576,8 +576,8 @@ CVAR(			hud_scale, "1", "HUD scaling",
 CVAR(			hud_scalescoreboard, "0", "Scoreboard scaling",
 				CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE)
 
-CVAR_RANGE(		hud_scaletext, "2", "Scaling multiplier for chat and midprint",
-                CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 1.0f, 4.0f)
+CVAR_RANGE(		hud_scaletext, "2", "Scaling multiplier for chat and midprint (0 = auto).",
+                CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 4.0f)
 
 CVAR_RANGE(		hud_targetcount, "2", "Number of players to reveal",
                 CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 32.0f)

--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -452,8 +452,8 @@ static void HU_DrawChatPrompt()
 	int surface_width = I_GetSurfaceWidth(), surface_height = I_GetSurfaceHeight();
 
 	// Set up text scaling
-	int scaledxfac = hud_scaletext ? V_TextScaleXAmount() : CleanXfac;
-	int scaledyfac = hud_scaletext ? V_TextScaleYAmount() : CleanYfac;
+	int scaledxfac = V_TextScaleXAmount();
+	int scaledyfac = V_TextScaleYAmount();
 
 	// Determine what Y height to display the chat prompt at.
 	// * I_GetSurfaceHeight() is the "actual" screen height.

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1113,7 +1113,7 @@ static menuitem_t MessagesItems[] = {
 #endif
 	{ slider,	"Message Timeout",		 {&con_notifytime},		{1.0}, {10.0},	{0.25}, {NULL} },
 	{ slider,	"Center Message Timeout",{&con_midtime},		{1.0}, {10.0},	{0.25}, {NULL} },
-	{ slider,	"Scale message text",    {&hud_scaletext},		{1.0}, {4.0}, 	{1.0}, {NULL} },
+	{ discrete,	"Scale message text",    {&hud_scaletext},		{5.0}, {0.0}, 	{0.0}, {ScaleFactors} },
 	{ discrete,	"Colorize messages",	{&con_coloredmessages},	{2.0}, {0.0},   {0.0},	{OnOff} },
 	{ discrete,	"Scale console text",   {&con_scaletext},		{5.0}, {0.0}, 	{0.0}, {ScaleFactors} },
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },

--- a/client/src/v_text.cpp
+++ b/client/src/v_text.cpp
@@ -163,12 +163,22 @@ void V_SetFont(const char* fontname)
 
 int V_TextScaleXAmount()
 {
-	return hud_scaletext.asInt();
+	int ret = hud_scaletext.asInt();
+
+	if (!ret)
+		return CleanXfac;
+
+	return ret;
 }
 
 int V_TextScaleYAmount()
 {
-	return hud_scaletext.asInt();
+	int ret = hud_scaletext.asInt();
+
+	if (!ret)
+		return CleanYfac;
+
+	return ret;
 }
 
 


### PR DESCRIPTION
Lets you set `hud_scaletext 0` to automatically scale chat & mid-prints to the screen resolution, similar to how `con_scaletext` works. Just found myself wanting this, so I poked around to figure out how to do it.

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/7fdef2a9-6008-4724-90e7-bb4d72cd0804" />
(Using "auto" on a resolution that would give me x5, if it were otherwise allowed.)