### PR TITLE
Critical transport timeout and sanity checks

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -444,6 +444,9 @@ void CL_QuitNetGame(const netQuitReason_e reason)
 	case NQ_PROTO:
 		PrintFmt("Disconnected from server: Unrecoverable protocol error\n");
 		break;
+	case NQ_SERVER_DROP:
+		PrintFmt("Dropped by server\n");
+		break;
 	}
 
 	if (::debug_disconnect)
@@ -2213,7 +2216,7 @@ void CL_SendCmd(void)
 			closestNonCredibleVisSprite->mo->credibility.Challenge();
 
 			MSG_WriteSVC(messenger.ReliableBuf(), CLC_SendMobjUpdate(closestNonCredibleVisSprite->mo->netid));
-            closestNonCredibleVisSprite = nullptr;
+			closestNonCredibleVisSprite = nullptr;
 		}
 
 		odaproto::clc::PlayerInput& currentNetcmd = localcmds[gametic % MAXSAVETICS];

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2243,18 +2243,24 @@ void CL_SendCmd(void)
 		}
 	}
 
-	messenger.SendAll(gametic, serveraddr);
+	const MessageResultEnum sendResult = messenger.SendAll(gametic, serveraddr);
 
-	const int retransmittedByteCount = messenger.HandleRetransmissions(gametic, serveraddr);
+	if (sendResult == MessageResultEnum::ABORT)
+	{
+		CL_QuitNetGame(NQ_SERVER_DROP);
+	}
+	else
+	{
+		const int retransmittedByteCount = messenger.HandleRetransmissions(gametic, serveraddr);
 
-	const int currentSendSize    = messenger.GetLastSendSize();
-	const int totalSentByteCount = currentSendSize + retransmittedByteCount;
+		const int currentSendSize    = messenger.GetLastSendSize();
+		const int totalSentByteCount = currentSendSize + retransmittedByteCount;
 
-	netgraph.setReliableNonContiguousRetransmits(messenger.GetNonContiguousRetransmitPackets());
-	netgraph.setReliableSendDepth(messenger.GetPendingAckCount());
-	netgraph.addTrafficOut(totalSentByteCount);
-	outrate += totalSentByteCount;
-
+		netgraph.setReliableNonContiguousRetransmits(messenger.GetNonContiguousRetransmitPackets());
+		netgraph.setReliableSendDepth(messenger.GetPendingAckCount());
+		netgraph.addTrafficOut(totalSentByteCount);
+		outrate += totalSentByteCount;
+	}
 }
 
 //

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -61,7 +61,6 @@ void SV_UpdateMobjState(const AActor* mo) {}
 void CTF_RememberFlagPos(const mapthing2_t& mthing) {}
 void CTF_SpawnFlag(team_t f) {}
 bool SV_AwarenessUpdate(player_t &pl, AActor* mo, AwarenessEnum requestedAwarenessLevel) { return true; }
-void SV_SendPackets(void) {}
 void SV_SendExecuteLineSpecial(byte special, const line_t* line, const AActor* activator, int arg0,
                                int arg1, int arg2, int arg3, int arg4)
 {

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -31,6 +31,11 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 {
 	const PacketHeaderType header {io_rawBuf};
 
+	if (m_sender.GetMode() == SequenceSender::CRITICAL_FAILURE)
+	{
+		return MessageResultEnum::ABORT;
+	}
+
 	if (header.flags & SVF_UNUSED_MASK)
 	{
 		PrintFmt(PRINT_WARNING, "Protocol flag bits ({}) were not understood", header.flags);
@@ -73,6 +78,11 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 
 bool OdaMessenger::NextReceivedPacket(buf_t& io_rawBuf)
 {
+	if (m_sender.GetMode() == SequenceSender::CRITICAL_FAILURE)
+	{
+		return false;
+	}
+
 	if (m_quickTurnaroundReceiveBuffer)
 	{
 		io_rawBuf.swap(*m_quickTurnaroundReceiveBuffer);
@@ -137,6 +147,7 @@ size_t OdaMessenger::PackAsUnreliable(Packet& io_packet, const buf_t& messageBuf
 
 MessageResultEnum OdaMessenger::SendAll(int i_currentTic, const netadr_t& i_dest)
 {
+	// Once a second, recalculate the budget to incorporate any changes made to maxRate.
 	const int ticPhase = i_currentTic % TICRATE;
 	if (ticPhase == 0)
 	{
@@ -150,14 +161,25 @@ MessageResultEnum OdaMessenger::SendAll(int i_currentTic, const netadr_t& i_dest
 
 	m_lastSendSize = 0;
 
+	if (m_recordingIsEnabled)
+	{
+		m_recordingBuffer.clear();
+	}
+
 	if (simulated_connection)
 	{
 		Clear();
 	}
 
-	if (m_recordingIsEnabled)
+	// Phase zero:  Detect if the client has become dangerously non-responsive,
+	//              and abort if so.
+	if (SequenceQueueEntryType* oldestOutgoingUnackedEntry = m_sender.IterateUnackedPackets().Next())
 	{
-		m_recordingBuffer.clear();
+		if (i_currentTic > oldestOutgoingUnackedEntry->originatingTic + m_criticalSequenceTimeoutInTics)
+		{
+			m_sender.SetMode(SequenceSender::CRITICAL_FAILURE);
+			return MessageResultEnum::ABORT;
+		}
 	}
 
 	// First phase - send high-priority non-reliables (acks, servertic, player updates)
@@ -265,7 +287,7 @@ int OdaMessenger::HandleRetransmissions(int i_currentTic, const netadr_t& i_dest
 	{
 		m_sender.SetMode(SequenceSender::RECOVERY);
 	}
-	else if (m_unackedGrowth == 0)
+	else if (m_unackedGrowth == 0 and m_sender.GetMode() == SequenceSender::RECOVERY)
 	{
 		m_sender.SetMode(SequenceSender::NORMAL);
 	}

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -173,12 +173,15 @@ MessageResultEnum OdaMessenger::SendAll(int i_currentTic, const netadr_t& i_dest
 
 	// Phase zero:  Detect if the client has become dangerously non-responsive,
 	//              and abort if so.
-	if (SequenceQueueEntryType* oldestOutgoingUnackedEntry = m_sender.IterateUnackedPackets().Next())
+	if (m_criticalSequenceTimeoutInTics > 0)
 	{
-		if (i_currentTic > oldestOutgoingUnackedEntry->originatingTic + m_criticalSequenceTimeoutInTics)
+		if (SequenceQueueEntryType* oldestOutgoingUnackedEntry = m_sender.IterateUnackedPackets().Next())
 		{
-			m_sender.SetMode(SequenceSender::CRITICAL_FAILURE);
-			return MessageResultEnum::ABORT;
+			if (i_currentTic > oldestOutgoingUnackedEntry->originatingTic + m_criticalSequenceTimeoutInTics)
+			{
+				m_sender.SetMode(SequenceSender::CRITICAL_FAILURE);
+				return MessageResultEnum::ABORT;
+			}
 		}
 	}
 

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -36,6 +36,12 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 		return MessageResultEnum::ABORT;
 	}
 
+	// If somehow we've overflowed on header decode, just shrug, discard, and move on.
+	if (io_rawBuf.overflowed)
+	{
+		return MessageResultEnum::ABORT;
+	}
+
 	if (header.flags & SVF_UNUSED_MASK)
 	{
 		PrintFmt(PRINT_WARNING, "Protocol flag bits ({}) were not understood", header.flags);
@@ -48,8 +54,17 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 
 	const size_t fullSize               = io_rawBuf.size();
 	const size_t startOfReliableData    = io_rawBuf.TellRead();
-	const size_t startOfNonReliableData = startOfReliableData + header.reliableSize;
-	const size_t sizeOfNonReliableData  = fullSize - startOfNonReliableData;
+
+	// Do some sanity checking.
+	//
+	// No need to check startOfReliableData because that and fullSize are direct results of packet reception
+	// and header read.  Once we start looking at the values in the header, then we take a closer look.
+	//
+	// Can't look beyond the end of the message.  Discard and move on if it's that bad.
+	if (fullSize < startOfReliableData + header.reliableSize)   // note: reliableSize is unsigned
+	{
+		return MessageResultEnum::ABORT;
+	}
 
 	if (header.reliableSize)
 	{

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -39,6 +39,11 @@ class OdaMessenger
 
 	public:
 
+		// With theoretical defaults:
+		//      800 KBps * 5 sec = 4000 KB backed-up retransmits max
+		//      4000 KB * 256 players = 1024000 KB total ~= 1.05 GB in memory at absolute worst
+		constexpr static int DEFAULT_CRITICAL_SEQUENCE_TIMEOUT_IN_TICS =  5 * TICRATE;
+
 		//  -------------- Receiving functions --------------
 
 		/// Receive and enqueue a packet for processing.  Every packet received with this function must be subsequently fetched via
@@ -178,9 +183,7 @@ class OdaMessenger
 		int m_maxPacketsPerRetransmission   { DEFAULT_RETRANSMISSIONS_PER_TIC };
 		int m_retransmitDelayInTics         { 0 };
 		int m_maxRate                       { 0 };
-		int m_criticalSequenceTimeoutInTics { 5 * TICRATE };    // With theoretical default:
-		                                                        //  800 KBps * 5 sec = 4000 KB backed-up retransmits max
-		                                                        //  4000 KB * 256 players = 1024000 KB total ~= 1.05 GB
+		int m_criticalSequenceTimeoutInTics { DEFAULT_CRITICAL_SEQUENCE_TIMEOUT_IN_TICS };
 
 		int m_byteBudget  {  0 };       ///< The live budget.  Signed so that it can also represent debt.
 		int m_perTicBudget{  0 };       ///< The value used to reset the budget every tic.

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -134,8 +134,9 @@ class OdaMessenger
 			// Track when reliable exceeds a certain percentage of the budget.  This could be configurable...
 			m_reliableOverloadThreshold = 9 * (m_perTicBudget / 10);
 		}
-		void SetPacketsPerRetransmit(int i_maxPackets)  { m_maxPacketsPerRetransmission = i_maxPackets; }
-		void SetRetransmitDelay     (int i_delayInTics) { m_retransmitDelayInTics = i_delayInTics; }
+		void SetPacketsPerRetransmit    (int i_maxPackets)   { m_maxPacketsPerRetransmission = i_maxPackets; }
+		void SetRetransmitDelay         (int i_delayInTics)  { m_retransmitDelayInTics = i_delayInTics; }
+		void SetCriticalSequenceTimeout (int i_timeoutInTics){ m_criticalSequenceTimeoutInTics = i_timeoutInTics; }
 
 		int GetLastReliableSendSize() const           { return static_cast<int>(m_bytesSentWithReliability); }
 		int GetLastSendSize() const                   { return m_lastSendSize; }
@@ -174,9 +175,12 @@ class OdaMessenger
 
 		buf_t* m_quickTurnaroundReceiveBuffer { nullptr };
 
-		int m_maxPacketsPerRetransmission { DEFAULT_RETRANSMISSIONS_PER_TIC };
-		int m_retransmitDelayInTics       { 0 };
-		int m_maxRate                     { 0 };
+		int m_maxPacketsPerRetransmission   { DEFAULT_RETRANSMISSIONS_PER_TIC };
+		int m_retransmitDelayInTics         { 0 };
+		int m_maxRate                       { 0 };
+		int m_criticalSequenceTimeoutInTics { 5 * TICRATE };    // With theoretical default:
+		                                                        //  800 KBps * 5 sec = 4000 KB backed-up retransmits max
+		                                                        //  4000 KB * 256 players = 1024000 KB total ~= 1.05 GB
 
 		int m_byteBudget  {  0 };       ///< The live budget.  Signed so that it can also represent debt.
 		int m_perTicBudget{  0 };       ///< The value used to reset the budget every tic.

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -87,6 +87,7 @@ class OdaMessenger
 		/// Return values:
 		///  ACCEPT - Normal result: Packet(s) were sent as needed without hitting a cap.
 		///  DEFER  - Packet(s) may have been sent, but a cap has been enountered.
+		///  ABORT  - Critical error sending: Time to drop the connection.
 		MessageResultEnum SendAll(int i_currentTic, const netadr_t& i_dest);
 
 		/// Retransmit the oldest reliable packets that were previously sent and are older than RetransmitDelay

--- a/common/SequenceSender.h
+++ b/common/SequenceSender.h
@@ -51,7 +51,8 @@ class SequenceSender
 		enum SenderModeEnum
 		{
 			NORMAL,
-			RECOVERY
+			RECOVERY,
+			CRITICAL_FAILURE,
 		};
 
 		struct QueueEntryResultType
@@ -60,9 +61,9 @@ class SequenceSender
 			int    sequence {-1};
 		};
 
-		explicit SequenceSender(size_t i_initialSize);
-
 	public:  // Functions.
+
+		explicit SequenceSender(size_t i_initialSize);
 
 		SequenceSender() :
 			SequenceSender(DEFAULT_RELIABILITY_QUEUE_SIZE)

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -549,24 +549,6 @@ void SZ_Write (buf_t *b, const byte *data, size_t startpos, size_t length)
 	b->WriteChunk(reinterpret_cast<const char*>(data), length, startpos);
 }
 
-//
-// MSG_WriteMarker
-//
-// denis - use this function to mark the start of your server message
-// as it allows for better debugging and optimization of network code
-//
-// [ML] 8/4/10: Moved to sv_main and slightly modified to provide an adequate
-//      but temporary fix for bug 594 until netcode_bringup2 is complete.
-//      Thanks to spleen for providing good brainpower!
-//
-// [SL] 2011-07-17 - Moved back to i_net.cpp so that it can be used by
-// both client & server code.  Client has a stub function for SV_SendPackets.
-//
-void SV_SendPackets(void);
-
-//
-// MSG_WriteMarker
-//
 
 void MSG_WriteByte (buf_t *b, byte c)
 {

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1600,9 +1600,9 @@ int SV_UpdateHiddenMobj(player_t& pl, AActor *mo, int updated, AwarenessEnum new
 	return updated;
 }
 
-bool SV_SendPacket(player_t &pl)
+MessageResultEnum SV_SendPacket(player_t &pl)
 {
-	return pl.client.messenger.SendAll(gametic, pl.client.address) != MessageResultEnum::ABORT;
+	return pl.client.messenger.SendAll(gametic, pl.client.address);
 }
 
 void SV_BroadcastNoiseAlert(const sector_t& sector)
@@ -3353,16 +3353,22 @@ void SV_SendPackets()
 	if (players.empty())
 		return;
 
-	std::vector<std::future<void>> futures;
+	struct SendResultType
+	{
+		std::reference_wrapper<player_t> playerRef;
+		std::future<MessageResultEnum>   sendResult;
+	};
+
+	std::vector<SendResultType> futures;
 
 	for (auto& player : players)
 	{
 		// Disconnecting players' messengers send their packets via the dead-end messenger collection.
 		if (player.playerstate != PST_DISCONNECT)
 		{
-			std::packaged_task<void ()> task { [&player] () { SV_SendPacket(player); } };
+			std::packaged_task<MessageResultEnum ()> task { [&player] () { return SV_SendPacket(player); } };
 
-			futures.emplace_back(task.get_future());
+			futures.emplace_back( std::ref(player), task.get_future() );
 
 			s_workers.MoveCommand(std::move(task));
 		}
@@ -3370,7 +3376,13 @@ void SV_SendPackets()
 
 	for (auto& future : futures)
 	{
-		future.wait();
+		const MessageResultEnum result = future.sendResult.get();
+		if (result == MessageResultEnum::ABORT)
+		{
+			player_t& player = future.playerRef.get();
+			PrintFmt(PRINT_WARNING, "Client at {} exceeded critical max send size\n", NET_AdrToString(player.client.address));
+			SV_DropClientUngracefully(player, "timed out");
+		}
 	}
 }
 

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -965,9 +965,12 @@ void SV_GetPackets()
 		}
 		else
 		{
-			player.client.messenger.Receive(::net_message);
-			player.client.last_received = gametic;
-			SV_ParseCommands(player);
+			const MessageResultEnum receiveResult = player.client.messenger.Receive(::net_message);
+			if (receiveResult != MessageResultEnum::ABORT)
+			{
+				player.client.last_received = gametic;
+				SV_ParseCommands(player);
+			}
 		}
 	}
 }

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3378,7 +3378,7 @@ void SV_SendPackets()
 
 			std::packaged_task<MessageResultEnum ()> task { [&player] () { return SV_SendPacket(player); } };
 
-			futures.emplace_back( std::ref(player), task.get_future() );
+			futures.emplace_back( SendResultType{std::ref(player), task.get_future()} );
 
 			s_workers.MoveCommand(std::move(task));
 		}

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3361,11 +3361,18 @@ void SV_SendPackets()
 
 	std::vector<SendResultType> futures;
 
+	// Allow a developer to sit with a client in a debugger for at least a minute.
+	const int criticalTimeoutInTics = (not ::developer.asBool()) ?
+	                                    OdaMessenger::DEFAULT_CRITICAL_SEQUENCE_TIMEOUT_IN_TICS :
+	                                    65 * TICRATE;
+
 	for (auto& player : players)
 	{
 		// Disconnecting players' messengers send their packets via the dead-end messenger collection.
 		if (player.playerstate != PST_DISCONNECT)
 		{
+			player.client.messenger.SetCriticalSequenceTimeout(criticalTimeoutInTics);
+
 			std::packaged_task<MessageResultEnum ()> task { [&player] () { return SV_SendPacket(player); } };
 
 			futures.emplace_back( std::ref(player), task.get_future() );

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -119,7 +119,7 @@ void SV_CheckTimeouts (void);
 void SV_ConnectClient(void);
 void SV_ConnectClient2(player_t& player);
 void SV_WriteCommands(void);
-bool SV_SendPacket(player_t &pl);
+MessageResultEnum SV_SendPacket(player_t &pl);
 void SV_DisplayTics();
 void SV_RunTics();
 void SV_ParseCommands(player_t &player);

--- a/tests/unit-tests/src/t_stubs.cpp
+++ b/tests/unit-tests/src/t_stubs.cpp
@@ -106,7 +106,6 @@ void SV_UpdateMobjState(const AActor* mo) {}
 void CTF_RememberFlagPos(const mapthing2_t& mthing) {}
 void CTF_SpawnFlag(team_t f) {}
 bool SV_AwarenessUpdate(player_t &pl, AActor* mo, AwarenessEnum requestedAwarenessLevel) { return true; }
-void SV_SendPackets(void) {}
 void SV_SendExecuteLineSpecial(byte special, line_t* line, AActor* activator, int arg0,
                                int arg1, int arg2, int arg3, int arg4) {}
 


### PR DESCRIPTION
Create a default 5-second timeout after which clients are dropped.  This timeout is based on the number of seconds any Reliable packet has gone without acknowledgement.  Also, add some sanity checks to protect against malformed buffers.

This closes a few attack vectors for bad actors to crash a server.

This branch is based on `CurrentResident:resurrect_flags_fix`, thus is dependent on https://github.com/odamex/odamex/pull/1763 being merged.