### PR TITLE
Remove msg cvar. It has no purpose, and was actually removed at one p…

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -885,8 +885,6 @@ static void TabComplete(TabCompleteDirection dir)
 
 static void setmsgcolor(int index, const char *color);
 
-cvar_t msglevel("msg", "0", "", CVARTYPE_INT, CVAR_ARCHIVE | CVAR_NOENABLEDISABLE);
-
 CVAR_FUNC_IMPL(msg0color)
 {
 	setmsgcolor(0, var.cstring());


### PR DESCRIPTION
…oint in 0.9.0s development, but I'm guessing it got accidentally re-added in a merge shortly after