### PR TITLE
Use Visual Studio 2026 in CI

### DIFF
--- a/ci/win-buildgen.ps1
+++ b/ci/win-buildgen.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 1
 mkdir build | Out-Null
 Set-Location build
 
-& cmake .. -G "Visual Studio 17 2022" `
+& cmake .. -G "Visual Studio 18 2026" `
     -DBUILD_OR_FAIL=1 `
     -DBUILD_CLIENT=1 -DBUILD_SERVER=1 `
     -DBUILD_MASTER=1 -DBUILD_LAUNCHER=1

--- a/ci/win-release-x64.ps1
+++ b/ci/win-release-x64.ps1
@@ -47,7 +47,7 @@ function BuildX64 {
     New-Item  -Force -ItemType "directory" -Path "${CurrentDir}\BuildX64"
     Set-Location -Path "${CurrentDir}\BuildX64"
 
-    cmake.exe -G "Visual Studio 17 2022" -A "x64" "${CurrentDir}" `
+    cmake.exe -G "Visual Studio 18 2026" -A "x64" "${CurrentDir}" `
         -DBUILD_OR_FAIL=1 `
         -DBUILD_CLIENT=1 -DBUILD_SERVER=1 `
         -DBUILD_MASTER=1 -DBUILD_LAUNCHER=1

--- a/ci/win-release-x86.ps1
+++ b/ci/win-release-x86.ps1
@@ -47,7 +47,7 @@ function BuildX86 {
     New-Item  -Force -ItemType "directory" -Path "${CurrentDir}\BuildX86"
     Set-Location -Path "${CurrentDir}\BuildX86"
 
-    cmake.exe -G "Visual Studio 17 2022" -A "Win32" "${CurrentDir}" `
+    cmake.exe -G "Visual Studio 18 2026" -A "Win32" "${CurrentDir}" `
         -DBUILD_OR_FAIL=1 `
         -DBUILD_CLIENT=1 -DBUILD_SERVER=1 `
         -DBUILD_MASTER=1 -DBUILD_LAUNCHER=1

--- a/ci/win-x32-buildgen.ps1
+++ b/ci/win-x32-buildgen.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 1
 mkdir "build-x32" | Out-Null
 Set-Location "build-x32"
 
-& cmake .. -G "Visual Studio 17 2022" `
+& cmake .. -G "Visual Studio 18 2026" `
     -A Win32 `
     -DBUILD_OR_FAIL=1 `
     -DBUILD_CLIENT=1 -DBUILD_SERVER=1 `

--- a/installer/windows/build_release.ps1
+++ b/installer/windows/build_release.ps1
@@ -31,7 +31,7 @@ function BuildX64 {
     New-Item  -Force -ItemType "directory" -Path "${CurrentDir}\BuildX64"
     Set-Location -Path "${CurrentDir}\BuildX64"
 
-    cmake.exe -G "Visual Studio 17 2022" -A "x64" "${CurrentDir}" `
+    cmake.exe -G "Visual Studio 18 2026" -A "x64" "${CurrentDir}" `
         -DBUILD_OR_FAIL=1 `
         -DBUILD_CLIENT=1 -DBUILD_SERVER=1 `
         -DBUILD_MASTER=1 -DBUILD_LAUNCHER=1
@@ -48,7 +48,7 @@ function BuildX86 {
     New-Item  -Force -ItemType "directory" -Path "${CurrentDir}\BuildX86"
     Set-Location -Path "${CurrentDir}\BuildX86"
 
-    cmake.exe -G "Visual Studio 17 2022" -A "Win32" "${CurrentDir}" `
+    cmake.exe -G "Visual Studio 18 2026" -A "Win32" "${CurrentDir}" `
         -DBUILD_OR_FAIL=1 `
         -DBUILD_CLIENT=1 -DBUILD_SERVER=1 `
         -DBUILD_MASTER=1 -DBUILD_LAUNCHER=1


### PR DESCRIPTION
GitHub Actions `windows-latest` image no longer includes 2022. I've been using 2026 locally for the last few months and haven't experienced any issues since #1443.