### PR TITLE
Fix playerstate freezing up when playing back a netdemo and rewinding to initial snapshot following levelchange

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -999,6 +999,8 @@ void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 //   the packet with sequence number 0 and writes them to netbuffer.
 //
 
+extern int last_svgametic;
+
 void NetDemo::writeConnectionSequence(buf_t *netbuffer)
 {
     PacketHeaderType header {0};
@@ -1029,7 +1031,7 @@ void NetDemo::writeConnectionSequence(buf_t *netbuffer)
 	MSG_WriteSVCBuffer(netbuffer, SVC_LoadMap(wadfiles, patchfiles, level.mapname.c_str(), level.time));
 
 	// Server spawns the player
-	MSG_WriteSVCBuffer(netbuffer, SVC_SpawnPlayer(consoleplayer()));
+	MSG_WriteSVCBuffer(netbuffer, SVC_SpawnPlayer(consoleplayer(), last_svgametic));
 }
 
 
@@ -1402,6 +1404,8 @@ void NetDemo::readSnapshotData(std::vector<byte>& buf)
 
 	// Remove all players
 	players.clear();
+
+	CL_ResetWorldPrediction();
 
 	// Remove all actors
 	TThinkerIterator<AActor> iterator;

--- a/client/src/cl_main.h
+++ b/client/src/cl_main.h
@@ -76,6 +76,7 @@ void CL_SendCmd(void);
 void CL_SaveCmd(void);
 void CL_MoveThing(AActor *mobj, fixed_t x, fixed_t y, fixed_t z);
 void CL_PredictWorld(void);
+void CL_ResetWorldPrediction();
 void CL_SendUserInfo(buf_t& netBuf);
 bool CL_Connect();
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1265,7 +1265,7 @@ static void CL_SpawnPlayer(const odaproto::svc::SpawnPlayer* msg)
 			::level.behavior->StartTypedScripts(SCRIPT_Enter, p.mo);
 	}
 
-	const int snaptime = last_svgametic;
+	const int snaptime = msg->server_tic();
 	PlayerSnapshot newsnap(snaptime, p);
 	newsnap.setAuthoritative(true);
 	newsnap.setContinuous(false);

--- a/client/src/cl_pred.cpp
+++ b/client/src/cl_pred.cpp
@@ -349,10 +349,10 @@ void CL_PredictWorld(void)
 
 void CL_ResetWorldPrediction()
 {
-    for (auto& savedPlayerSnapshot : cl_savedsnaps)
-    {
-        savedPlayerSnapshot = PlayerSnapshot{};
-    }
+	for (auto& savedPlayerSnapshot : cl_savedsnaps)
+	{
+		savedPlayerSnapshot = PlayerSnapshot{};
+	}
 }
 
 VERSION_CONTROL (cl_pred_cpp, "$Id$")

--- a/client/src/cl_pred.cpp
+++ b/client/src/cl_pred.cpp
@@ -347,5 +347,12 @@ void CL_PredictWorld(void)
 	CL_PredictLocalPlayer(gametic);
 }
 
+void CL_ResetWorldPrediction()
+{
+    for (auto& savedPlayerSnapshot : cl_savedsnaps)
+    {
+        savedPlayerSnapshot = PlayerSnapshot{};
+    }
+}
 
 VERSION_CONTROL (cl_pred_cpp, "$Id$")

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -675,12 +675,13 @@ odaproto::svc::UpdateMobj SVC_UpdateMobj(const AActor& mobj)
 
 EXTERN_CVAR(sv_sharekeys);
 
-odaproto::svc::SpawnPlayer SVC_SpawnPlayer(const player_t& player)
+odaproto::svc::SpawnPlayer SVC_SpawnPlayer(const player_t& player, int tic)
 {
 	odaproto::svc::SpawnPlayer msg;
 
 	msg.set_pid(player.id);
 	msg.set_player_tic(player.tic);
+	msg.set_server_tic(tic);
 
 	odaproto::Actor* act = msg.mutable_actor();
 	if (player.mo)

--- a/common/svc_message.h
+++ b/common/svc_message.h
@@ -97,7 +97,7 @@ odaproto::svc::ExplodeMissile SVC_ExplodeMissile(const AActor& mobj);
 odaproto::svc::RemoveMobj SVC_RemoveMobj(const AActor& mobj);
 odaproto::svc::UserInfo SVC_UserInfo(const player_t& player, int64_t time);
 odaproto::svc::UpdateMobj SVC_UpdateMobj(const AActor& mobj);
-odaproto::svc::SpawnPlayer SVC_SpawnPlayer(const player_t& player);
+odaproto::svc::SpawnPlayer SVC_SpawnPlayer(const player_t& player, int tic);
 odaproto::svc::DamagePlayer SVC_DamagePlayer(const player_t& player, const AActor *inflictor, int health, int armor, int destinationClientTicOfValidity);
 odaproto::svc::KillMobj SVC_KillMobj(const AActor* source, const AActor* target, const AActor* inflictor,
                                      int mod, bool joinkill);

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -152,6 +152,7 @@ message SpawnPlayer
 	Actor  actor = 2;
 	uint32 cards = 3;
 	int32  player_tic = 4;
+	int32  server_tic = 5;
 }
 
 // svc_damageplayer

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1461,7 +1461,7 @@ bool SV_ApplyAwareness(player_t& player, AActor* mo, AwarenessEnum awarenessLeve
 		}
 		else
 		{
-			MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_SpawnPlayer(*mo->player));
+			MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_SpawnPlayer(*mo->player, gametic));
 		}
 		return true;
 	}


### PR DESCRIPTION
This is tough to describe.  A video would go a long way to illustrate the symptom.  The misbehavior shows up when we do a rewind-to-beginning in the middle of the following video:


https://github.com/user-attachments/assets/717a1ba8-8973-4b34-bf38-c7cff7229f27

Here's the exact same demo after the fix:

https://github.com/user-attachments/assets/5cea6c3e-83e4-4916-a1a4-ddd8d8b29518

