### PR TITLE
[BUGFIX] Set frontsector of linedefs to sector 0 when they have no frontsector

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -989,6 +989,7 @@ void P_AdjustLine (line_t *ld)
 		ld->bbox[BOXTOP] = v1->y;
 	}
 
+	// TODO: should this all get moved into map_format.post_process_linedef_special?
 	if (map_format.getZDoom())
 	{
 		// [RH] Set line id (as appropriate) here
@@ -1098,8 +1099,16 @@ void P_FinishLoadingLineDefs (void)
 
 	for (int i = numlines, linenum = 0; i--; ld++, linenum++)
 	{
-		ld->frontsector = ld->sidenum[0]!=R_NOSIDE ? sides[ld->sidenum[0]].sector : 0;
-		ld->backsector  = ld->sidenum[1]!=R_NOSIDE ? sides[ld->sidenum[1]].sector : 0;
+		// Substitute sidedef 0 if the front is missing
+		if (ld->sidenum[0] == R_NOSIDE)
+			ld->sidenum[0] = 0;
+
+		// Clear 2s flag for missing back side
+		if (ld->sidenum[1] == R_NOSIDE && !demoplayback)
+			ld->flags &= ~ML_TWOSIDED;
+
+		ld->frontsector = sides[ld->sidenum[0]].sector;
+		ld->backsector  = ld->sidenum[1]!=R_NOSIDE ? sides[ld->sidenum[1]].sector : nullptr;
 		if (ld->sidenum[0] != R_NOSIDE)
 			sides[ld->sidenum[0]].linenum = linenum;
 		if (ld->sidenum[1] != R_NOSIDE)


### PR DESCRIPTION
This fixes crashes that can happen in parts of the codebase that assume linedefs always have a valid frontsector. We are already handling similar fixes when loading segs, but not when loading linedefs. Only doing this while loading segs has 2 issues:
1. In the case of a broken map where somehow the segs and linedefs differ in their front/back sides, ML_TWOSIDED may never be removed from the line, if the segs have valid fronts and backs.
2. Because linedefs and segs have separate frontsector/backsector pointers, they could end up out of sync, with the segs properly handled but the linedefs holding garbage data from past the end of the sides array.

This isn't an ideal solution, but it's the one that has been taken in other ports, so it's what should be done for compatibility.