### PR TITLE
Roll NETDEMOVER to 4 and allow developers to attempt loading old version netdemos

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -45,6 +45,9 @@
 EXTERN_CVAR(sv_maxclients)
 EXTERN_CVAR(sv_maxplayers)
 
+// Want to press your luck loading previous-versioned netdemos?  Press this button!  Don't get a whammy!
+constexpr bool TRY_LOADING_OLD_NETDEMOS = false;
+
 extern std::string server_host;
 extern std::string digest;
 extern OResFiles wadfiles;
@@ -83,7 +86,7 @@ void NetDemo::reset()
 	cleanUp();
 
 	filename = "";
-	header = netdemo_header_t{};
+	header = netdemo_header4_t{};
 	captured.clear();
 }
 
@@ -147,19 +150,17 @@ void NetDemo::fatalError(const std::string &message)
 
 bool NetDemo::writeHeader()
 {
-	memcpy(header.identifier, "ODAD", 4);
-	header.version = NETDEMOVER;
+	memcpy(header.id.identifier, "ODAD", 4);
+	header.id.version = NETDEMOVER;
 	header.compression = 0;
 	header.snapshot_spacing = NetDemo::SNAPSHOT_SPACING;
-
-	netdemo_header_t tmpheader {header};
 
 	demofp.seekp(0, std::ios::beg);
 	const auto startingPosition = demofp.tellp();
 
 	const bool result = startingPosition >= 0
-	                    and M_WriteLE(demofp, header.identifier)
-	                    and M_WriteLE(demofp, header.version)
+	                    and M_WriteLE(demofp, header.id.identifier)
+	                    and M_WriteLE(demofp, header.id.version)
 	                    and M_WriteLE(demofp, header.compression)
 	                    and M_WriteLE(demofp, header.snapshot_spacing)
 	                    and M_WriteLE(demofp, header.starting_gametic)
@@ -169,6 +170,48 @@ bool NetDemo::writeHeader()
 	return result;
 }
 
+
+bool NetDemo::netdemo_header_id_t::Read(std::fstream& io_stream)
+{
+    if (io_stream.good())
+    {
+        return  M_ReadLE(io_stream, identifier)
+            and M_ReadLE(io_stream, version);
+    }
+    return false;
+}
+
+bool NetDemo::netdemo_header3_t::Read(std::fstream& io_stream)
+{
+    if (io_stream.good())
+    {
+        return  id.Read(io_stream)
+            and M_ReadLE(io_stream, compression)
+            and M_ReadLE(io_stream, snapshot_index_size)
+            and M_ReadLE(io_stream, snapshot_index_offset)
+            and M_ReadLE(io_stream, map_index_size)
+            and M_ReadLE(io_stream, map_index_offset)
+            and M_ReadLE(io_stream, snapshot_spacing)
+            and M_ReadLE(io_stream, starting_gametic)
+            and M_ReadLE(io_stream, ending_gametic)
+            and M_ReadLE(io_stream, reserved);
+    }
+    return false;
+}
+
+bool NetDemo::netdemo_header4_t::Read(std::fstream& io_stream)
+{
+    if (io_stream.good())
+    {
+        return  id.Read(io_stream)
+            and M_ReadLE(io_stream, compression)
+            and M_ReadLE(io_stream, snapshot_spacing)
+            and M_ReadLE(io_stream, starting_gametic)
+            and M_ReadLE(io_stream, ending_gametic)
+            and M_ReadLE(io_stream, reserved);
+    }
+    return false;
+}
 
 //
 // readHeader()
@@ -182,16 +225,43 @@ bool NetDemo::readHeader()
 	demofp.seekg(0, std::ios::beg);
 	const auto startingPosition = demofp.tellg();
 
-	const bool result = startingPosition >= 0
-	                    and M_ReadLE(demofp, header.identifier)
-	                    and M_ReadLE(demofp, header.version)
-	                    and M_ReadLE(demofp, header.compression)
-	                    and M_ReadLE(demofp, header.snapshot_spacing)
-	                    and M_ReadLE(demofp, header.starting_gametic)
-	                    and M_ReadLE(demofp, header.ending_gametic)
-	                    and M_ReadLE(demofp, header.reserved)
-	                    and demofp.tellg() - startingPosition == HEADER_SIZE;
-	return result;
+    netdemo_header_id_t headerId;
+    const bool headerIDOk = headerId.Read(demofp);
+
+    if (not (headerIDOk
+             and headerId.identifier[0] == 'O'
+             and headerId.identifier[1] == 'D'
+             and headerId.identifier[2] == 'A'
+             and headerId.identifier[3] == 'D'))
+    {
+        return false;
+    }
+
+    header.id = headerId;
+
+    if (header.id.version == NETDEMOVER)
+    {
+        demofp.seekg(startingPosition, std::ios::beg);
+
+        return header.Read(demofp)
+                and demofp.tellg() - startingPosition == HEADER_SIZE;
+    }
+
+    if (header.id.version == 3)
+    {
+        demofp.seekg(startingPosition, std::ios::beg);
+
+        netdemo_header3_t header3;
+
+        if (header3.Read(demofp)
+                and demofp.tellg() - startingPosition == HEADER_SIZE)
+        {
+            // Translate from 3 to NETDEMOVER
+            header.Import(header3);
+            return true;
+        }
+    }
+	return false;
 }
 
 //
@@ -278,7 +348,7 @@ bool NetDemo::startRecording(const std::string &filename)
 		return false;
 	}
 
-	header = netdemo_header_t{};
+	header = netdemo_header4_t{};
 	header.starting_gametic = gametic;
 
 	// Note: The header is not finalized at this point.  Write it anyway to
@@ -368,10 +438,14 @@ bool NetDemo::startPlaying(const std::string &filename)
 		return false;
 	}
 
-	if (header.version != NETDEMOVER)
+    if constexpr (TRY_LOADING_OLD_NETDEMOS)
+    {
+        PrintFmt(PRINT_WARNING, "Attempting to load a version {} netdemo...\n", header.id.version);
+    }
+    else if (header.id.version != NETDEMOVER)
 	{
 		std::string buffer;
-		const int latestVersion = LatestDemoVersion(header.version);
+		const int latestVersion = LatestDemoVersion(header.id.version);
 		if (latestVersion)
 		{
 			int maj, min, patch;

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -65,8 +65,10 @@ int LatestDemoVersion(const int version)
 {
 	switch (version)
 	{
-	case 3:
+	case 4:
 		return GAMEVER;
+	case 3:
+		return MAKEVER(12, 2, 1);
 	case 2:
 		return MAKEVER(0, 6, 0);
 	case 1:

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -113,15 +113,54 @@ private:
 
 	static constexpr uint16_t SNAPSHOT_SPACING = 20 * TICRATE;
 
-	struct netdemo_header_t
+	struct netdemo_header_id_t
 	{
 		char        identifier[4]   { 0, 0, 0, 0};  // "ODAD"
-		byte        version         { 0 };
+		byte        version         { 0 };          // 4, 3, etc...
+
+		bool Read(std::fstream& io_stream);
+	};
+
+	// The following exists only for a remote chance of compatibility with old netdemos.
+	// At the very least, we want to be able to make sense of the headers, but there's
+	// zero guarantee of it working.  In fact, it's likely to not work because the message
+	// content is almost certainly different enough to be non-functional with current
+	// message body formats.
+	struct netdemo_header3_t
+	{
+		netdemo_header_id_t id              {};     // version 3
+		byte        compression             { 0 };  // type of compression used
+		uint16_t    snapshot_index_size     { 0 };  // number of snapshots in the index
+		uint32_t    snapshot_index_offset   { 0 };  // offset from start of the file for the index
+		uint16_t    map_index_size          { 0 };  // number of maps in the mapindex
+		uint32_t    map_index_offset        { 0 };  // offset from start of the file for the mapindex
+		uint16_t    snapshot_spacing        { 0 };  // number of gametics between indices
+		uint32_t    starting_gametic        { 0 };  // the gametic the demo starts at
+		uint32_t    ending_gametic          { 0 };  // the last gametic of the demo
+		byte        reserved[36]            { 0 };  // for future use
+
+		bool Read(std::fstream& io_stream);
+	};
+
+    // Now for the current netdemo version.
+	struct netdemo_header4_t
+	{
+		netdemo_header_id_t id      {};             // version 4
 		byte        compression     { 0 };          // type of compression used
 		uint16_t    snapshot_spacing{ 0 };          // number of gametics between indices
 		uint32_t    starting_gametic{ 0 };          // the gametic the demo starts at
 		uint32_t    ending_gametic  { 0 };          // the last gametic of the demo
 		byte        reserved[48]    { 0 };          // for future use
+
+		bool Read(std::fstream& io_stream);
+		void Import(const netdemo_header3_t& oldHeader)
+		{
+			// we deliberately skip 'id' and 'reserved'.
+			compression      = oldHeader.compression;
+			snapshot_spacing = oldHeader.snapshot_spacing;
+			starting_gametic = oldHeader.starting_gametic;
+			ending_gametic   = oldHeader.ending_gametic;
+		}
 	};
 
 	netdemo_state_t state   { st_stopped };
@@ -131,7 +170,7 @@ private:
 
 	std::deque<buf_t>   captured {};
 
-	netdemo_header_t                   header        {};
+	netdemo_header4_t                  header        {};
 	std::vector<netdemo_index_entry_t> snapshot_index{};
 	std::vector<netdemo_index_entry_t> map_index     {};
 

--- a/common/version.h
+++ b/common/version.h
@@ -96,7 +96,7 @@
 // upversion.py will update thie field deterministically and unambiguously.
 #define SAVESIG "ODAMEXSAVE013000"
 
-#define NETDEMOVER 3
+#define NETDEMOVER 4
 
 int VersionCompat(const int server, const int client);
 std::string VersionMessage(const int server, const int client, const char* email);


### PR DESCRIPTION
The update to allow truncated netdemos to be played back also changed the netdemo's header format in an incompatible manner due to fields being relocated to different offsets.  This updates the netdemo code so that it is capable of reading the header of the current format (4) and the previous format (3).

By default, any non-current format is rejected.  It also allows a developer to enable `TRY_LOADING_OLD_NETDEMOS` to proceed with the decode attempt anyway.