### PR TITLE
[BUGFIX] `defaultmap` is not applied

### DIFF
--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -1663,6 +1663,14 @@ void ParseMapInfoLump(int lump, const OLumpName& lumpname)
 
 	level_pwad_info_t defaultinfo{};
 
+	// if no sky is defined, it will show texture 0 (aastinky/aashitty)
+	// so instead, lets just try to give it the first defined sky in the level set.
+	if (levels.size() > 0 && defaultinfo.skypic == "")
+	{
+		level_pwad_info_t& def = levels.at(0);
+		defaultinfo.skypic = def.skypic;
+	}
+
 	const char* buffer = static_cast<char*>(W_CacheLumpNum(lump, PU_STATIC));
 
 	const OScannerConfig config = {
@@ -1677,6 +1685,14 @@ void ParseMapInfoLump(int lump, const OLumpName& lumpname)
 		if (os.compareTokenNoCase("defaultmap"))
 		{
 			defaultinfo = level_pwad_info_t();
+
+			// if no sky is defined, it will show texture 0 (aastinky/aashitty)
+			// so instead, lets just try to give it the first defined sky in the level set.
+			if (levels.size() > 0 && defaultinfo.skypic == "")
+			{
+				level_pwad_info_t& def = levels.at(0);
+				defaultinfo.skypic = def.skypic;
+			}
 
 			MapInfoDataSetter<level_pwad_info_t> defaultsetter(defaultinfo);
 			ParseMapInfoLower<level_pwad_info_t>(os, defaultsetter);
@@ -1704,25 +1720,14 @@ void ParseMapInfoLump(int lump, const OLumpName& lumpname)
 				    LEVEL_NOINTERMISSION | LEVEL_EVENLIGHTING | LEVEL_SNDSEQTOTALCTRL;
 			}
 
-			// Build upon already defined levels, that way we don't miss any defaults
-			bool levelExists = levels.findByName(map_name).exists();
-
 			// Find the level.
-			level_pwad_info_t& info = levelExists
+			level_pwad_info_t& info = levels.findByName(map_name).exists()
 				? levels.findByName(map_name)
 				: levels.create();
 
-			if (!levelExists)
-				info = defaultinfo;
-
-			// for maps above 32, if no sky is defined, it will show texture 0 (aastinky)
-			// so instead, lets just try to give it the first defined sky in the level set.
-			if (levels.size() > 0 && defaultinfo.skypic == "")
-			{
-				level_pwad_info_t& def = levels.at(0);
-				info.skypic = def.skypic;
-			}
-
+			// Hexen/ZDoom mapinfo always loads from the default defining a new map
+			// Changing this to be conditional will break most wads that use defaultmap
+			info = defaultinfo;
 			info.mapname = map_name;
 
 			// Map name.

--- a/common/g_umapinfo.cpp
+++ b/common/g_umapinfo.cpp
@@ -497,9 +497,9 @@ void ParseUMapInfoLump(int lump, const OLumpName& lumpname)
 			? levels.findByName(mapname)
 			: levels.create();
 
-		// for maps above 32, if no sky is defined, it will show texture 0 (aastinky)
+		// if no sky is defined, it will show texture 0 (aastinky/aashitty)
 		// so instead, lets just try to give it the first defined sky in the level set.
-		if (levels.size() > 0)
+		if (levels.size() > 0 && info.skypic.empty())
 		{
 			level_pwad_info_t& def = levels.at(0);
 			info.skypic = def.skypic;

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -658,6 +658,9 @@ void R_InitTextures()
 		numtextures += tx_numtextures;
 	}
 
+	const int first_pname_tex = numtextures;
+	numtextures += nummappatches;
+
 	textures = new texture_t *[numtextures];
 	texturecolumnofs = new unsigned int *[numtextures];
 	texturecomposite = new byte *[numtextures];
@@ -674,29 +677,48 @@ void R_InitTextures()
 	texnum = R_LoadTextureLump(texture2, patchlookup.get(), texnum, texturehash, errors);
 	texturehash.insert(texturehash2.begin(), texturehash2.end());
 
+	const auto createTexture = [&](int textureIndex,
+	                                               int sourceLump,
+	                                               int patchLump,
+	                                               bool overwriteHash)
+	{
+	    const patch_t* patch = W_CachePatch(sourceLump, PU_CACHE);
+
+		texture_t* texture =
+			textures[textureIndex] =
+				static_cast<texture_t*>(Z_Malloc(sizeof(texture_t), PU_STATIC, nullptr));
+
+		texture->name = lumpinfo[sourceLump].name;
+		texture->width = patch->width();
+		texture->height = patch->height();
+		texture->patchcount = 1;
+
+		texture->patches->patch = patchLump;
+		texture->patches->originx = 0;
+		texture->patches->originy = 0;
+
+		RegisterTexture(texture, textureIndex);
+
+		if (overwriteHash)
+			texturehash[texture->name] = textureIndex;
+		else
+			texturehash.try_emplace(texture->name, textureIndex);
+	};
+
 	// TX_ marker (texture namespace) parsed here
 	if (tx_numtextures > 0)
 	{
 		for (int i = texnum, j = 0;
-			i < numtextures;
+			i < first_pname_tex;
 			i++, j++)
 		{
-			const patch_t* tx_patch = W_CachePatch(first_tx + j, PU_CACHE);
-
-			texture_t* texture = textures[i] = static_cast<texture_t*>(Z_Malloc(sizeof(texture_t), PU_STATIC, nullptr));
-
-			texture->name = lumpinfo[first_tx + j].name;
-			texture->width = tx_patch->width();
-			texture->height = tx_patch->height();
-			texture->patchcount = 1;
-
-			texture->patches->patch = patchlookup[nummappatches + j];
-			texture->patches->originx = 0;
-			texture->patches->originy = 0;
-
-			RegisterTexture(texture, i);
-			texturehash[texture->name] = i;
+			createTexture(i, first_tx + j, patchlookup[nummappatches + j], true);
 		}
+	}
+
+	for (int i = first_pname_tex, j = 0; i < numtextures; i++, j++)
+	{
+		createTexture(i, patchlookup[j], patchlookup[j], false);
 	}
 
 	if (errors)
@@ -1058,7 +1080,10 @@ int R_TextureNumForName (const OLumpName& name)
 	{
 		//I_Error ("R_TextureNumForName: %s not found", namet);
 		// [RH] Return empty texture if it wasn't found.
-		PrintFmt(PRINT_WARNING, "Texture {} not found\n", name);
+		if (name == "")
+			PrintFmt(PRINT_WARNING, "Unnamed texture not found\n");
+		else
+			PrintFmt(PRINT_WARNING, "Texture {} not found\n", name);
 		return 0;
 	}
 

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -678,9 +678,9 @@ void R_InitTextures()
 	texturehash.insert(texturehash2.begin(), texturehash2.end());
 
 	const auto createTexture = [&](int textureIndex,
-	                                               int sourceLump,
-	                                               int patchLump,
-	                                               bool overwriteHash)
+	                               int sourceLump,
+	                               int patchLump,
+	                               bool overwriteHash)
 	{
 	    const patch_t* patch = W_CachePatch(sourceLump, PU_CACHE);
 


### PR DESCRIPTION
Fixes #1415

I've made sure that these changes don't undo the intended effect of the commits that broke `defaultmap`. This required adding support for loading patches as textures. They have the lowest priority, so any textures with the same name defined in TEXTURE1/TEXTURE2 or between the TX_ markers will override them.