### PR TITLE
Predicted player major position error recovery

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2429,6 +2429,20 @@ void CL_SimulateSectors()
 	}
 }
 
+static PlayerSnapshot GetHistoricalSnapshot(const player_t& player, int ticsAgo)
+{
+    return player.snapshots.getSnapshot(world_index - ticsAgo);
+}
+
+static v3fixed_t CurrentDeltaFromSnapshot(const player_t& player, const PlayerSnapshot& prevsnap)
+{
+	v3fixed_t offset;
+	M_SetVec3Fixed(&offset, prevsnap.getX() - player.mo->x,
+	                        prevsnap.getY() - player.mo->y,
+	                        prevsnap.getZ() - player.mo->z);
+	return offset;
+}
+
 //
 // CL_SimulatePlayers()
 //
@@ -2465,15 +2479,34 @@ void CL_SimulatePlayers()
 				player.mo->prevangle = player.mo->angle;
 				player.mo->prevpitch = player.mo->pitch;
 
-				PlayerSnapshot prevsnap = player.snapshots.getSnapshot(world_index - 1);
+				v3fixed_t offset = CurrentDeltaFromSnapshot(player, GetHistoricalSnapshot(player, 1));
 
-				v3fixed_t offset;
-				M_SetVec3Fixed(&offset, prevsnap.getX() - player.mo->x,
-				                        prevsnap.getY() - player.mo->y,
-				                        prevsnap.getZ() - player.mo->z);
+				constexpr fixed_t EXCESSIVE_DISTANCE = 500 * FRACUNIT;
+				constexpr int     EXCESSIVE_TIME     = 10;
 
-				fixed_t dist = M_LengthVec3Fixed(&offset);
-				if (dist > 2 * FRACUNIT)
+				if (offset.MagnitudeIsGreaterThan(EXCESSIVE_DISTANCE))
+				{
+					int ticsAgo = 2;
+					while (ticsAgo <= EXCESSIVE_TIME)
+					{
+						const PlayerSnapshot historicalSnap = GetHistoricalSnapshot(player, ticsAgo);
+
+							if (not (    historicalSnap.isValid()
+							     and historicalSnap.isContinuous()
+							     and CurrentDeltaFromSnapshot(player, historicalSnap).MagnitudeIsGreaterThan(EXCESSIVE_DISTANCE)))
+						{
+							break;
+						}
+						++ticsAgo;
+					}
+
+					if (ticsAgo > EXCESSIVE_TIME)
+					{
+						snap.setContinuous(false);
+					}
+				}
+
+				if (snap.isContinuous() and offset.MagnitudeIsGreaterThan(2 * FRACUNIT))
 				{
 					#ifdef _SNAPSHOT_DEBUG_
 					PrintFmt(PRINT_HIGH, "Snapshot {}, Correcting extrapolation error of {}\n",

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2431,7 +2431,7 @@ void CL_SimulateSectors()
 
 static PlayerSnapshot GetHistoricalSnapshot(const player_t& player, int ticsAgo)
 {
-    return player.snapshots.getSnapshot(world_index - ticsAgo);
+	return player.snapshots.getSnapshot(world_index - ticsAgo);
 }
 
 static v3fixed_t CurrentDeltaFromSnapshot(const player_t& player, const PlayerSnapshot& prevsnap)
@@ -2481,7 +2481,7 @@ void CL_SimulatePlayers()
 
 				v3fixed_t offset = CurrentDeltaFromSnapshot(player, GetHistoricalSnapshot(player, 1));
 
-				constexpr fixed_t EXCESSIVE_DISTANCE = 500 * FRACUNIT;
+				constexpr fixed_t EXCESSIVE_DISTANCE = 128 * FRACUNIT;
 				constexpr int     EXCESSIVE_TIME     = 10;
 
 				if (offset.MagnitudeIsGreaterThan(EXCESSIVE_DISTANCE))

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2429,11 +2429,6 @@ void CL_SimulateSectors()
 	}
 }
 
-static PlayerSnapshot GetHistoricalSnapshot(const player_t& player, int ticsAgo)
-{
-	return player.snapshots.getSnapshot(world_index - ticsAgo);
-}
-
 static v3fixed_t CurrentDeltaFromSnapshot(const player_t& player, const PlayerSnapshot& prevsnap)
 {
 	v3fixed_t offset;
@@ -2479,7 +2474,29 @@ void CL_SimulatePlayers()
 				player.mo->prevangle = player.mo->angle;
 				player.mo->prevpitch = player.mo->pitch;
 
-				v3fixed_t offset = CurrentDeltaFromSnapshot(player, GetHistoricalSnapshot(player, 1));
+				v3fixed_t offset = CurrentDeltaFromSnapshot(player,
+				                                            player.snapshots.getSnapshot(world_index - 1));
+
+				// The following block is there to "jailbreak" a remote player whose predicted mobj
+				// movement resulted in a substantial disagreement with the server for a relatively
+				// excessive period of time.  In practice, this has been seen in rare conditions where
+				// a remote player is sandwiched by one or more moving sectors where the combined
+				// predictions result in a wildly different outcome than the server - i.e. did the
+				// player escape from the sandwich, and in what direction?  It can be a matter of just
+				// a few tics where there's an opportunity to escape, but the observer's latency and
+				// predicted sector motion causes the simulated player to miss its chance.
+				//
+				// When this happens, the remote player mobj can become trapped in a location where
+				// the movement prediction logic blocks motion, but the server MovePlayer messages
+				// yield snapshots that specify positions that are excessively distant from the mobj.
+				//
+				// This can happen naturally and in a benign manner *very* briefly for things like
+				// instant-mover lift sectors, which resolve naturally via extrapolation handling,
+				// so we need to check to see if this excessive distance persists for multiple tics.
+				//
+				// When this condition holds for a relatively long amount of time, we set the current
+				// snapshot to discontinuous so that the remote player's mobj makes an instantaneous
+				// jump to the official position.  From that point forward, normal prediction resumes.
 
 				constexpr fixed_t EXCESSIVE_DISTANCE = 128 * FRACUNIT;
 				constexpr int     EXCESSIVE_TIME     = 10;
@@ -2489,7 +2506,7 @@ void CL_SimulatePlayers()
 					int ticsAgo = 2;
 					while (ticsAgo <= EXCESSIVE_TIME)
 					{
-						const PlayerSnapshot historicalSnap = GetHistoricalSnapshot(player, ticsAgo);
+						const PlayerSnapshot historicalSnap = player.snapshots.getSnapshot(world_index - ticsAgo);
 
 							if (not (    historicalSnap.isValid()
 							     and historicalSnap.isContinuous()

--- a/common/m_vectors.h
+++ b/common/m_vectors.h
@@ -92,6 +92,16 @@ struct vector3_t
 		    >> o_obj.z;
 		return io_stream;
 	}
+
+	bool MagnitudeIsGreaterThan(const ElementType& length) const requires std::is_integral_v<ElementType>
+	{
+		const int64_t x64 { x };
+		const int64_t y64 { y };
+		const int64_t z64 { z };
+		const int64_t length64 { length };
+
+		return (x64 * x64) + (y64 * y64) + (z64 * z64) > (length64 * length64);
+	}
 };
 
 using v3fixed_t  = vector3_t<fixed_t>;


### PR DESCRIPTION
### Overview

On the client, if a remote player's predicted position diverges from the canonical server snapshots by at least 128 units for 10 consecutive tics, the client makes a teleport-like discontinuous jump of the remote player's mobj to the exact newest position from the server.

This resolves a special desync case described below.

### The background

Paraphrased from discord:

The big desync in gobolt's previous playtesting session (see [here](https://discord.com/channels/236518337671200768/1517777868242026526/1517778039302258688) and [here](https://discord.com/channels/236518337671200768/1517777868242026526/1518903741150134305)) was due to a perfect-storm kind of situation between sector prediction and player prediction, where a player got temporarily semi-crushed by a slow-ish moving floor for a brief period of time, then semi-crushed by another immediately adjacted sector doing the same motion with a timing offset.

Between the server and the player's commands and local sector prediction, those both determined that the player successfully escaped.  But the simulated player counterpart on all other clients did NOT escape, and the movement logic for the remote player mobj determined that the player was colliding in a way that prevented motion.

Because the player was actually moving all over the place, ultimately the simulated player escaped in the OPPOSITE direction from what they really did, and got trapped in one side of the map that is totally isolated from where the real player and all other players were actually going.  All the while, the simulated player's "smoothed over" extrapolation was rejected for motion because it would push the simulated player through a distant wall.

The remote player recovered when the real player went through a teleporter, which is fundamentally a discontinuous jump and corrects the mobj's position, resyncing across all clients.