### PR TITLE
Load odd wads using fstreams and vectors

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -532,7 +532,7 @@ void NetDemo::writeChunk(const byte *data, size_t size, netdemo_message_t type)
                                 and M_WriteLE(demofp, msgheader.type)
                                 and M_WriteLE(demofp, msgheader.length)
                                 and M_WriteLE(demofp, msgheader.gametic)
-                                and demofp.tellp() - startingPosition == HEADER_SIZE;
+                                and demofp.tellp() - startingPosition == MESSAGE_HEADER_SIZE;
 
     if (headerResult)
     {

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -73,51 +73,10 @@ int LatestDemoVersion(const int version)
 	}
 }
 
-NetDemo::NetDemo()
-    : state(st_stopped), oldstate(st_stopped), filename(""), demofp(NULL), netdemotic(0),
-      pause_netdemotic(0), last_map_tic(0)
-{
-	memset(&header, 0, sizeof(header));
-}
-
 NetDemo::~NetDemo()
 {
 	cleanUp();
 }
-
-
-//
-// copy
-//
-//   Copies the data from one NetDemo object to another
-
-void NetDemo::copy(NetDemo &to, const NetDemo &from)
-{
-	// free any memory used by structures and close open files
-	cleanUp();
-
-	to.state 			= from.state;
-	to.oldstate			= from.oldstate;
-	to.filename			= from.filename;
-	to.demofp			= from.demofp;
-	to.captured			= from.captured;
-	to.snapshot_index	= from.snapshot_index;
-	to.map_index		= from.map_index;
-	memcpy(&to.header, &from.header, sizeof(header));
-}
-
-
-NetDemo::NetDemo(const NetDemo &rhs)
-{
-	copy(*this, rhs);
-}
-
-NetDemo& NetDemo::operator=(const NetDemo &rhs)
-{
-	copy(*this, rhs);
-	return *this;
-}
-
 
 void NetDemo::reset()
 {
@@ -142,11 +101,7 @@ void NetDemo::cleanUp()
 	}
 
 	// close all files
-	if (demofp)
-	{
-		fclose(demofp);
-		demofp = NULL;
-	}
+	demofp.close();
 
 	snapshot_index.clear();
 	map_index.clear();
@@ -197,35 +152,21 @@ bool NetDemo::writeHeader()
 	header.compression = 0;
 	header.snapshot_spacing = NetDemo::SNAPSHOT_SPACING;
 
-	netdemo_header_t tmpheader;
-	memcpy(&tmpheader, &header, sizeof(header));
+	netdemo_header_t tmpheader {header};
 
-	// convert from native byte ordering to little-endian
-	tmpheader.snapshot_spacing		= LESHORT(tmpheader.snapshot_spacing);
-	tmpheader.starting_gametic		= LELONG(tmpheader.starting_gametic);
-	tmpheader.ending_gametic		= LELONG(tmpheader.ending_gametic);
+	demofp.seekp(0, std::ios::beg);
+    const auto startingPosition = demofp.tellp();
 
-	fseek(demofp, 0, SEEK_SET);
-	size_t cnt = 0;
-	cnt += sizeof(tmpheader.identifier) *
-		fwrite(&tmpheader.identifier, sizeof(tmpheader.identifier), 1, demofp);
-	cnt += sizeof(tmpheader.version) *
-		fwrite(&tmpheader.version, sizeof(tmpheader.version), 1, demofp);
-	cnt += sizeof(tmpheader.compression) *
-		fwrite(&tmpheader.compression, sizeof(tmpheader.compression), 1, demofp);
-	cnt += sizeof(tmpheader.snapshot_spacing) *
-		fwrite(&tmpheader.snapshot_spacing, sizeof(tmpheader.snapshot_spacing), 1, demofp);
-	cnt += sizeof(tmpheader.starting_gametic) *
-		fwrite(&tmpheader.starting_gametic, sizeof(tmpheader.starting_gametic), 1, demofp);
-	cnt += sizeof(tmpheader.ending_gametic) *
-		fwrite(&tmpheader.ending_gametic, sizeof(tmpheader.ending_gametic), 1, demofp);
-	cnt += sizeof(tmpheader.reserved) *
-		fwrite(&tmpheader.reserved, sizeof(tmpheader.reserved), 1, demofp);
-
-	if (cnt < NetDemo::HEADER_SIZE)
-		return false;
-
-	return true;
+    const bool result = startingPosition >= 0
+                        and M_WriteLE(demofp, header.identifier)
+                        and M_WriteLE(demofp, header.version)
+                        and M_WriteLE(demofp, header.compression)
+                        and M_WriteLE(demofp, header.snapshot_spacing)
+                        and M_WriteLE(demofp, header.starting_gametic)
+                        and M_WriteLE(demofp, header.ending_gametic)
+                        and M_WriteLE(demofp, header.reserved)
+                        and demofp.tellp() - startingPosition == HEADER_SIZE;
+    return result;
 }
 
 
@@ -238,33 +179,19 @@ bool NetDemo::writeHeader()
 
 bool NetDemo::readHeader()
 {
-	fseek(demofp, 0, SEEK_SET);
+    demofp.seekg(0, std::ios::beg);
+    const auto startingPosition = demofp.tellg();
 
-	size_t cnt = 0;
-	cnt += sizeof(header.identifier) *
-		fread(&header.identifier, sizeof(header.identifier), 1, demofp);
-	cnt += sizeof(header.version) *
-		fread(&header.version, sizeof(header.version), 1, demofp);
-	cnt += sizeof(header.compression) *
-		fread(&header.compression, sizeof(header.compression), 1, demofp);
-	cnt += sizeof(header.snapshot_spacing) *
-		fread(&header.snapshot_spacing, sizeof(header.snapshot_spacing), 1, demofp);
-	cnt += sizeof(header.starting_gametic) *
-		fread(&header.starting_gametic, sizeof(header.starting_gametic), 1, demofp);
-	cnt += sizeof(header.ending_gametic) *
-		fread(&header.ending_gametic, sizeof(header.ending_gametic), 1, demofp);
-	cnt += sizeof(header.reserved) *
-		fread(&header.reserved, sizeof(header.reserved), 1, demofp);
-
-	if (cnt < NetDemo::HEADER_SIZE)
-		return false;
-
-	// convert from little-endian to native byte ordering
-	header.snapshot_spacing 		= LESHORT(header.snapshot_spacing);
-	header.starting_gametic 		= LELONG(header.starting_gametic);
-	header.ending_gametic			= LELONG(header.ending_gametic);
-
-	return true;
+    const bool result = startingPosition >= 0
+                        and M_ReadLE(demofp, header.identifier)
+                        and M_ReadLE(demofp, header.version)
+                        and M_ReadLE(demofp, header.compression)
+                        and M_ReadLE(demofp, header.snapshot_spacing)
+                        and M_ReadLE(demofp, header.starting_gametic)
+                        and M_ReadLE(demofp, header.ending_gametic)
+                        and M_ReadLE(demofp, header.reserved)
+                        and demofp.tellg() - startingPosition == HEADER_SIZE;
+    return result;
 }
 
 //
@@ -274,7 +201,7 @@ bool NetDemo::readHeader()
 //   map_index and snapshot_index vecs
 void NetDemo::populateMessageIndexes()
 {
-	fseek(demofp, NetDemo::HEADER_SIZE, SEEK_SET);
+	demofp.seekg(NetDemo::HEADER_SIZE, std::ios::beg);
 
 	netdemo_message_t type;
 	uint32_t len = 0, tic = 0, last_tic = 0;
@@ -287,17 +214,17 @@ void NetDemo::populateMessageIndexes()
 			break;
 		}
 
-		long offset = ftell(demofp) - NetDemo::MESSAGE_HEADER_SIZE;
+		const std::streampos offset = demofp.tellg() - NetDemo::MESSAGE_HEADER_SIZE;
 
 		if (type == NetDemo::msg_snapshot)
 		{
-			netdemo_index_entry_t entry = {tic, static_cast<uint32_t>(offset)};
+			netdemo_index_entry_t entry = {tic, offset};
 			snapshot_index.push_back(entry);
 		}
 
 		else if (type == NetDemo::msg_map_change)
 		{
-			netdemo_index_entry_t entry = {tic, static_cast<uint32_t>(offset)};
+			netdemo_index_entry_t entry = {tic, offset};
 			map_index.push_back(entry);
 			snapshot_index.push_back(entry);
 		}
@@ -307,7 +234,8 @@ void NetDemo::populateMessageIndexes()
 			break;
 		}
 
-	} while (fseek(demofp, len, SEEK_CUR) == 0);
+		demofp.seekg(len, std::ios::cur);
+	} while (demofp.good());
 
 	// fix for playing a demo that hard crashed and couldnt write ending_gametic
 	if (header.ending_gametic == 0)
@@ -337,22 +265,20 @@ bool NetDemo::startRecording(const std::string &filename)
 	if (isRecording())
 		return true;
 
-	if (demofp != NULL)		// file is already open for some reason
-	{
-		fclose(demofp);
-		demofp = NULL;
-	}
+	demofp.close();
 
-	demofp = fopen(filename.c_str(), "wb");
-	if (!demofp)
+	demofp = std::fstream(filename,
+	                      std::ios::out |
+	                      std::ios::binary |
+	                      std::ios::trunc);
+	if (not demofp.good())
 	{
 		//error("Unable to create netdemo file " + filename + ".");
 		I_Warning("Unable to create netdemo file {}", filename);
 		return false;
 	}
 
-	memset(&header, 0, sizeof(header));
-	
+	header = netdemo_header_t{};
 	header.starting_gametic = gametic;
 
 	// Note: The header is not finalized at this point.  Write it anyway to
@@ -427,7 +353,10 @@ bool NetDemo::startPlaying(const std::string &filename)
 		return false;
 	}
 
-	if (!(demofp = fopen(filename.c_str(), "rb")))
+	demofp = std::fstream(filename,
+	                      std::ios::in |
+	                      std::ios::binary);
+	if (not demofp.good())
 	{
 		error("Unable to open netdemo file.");
 		return false;
@@ -466,7 +395,7 @@ bool NetDemo::startPlaying(const std::string &filename)
 	populateMessageIndexes();
 
 	// get set up to read server cmds
-	fseek(demofp, NetDemo::HEADER_SIZE, SEEK_SET);
+	demofp.seekg(NetDemo::HEADER_SIZE, std::ios::beg);
 	state = NetDemo::st_playing;
 
 	PrintFmt(PRINT_HIGH, "Playing netdemo {}.\n", filename);
@@ -535,7 +464,7 @@ bool NetDemo::stopRecording()
 	// write the number of the last gametic in the recording
 	header.ending_gametic = gametic;
 
-	fflush(demofp);
+	demofp.flush();
 
 	// rewrite the header for ending_gametic
 	if (!writeHeader())
@@ -544,8 +473,7 @@ bool NetDemo::stopRecording()
 		return false;
 	}
 
-	fclose(demofp);
-	demofp = NULL;
+	demofp.close();
 
 	PrintFmt(PRINT_HIGH, "Demo recording has stopped.\n");
 	reset();
@@ -565,11 +493,7 @@ bool NetDemo::stopPlaying()
 	SZ_Clear(&net_message);
 	CL_QuitNetGame(NQ_SILENT);
 
-	if (demofp)
-	{
-		fclose(demofp);
-		demofp = NULL;
-	}
+	demofp.close();
 
 	PrintFmt(PRINT_HIGH, "Demo has ended.\n");
 	reset();
@@ -598,26 +522,27 @@ void NetDemo::writeLocalCmd(buf_t *netbuffer) const
 void NetDemo::writeChunk(const byte *data, size_t size, netdemo_message_t type)
 {
 	message_header_t msgheader;
-	memset(&msgheader, 0, sizeof(msgheader));
 
-	msgheader.type = static_cast<byte>(type);
-	msgheader.length = LELONG(static_cast<uint32_t>(size));
-	msgheader.gametic = LELONG(gametic);
+	msgheader.type      = static_cast<byte>(type);
+	msgheader.length    = size;
+	msgheader.gametic   = gametic;
 
-	size_t cnt = 0;
-	cnt += sizeof(msgheader.type) *
-		fwrite(&msgheader.type, sizeof(msgheader.type), 1, demofp);
-	cnt += sizeof(msgheader.length) *
-		fwrite(&msgheader.length, sizeof(msgheader.length), 1, demofp);
-	cnt += sizeof(msgheader.gametic) *
-		fwrite(&msgheader.gametic, sizeof(msgheader.gametic), 1, demofp);
+    const auto startingPosition = demofp.tellp();
+    const bool headerResult = startingPosition >= 0
+                                and M_WriteLE(demofp, msgheader.type)
+                                and M_WriteLE(demofp, msgheader.length)
+                                and M_WriteLE(demofp, msgheader.gametic)
+                                and demofp.tellp() - startingPosition == HEADER_SIZE;
 
-	cnt += fwrite(data, 1, size, demofp);
-	if (cnt < size + NetDemo::MESSAGE_HEADER_SIZE)
-	{
-		error("Unable to write netdemo message chunk\n");
-		return;
-	}
+    if (headerResult)
+    {
+        const auto dataStartPosition = demofp.tellp();
+        demofp.write(reinterpret_cast<const char*>(data), size);
+        if (demofp.tellp() - dataStartPosition != size)
+        {
+            error("Unable to write netdemo message chunk\n");
+        }
+    }
 }
 
 
@@ -703,28 +628,23 @@ void NetDemo::writeMessages()
 //   len and tic parameters.
 //   Returns false upon file read error.
 
-bool NetDemo::readMessageHeader(netdemo_message_t &type, uint32_t &len, uint32_t &tic) const
+bool NetDemo::readMessageHeader(netdemo_message_t &type, uint32_t &len, uint32_t &tic)
 {
 	len = tic = 0;
 
 	message_header_t msgheader;
 
-	size_t cnt = 0;
-	cnt += sizeof(msgheader.type) *
-		fread(&msgheader.type, sizeof(msgheader.type), 1, demofp);
-	cnt += sizeof(msgheader.length) *
-		fread(&msgheader.length, sizeof(msgheader.length), 1, demofp);
-	cnt += sizeof(msgheader.gametic) *
-		fread(&msgheader.gametic, sizeof(msgheader.gametic), 1, demofp);
-
-	if (cnt < NetDemo::MESSAGE_HEADER_SIZE)
+    const bool headerIsGood =   M_ReadLE(demofp, msgheader.type)
+                            and M_ReadLE(demofp, msgheader.length)
+                            and M_ReadLE(demofp, msgheader.gametic);
+	if (not headerIsGood)
 	{
 		return false;
 	}
 
 	// convert the values to native byte order
-	len = LELONG(msgheader.length);
-	tic = LELONG(msgheader.gametic);
+	len = msgheader.length;
+	tic = msgheader.gametic;
 	type = static_cast<netdemo_message_t>(msgheader.type);
 
 	return true;
@@ -742,8 +662,8 @@ void NetDemo::readMessageBody(buf_t *netbuffer, uint32_t len)
 {
 	auto msgdata = std::make_unique<char[]>(len);
 
-	size_t cnt = fread(msgdata.get(), 1, len, demofp);
-	if (cnt < len)
+	demofp.read(msgdata.get(), len);
+	if (demofp.gcount() < len)
 	{
 		fatalError("Can not read netdemo message.");
 		return;
@@ -818,7 +738,7 @@ void NetDemo::readMessages(buf_t* netbuffer)
 	while (type == NetDemo::msg_snapshot || type == NetDemo::msg_map_change)
 	{
 		// skip over snapshots and read the next message instead
-		fseek(demofp, len, SEEK_CUR);
+		demofp.seekg(len, std::ios::cur);
 		if (!readMessageHeader(type, len, tic))
 		{
 			fatalError("Failed to read netdemo message header.");
@@ -1195,7 +1115,7 @@ void NetDemo::readSnapshot(const netdemo_index_entry_t *snap)
 
 	gametic = snap->ticnum;
 	int file_offset = snap->offset;
-	fseek(demofp, file_offset, SEEK_SET);
+	demofp.seekg(file_offset, std::ios::beg);
 
 	// read the values for length, gametic, and message type
 	netdemo_message_t type;
@@ -1210,8 +1130,8 @@ void NetDemo::readSnapshot(const netdemo_index_entry_t *snap)
 	snapbuf.clear();
 	snapbuf.resize(len);
 
-	size_t cnt = fread(snapbuf.data(), 1, len, demofp);
-	if (cnt < len)
+	demofp.read(reinterpret_cast<char*>(snapbuf.data()), len);
+	if (demofp.gcount() < len)
 	{
 		fatalError("Unable to read snapshot from data file");
 		return;

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -83,7 +83,7 @@ void NetDemo::reset()
 	cleanUp();
 
 	filename = "";
-	memset(&header, 0, sizeof(header));
+	header = netdemo_header_t{};
 	captured.clear();
 }
 

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -155,18 +155,18 @@ bool NetDemo::writeHeader()
 	netdemo_header_t tmpheader {header};
 
 	demofp.seekp(0, std::ios::beg);
-    const auto startingPosition = demofp.tellp();
+	const auto startingPosition = demofp.tellp();
 
-    const bool result = startingPosition >= 0
-                        and M_WriteLE(demofp, header.identifier)
-                        and M_WriteLE(demofp, header.version)
-                        and M_WriteLE(demofp, header.compression)
-                        and M_WriteLE(demofp, header.snapshot_spacing)
-                        and M_WriteLE(demofp, header.starting_gametic)
-                        and M_WriteLE(demofp, header.ending_gametic)
-                        and M_WriteLE(demofp, header.reserved)
-                        and demofp.tellp() - startingPosition == HEADER_SIZE;
-    return result;
+	const bool result = startingPosition >= 0
+	                    and M_WriteLE(demofp, header.identifier)
+	                    and M_WriteLE(demofp, header.version)
+	                    and M_WriteLE(demofp, header.compression)
+	                    and M_WriteLE(demofp, header.snapshot_spacing)
+	                    and M_WriteLE(demofp, header.starting_gametic)
+	                    and M_WriteLE(demofp, header.ending_gametic)
+	                    and M_WriteLE(demofp, header.reserved)
+	                    and demofp.tellp() - startingPosition == HEADER_SIZE;
+	return result;
 }
 
 
@@ -179,19 +179,19 @@ bool NetDemo::writeHeader()
 
 bool NetDemo::readHeader()
 {
-    demofp.seekg(0, std::ios::beg);
-    const auto startingPosition = demofp.tellg();
+	demofp.seekg(0, std::ios::beg);
+	const auto startingPosition = demofp.tellg();
 
-    const bool result = startingPosition >= 0
-                        and M_ReadLE(demofp, header.identifier)
-                        and M_ReadLE(demofp, header.version)
-                        and M_ReadLE(demofp, header.compression)
-                        and M_ReadLE(demofp, header.snapshot_spacing)
-                        and M_ReadLE(demofp, header.starting_gametic)
-                        and M_ReadLE(demofp, header.ending_gametic)
-                        and M_ReadLE(demofp, header.reserved)
-                        and demofp.tellg() - startingPosition == HEADER_SIZE;
-    return result;
+	const bool result = startingPosition >= 0
+	                    and M_ReadLE(demofp, header.identifier)
+	                    and M_ReadLE(demofp, header.version)
+	                    and M_ReadLE(demofp, header.compression)
+	                    and M_ReadLE(demofp, header.snapshot_spacing)
+	                    and M_ReadLE(demofp, header.starting_gametic)
+	                    and M_ReadLE(demofp, header.ending_gametic)
+	                    and M_ReadLE(demofp, header.reserved)
+	                    and demofp.tellg() - startingPosition == HEADER_SIZE;
+	return result;
 }
 
 //
@@ -497,8 +497,8 @@ bool NetDemo::stopPlaying()
 
 	PrintFmt(PRINT_HIGH, "Demo has ended.\n");
 	reset();
-    gameaction = ga_fullconsole;
-    gamestate = GS_FULLCONSOLE;
+	gameaction = ga_fullconsole;
+	gamestate = GS_FULLCONSOLE;
 
 	return true;
 }
@@ -527,22 +527,22 @@ void NetDemo::writeChunk(const byte *data, size_t size, netdemo_message_t type)
 	msgheader.length    = size;
 	msgheader.gametic   = gametic;
 
-    const auto startingPosition = demofp.tellp();
-    const bool headerResult = startingPosition >= 0
-                                and M_WriteLE(demofp, msgheader.type)
-                                and M_WriteLE(demofp, msgheader.length)
-                                and M_WriteLE(demofp, msgheader.gametic)
-                                and demofp.tellp() - startingPosition == MESSAGE_HEADER_SIZE;
+	const auto startingPosition = demofp.tellp();
+	const bool headerResult = startingPosition >= 0
+	                            and M_WriteLE(demofp, msgheader.type)
+	                            and M_WriteLE(demofp, msgheader.length)
+	                            and M_WriteLE(demofp, msgheader.gametic)
+	                            and demofp.tellp() - startingPosition == MESSAGE_HEADER_SIZE;
 
-    if (headerResult)
-    {
-        const auto dataStartPosition = demofp.tellp();
-        demofp.write(reinterpret_cast<const char*>(data), size);
-        if (demofp.tellp() - dataStartPosition != size)
-        {
-            error("Unable to write netdemo message chunk\n");
-        }
-    }
+	if (headerResult)
+	{
+		const auto dataStartPosition = demofp.tellp();
+		demofp.write(reinterpret_cast<const char*>(data), size);
+		if (demofp.tellp() - dataStartPosition != size)
+		{
+			error("Unable to write netdemo message chunk\n");
+		}
+	}
 }
 
 
@@ -634,9 +634,9 @@ bool NetDemo::readMessageHeader(netdemo_message_t &type, uint32_t &len, uint32_t
 
 	message_header_t msgheader;
 
-    const bool headerIsGood =   M_ReadLE(demofp, msgheader.type)
-                            and M_ReadLE(demofp, msgheader.length)
-                            and M_ReadLE(demofp, msgheader.gametic);
+	const bool headerIsGood =   M_ReadLE(demofp, msgheader.type)
+	                        and M_ReadLE(demofp, msgheader.length)
+	                        and M_ReadLE(demofp, msgheader.gametic);
 	if (not headerIsGood)
 	{
 		return false;
@@ -796,22 +796,22 @@ void NetDemo::capture(const std::basic_string<byte>& buffer)
 void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 {
 	// Server sends launcher info
-	MSG_WriteLong	(netbuffer, PROTO_CHALLENGE);
-	MSG_WriteLong	(netbuffer, 0);		// server_token
+	MSG_WriteLong   (netbuffer, PROTO_CHALLENGE);
+	MSG_WriteLong   (netbuffer, 0);     // server_token
 
 	// get sv_hostname and write it
 	MSG_WriteString (netbuffer, server_host.c_str());
 
 	int playersingame = std::count_if(players.cbegin(), players.cend(), [](const auto& player){ return player.ingame(); });
-	MSG_WriteByte	(netbuffer, playersingame);
-	MSG_WriteByte	(netbuffer, 0);				// sv_maxclients
-	MSG_WriteString	(netbuffer, level.mapname.c_str());
+	MSG_WriteByte   (netbuffer, playersingame);
+	MSG_WriteByte   (netbuffer, 0);             // sv_maxclients
+	MSG_WriteString (netbuffer, level.mapname.c_str());
 
 	// names of all the wadfiles on the server
 	size_t numwads = wadfiles.size();
 	if (numwads > 0xff)
-		numwads = 0xff;
-	MSG_WriteByte	(netbuffer, numwads - 1);
+	    numwads = 0xff;
+	MSG_WriteByte   (netbuffer, numwads - 1);
 
 	for (size_t n = 1; n < numwads; n++)
 	{
@@ -819,10 +819,10 @@ void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 		MSG_WriteString(netbuffer, ::wadfiles[n].getBasename().c_str());
 	}
 
-	MSG_WriteBool	(netbuffer, 0);		// deathmatch?
-	MSG_WriteByte	(netbuffer, 0);		// sv_skill
-	MSG_WriteBool	(netbuffer, (sv_gametype == GM_TEAMDM));
-	MSG_WriteBool	(netbuffer, (sv_gametype == GM_CTF));
+	MSG_WriteBool   (netbuffer, 0);     // deathmatch?
+	MSG_WriteByte   (netbuffer, 0);     // sv_skill
+	MSG_WriteBool   (netbuffer, (sv_gametype == GM_TEAMDM));
+	MSG_WriteBool   (netbuffer, (sv_gametype == GM_CTF));
 
 	for (const auto& player : players)
 	{
@@ -840,41 +840,41 @@ void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 	for (size_t n = 1; n < numwads; n++)
 		MSG_WriteString(netbuffer, ::wadfiles[n].getMD5().getHexCStr());
 
-	MSG_WriteString	(netbuffer, "");	// sv_website.cstring()
+	MSG_WriteString (netbuffer, "");    // sv_website.cstring()
 
 	if (G_IsTeamGame())
 	{
-		MSG_WriteLong	(netbuffer, 0);		// sv_scorelimit
+		MSG_WriteLong   (netbuffer, 0);     // sv_scorelimit
 		for (size_t n = 0; n < NUMTEAMS; n++)
 		{
-			MSG_WriteBool	(netbuffer, false);
+			MSG_WriteBool   (netbuffer, false);
 		}
 	}
 
-    MSG_WriteShort	(netbuffer, VERSION);
+	MSG_WriteShort  (netbuffer, VERSION);
 
-  	// Note: these are ignored by clients when the client connects anyway
-  	// so they don't need real data
-	MSG_WriteString	(netbuffer, "");	// sv_email.cstring()
+	// Note: these are ignored by clients when the client connects anyway
+	// so they don't need real data
+	MSG_WriteString (netbuffer, "");    // sv_email.cstring()
 
-	MSG_WriteShort	(netbuffer, 0);		// sv_timelimit
-	MSG_WriteShort	(netbuffer, 0);		// timeleft before end of level
-	MSG_WriteShort	(netbuffer, 0);		// sv_fraglimit
+	MSG_WriteShort  (netbuffer, 0);     // sv_timelimit
+	MSG_WriteShort  (netbuffer, 0);     // timeleft before end of level
+	MSG_WriteShort  (netbuffer, 0);     // sv_fraglimit
 
-	MSG_WriteBool	(netbuffer, false);	// sv_itemrespawn
-	MSG_WriteBool	(netbuffer, false);	// sv_weaponstay
-	MSG_WriteBool	(netbuffer, false);	// sv_friendlyfire
-	MSG_WriteBool	(netbuffer, false);	// sv_allowexit
-	MSG_WriteBool	(netbuffer, false);	// sv_infiniteammo
-	MSG_WriteBool	(netbuffer, false);	// sv_nomonsters
-	MSG_WriteBool	(netbuffer, false);	// sv_monstersrespawn
-	MSG_WriteBool	(netbuffer, false);	// sv_fastmonsters
-	MSG_WriteBool	(netbuffer, false);	// sv_allowjump
-	MSG_WriteBool	(netbuffer, false);	// sv_freelook
-	MSG_WriteBool	(netbuffer, false);	// sv_waddownload -- removed
-	MSG_WriteBool	(netbuffer, false);	// sv_emptyreset
-	MSG_WriteBool	(netbuffer, false);	// sv_cleanmaps -- removed
-	MSG_WriteBool	(netbuffer, false);	// sv_fragexitswitch
+	MSG_WriteBool   (netbuffer, false); // sv_itemrespawn
+	MSG_WriteBool   (netbuffer, false); // sv_weaponstay
+	MSG_WriteBool   (netbuffer, false); // sv_friendlyfire
+	MSG_WriteBool   (netbuffer, false); // sv_allowexit
+	MSG_WriteBool   (netbuffer, false); // sv_infiniteammo
+	MSG_WriteBool   (netbuffer, false); // sv_nomonsters
+	MSG_WriteBool   (netbuffer, false); // sv_monstersrespawn
+	MSG_WriteBool   (netbuffer, false); // sv_fastmonsters
+	MSG_WriteBool   (netbuffer, false); // sv_allowjump
+	MSG_WriteBool   (netbuffer, false); // sv_freelook
+	MSG_WriteBool   (netbuffer, false); // sv_waddownload -- removed
+	MSG_WriteBool   (netbuffer, false); // sv_emptyreset
+	MSG_WriteBool   (netbuffer, false); // sv_cleanmaps -- removed
+	MSG_WriteBool   (netbuffer, false); // sv_fragexitswitch
 
 	for (const auto& player : players)
 	{
@@ -899,17 +899,17 @@ void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 			MSG_WriteBool(netbuffer, player.spectator);
 	}
 
-	MSG_WriteLong	(netbuffer, static_cast<uint32_t>(0x01020305));
-	MSG_WriteShort	(netbuffer, 0);	// join_passowrd
+	MSG_WriteLong   (netbuffer, static_cast<uint32_t>(0x01020305));
+	MSG_WriteShort  (netbuffer, 0); // join_passowrd
 
-	MSG_WriteLong	(netbuffer, GAMEVER);
+	MSG_WriteLong   (netbuffer, GAMEVER);
 
-    // TODO: handle patch files
-	MSG_WriteByte	(netbuffer, 0);  // patchfiles.size()
-//	MSG_WriteByte	(netbuffer, patchfiles.size());
+	// TODO: handle patch files
+	MSG_WriteByte   (netbuffer, 0);  // patchfiles.size()
+//  MSG_WriteByte   (netbuffer, patchfiles.size());
 
-//	for (size_t n = 0; n < patchfiles.size(); n++)
-//		MSG_WriteString(netbuffer, patchfiles[n].c_str());
+//  for (size_t n = 0; n < patchfiles.size(); n++)
+//      MSG_WriteString(netbuffer, patchfiles[n].c_str());
 }
 
 //
@@ -921,9 +921,9 @@ void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 
 void NetDemo::writeConnectionSequence(buf_t *netbuffer)
 {
-    PacketHeaderType header {0};
+	PacketHeaderType header {0};
 
-    header.Pack(*netbuffer);
+	header.Pack(*netbuffer);
 
 	// Server sends our player id and digest
 	MSG_WriteSVCBuffer(netbuffer, SVC_ConsolePlayer(consoleplayer(), digest));
@@ -956,8 +956,8 @@ void NetDemo::writeConnectionSequence(buf_t *netbuffer)
 //
 // snapshotLookup()
 //
-//		Returns the snapshot that preceeds the ticnum parameter or returns
-//		NULL if the ticnum is out of bounds.
+//      Returns the snapshot that preceeds the ticnum parameter or returns
+//      NULL if the ticnum is out of bounds.
 //
 const NetDemo::netdemo_index_entry_t *NetDemo::snapshotLookup(int ticnum) const
 {
@@ -976,8 +976,8 @@ const NetDemo::netdemo_index_entry_t *NetDemo::snapshotLookup(int ticnum) const
 //
 // getCurrentSnapshotIndex()
 //
-//		Returns the index into the snapshot_index vector that immediately
-//		preceeds the current gametic.
+//      Returns the index into the snapshot_index vector that immediately
+//      preceeds the current gametic.
 //
 int NetDemo::getCurrentSnapshotIndex() const
 {
@@ -994,8 +994,8 @@ int NetDemo::getCurrentSnapshotIndex() const
 //
 // getCurrentMapIndex()
 //
-//		Returns the index into the map_index vector for the map that the
-//		is currently being played.
+//      Returns the index into the map_index vector for the map that the
+//      is currently being played.
 //
 int NetDemo::getCurrentMapIndex() const
 {
@@ -1011,7 +1011,7 @@ int NetDemo::getCurrentMapIndex() const
 //
 // nextTic()
 //
-//		Advance to the next gametic.
+//      Advance to the next gametic.
 //
 void NetDemo::nextTic()
 {
@@ -1026,8 +1026,8 @@ void NetDemo::nextTic()
 //
 // nextSnapshot()
 //
-//		Reads the snapshot that follows the current gametic and
-//		restores the world state to the snapshot
+//      Reads the snapshot that follows the current gametic and
+//      restores the world state to the snapshot
 //
 void NetDemo::nextSnapshot()
 {
@@ -1047,8 +1047,8 @@ void NetDemo::nextSnapshot()
 //
 // prevSnapshot()
 //
-//		Reads the snapshot that preceeds the current gametic and
-//		restores the world state to the snapshot
+//      Reads the snapshot that preceeds the current gametic and
+//      restores the world state to the snapshot
 //
 void NetDemo::prevSnapshot()
 {
@@ -1066,8 +1066,8 @@ void NetDemo::prevSnapshot()
 //
 // nextMap()
 //
-//		Reads the snapshot at the begining of the next map and
-//		restores the world state to the snapshot
+//      Reads the snapshot at the begining of the next map and
+//      restores the world state to the snapshot
 //
 void NetDemo::nextMap()
 {
@@ -1086,8 +1086,8 @@ void NetDemo::nextMap()
 //
 // prevMap()
 //
-//		Reads the snapshot at the begining of the previous map and
-//		restores the world state to the snapshot
+//      Reads the snapshot at the begining of the previous map and
+//      restores the world state to the snapshot
 //
 void NetDemo::prevMap()
 {
@@ -1221,7 +1221,7 @@ void NetDemo::writeSnapshotData(std::vector<byte>& buf)
 	G_SnapshotLevel();
 
 	FLZOMemFile memfile;
-	memfile.Open();			// open for writing
+	memfile.Open();         // open for writing
 
 	FArchive arc(memfile);
 
@@ -1305,11 +1305,11 @@ void NetDemo::writeSnapshotData(std::vector<byte>& buf)
 	buf.resize(memfile.Length());
 	memfile.WriteToBuffer(buf.data(), buf.size());
 
-    if (level.info->snapshot != NULL)
-    {
-        delete level.info->snapshot;
-        level.info->snapshot = NULL;
-    }
+	if (level.info->snapshot != NULL)
+	{
+		delete level.info->snapshot;
+		level.info->snapshot = NULL;
+	}
 }
 
 

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -1,15 +1,21 @@
 #pragma once
 
-#include "i_net.h"
 #include <deque>
+#include <fstream>
+
+#include "i_net.h"
 
 class NetDemo
 {
 public:
-	NetDemo();
+	NetDemo() = default;
 	~NetDemo();
-	NetDemo(const NetDemo &rhs);
-	NetDemo& operator=(const NetDemo &rhs);
+	NetDemo(const NetDemo &rhs)             = delete;
+	NetDemo& operator=(const NetDemo &rhs)  = delete;
+
+    NetDemo(NetDemo&&) = default;
+    NetDemo& operator=(NetDemo&&) = default;
+
 
 	bool startPlaying(const std::string &filename);
 	bool startRecording(const std::string &filename);
@@ -44,37 +50,36 @@ public:
 	[[nodiscard]] const std::string &getFileName() const { return filename; }
 
 private:
-	typedef enum
+	enum netdemo_state_t
 	{
 		st_stopped,
 		st_recording,
 		st_playing,
 		st_paused
-	} netdemo_state_t;
+	};
 
-	typedef enum
+	enum netdemo_message_t
 	{
-		msg_packet		= 0xAA,
+		msg_packet      = 0xAA,
 		msg_snapshot,
 		msg_map_change,
 		msg_eof
-	} netdemo_message_t;
+	};
 
-	typedef struct
+	struct message_header_t
 	{
-		byte		type;
-		uint32_t	length;
-		uint32_t	gametic;
-	} message_header_t;
+		byte        type    { 0 };
+		uint32_t    length  { 0 };
+		uint32_t    gametic { 0 };
+	};
 
-	typedef struct
+	struct netdemo_index_entry_t
 	{
-		uint32_t	ticnum;
-		uint32_t	offset;			// offset in the demo file
-	} netdemo_index_entry_t;
+		uint32_t        ticnum  { 0 };
+		std::streampos  offset  { 0 };  // offset in the demo file
+	};
 
 	void cleanUp();
-	void copy(NetDemo &to, const NetDemo &from);
 	void error(const std::string &message);
 	void fatalError(const std::string &message);
 	void reset();
@@ -99,39 +104,39 @@ private:
 	[[nodiscard]] int getCurrentMapIndex() const;
 
 	void writeLocalCmd(buf_t *netbuffer) const;
-	bool readMessageHeader(netdemo_message_t &type, uint32_t &len, uint32_t &tic) const;
+	bool readMessageHeader(netdemo_message_t &type, uint32_t &len, uint32_t &tic);
 	void readMessageBody(buf_t *netbuffer, uint32_t len);
 
-	typedef struct
-	{
-		char		identifier[4];  		// "ODAD"
-		byte		version;
-		byte    	compression;    		// type of compression used
-		uint16_t	snapshot_spacing;		// number of gametics between indices
-		uint32_t	starting_gametic;		// the gametic the demo starts at
-		uint32_t	ending_gametic;			// the last gametic of the demo
-		byte		reserved[48];   		// for future use
-	} netdemo_header_t;
-
-	static constexpr size_t HEADER_SIZE = 64;
-	static constexpr size_t MESSAGE_HEADER_SIZE = 9;
-	static constexpr size_t INDEX_ENTRY_SIZE = 8;
+	static constexpr size_t         HEADER_SIZE = 64;
+	static constexpr std::streamoff MESSAGE_HEADER_SIZE = 9;
+	static constexpr size_t         INDEX_ENTRY_SIZE = 8;
 
 	static constexpr uint16_t SNAPSHOT_SPACING = 20 * TICRATE;
 
-	netdemo_state_t		state;
-	netdemo_state_t		oldstate;	// used when unpausing
-	std::string			filename;
-	FILE*				demofp;
+	struct netdemo_header_t
+	{
+		char        identifier[4]   { 0, 0, 0, 0};  // "ODAD"
+		byte        version         { 0 };
+		byte        compression     { 0 };          // type of compression used
+		uint16_t    snapshot_spacing{ 0 };          // number of gametics between indices
+		uint32_t    starting_gametic{ 0 };          // the gametic the demo starts at
+		uint32_t    ending_gametic  { 0 };          // the last gametic of the demo
+		byte        reserved[48]    { 0 };          // for future use
+	};
 
-	std::deque<buf_t>   captured;
+	netdemo_state_t state   { st_stopped };
+	netdemo_state_t oldstate{ st_stopped };   // used when unpausing
+	std::string     filename{ };
+	std::fstream    demofp  { };
 
-	netdemo_header_t	header;
-	std::vector<netdemo_index_entry_t> snapshot_index;
-	std::vector<netdemo_index_entry_t> map_index;
+	std::deque<buf_t>   captured {};
 
-	std::vector<byte>	snapbuf;
-	int					netdemotic;
-	int					pause_netdemotic;
-	int					last_map_tic;
+	netdemo_header_t                   header        {};
+	std::vector<netdemo_index_entry_t> snapshot_index{};
+	std::vector<netdemo_index_entry_t> map_index     {};
+
+	std::vector<byte>   snapbuf         { };
+	int                 netdemotic      { 0 };
+	int                 pause_netdemotic{ 0 };
+	int                 last_map_tic    { 0 };
 };

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -13,8 +13,8 @@ public:
 	NetDemo(const NetDemo &rhs)             = delete;
 	NetDemo& operator=(const NetDemo &rhs)  = delete;
 
-    NetDemo(NetDemo&&) = default;
-    NetDemo& operator=(NetDemo&&) = default;
+	NetDemo(NetDemo&&) = default;
+	NetDemo& operator=(NetDemo&&) = default;
 
 
 	bool startPlaying(const std::string &filename);

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -1245,7 +1245,7 @@ void S_ChangeMusic(std::string musicname, bool looping, int order)
 		f.read(reinterpret_cast<char*>(data), length);
 
 		const size_t result = f.gcount();
-		if (result == 1)
+		if (result == length)
 		{
 			I_PlaySong({data, length}, looping, order);
 		}

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -698,7 +698,7 @@ static void S_StartSound(sound_origin_t origin, int channel,
 	}
 
   	// check for bogus sound lump
-	if (sfxinfo->lumpnum < 0 || sfxinfo->lumpnum > static_cast<int>(numlumps))
+	if (sfxinfo->lumpnum < 0 || sfxinfo->lumpnum > static_cast<int>(W_NumLumps()))
 	{
 		DPrintFmt("Bad sfx lump #: {}\n", sfxinfo->lumpnum);
 		return;
@@ -1220,9 +1220,12 @@ void S_ChangeMusic(std::string musicname, bool looping, int order)
 
 	byte* data = nullptr;
 	size_t length = 0;
-	FILE *f;
 
-	if (!(f = fopen (musicname.c_str(), "rb")))
+	std::ifstream f(musicname,
+	                std::ios::in |
+	                std::ios::binary);
+
+	if (not f.good())
 	{
 		int lumpnum;
 		if ((lumpnum = W_CheckNumForName (musicname.c_str())) == -1)
@@ -1234,14 +1237,14 @@ void S_ChangeMusic(std::string musicname, bool looping, int order)
 		data = W_CacheLumpNum<byte>(lumpnum, PU_CACHE);
 		length = W_LumpLength(lumpnum);
 		I_PlaySong({data, length}, looping, order);
-    }
-    else
+	}
+	else
 	{
 		length = M_FileLength(f);
 		data = static_cast<byte*>(M_Malloc(length));
-		const size_t result = fread(data, length, 1, f);
-		fclose(f);
+		f.read(reinterpret_cast<char*>(data), length);
 
+		const size_t result = f.gcount();
 		if (result == 1)
 		{
 			I_PlaySong({data, length}, looping, order);

--- a/common/am_map.cpp
+++ b/common/am_map.cpp
@@ -58,7 +58,7 @@ static bool ScanAndSetRealNum(OScanner& os, fixed64_t& num)
 // Scans through and interprets a file of lines
 nonstd::expected<std::vector<mline_t>, am_lump_parse_error_t> AM_ParseVectorLump(const OLumpName& name)
 {
-	const int lump = W_CheckNumForName(name, 0);
+	const int lump = W_CheckNumForName(name);
 	if (lump == -1)
 		return nonstd::make_unexpected(am_lump_parse_error_t::LUMP_NOT_FOUND);
 

--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -2260,8 +2260,10 @@ bool D_DoDehPatch(const OResFile* patchfile, const int lump, bool textonly, bool
 	else if (patchfile)
 	{
 		// Try to use patchfile as a patch.
-		FILE* fh = fopen(patchfile->getFullpath().c_str(), "rb+");
-		if (fh == NULL)
+		std::ifstream fh(patchfile->getFullpath(),
+                         std::ios::in |
+                         std::ios::binary);
+		if (not fh.good())
 		{
 			PrintFmt(PRINT_WARNING, "Could not open DeHackEd patch \"{}\"\n",
 			         patchfile->getBasename());
@@ -2271,7 +2273,9 @@ bool D_DoDehPatch(const OResFile* patchfile, const int lump, bool textonly, bool
 		const auto filelen = M_FileLength(fh);
 		buffer.resize(filelen);
 
-		size_t read = fread(buffer.data(), 1, filelen, fh);
+		fh.read(buffer.data(), filelen);
+		const size_t read = fh.gcount();
+
 		if (read < filelen)
 		{
 			DPrintFmt("Could not read file\n");

--- a/common/m_fileio.cpp
+++ b/common/m_fileio.cpp
@@ -214,7 +214,7 @@ bool M_WriteFile(std::string filename, void *source, size_t length)
 		return false;
 	}
 
-    return true;
+	return true;
 }
 
 
@@ -225,9 +225,9 @@ bool M_WriteFile(std::string filename, void *source, size_t length)
 // the buffer and the size.
 size_t M_ReadFile(const std::string& filename, byte **buffer)
 {
-    std::ifstream handle(filename,
-                         std::ios::in |
-                         std::ios::binary);
+	std::ifstream handle(filename,
+	                     std::ios::in |
+	                     std::ios::binary);
 
 	if (not handle.good())
 	{
@@ -235,20 +235,20 @@ size_t M_ReadFile(const std::string& filename, byte **buffer)
 		return false;
 	}
 
-    const uintmax_t length = M_FileLength(handle);
+	const uintmax_t length = M_FileLength(handle);
 
-    byte* buf = Z_Malloc<byte>(length, PU_STATIC);
-    handle.read(reinterpret_cast<char*>(buf), length);
-    const uintmax_t count = handle.gcount();
+	byte* buf = Z_Malloc<byte>(length, PU_STATIC);
+	handle.read(reinterpret_cast<char*>(buf), length);
+	const uintmax_t count = handle.gcount();
 
-    if (count != length)
+	if (count != length)
 	{
 		PrintFmt(PRINT_HIGH, "Failed while reading from file {}\n", filename);
 		return false;
 	}
 
-    *buffer = buf;
-    return length;
+	*buffer = buf;
+	return length;
 }
 
 //
@@ -260,7 +260,7 @@ size_t M_ReadFile(const std::string& filename, byte **buffer)
 // The extension must contain a . at the beginning
 bool M_AppendExtension (std::string &filename, std::string extension, bool if_needed)
 {
-    M_FixPathSep(filename);
+	M_FixPathSep(filename);
 
 	fs::path path(filename);
 
@@ -275,9 +275,9 @@ bool M_AppendExtension (std::string &filename, std::string extension, bool if_ne
 		return true;
 	}
 
-    filename.append(extension);
+	filename.append(extension);
 
-    return true;
+	return true;
 }
 
 //
@@ -329,7 +329,7 @@ bool M_ExtractFileExtension(const std::string& filename, std::string &dest)
 // .'s won't be removed
 void M_ExtractFileBase (std::string filename, std::string &dest)
 {
-    M_FixPathSep(filename);
+	M_FixPathSep(filename);
 
 	dest = fs::path(filename).stem().string();
 }
@@ -340,7 +340,7 @@ void M_ExtractFileBase (std::string filename, std::string &dest)
 // Extract the name of a file from a path (name = filename with extension)
 void M_ExtractFileName (std::string filename, std::string &dest)
 {
-    M_FixPathSep(filename);
+	M_FixPathSep(filename);
 
 	dest = fs::path(filename).filename().string();
 }
@@ -602,7 +602,7 @@ std::vector<std::string> M_BaseFilesScanDir(std::string dir, std::vector<OString
 			// Find the file.
 			std::string filename = entry.path().filename().string();
 			std::vector<OString>::iterator it =
-		    	std::find(files.begin(), files.end(), OStringToUpper(filename));
+			std::find(files.begin(), files.end(), OStringToUpper(filename));
 
 			if (it == files.end())
 				continue;

--- a/common/m_fileio.cpp
+++ b/common/m_fileio.cpp
@@ -145,19 +145,16 @@ std::string M_GetCWD()
 // M_FileLength
 //
 // Returns the length of a file using an open descriptor
-int64_t M_FileLength (FILE *f)
+uintmax_t M_FileLength (std::istream& f)
 {
-	int64_t FileSize = -1;
+	uintmax_t fileSize = -1;
 
-	if (f != nullptr)
-	{
-		const auto CurrentPosition = ftell(f);
-		fseek (f, 0, SEEK_END);
-		FileSize = ftell (f);
-		fseek (f, CurrentPosition, SEEK_SET);
-	}
+	const auto currentPosition = f.tellg();
+	f.seekg(0, std::ios::end);
+	fileSize = f.tellg();
+	f.seekg(currentPosition, std::ios::beg);
 
-	return FileSize;
+	return fileSize;
 }
 
 
@@ -226,21 +223,23 @@ bool M_WriteFile(std::string filename, void *source, size_t length)
 //
 // Reads a file, it will allocate storage via Z_Malloc for it and return
 // the buffer and the size.
-size_t M_ReadFile(std::string filename, byte **buffer)
+size_t M_ReadFile(const std::string& filename, byte **buffer)
 {
-    FILE* handle = fopen(filename.c_str(), "rb");
+    std::ifstream handle(filename,
+                         std::ios::in |
+                         std::ios::binary);
 
-	if (handle == NULL)
+	if (not handle.good())
 	{
 		PrintFmt(PRINT_HIGH, "Could not open file {} for reading\n", filename);
 		return false;
 	}
 
-    size_t length = M_FileLength(handle);
+    const uintmax_t length = M_FileLength(handle);
 
     byte* buf = Z_Malloc<byte>(length, PU_STATIC);
-    size_t count = fread(buf, 1, length, handle);
-    fclose (handle);
+    handle.read(reinterpret_cast<char*>(buf), length);
+    const uintmax_t count = handle.gcount();
 
     if (count != length)
 	{

--- a/common/m_fileio.h
+++ b/common/m_fileio.h
@@ -39,54 +39,54 @@ std::string M_GetCWD();
 template <typename ElementType>
 bool M_ReadLE(std::istream& io_stream, ElementType& o_data)
 {
-    if (io_stream.good())
-    {
-        io_stream.read(reinterpret_cast<char*>(&o_data), sizeof(o_data));
-        if (io_stream.gcount() == sizeof(o_data))
-        {
-            o_data = nonstd::bit::to_native_endian(o_data, /* from */ nonstd::bit::little_endian_type());
-            return true;
-        }
-    }
-    return false;
+	if (io_stream.good())
+	{
+		io_stream.read(reinterpret_cast<char*>(&o_data), sizeof(o_data));
+		if (io_stream.gcount() == sizeof(o_data))
+		{
+			o_data = nonstd::bit::to_native_endian(o_data, /* from */ nonstd::bit::little_endian_type());
+			return true;
+		}
+	}
+	return false;
 }
 
 template <typename ElementType, size_t N>
 bool M_ReadLE(std::istream& io_stream, ElementType (&o_dataArray)[N])
 {
-    for (size_t i = 0; i < N; ++i)
-    {
-        if (not M_ReadLE(io_stream, o_dataArray[i]))
-        {
-            return false;
-        }
-    }
-    return true;
+	for (size_t i = 0; i < N; ++i)
+	{
+		if (not M_ReadLE(io_stream, o_dataArray[i]))
+		{
+			return false;
+		}
+	}
+	return true;
 }
 
 template <typename ElementType>
 bool M_WriteLE(std::ostream& io_stream, const ElementType& i_data)
 {
-    if (io_stream.good())
-    {
-        ElementType temp = nonstd::bit::as_little_endian(i_data);
-        io_stream.write(reinterpret_cast<char*>(&temp), sizeof(temp));
-        return true;
-    }
-    return false;
+	if (io_stream.good())
+	{
+		ElementType temp = nonstd::bit::as_little_endian(i_data);
+		io_stream.write(reinterpret_cast<char*>(&temp), sizeof(temp));
+		return true;
+	}
+	return false;
 }
 
 template <typename ElementType, size_t N>
 bool M_WriteLE(std::ostream& io_stream, const ElementType (&i_dataArray)[N])
 {
-    for (size_t i = 0; i < N; ++i)
-    {
-        if (not M_WriteLE(io_stream, i_dataArray[i]))
-        {
-            return false;
-        }
-    }
-    return true;
+	for (size_t i = 0; i < N; ++i)
+	{
+		if (not M_WriteLE(io_stream, i_dataArray[i]))
+		{
+			return false;
+		}
+	}
+	return true;
 }
 
 uintmax_t M_FileLength (std::istream& f);

--- a/common/m_fileio.h
+++ b/common/m_fileio.h
@@ -36,12 +36,40 @@ std::string M_FindUserFileName(const std::string& file, const char* ext);
 void M_FixPathSep(std::string& path);
 std::string M_GetCWD();
 
-int64_t M_FileLength (FILE *f);
+template <typename ElementType>
+bool M_ReadLE(std::istream& io_stream, ElementType& o_data)
+{
+    if (io_stream.good())
+    {
+        io_stream.read(reinterpret_cast<char*>(&o_data), sizeof(o_data));
+        if (io_stream.gcount() == sizeof(o_data))
+        {
+            o_data = nonstd::bit::to_native_endian(o_data, /* from */ nonstd::bit::little_endian_type());
+            return true;
+        }
+    }
+    return false;
+}
+
+template <typename ElementType, size_t N>
+bool M_ReadLE(std::istream& io_stream, ElementType (&o_dataArray)[N])
+{
+    for (size_t i = 0; i < N; ++i)
+    {
+        if (not M_ReadLE(io_stream, o_dataArray[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+uintmax_t M_FileLength (std::ifstream& f);
 bool M_FileExists(const std::string& filename);
 bool M_FileExistsExt(const std::string& filename, const char* ext);
 
 bool M_WriteFile(std::string filename, void *source, size_t length);
-size_t M_ReadFile(std::string filename, byte **buffer);
+size_t M_ReadFile(const std::string& filename, byte **buffer);
 
 bool M_AppendExtension (std::string &filename, std::string extension, bool if_needed = true);
 void M_ExtractFilePath(const std::string& filename, std::string &dest);

--- a/common/m_fileio.h
+++ b/common/m_fileio.h
@@ -64,6 +64,31 @@ bool M_ReadLE(std::istream& io_stream, ElementType (&o_dataArray)[N])
     return true;
 }
 
+template <typename ElementType>
+bool M_WriteLE(std::ostream& io_stream, const ElementType& i_data)
+{
+    if (io_stream.good())
+    {
+        ElementType temp = nonstd::bit::as_little_endian(i_data);
+        io_stream.write(reinterpret_cast<char*>(&temp), sizeof(temp));
+        return true;
+    }
+    return false;
+}
+
+template <typename ElementType, size_t N>
+bool M_WriteLE(std::ostream& io_stream, const ElementType (&i_dataArray)[N])
+{
+    for (size_t i = 0; i < N; ++i)
+    {
+        if (not M_WriteLE(io_stream, i_dataArray[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 uintmax_t M_FileLength (std::istream& f);
 bool M_FileExists(const std::string& filename);
 bool M_FileExistsExt(const std::string& filename, const char* ext);

--- a/common/m_fileio.h
+++ b/common/m_fileio.h
@@ -44,7 +44,9 @@ bool M_ReadLE(std::istream& io_stream, ElementType& o_data)
 		io_stream.read(reinterpret_cast<char*>(&o_data), sizeof(o_data));
 		if (io_stream.gcount() == sizeof(o_data))
 		{
-			o_data = nonstd::bit::to_native_endian(o_data, /* from */ nonstd::bit::little_endian_type());
+			using namespace nonstd::bit;
+			o_data = to_native_endian(o_data,
+			                          little_endian_type());    // from
 			return true;
 		}
 	}

--- a/common/m_fileio.h
+++ b/common/m_fileio.h
@@ -64,7 +64,7 @@ bool M_ReadLE(std::istream& io_stream, ElementType (&o_dataArray)[N])
     return true;
 }
 
-uintmax_t M_FileLength (std::ifstream& f);
+uintmax_t M_FileLength (std::istream& f);
 bool M_FileExists(const std::string& filename);
 bool M_FileExistsExt(const std::string& filename, const char* ext);
 

--- a/common/olumpname.cpp
+++ b/common/olumpname.cpp
@@ -36,7 +36,7 @@ void OLumpName::MakeDataPresentable()
 	for (int i = 0; i < 8; ++i)
 		m_data[i] = static_cast<char>(toupper(m_data[i]));
 
-	// ensure last char is escape character
+	// ensure last char is a null terminator
 	m_data[8] = '\0';
 }
 

--- a/common/res_texture.cpp
+++ b/common/res_texture.cpp
@@ -1026,7 +1026,7 @@ void TextureManager::freeTexture(texhandle_t texhandle)
 //
 texhandle_t TextureManager::getPatchHandle(unsigned int lumpnum)
 {
-	if (lumpnum >= numlumps)
+	if (lumpnum >= W_NumLumps())
 		return NOT_FOUND_TEXTURE_HANDLE;
 
 	if (W_LumpLength(lumpnum) == 0)
@@ -1089,7 +1089,7 @@ void TextureManager::cachePatch(texhandle_t handle)
 //
 texhandle_t TextureManager::getSpriteHandle(unsigned int lumpnum)
 {
-	if (lumpnum >= numlumps)
+	if (lumpnum >= W_NumLumps())
 		return NOT_FOUND_TEXTURE_HANDLE;
 
 	if (W_LumpLength(lumpnum) == 0)
@@ -1269,7 +1269,7 @@ void TextureManager::cacheWallTexture(texhandle_t handle)
 //
 texhandle_t TextureManager::getRawTextureHandle(unsigned int lumpnum)
 {
-	if (lumpnum >= numlumps)
+	if (lumpnum >= W_NumLumps())
 		return NOT_FOUND_TEXTURE_HANDLE;
 
 	if (W_LumpLength(lumpnum) == 0)
@@ -1322,7 +1322,7 @@ void TextureManager::cacheRawTexture(texhandle_t handle)
 //
 texhandle_t TextureManager::getPNGTextureHandle(unsigned int lumpnum)
 {
-	if (lumpnum >= numlumps)
+	if (lumpnum >= W_NumLumps())
 		return NOT_FOUND_TEXTURE_HANDLE;
 
 	if (W_LumpLength(lumpnum) == 0)

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -393,7 +393,7 @@ static bool IsMarker (const lumpinfo_t& lump, const char *marker)
 // Basically from BOOM, too, although I tried to write it independently.
 //
 
-void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
+void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t space)
 {
 	// Some pwads use an icky hack to get flats with regular Doom.
 	// This tries to detect them.
@@ -628,7 +628,7 @@ int W_HandleToLump(const lumpHandle_t handle)
 //
 // [SL] taken from prboom-plus
 //
-int W_CheckNumForName(const char *name, int namespc)
+int W_CheckNumForName(const char *name, namespace_t namespc)
 {
 	// Hash function maps the name to one of possibly numlump chains.
 	// It has been tuned so that the average chain length never exceeds 2.
@@ -654,7 +654,7 @@ int W_CheckNumForName(const char *name, int namespc)
 // W_GetNumForName
 // Calls W_CheckNumForName, but bombs out if not found.
 //
-int W_GetNumForName(const char* name, int namespc)
+int W_GetNumForName(const char* name, namespace_t namespc)
 {
 	int i = W_CheckNumForName(name, namespc);
 
@@ -900,7 +900,7 @@ lumpHandle_t W_CachePatchHandle(const int lumpNum, const zoneTag_e tag)
 /**
  * @brief Cache a patch by name and namespace and return a handle to it.
  */
-lumpHandle_t W_CachePatchHandle(const char* name, const zoneTag_e tag, const int ns)
+lumpHandle_t W_CachePatchHandle(const char* name, const zoneTag_e tag, const namespace_t ns)
 {
 	return W_CachePatchHandle(W_GetNumForName(name, ns), tag);
 }
@@ -908,7 +908,7 @@ lumpHandle_t W_CachePatchHandle(const char* name, const zoneTag_e tag, const int
 /**
  * @brief Cache a patch by name and namespace and return a handle to it.
  */
-lumpHandle_t W_CachePatchHandle(const OLumpName& name, const zoneTag_e tag, const int ns)
+lumpHandle_t W_CachePatchHandle(const OLumpName& name, const zoneTag_e tag, const namespace_t ns)
 {
 	return W_CachePatchHandle(W_GetNumForName(name, ns), tag);
 }

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -266,30 +266,6 @@ fhfprint_t W_FarmHash128(const byte* lumpdata, int length)
 //
 
 //
-// W_AddLumps
-//
-// Adds lumps from the array of filelump_t.
-//
-void W_AddLumps(const std::shared_ptr<std::istream>& handle, const filelump_t* fileinfo, size_t newlumps)
-{
-	const size_t oldOnePastEndIndex = lumpinfo.size();
-	lumpinfo.resize(lumpinfo.size() + newlumps);
-
-	const filelump_t* info = &fileinfo[0];
-
-	for (auto iter  = lumpinfo.begin() + oldOnePastEndIndex;
-	          iter != lumpinfo.end();
-	          iter++, info++)
-	{
-		iter->handle    = handle;
-		iter->position  = info->filepos;
-		iter->size      = info->size;
-		iter->name      = info->name;
-	}
-}
-
-
-//
 // W_AddFile
 //
 // All files are optional, but at least one file must be found
@@ -302,10 +278,7 @@ void W_AddLumps(const std::shared_ptr<std::istream>& handle, const filelump_t* f
 //
 void AddFile(const OResFile& file)
 {
-	std::vector<filelump_t> fileinfo;
-
 	const std::string filename = file.getFullpath();
-
 	auto handle = std::make_shared<std::ifstream>(filename,
 	                                              std::ios::in |
 	                                              std::ios::binary);
@@ -326,19 +299,15 @@ void AddFile(const OResFile& file)
 		return;
 	}
 
-	size_t newlumps;
 	if (header.identification != IWAD_ID && header.identification != PWAD_ID)
 	{
 		// raw lump file
 		std::string lumpname;
 		M_ExtractFileBase(filename, lumpname);
 
-		fileinfo.push_back(filelump_t{});
-		fileinfo.back().filepos = 0;
-		fileinfo.back().size = static_cast<int>(M_FileLength(*handle));
-		std::transform(lumpname.c_str(), lumpname.c_str() + 8, fileinfo.back().name, toupper);
+		lumpinfo.emplace_back(lumpname);    // FYI - OLumpName's constructor does the toupper.
+		lumpinfo.back().size = static_cast<int>(M_FileLength(*handle));
 
-		newlumps = 1;
 		PrintFmt(PRINT_HIGH, " (single lump)\n");
 	}
 	else
@@ -352,23 +321,21 @@ void AddFile(const OResFile& file)
 			return;
 		}
 
-		fileinfo.resize(header.numlumps);
+		filelump_t lump;
+		lumpinfo.reserve(lumpinfo.size() + static_cast<size_t>(header.numlumps));
 
 		handle->seekg(header.infotableofs, std::ios::beg);
-		for (size_t i = 0; i < fileinfo.size(); i++)
+		for (int i = 0; i < header.numlumps; i++)
 		{
-			if (not fileinfo[i].Read(*handle))
+			if (not lump.Read(*handle))
 			{
 				PrintFmt(PRINT_HIGH, "failed to read file info for lump number {} in {}\n", i, filename);
 				return;
 			}
-			std::transform(fileinfo[i].name, fileinfo[i].name + 8, fileinfo[i].name, toupper);
+			lumpinfo.emplace_back(handle, lump);
 		}
-		newlumps = header.numlumps;
 		PrintFmt(PRINT_HIGH, " ({} lumps)\n", header.numlumps);
 	}
-
-	W_AddLumps(handle, fileinfo.data(), newlumps);
 }
 
 

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -415,7 +415,8 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 			flatHack = 0;
 	}
 
-	auto newlumpinfos = std::make_unique<lumpinfo_t[]>(lumpinfo.size());
+    std::vector<lumpinfo_t> newlumpinfos;
+    newlumpinfos.reserve(lumpinfo.size());
 
 	size_t newlumps = 0;
 	size_t oldlumps = 0;
@@ -431,14 +432,9 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 				insideBlock = true;
 
 				// Create start marker if we haven't already
-				if (!newlumps)
+				if (newlumpinfos.empty())
 				{
-					newlumps++;
-					newlumpinfos[0].handle.reset();
-					newlumpinfos[0].name     = start;
-					newlumpinfos[0].position = 0;
-					newlumpinfos[0].size     = 0;
-					newlumpinfos[0].namespc  = ns_global;
+                    newlumpinfos.emplace_back(start);
 				}
 			}
 			else
@@ -465,8 +461,8 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 					}
 					else
 					{
-						newlumpinfos[newlumps] = lumpinfo[i];
-						newlumpinfos[newlumps++].namespc = space;
+                        newlumpinfos.push_back(lumpinfo[i]);
+                        newlumpinfos.back().namespc = space;
 					}
 				}
 			}
@@ -484,8 +480,8 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 			}
 			else
 			{
-				newlumpinfos[newlumps] = lumpinfo[i];
-				newlumpinfos[newlumps++].namespc = space;
+                newlumpinfos.push_back(lumpinfo[i]);
+                newlumpinfos.back().namespc = space;
 			}
 		}
 	}
@@ -493,22 +489,15 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 	// Now copy the merged lumps to the end of the old list
 	// and create the end marker entry.
 
-	if (newlumps)
+	if (newlumpinfos.size())
 	{
 		// Because the above algorithm only ever causes the lump count to shrink or stay the same,
 		// we just do the resize unconditionally.
-		lumpinfo.resize(oldlumps + newlumps);
+		lumpinfo.resize(oldlumps + newlumpinfos.size());
 
-		std::copy_n(newlumpinfos.get(), newlumps, lumpinfo.begin() + oldlumps);
+		std::copy(newlumpinfos.begin(), newlumpinfos.end(), lumpinfo.begin() + oldlumps);
 
-		lumpinfo_t marker;
-		marker.handle.reset();
-		marker.name     = end;
-		marker.position = 0;
-		marker.size     = 0;
-		marker.namespc  = ns_global;
-
-		lumpinfo.emplace_back(std::move(marker));
+		lumpinfo.emplace_back(end);
 	}
 }
 

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -258,7 +258,7 @@ fhfprint_t W_FarmHash128(const byte* lumpdata, int length)
 // Adds lumps from the array of filelump_t. If clientonly is true,
 // only certain lumps will be added.
 //
-void W_AddLumps(FILE* handle, const filelump_t* fileinfo, size_t newlumps, bool clientonly)
+void W_AddLumps(const std::shared_ptr<std::istream>& handle, const filelump_t* fileinfo, size_t newlumps, bool clientonly)
 {
 	lumpinfo = static_cast<lumpinfo_t*>(M_Realloc(lumpinfo, (numlumps + newlumps) * sizeof(lumpinfo_t)));
 	if (!lumpinfo)
@@ -293,12 +293,15 @@ void W_AddLumps(FILE* handle, const filelump_t* fileinfo, size_t newlumps, bool 
 //
 void AddFile(const OResFile& file)
 {
-	uqFile handle;
-	std::unique_ptr<filelump_t[]> fileinfo{};
+	std::vector<filelump_t> fileinfo;
 
 	const std::string filename = file.getFullpath();
 
-	if ( (handle = uqFile(fopen(filename.c_str(), "rb"))) == nullptr)
+	auto handle = std::make_shared<std::ifstream>(filename,
+	                                              std::ios::in |
+	                                              std::ios::binary);
+
+	if (not handle->good())
 	{
 		PrintFmt(PRINT_WARNING, "couldn't open {}\n", filename);
 		return;
@@ -307,13 +310,12 @@ void AddFile(const OResFile& file)
 	PrintFmt(PRINT_HIGH, "adding {}", filename);
 
 	wadinfo_t header;
-	size_t readlen = fread(&header, sizeof(header), 1, handle.get());
-	if (readlen < 1)
+
+	if (not header.Read(*handle))
 	{
 		PrintFmt(PRINT_HIGH, "failed to read {}.\n", filename);
 		return;
 	}
-	header.identification = LELONG(header.identification);
 
 	size_t newlumps;
 	if (header.identification != IWAD_ID && header.identification != PWAD_ID)
@@ -322,10 +324,10 @@ void AddFile(const OResFile& file)
 		std::string lumpname;
 		M_ExtractFileBase(filename, lumpname);
 
-		fileinfo = std::make_unique<filelump_t[]>(1);
-		fileinfo[0].filepos = 0;
-		fileinfo[0].size = M_FileLength(handle.get());
-		std::transform(lumpname.c_str(), lumpname.c_str() + 8, fileinfo[0].name, toupper);
+		fileinfo.push_back(filelump_t{});
+		fileinfo.back().filepos = 0;
+		fileinfo.back().size = static_cast<int>(M_FileLength(*handle));
+		std::transform(lumpname.c_str(), lumpname.c_str() + 8, fileinfo.back().name, toupper);
 
 		newlumps = 1;
 		PrintFmt(PRINT_HIGH, " (single lump)\n");
@@ -333,38 +335,31 @@ void AddFile(const OResFile& file)
 	else
 	{
 		// WAD file
-		header.numlumps = LELONG(header.numlumps);
-		header.infotableofs = LELONG(header.infotableofs);
-		size_t length = header.numlumps * sizeof(filelump_t);
+		uintmax_t length = header.numlumps * filelump_t::SIZE_IN_BYTES;
 
-		if (length > M_FileLength(handle.get()))
+		if (length > M_FileLength(*handle))
 		{
 			PrintFmt(PRINT_WARNING, "\nbad number of lumps for {}\n", filename);
 			return;
 		}
 
-		fileinfo = std::make_unique<filelump_t[]>(header.numlumps);
-		fseek(handle.get(), header.infotableofs, SEEK_SET);
-		readlen = fread(fileinfo.get(), length, 1, handle.get());
-		if (readlen < 1)
-		{
-			PrintFmt(PRINT_HIGH, "failed to read file info in {}\n", filename);
-			return;
-		}
+        fileinfo.resize(header.numlumps);
 
-		// convert from little-endian to target arch and capitalize lump name
-		for (int i = 0; i < header.numlumps; i++)
-		{
-			fileinfo[i].filepos = LELONG(fileinfo[i].filepos);
-			fileinfo[i].size = LELONG(fileinfo[i].size);
-			std::transform(fileinfo[i].name, fileinfo[i].name + 8, fileinfo[i].name, toupper);
-		}
-
+        handle->seekg(header.infotableofs, std::ios::beg);
+		for (size_t i = 0; i < fileinfo.size(); i++)
+        {
+            if (not fileinfo[i].Read(*handle))
+            {
+                PrintFmt(PRINT_HIGH, "failed to read file info in {}\n", filename);
+                return;
+            }
+            std::transform(fileinfo[i].name, fileinfo[i].name + 8, fileinfo[i].name, toupper);
+        }
 		newlumps = header.numlumps;
 		PrintFmt(PRINT_HIGH, " ({} lumps)\n", header.numlumps);
 	}
 
-	W_AddLumps(handle.release(), fileinfo.get(), newlumps, false);
+	W_AddLumps(handle, fileinfo.data(), newlumps, false);
 }
 
 
@@ -430,11 +425,11 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 				if (!newlumps)
 				{
 					newlumps++;
-					newlumpinfos[0].name = start;
-					newlumpinfos[0].handle = NULL;
-					newlumpinfos[0].position =
-						newlumpinfos[0].size = 0;
-					newlumpinfos[0].namespc = ns_global;
+					newlumpinfos[0].handle.reset();
+					newlumpinfos[0].name     = start;
+					newlumpinfos[0].position = 0;
+					newlumpinfos[0].size     = 0;
+					newlumpinfos[0].namespc  = ns_global;
 				}
 			}
 			else
@@ -498,11 +493,11 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 
 		numlumps = oldlumps + newlumps;
 
-		lumpinfo[numlumps].name = end;
-		lumpinfo[numlumps].handle = NULL;
-		lumpinfo[numlumps].position =
-			lumpinfo[numlumps].size = 0;
-		lumpinfo[numlumps].namespc = ns_global;
+		lumpinfo[numlumps].handle.reset();
+		lumpinfo[numlumps].name     = end;
+		lumpinfo[numlumps].position = 0;
+		lumpinfo[numlumps].size     = 0;
+		lumpinfo[numlumps].namespc  = ns_global;
 		numlumps++;
 	}
 }
@@ -708,11 +703,11 @@ void W_ReadLump(unsigned int lump, void* dest)
 	if (lump != stdisk_lumpnum)
     	I_BeginRead();
 
-	fseek (l->handle, l->position, SEEK_SET);
-	int c = fread (dest, l->size, 1, l->handle);
+	l->handle->seekg(l->position, std::ios::beg);
+	l->handle->read(reinterpret_cast<char*>(dest), l->size);
 
-	if (feof(l->handle))
-		I_Error("W_ReadLump: only read {} of {} on lump {}", c, l->size, lump);
+	if (not l->handle->good())
+		I_Error("W_ReadLump: only read {} of {} on lump {}", l->handle->gcount(), l->size, lump);
 
 	if (lump != stdisk_lumpnum)
     	I_EndRead();
@@ -725,15 +720,19 @@ void W_ReadLump(unsigned int lump, void* dest)
 //
 unsigned W_ReadChunk (const char *file, unsigned offs, unsigned len, void *dest, unsigned &filelen)
 {
-	auto fp = uqFile(fopen(file, "rb"));
+    std::ifstream fp(file,
+                     std::ios::in |
+                     std::ios::binary);
+
 	unsigned read = 0;
 
-	if(fp)
+	if (fp.good())
 	{
-		filelen = M_FileLength(fp.get());
+		filelen = static_cast<unsigned>(M_FileLength(fp));
 
-		fseek(fp.get(), offs, SEEK_SET);
-		read = fread(dest, 1, len, fp.get());
+		fp.seekg(offs, std::ios::beg);
+		fp.read(reinterpret_cast<char*>(dest), len);
+		read = fp.gcount();
 	}
 	else
 		filelen = 0;
@@ -955,21 +954,11 @@ int W_FindLump (const char *name, int lastlump)
 
 void W_Close ()
 {
-	// store closed handles, so that fclose isn't called multiple times
-	// for the same handle
-	std::vector<FILE *> handles;
-
-	lumpinfo_t * lump_p = lumpinfo;
-	while (lump_p < lumpinfo + numlumps)
+	for (lumpinfo_t * lump_p = lumpinfo;
+	                  lump_p < lumpinfo + numlumps;
+	                  lump_p++)
 	{
-		// if file not previously closed, close it now
-		if(lump_p->handle &&
-		   std::find(handles.begin(), handles.end(), lump_p->handle) == handles.end())
-		{
-			fclose(lump_p->handle);
-			handles.push_back(lump_p->handle);
-		}
-		lump_p++;
+		lump_p->handle.reset();
 	}
 
 	::handleGen = (::handleGen + 1) & HANDLE_GEN_MASK;

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -63,8 +63,7 @@
 //
 
 // Location of each lump on disk.
-lumpinfo_t*		lumpinfo;
-size_t			numlumps;
+std::vector<lumpinfo_t> lumpinfo;
 
 // Generation of handle.
 // Takes up the first three bits of the handle id.  Starts at 1, increments
@@ -78,6 +77,20 @@ const size_t HANDLE_GEN_BITS = 3;
 void**			lumpcache;
 
 static unsigned	stdisk_lumpnum;
+
+bool wadinfo_t::Read(std::istream& io_stream)
+{
+    return M_ReadLE(io_stream, identification) and
+           M_ReadLE(io_stream, numlumps) and
+           M_ReadLE(io_stream, infotableofs);
+}
+
+bool filelump_t::Read(std::istream& io_stream)
+{
+    return M_ReadLE(io_stream, filepos) and
+           M_ReadLE(io_stream, size) and
+           M_ReadLE(io_stream, name);
+}
 
 //
 // W_LumpNameHash
@@ -112,16 +125,16 @@ unsigned int W_LumpNameHash(const char *s)
 //
 void W_HashLumps(void)
 {
-	for (unsigned int i = 0; i < numlumps; i++)
-		lumpinfo[i].index = -1;			// mark slots empty
+	for (auto& lump : lumpinfo)
+		lump.index = -1;                // mark slots empty
 
 	// Insert nodes to the beginning of each chain, in first-to-last
 	// lump order, so that the last lump of a given name appears first
 	// in any chain, observing pwad ordering rules. killough
 
-	for (unsigned int i = 0; i < numlumps; i++)
+	for (unsigned int i = 0; i < lumpinfo.size(); i++)
 	{
-		unsigned int j = W_LumpNameHash(lumpinfo[i].name.c_str()) % static_cast<unsigned int>(numlumps);
+		unsigned int j = W_LumpNameHash(lumpinfo[i].name.c_str()) % static_cast<unsigned int>(lumpinfo.size());
 		lumpinfo[i].next = lumpinfo[j].index;     // Prepend to list
 		lumpinfo[j].index = i;
 	}
@@ -255,27 +268,23 @@ fhfprint_t W_FarmHash128(const byte* lumpdata, int length)
 //
 // W_AddLumps
 //
-// Adds lumps from the array of filelump_t. If clientonly is true,
-// only certain lumps will be added.
+// Adds lumps from the array of filelump_t.
 //
-void W_AddLumps(const std::shared_ptr<std::istream>& handle, const filelump_t* fileinfo, size_t newlumps, bool clientonly)
+void W_AddLumps(const std::shared_ptr<std::istream>& handle, const filelump_t* fileinfo, size_t newlumps)
 {
-	lumpinfo = static_cast<lumpinfo_t*>(M_Realloc(lumpinfo, (numlumps + newlumps) * sizeof(lumpinfo_t)));
-	if (!lumpinfo)
-		I_Error("Couldn't realloc lumpinfo");
+	const size_t oldOnePastEndIndex = lumpinfo.size();
+	lumpinfo.resize(lumpinfo.size() + newlumps);
 
-	lumpinfo_t* lump = &lumpinfo[numlumps];
 	const filelump_t* info = &fileinfo[0];
 
-	for (size_t i = 0; i < newlumps; i++, info++)
+	for (auto iter  = lumpinfo.begin() + oldOnePastEndIndex;
+	          iter != lumpinfo.end();
+	          iter++, info++)
 	{
-		lump->handle = handle;
-		lump->position = info->filepos;
-		lump->size = info->size;
-		lump->name = info->name;
-
-		lump++;
-		numlumps++;
+		iter->handle    = handle;
+		iter->position  = info->filepos;
+		iter->size      = info->size;
+		iter->name      = info->name;
 	}
 }
 
@@ -359,7 +368,7 @@ void AddFile(const OResFile& file)
 		PrintFmt(PRINT_HIGH, " ({} lumps)\n", header.numlumps);
 	}
 
-	W_AddLumps(handle, fileinfo.data(), newlumps, false);
+	W_AddLumps(handle, fileinfo.data(), newlumps);
 }
 
 
@@ -371,10 +380,10 @@ void AddFile(const OResFile& file)
 //
 //
 
-static bool IsMarker (const lumpinfo_t *lump, const char *marker)
+static bool IsMarker (const lumpinfo_t& lump, const char *marker)
 {
-	return (lump->namespc == ns_global) && (!strncmp (lump->name.c_str(), marker, 8) ||
-			(*(lump->name.c_str()) == *marker && !strncmp (lump->name.c_str() + 1, marker, 7)));
+	return (lump.namespc == ns_global) && (!strncmp (lump.name.c_str(), marker, 8) ||
+			(*(lump.name.c_str()) == *marker && !strncmp (lump.name.c_str() + 1, marker, 7)));
 }
 
 //
@@ -394,10 +403,10 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 		int fudge = 0;
 		unsigned istart = 0;
 
-		for (size_t i = 0; i < numlumps; i++) {
-			if (IsMarker (lumpinfo + i, start.c_str()))
+		for (size_t i = 0; i < lumpinfo.size(); i++) {
+			if (IsMarker (lumpinfo[i], start.c_str()))
 				fudge++, istart = i;
-			else if (IsMarker (lumpinfo + i, end.c_str()))
+			else if (IsMarker (lumpinfo[i], end.c_str()))
 				fudge--, flatHack = i;
 		}
 		if (istart > flatHack)
@@ -406,18 +415,18 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 			flatHack = 0;
 	}
 
-	auto newlumpinfos = std::make_unique<lumpinfo_t[]>(numlumps);
+	auto newlumpinfos = std::make_unique<lumpinfo_t[]>(lumpinfo.size());
 
 	size_t newlumps = 0;
 	size_t oldlumps = 0;
 	bool insideBlock = false;
 
-	for (size_t i = 0; i < numlumps; i++)
+	for (size_t i = 0; i < lumpinfo.size(); i++)
 	{
 		if (!insideBlock)
 		{
 			// Check if this is the start of a block
-			if (IsMarker (lumpinfo + i, start.c_str()))
+			if (IsMarker (lumpinfo[i], start.c_str()))
 			{
 				insideBlock = true;
 
@@ -467,7 +476,7 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 				insideBlock = false;
 				lumpinfo[oldlumps++] = lumpinfo[i];
 			}
-			else if (IsMarker (lumpinfo + i, end.c_str()))
+			else if (IsMarker (lumpinfo[i], end.c_str()))
 			{
 				// It is. We'll add the end marker once
 				// we've processed everything.
@@ -486,19 +495,16 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 
 	if (newlumps)
 	{
-		if (oldlumps + newlumps > numlumps)
-			lumpinfo = static_cast<lumpinfo_t*>(M_Realloc(lumpinfo, oldlumps + newlumps));
+		if (oldlumps + newlumps + 1 > lumpinfo.size())
+			lumpinfo.resize(oldlumps + newlumps + 1);
 
-		std::copy_n(newlumpinfos.get(), newlumps, lumpinfo + oldlumps);
+		std::copy_n(newlumpinfos.get(), newlumps, lumpinfo.begin() + oldlumps);
 
-		numlumps = oldlumps + newlumps;
-
-		lumpinfo[numlumps].handle.reset();
-		lumpinfo[numlumps].name     = end;
-		lumpinfo[numlumps].position = 0;
-		lumpinfo[numlumps].size     = 0;
-		lumpinfo[numlumps].namespc  = ns_global;
-		numlumps++;
+		lumpinfo.back().handle.reset();
+		lumpinfo.back().name     = end;
+		lumpinfo.back().position = 0;
+		lumpinfo.back().size     = 0;
+		lumpinfo.back().namespc  = ns_global;
 	}
 }
 
@@ -520,16 +526,13 @@ void W_InitMultipleFiles(const OResFiles& files)
 	// [EB] Fix for use-after-free when OZone tries to null the "user" pointers
 	if (lumpcache)
 	{
-		for (size_t i = 0; i < numlumps; i++)
+		for (size_t i = 0; i < lumpinfo.size(); i++)
 			Z_Free(lumpcache[i]);
 	}
 
 	// open all the files, load headers, and count lumps
 	// will be realloced as lumps are added
-	::numlumps = 0;
-
-	M_Free(::lumpinfo);
-	::lumpinfo = NULL;
+	lumpinfo.clear();
 
 	// open each file once, load headers, and count lumps
 	std::vector<OMD5Hash> loaded;
@@ -543,12 +546,12 @@ void W_InitMultipleFiles(const OResFiles& files)
 		}
 	}
 
-	if (!numlumps)
+	if (!lumpinfo.size())
 		I_Error("W_InitFiles: no files found");
 
 	// [RH] Set namespace markers to global for everything
-	for (size_t i = 0; i < numlumps; i++)
-		lumpinfo[i].namespc = ns_global;
+	for (auto& lump : lumpinfo)
+		lump.namespc = ns_global;
 
 	// [RH] Merge sprite and flat groups.
 	//		(We don't need to bother with patches, since
@@ -561,7 +564,7 @@ void W_InitMultipleFiles(const OResFiles& files)
     // set up caching
 	M_Free(lumpcache);
 
-	size_t size = numlumps * sizeof(*lumpcache);
+	size_t size = lumpinfo.size() * sizeof(*lumpcache);
 	lumpcache = static_cast<void**>(M_Malloc(size));
 
 	if (!lumpcache)
@@ -597,7 +600,7 @@ int W_HandleToLump(const lumpHandle_t handle)
 		return -1;
 	}
 	const unsigned lump = handle.id >> HANDLE_GEN_BITS;
-	if (lump >= ::numlumps)
+	if (lump >= ::lumpinfo.size())
 	{
 		return -1;
 	}
@@ -627,7 +630,7 @@ int W_CheckNumForName(const char *name, int namespc)
 	// It has been tuned so that the average chain length never exceeds 2.
 
 	// proff 2001/09/07 - check numlumps==0, this happens when called before WAD loaded
-	int i = (numlumps == 0 || name == nullptr)?(-1):(lumpinfo[W_LumpNameHash(name) % numlumps].index);
+	int i = (lumpinfo.size() == 0 || name == nullptr)?(-1):(lumpinfo[W_LumpNameHash(name) % lumpinfo.size()].index);
 
 	// We search along the chain until end, looking for case-insensitive
 	// matches which also match a namespace tag. Separate hash tables are
@@ -668,7 +671,7 @@ int W_GetNumForName(const char* name, int namespc)
  */
 OLumpName W_LumpName(unsigned lump)
 {
-	if (lump >= ::numlumps)
+	if (lump >= ::lumpinfo.size())
 		I_Error("{}: {} >= numlumps", __FUNCTION__, lump);
 
 	return ::lumpinfo[lump].name;
@@ -680,7 +683,7 @@ OLumpName W_LumpName(unsigned lump)
 //
 unsigned W_LumpLength (unsigned lump)
 {
-	if (lump >= numlumps)
+	if (lump >= lumpinfo.size())
 		I_Error("W_LumpLength: {} >= numlumps", lump);
 
 	return lumpinfo[lump].size;
@@ -695,10 +698,10 @@ unsigned W_LumpLength (unsigned lump)
 //
 void W_ReadLump(unsigned int lump, void* dest)
 {
-	if (lump >= numlumps)
+	if (lump >= lumpinfo.size())
 		I_Error("W_ReadLump: {} >= numlumps", lump);
 
-	lumpinfo_t* l = lumpinfo + lump;
+	auto l = lumpinfo.begin() + lump;
 
 	if (lump != stdisk_lumpnum)
     	I_BeginRead();
@@ -746,7 +749,7 @@ unsigned W_ReadChunk (const char *file, unsigned offs, unsigned len, void *dest,
 //
 bool W_CheckLumpName (unsigned lump, const char *name)
 {
-	if (lump >= numlumps)
+	if (lump >= lumpinfo.size())
 		return false;
 
 	return !strnicmp (lumpinfo[lump].name.c_str(), name, 8);
@@ -757,7 +760,7 @@ bool W_CheckLumpName (unsigned lump, const char *name)
 //
 void W_GetLumpName(char *to, unsigned lump)
 {
-	if (lump >= numlumps)
+	if (lump >= lumpinfo.size())
 		*to = 0;
 	else
 	{
@@ -772,7 +775,7 @@ void W_GetLumpName(char *to, unsigned lump)
 //
 void W_GetOLumpName(OLumpName& to, unsigned lump)
 {
-	if (lump >= numlumps)
+	if (lump >= lumpinfo.size())
 		to.clear();
 	else
 		to = lumpinfo[lump].name;
@@ -791,7 +794,7 @@ OLumpName W_GetOLumpName(unsigned lump)
 //
 void* W_CacheLumpNum(unsigned int lump, const zoneTag_e tag)
 {
-	if (lump >= numlumps)
+	if (lump >= lumpinfo.size())
 		I_Error("W_CacheLumpNum: {} >= numlumps",lump);
 
 	if (!lumpcache[lump])
@@ -829,7 +832,7 @@ void R_ConvertPatch(patch_t* rawpatch, patch_t* newpatch, const unsigned int lum
 //
 patch_t* W_CachePatch(unsigned lumpnum, const zoneTag_e tag)
 {
-	if (lumpnum >= numlumps)
+	if (lumpnum >= lumpinfo.size())
 		I_Error("W_CachePatch: {} >= numlumps", lumpnum);
 
 	if (!lumpcache[lumpnum])
@@ -937,7 +940,7 @@ int W_FindLump (const char *name, int lastlump)
 	if (lastlump < -1)
 		lastlump = -1;
 
-	for (size_t i = lastlump + 1; i < numlumps; i++)
+	for (size_t i = lastlump + 1; i < lumpinfo.size(); i++)
 	{
 		if (strnicmp(lumpinfo[i].name.c_str(), name, 8) == 0)
 			return i;
@@ -954,11 +957,9 @@ int W_FindLump (const char *name, int lastlump)
 
 void W_Close ()
 {
-	for (lumpinfo_t * lump_p = lumpinfo;
-	                  lump_p < lumpinfo + numlumps;
-	                  lump_p++)
+	for (auto& lump : lumpinfo)
 	{
-		lump_p->handle.reset();
+		lump.handle.reset();
 	}
 
 	::handleGen = (::handleGen + 1) & HANDLE_GEN_MASK;

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -74,22 +74,22 @@ size_t handleGen = 1;
 const size_t HANDLE_GEN_MASK = BIT_MASK(0, 2);
 const size_t HANDLE_GEN_BITS = 3;
 
-void**			lumpcache;
+void**  lumpcache;
 
-static unsigned	stdisk_lumpnum;
+static unsigned stdisk_lumpnum;
 
 bool wadinfo_t::Read(std::istream& io_stream)
 {
-    return M_ReadLE(io_stream, identification) and
-           M_ReadLE(io_stream, numlumps) and
-           M_ReadLE(io_stream, infotableofs);
+	return M_ReadLE(io_stream, identification) and
+	       M_ReadLE(io_stream, numlumps) and
+	       M_ReadLE(io_stream, infotableofs);
 }
 
 bool filelump_t::Read(std::istream& io_stream)
 {
-    return M_ReadLE(io_stream, filepos) and
-           M_ReadLE(io_stream, size) and
-           M_ReadLE(io_stream, name);
+	return M_ReadLE(io_stream, filepos) and
+	       M_ReadLE(io_stream, size) and
+	       M_ReadLE(io_stream, name);
 }
 
 //
@@ -352,18 +352,18 @@ void AddFile(const OResFile& file)
 			return;
 		}
 
-        fileinfo.resize(header.numlumps);
+		fileinfo.resize(header.numlumps);
 
-        handle->seekg(header.infotableofs, std::ios::beg);
+		handle->seekg(header.infotableofs, std::ios::beg);
 		for (size_t i = 0; i < fileinfo.size(); i++)
-        {
-            if (not fileinfo[i].Read(*handle))
-            {
-                PrintFmt(PRINT_HIGH, "failed to read file info for lump number {} in {}\n", i, filename);
-                return;
-            }
-            std::transform(fileinfo[i].name, fileinfo[i].name + 8, fileinfo[i].name, toupper);
-        }
+		{
+			if (not fileinfo[i].Read(*handle))
+			{
+				PrintFmt(PRINT_HIGH, "failed to read file info for lump number {} in {}\n", i, filename);
+				return;
+			}
+			std::transform(fileinfo[i].name, fileinfo[i].name + 8, fileinfo[i].name, toupper);
+		}
 		newlumps = header.numlumps;
 		PrintFmt(PRINT_HIGH, " ({} lumps)\n", header.numlumps);
 	}
@@ -415,8 +415,8 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 			flatHack = 0;
 	}
 
-    std::vector<lumpinfo_t> newlumpinfos;
-    newlumpinfos.reserve(lumpinfo.size());
+	std::vector<lumpinfo_t> newlumpinfos;
+	newlumpinfos.reserve(lumpinfo.size());
 
 	size_t newlumps = 0;
 	size_t oldlumps = 0;
@@ -434,7 +434,7 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 				// Create start marker if we haven't already
 				if (newlumpinfos.empty())
 				{
-                    newlumpinfos.emplace_back(start);
+					newlumpinfos.emplace_back(start);
 				}
 			}
 			else
@@ -461,8 +461,8 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 					}
 					else
 					{
-                        newlumpinfos.push_back(lumpinfo[i]);
-                        newlumpinfos.back().namespc = space;
+						newlumpinfos.push_back(lumpinfo[i]);
+						newlumpinfos.back().namespc = space;
 					}
 				}
 			}
@@ -480,8 +480,8 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t spa
 			}
 			else
 			{
-                newlumpinfos.push_back(lumpinfo[i]);
-                newlumpinfos.back().namespc = space;
+				newlumpinfos.push_back(lumpinfo[i]);
+				newlumpinfos.back().namespc = space;
 			}
 		}
 	}
@@ -547,14 +547,14 @@ void W_InitMultipleFiles(const OResFiles& files)
 		lump.namespc = ns_global;
 
 	// [RH] Merge sprite and flat groups.
-	//		(We don't need to bother with patches, since
-	//		Doom doesn't use markers to identify them.)
+	//      (We don't need to bother with patches, since
+	//      Doom doesn't use markers to identify them.)
 	W_MergeLumps ("TX_START", "TX_END", ns_textures);
 	W_MergeLumps ("S_START", "S_END", ns_sprites); // denis - fixme - security
 	W_MergeLumps ("F_START", "F_END", ns_flats);
 	W_MergeLumps ("C_START", "C_END", ns_colormaps);
 
-    // set up caching
+	// set up caching
 	M_Free(lumpcache);
 
 	size_t size = lumpinfo.size() * sizeof(*lumpcache);
@@ -697,7 +697,7 @@ void W_ReadLump(unsigned int lump, void* dest)
 	auto l = lumpinfo.begin() + lump;
 
 	if (lump != stdisk_lumpnum)
-    	I_BeginRead();
+		I_BeginRead();
 
 	l->handle->seekg(l->position, std::ios::beg);
 	l->handle->read(reinterpret_cast<char*>(dest), l->size);
@@ -706,7 +706,7 @@ void W_ReadLump(unsigned int lump, void* dest)
 		I_Error("W_ReadLump: only read {} of {} on lump {}", l->handle->gcount(), l->size, lump);
 
 	if (lump != stdisk_lumpnum)
-    	I_EndRead();
+		I_EndRead();
 }
 
 //
@@ -716,9 +716,9 @@ void W_ReadLump(unsigned int lump, void* dest)
 //
 unsigned W_ReadChunk (const char *file, unsigned offs, unsigned len, void *dest, unsigned &filelen)
 {
-    std::ifstream fp(file,
-                     std::ios::in |
-                     std::ios::binary);
+	std::ifstream fp(file,
+	                 std::ios::in |
+	                 std::ios::binary);
 
 	unsigned read = 0;
 

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -359,7 +359,7 @@ void AddFile(const OResFile& file)
         {
             if (not fileinfo[i].Read(*handle))
             {
-                PrintFmt(PRINT_HIGH, "failed to read file info in {}\n", filename);
+                PrintFmt(PRINT_HIGH, "failed to read file info for lump number {} in {}\n", i, filename);
                 return;
             }
             std::transform(fileinfo[i].name, fileinfo[i].name + 8, fileinfo[i].name, toupper);
@@ -495,16 +495,19 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 
 	if (newlumps)
 	{
-		if (oldlumps + newlumps + 1 > lumpinfo.size())
-			lumpinfo.resize(oldlumps + newlumps + 1);
+		if (oldlumps + newlumps > lumpinfo.size())
+			lumpinfo.resize(oldlumps + newlumps);
 
 		std::copy_n(newlumpinfos.get(), newlumps, lumpinfo.begin() + oldlumps);
 
-		lumpinfo.back().handle.reset();
-		lumpinfo.back().name     = end;
-		lumpinfo.back().position = 0;
-		lumpinfo.back().size     = 0;
-		lumpinfo.back().namespc  = ns_global;
+		lumpinfo_t marker;
+		marker.handle.reset();
+		marker.name     = end;
+		marker.position = 0;
+		marker.size     = 0;
+		marker.namespc  = ns_global;
+
+		lumpinfo[oldlumps+newlumps] = marker;
 	}
 }
 

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -495,8 +495,9 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 
 	if (newlumps)
 	{
-		if (oldlumps + newlumps > lumpinfo.size())
-			lumpinfo.resize(oldlumps + newlumps);
+		// Because the above algorithm only ever causes the lump count to shrink or stay the same,
+		// we just do the resize unconditionally.
+		lumpinfo.resize(oldlumps + newlumps);
 
 		std::copy_n(newlumpinfos.get(), newlumps, lumpinfo.begin() + oldlumps);
 
@@ -507,7 +508,7 @@ void W_MergeLumps (const OLumpName& start, const OLumpName& end, int space)
 		marker.size     = 0;
 		marker.namespc  = ns_global;
 
-		lumpinfo[oldlumps+newlumps] = marker;
+		lumpinfo.emplace_back(std::move(marker));
 	}
 }
 

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -88,6 +88,12 @@ struct lumpinfo_t
 	int index   { -1 };
 
 	namespace_t namespc { ns_global };
+
+    lumpinfo_t() = default;
+    explicit lumpinfo_t(const OLumpName& i_name) :
+        name(i_name)
+    {
+    }
 };
 
 struct lumpHandle_t

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -89,10 +89,18 @@ struct lumpinfo_t
 
 	namespace_t namespc { ns_global };
 
-	lumpinfo_t() = default;     // Needed because the following ctor implicitly deletes the default ctor.
+	lumpinfo_t() = default;     // Needed because the following ctors implicitly delete the default ctor.
 
 	explicit lumpinfo_t(const OLumpName& i_name) :
 		name(i_name)
+	{
+	}
+
+	lumpinfo_t(const std::shared_ptr<std::istream>& i_stream, const filelump_t& i_fileinfo) :
+		name    (i_fileinfo.name),
+		handle  (i_stream),
+		position(i_fileinfo.filepos),
+		size    (i_fileinfo.size)
 	{
 	}
 };

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -42,41 +42,53 @@ extern bool missingCommercialIWAD;
 //
 // TYPES
 //
-typedef struct
+struct wadinfo_t
 {
 	// Should be "IWAD" or "PWAD".
-	unsigned	identification;
-	int			numlumps;
-	int			infotableofs;
+	unsigned    identification;
+	int         numlumps;
+	int         infotableofs;
 
-} wadinfo_t;
+    bool Read(std::istream& io_stream)
+    {
+        return M_ReadLE(io_stream, identification) and
+               M_ReadLE(io_stream, numlumps) and
+               M_ReadLE(io_stream, infotableofs);
+    }
+};
 
-#pragma pack(push, 1)
 struct filelump_t
 {
-	int			filepos;
-	int			size;
-	char		name[8]; // denis - todo - string
+	constexpr static size_t SIZE_IN_BYTES = 16;
 
+	int     filepos;
+	int     size;
+	char    name[8]; // denis - todo - string
+
+    bool Read(std::istream& io_stream)
+    {
+        return M_ReadLE(io_stream, filepos) and
+               M_ReadLE(io_stream, size) and
+               M_ReadLE(io_stream, name);
+    }
 };
-#pragma pack(pop)
 
 //
 // WADFILE I/O related stuff.
 //
-typedef struct lumpinfo_s
+struct lumpinfo_t
 {
-	OLumpName	name;
-	FILE		*handle; // TODO: uqFile
-	int			position;
-	int			size;
+	OLumpName                     name;
+	std::shared_ptr<std::istream> handle;
+	int                           position;
+	int                           size;
 
 	// [RH] Hashing stuff
-	int			next;
-	int			index;
+	int next;
+	int index;
 
-	int			namespc;
-} lumpinfo_t;
+	int namespc;
+};
 
 // [RH] Namespaces from BOOM.
 typedef enum {

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -49,12 +49,7 @@ struct wadinfo_t
 	int         numlumps;
 	int         infotableofs;
 
-    bool Read(std::istream& io_stream)
-    {
-        return M_ReadLE(io_stream, identification) and
-               M_ReadLE(io_stream, numlumps) and
-               M_ReadLE(io_stream, infotableofs);
-    }
+	bool Read(std::istream& io_stream);
 };
 
 struct filelump_t
@@ -65,12 +60,7 @@ struct filelump_t
 	int     size;
 	char    name[8]; // denis - todo - string
 
-    bool Read(std::istream& io_stream)
-    {
-        return M_ReadLE(io_stream, filepos) and
-               M_ReadLE(io_stream, size) and
-               M_ReadLE(io_stream, name);
-    }
+	bool Read(std::istream& io_stream);
 };
 
 //
@@ -121,8 +111,8 @@ struct lumpHandle_t
 };
 
 extern	void**		lumpcache;
-extern	lumpinfo_t*	lumpinfo;
-extern	size_t	numlumps;
+extern std::vector<lumpinfo_t> lumpinfo;
+inline size_t W_NumLumps() { return lumpinfo.size(); }
 
 OCRC32Sum W_CRC32(const std::string& filename);
 OMD5Hash W_MD5(const std::string& filename);

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -89,11 +89,12 @@ struct lumpinfo_t
 
 	namespace_t namespc { ns_global };
 
-    lumpinfo_t() = default;
-    explicit lumpinfo_t(const OLumpName& i_name) :
-        name(i_name)
-    {
-    }
+	lumpinfo_t() = default;     // Needed because the following ctor implicitly deletes the default ctor.
+
+	explicit lumpinfo_t(const OLumpName& i_name) :
+		name(i_name)
+	{
+	}
 };
 
 struct lumpHandle_t

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -63,31 +63,32 @@ struct filelump_t
 	bool Read(std::istream& io_stream);
 };
 
-//
-// WADFILE I/O related stuff.
-//
-struct lumpinfo_t
-{
-	OLumpName                     name;
-	std::shared_ptr<std::istream> handle;
-	int                           position;
-	int                           size;
-
-	// [RH] Hashing stuff
-	int next;
-	int index;
-
-	int namespc;
-};
-
 // [RH] Namespaces from BOOM.
-typedef enum {
+enum namespace_t
+{
 	ns_global = 0,
 	ns_textures,
 	ns_sprites,
 	ns_flats,
 	ns_colormaps,
-} namespace_t;
+};
+
+//
+// WADFILE I/O related stuff.
+//
+struct lumpinfo_t
+{
+	OLumpName                     name      {};
+	std::shared_ptr<std::istream> handle    {};
+	int                           position  { 0 };
+	int                           size      { 0 };
+
+	// [RH] Hashing stuff
+	int next    { -1 };
+	int index   { -1 };
+
+	namespace_t namespc { ns_global };
+};
 
 struct lumpHandle_t
 {
@@ -121,10 +122,10 @@ void W_InitMultipleFiles(const OResFiles& filenames);
 lumpHandle_t W_LumpToHandle(const unsigned lump);
 int W_HandleToLump(const lumpHandle_t handle);
 
-int W_CheckNumForName(const char *name, int ns = ns_global);
-inline int W_CheckNumForName(const OLumpName& name, int ns = ns_global) { return W_CheckNumForName(name.c_str(), ns); };
-int W_GetNumForName(const char *name, int ns = ns_global);
-inline int W_GetNumForName(const OLumpName& name, int ns = ns_global) { return W_GetNumForName(name.c_str(), ns); };
+int W_CheckNumForName(const char *name, namespace_t ns = ns_global);
+inline int W_CheckNumForName(const OLumpName& name, namespace_t ns = ns_global) { return W_CheckNumForName(name.c_str(), ns); };
+int W_GetNumForName(const char *name, namespace_t ns = ns_global);
+inline int W_GetNumForName(const OLumpName& name, namespace_t ns = ns_global) { return W_GetNumForName(name.c_str(), ns); };
 
 OLumpName W_LumpName(unsigned lump);
 unsigned	W_LumpLength (unsigned lump);
@@ -168,10 +169,8 @@ patch_t* W_CachePatch(unsigned lump, const zoneTag_e tag = PU_CACHE);
 patch_t* W_CachePatch(const char* name, const zoneTag_e tag = PU_CACHE);
 patch_t* W_CachePatch(const OLumpName& name, const zoneTag_e tag = PU_CACHE);
 lumpHandle_t W_CachePatchHandle(const int lumpNum, const zoneTag_e tag = PU_CACHE);
-lumpHandle_t W_CachePatchHandle(const char* name, const zoneTag_e tag = PU_CACHE,
-                                int ns = ns_global);
-lumpHandle_t W_CachePatchHandle(const OLumpName&, const zoneTag_e tag = PU_CACHE,
-                                int ns = ns_global);
+lumpHandle_t W_CachePatchHandle(const char* name, const zoneTag_e tag = PU_CACHE, namespace_t ns = ns_global);
+lumpHandle_t W_CachePatchHandle(const OLumpName&, const zoneTag_e tag = PU_CACHE, namespace_t ns = ns_global);
 patch_t* W_ResolvePatchHandle(const lumpHandle_t lump);
 
 void	W_Profile (const char *fname);
@@ -184,7 +183,7 @@ bool	W_CheckLumpName (unsigned lump, const char *name);	// [RH] True if lump's n
 //unsigned W_LumpNameHash (const char *name);				// [RH] Create hash key from an 8-char name
 
 // [RH] Combine multiple marked ranges of lumps into one.
-void W_MergeLumps (const OLumpName& start, const OLumpName& end, int);
+void W_MergeLumps (const OLumpName& start, const OLumpName& end, namespace_t);
 
 // [RH] Copy an 8-char string and uppercase it.
 void uppercopy (char *to, const char *from);


### PR DESCRIPTION
### Overview

This replaces the use of:

1. C-style IO streams (aka `FILE`) with C++ IO streams (aka `std::fstream`), and
2. Quasi-C, quasi-C++ allocation and buffering of wad resources to using proper `std::vector`s and appropriate constructors.

The driver for this was the fact that C-style IO streams are constrained to size representation using `long`, which is 32 bits on Windows.  Rather than insert another Windows-specific check and piece of code, instead switching to C++ IO streams relieves the constraint entirely, because the C++ standard guarantees that the types used for position and size in the IO stream classes will be sized to accommodate the maximums allowed by the underlying OS.

Additionally, this PR includes a few cleanup items:

- Add templated `M_ReadLE`, `M_WriteLE` using the `nonstd::bit` to do swaps at serialize/deserialize time.
- Read wad headers and lump infos using appropriate per-field deserialization.
- Read and write odd headers and markers using appropriate per-field deserialization/serialization.
- Indentation and visual alignment fixes
- Stop conflating the enumerated wad lump namespace with `int`

NOTE: the serialization changes were verified by loading and playing back netdemos that were recorded before the above changes.