### PR TITLE
[Feature] Enable Dark Mode for Odalaunch on Windows

### DIFF
--- a/odalaunch/src/main.cpp
+++ b/odalaunch/src/main.cpp
@@ -56,7 +56,9 @@ bool Application::OnInit()
 	// load resources
 	InitXmlResource();
 
+  #if wxCHECK_VERSION(3, 3, 0)
 	wxApp::SetAppearance(Appearance::System);
+	#endif
 
 	// create main window, get size dimensions and show it
 	MAIN_DIALOG = new dlgMain(nullptr);

--- a/odalaunch/src/main.cpp
+++ b/odalaunch/src/main.cpp
@@ -56,6 +56,8 @@ bool Application::OnInit()
 	// load resources
 	InitXmlResource();
 
+	wxApp::SetAppearance(Appearance::System);
+
 	// create main window, get size dimensions and show it
 	MAIN_DIALOG = new dlgMain(nullptr);
 

--- a/odalaunch/src/main.cpp
+++ b/odalaunch/src/main.cpp
@@ -56,7 +56,7 @@ bool Application::OnInit()
 	// load resources
 	InitXmlResource();
 
-  #if wxCHECK_VERSION(3, 3, 0)
+	#if wxCHECK_VERSION(3, 3, 0)
 	wxApp::SetAppearance(Appearance::System);
 	#endif
 


### PR DESCRIPTION
Since wxWidgets 3.3.0, dark mode has been available to use for all wxWidgets projects. However, since there isn't a native function in wx to gather a Windows dark mode setting, this setting needs to be explicitly set in wxApp::onInit(). This behavior now matches the wxWidgets launcher dark mode/light mode behavior in MacOS and Linux.