### PR TITLE
Add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root=true
+
+[*]
+trim_trailing_whitespace = true
+
+[*.{h,c,hpp,cpp}]
+indent_style = tab
+indent_size = tab
+curly_bracket_next_line = true
+spaces_around_operators = true
+# spaces_around_brackets =
+indent_brace_style = Allman
+
+[*.py]
+indent_style = space
+indent_size = 4
+quote_type = double

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,13 +2,13 @@ root=true
 
 [*]
 trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.{h,c,hpp,cpp}]
 indent_style = tab
 indent_size = tab
 curly_bracket_next_line = true
 spaces_around_operators = true
-# spaces_around_brackets =
 indent_brace_style = Allman
 
 [*.py]


### PR DESCRIPTION
This will set a few basic stylistic options in many common editors. This should slightly reduce the amount of setup needed when working on Odamex in a new workspace. I've also noticed a number of new contributors don't seem to read https://github.com/odamex/odamex/wiki/Coding-Standard, particularly the part about stripping trailing whitespace. Hopefully this will mostly prevent that particular issue.