### PR TITLE
Monster resurrection flags fix

### DIFF
--- a/common/actor.h
+++ b/common/actor.h
@@ -636,6 +636,7 @@ public:
 	void UnlinkFromWorld ();
 
 	void SetOrigin (fixed_t x, fixed_t y, fixed_t z);
+	void ResetFlagsToDefault();
 
 	bool IsFriendly() const { return flags & MF_FRIEND; }
 	void SetFriendly (bool isFriendly, const AActor* owner);

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -1117,10 +1117,9 @@ void P_SetupHelpers()
 
 void P_RunHelperTics()
 {
-
-	// Only the server continues on to spawn management.
-	if (not serverside)
+	if (::helperspawns.empty())
 	{
+		// nothing to do
 		return;
 	}
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2889,6 +2889,7 @@ bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 
 					info = corpsehit->info;
 
+					corpsehit->ResetFlagsToDefault();
 					corpsehit->SetFriendly(actor->IsFriendly(), actor);
 
 					if (serverside)

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -405,40 +405,50 @@ AActor::AActor(fixed_t ix, fixed_t iy, fixed_t iz, int32_t itype)
 	args.fill(0);
 }
 
-void AActor::ClearFriendly()
+void AActor::ResetFlagsToDefault()
 {
-    if (IsFriendly())
-    {
-        this->flags &= ~MF_FRIEND;
-        std::erase_if(s_friendlies, [this] (const AActor::AActorPtr& friendly)
-                                    {
-                                        return friendly == this;
-                                    });
-    }
+	// First, manage any special states that are strictly tied to any of the flags
+	// which may or may not have changed since construction.
+
+	SetFriendly(this->info->flags & MF_FRIEND, nullptr);
+
+	// Then assign the flags.
+	this->flags = info->flags;
 }
 
+void AActor::ClearFriendly()
+{
+	if (IsFriendly())
+	{
+		this->flags &= ~MF_FRIEND;
+		std::erase_if(s_friendlies, [this] (const AActor::AActorPtr& friendly)
+		                            {
+		                                return friendly == this;
+		                            });
+	}
+}
 
 void AActor::SetFriendly (bool i_isFriendly, const AActor* owner)
 {
-    const bool isAlreadyFriendly = IsFriendly();
+	const bool isAlreadyFriendly = IsFriendly();
 
-    if (i_isFriendly != isAlreadyFriendly)
-    {
-        if (i_isFriendly)
-        {
-            this->flags |= MF_FRIEND;
-            s_friendlies.push_back(ptr());
+	if (i_isFriendly != isAlreadyFriendly)
+	{
+		if (i_isFriendly)
+		{
+			this->flags |= MF_FRIEND;
+			s_friendlies.push_back(ptr());
 
-            P_FriendlyEffects(this);
-        }
-        else
-        {
-            ClearFriendly();
-        }
-    }
+			P_FriendlyEffects(this);
+		}
+		else
+		{
+			ClearFriendly();
+		}
+	}
 
-    if (owner)
-    {
+	if (owner)
+	{
 		if (owner->player and i_isFriendly)
 		{
 			this->friend_playerid = owner->player->id;
@@ -449,9 +459,8 @@ void AActor::SetFriendly (bool i_isFriendly, const AActor* owner)
 			this->friend_playerid = owner->friend_playerid;
 			this->friend_teamid   = owner->friend_teamid;
 		}
-    }
+	}
 }
-
 
 bool P_IsVoodooDoll(const AActor* mo)
 {

--- a/common/p_tick.cpp
+++ b/common/p_tick.cpp
@@ -63,9 +63,8 @@ void P_Ticker (void)
 	if (serverside)
 	{
 		P_RunHordeTics();
+		P_RunHelperTics();
 	}
-
-	P_RunHelperTics();
 
 	if (clientside)
 		P_ThinkParticles ();	// [RH] make the particles think


### PR DESCRIPTION
This fixes a regression where resurrected enemies don't work due to their flags being left at their post-killed state, rather than reset to their post-spawned state.

I locally verified that protobreak has 6 new odatest suite failures that are now fixed on this branch.