### PR TITLE
[FEATURE] Create "cvardocjson" command

### DIFF
--- a/common/c_doc.cpp
+++ b/common/c_doc.cpp
@@ -230,32 +230,16 @@ static CvarView GetSortedCvarView()
 }
 
 /**
- * @brief Serialize a single JSON value to a compact, one-line string with no
- *        trailing newline, for embedding in hand-ordered output.
- */
-static std::string JSONScalar(const Json::Value& value)
-{
-	Json::FastWriter writer;
-	writer.omitEndingLineFeed();
-	return writer.write(value);
-}
-
-/**
- * @brief Render cvar information as a JSON object string.
+ * @brief Render cvar information as a JSON object.
  *
- * This is because jsoncpp serializes objects in alphabetical order,
- * so to get a custom order, we must do it by hand.
- *
- * @param cvar Cvar to read.
- * 
- * @param indent Indentation string for the object's braces. Fields are
- * indented one further level (3 spaces).
- * 
- * @return The serialized object, or an empty string for cvars that have no
+ * @param out Output value to write to. Set to null for cvars that have no
  * representable type.
+ * @param cvar Cvar to read.
  */
-static std::string JSONCvarObject(const cvar_t& cvar, const std::string& indent)
+static void JSONCvarObject(Json::Value& out, const cvar_t& cvar)
 {
+	out = Json::Value(Json::objectValue);
+
 	// Type string and whether the cvar carries a numeric range.
 	const char* typestr = NULL;
 	bool numeric = false;
@@ -278,29 +262,53 @@ static std::string JSONCvarObject(const cvar_t& cvar, const std::string& indent)
 		typestr = "string";
 		break;
 	default:
-		return "";
+		out = Json::Value(Json::nullValue);
+		return;
 	}
 
+	out["name"] = cvar.name();
+	out["type"] = typestr;
+	out["helptext"] = cvar.helptext();
+
 	// Default value, typed to match the cvar.
-	Json::Value defval;
 	switch (cvar.type())
 	{
 	case CVARTYPE_BOOL:
-		defval = atoi(cvar.getDefault().c_str()) != 0;
+		out["default"] = atoi(cvar.getDefault().c_str()) != 0;
 		break;
 	case CVARTYPE_BYTE:
 	case CVARTYPE_WORD:
 	case CVARTYPE_INT:
-		defval = atoi(cvar.getDefault().c_str());
+		out["default"] = atoi(cvar.getDefault().c_str());
 		break;
 	case CVARTYPE_FLOAT:
-		defval = atof(cvar.getDefault().c_str());
+		out["default"] = atof(cvar.getDefault().c_str());
 		break;
 	case CVARTYPE_STRING:
-		defval = cvar.getDefault();
+		out["default"] = cvar.getDefault();
 		break;
 	default:
 		break;
+	}
+
+	// Min/max only for numeric cvars, and only when a bound is actually set.
+	if (numeric)
+	{
+		if (cvar.getMinValue() != -FLT_MAX)
+		{
+			if (cvar.type() == CVARTYPE_FLOAT)
+				out["min"] = cvar.getMinValue();
+			else
+				out["min"] = static_cast<int>(cvar.getMinValue());
+		}
+
+		if (cvar.getMaxValue() != FLT_MAX)
+		{
+			if (cvar.type() == CVARTYPE_FLOAT)
+				out["max"] = cvar.getMaxValue();
+			else
+				out["max"] = static_cast<int>(cvar.getMaxValue());
+		}
 	}
 
 	// Flags as an array of string names.
@@ -321,36 +329,7 @@ static std::string JSONCvarObject(const cvar_t& cvar, const std::string& indent)
 		flags.append("SERVERARCHIVE");
 	if (cvar.flags() & CVAR_CLIENTARCHIVE)
 		flags.append("CLIENTARCHIVE");
-
-	// Emit fields in a fixed order: name, type, helptext, min, max, default,
-	// flags. min/max are only present for numeric cvars with a bound set.
-	const std::string field = indent + "   ";
-	std::string out;
-	out += indent + "{\n";
-	out += field + "\"name\" : " + JSONScalar(Json::Value(cvar.name())) + ",\n";
-	out += field + "\"type\" : " + JSONScalar(Json::Value(typestr)) + ",\n";
-	out += field + "\"helptext\" : " + JSONScalar(Json::Value(cvar.helptext())) + ",\n";
-
-	if (numeric && cvar.getMinValue() != -FLT_MAX)
-	{
-		Json::Value minv = (cvar.type() == CVARTYPE_FLOAT)
-		                       ? Json::Value(static_cast<double>(cvar.getMinValue()))
-		                       : Json::Value(static_cast<int>(cvar.getMinValue()));
-		out += field + "\"min\" : " + JSONScalar(minv) + ",\n";
-	}
-
-	if (numeric && cvar.getMaxValue() != FLT_MAX)
-	{
-		Json::Value maxv = (cvar.type() == CVARTYPE_FLOAT)
-		                       ? Json::Value(static_cast<double>(cvar.getMaxValue()))
-		                       : Json::Value(static_cast<int>(cvar.getMaxValue()));
-		out += field + "\"max\" : " + JSONScalar(maxv) + ",\n";
-	}
-
-	out += field + "\"default\" : " + JSONScalar(defval) + ",\n";
-	out += field + "\"flags\" : " + JSONScalar(flags) + "\n";
-	out += indent + "}";
-	return out;
+	out["flags"] = flags;
 }
 
 BEGIN_COMMAND(cvardoc)
@@ -449,39 +428,28 @@ BEGIN_COMMAND(cvardocjson)
 		return;
 	}
 
-	// Build the cvar objects, each hand-ordered (array elements indent two
-	// levels under the document root).
-	std::vector<std::string> entries;
+	// Build the final json document.
+	Json::Value root(Json::objectValue);
+	root["schema_version"] = 1;
+	root["odamex_version"] = DOTVERSIONSTR;
+	root["odamex_commithash"] = GitHash();
+	root["odamex_branchname"] = GitBranch();
+
+	Json::Value cvars(Json::arrayValue);
 	CvarView view = GetSortedCvarView();
 	for (const auto& cvar : view)
 	{
-		std::string obj = JSONCvarObject(*cvar, "      ");
-		if (obj.empty())
+		Json::Value obj;
+		JSONCvarObject(obj, *cvar);
+		if (obj.isNull())
 			continue;
-		entries.push_back(obj);
+		cvars.append(obj);
 	}
+	root["cvars"] = cvars;
 
-	// jsoncpp serializes object keys alphabetically, so we assemble the whole
-	// document by hand to keep the metadata first and the cvars array last.
-	std::string buffer;
-	buffer += "{\n";
-	buffer += fmt::sprintf("   \"schema_version\" : %d,\n", 1);
-	buffer += fmt::sprintf("   \"odamex_version\" : %s,\n",
-	                       Json::valueToQuotedString(DOTVERSIONSTR));
-	buffer += fmt::sprintf("   \"odamex_commithash\" : %s,\n",
-	                       Json::valueToQuotedString(GitHash()));
-	buffer += fmt::sprintf("   \"odamex_branchname\" : %s,\n",
-	                       Json::valueToQuotedString(GitBranch()));
-	buffer += "   \"cvars\" :\n";
-	buffer += "   [\n";
-	for (size_t i = 0; i < entries.size(); i++)
-	{
-		buffer += entries[i];
-		buffer += (i + 1 < entries.size()) ? ",\n" : "\n";
-	}
-	buffer += "   ]\n";
-	buffer += "}\n";
 
+	Json::StyledWriter writer;
+	std::string buffer = writer.write(root);
 	fwrite(buffer.data(), sizeof(char), buffer.size(), fh);
 
 	long bytes = ftell(fh);

--- a/common/c_doc.cpp
+++ b/common/c_doc.cpp
@@ -246,16 +246,16 @@ static void JSONCvarObject(Json::Value& out, const cvar_t& cvar)
 	switch (cvar.type())
 	{
 	case CVARTYPE_BOOL:
-		typestr = "bool";
+		typestr = "boolean";
 		break;
 	case CVARTYPE_BYTE:
 	case CVARTYPE_WORD:
 	case CVARTYPE_INT:
-		typestr = "number";
+		typestr = "integer";
 		numeric = true;
 		break;
 	case CVARTYPE_FLOAT:
-		typestr = "float";
+		typestr = "number";
 		numeric = true;
 		break;
 	case CVARTYPE_STRING:

--- a/common/c_doc.cpp
+++ b/common/c_doc.cpp
@@ -26,10 +26,13 @@
 
 #include <algorithm>
 
+#include <json/json.h>
+
 #include "c_dispatch.h"
 #include "cmdlib.h"
 #include "i_system.h"
 #include "m_fileio.h"
+#include "version.h"
 
 #ifdef CLIENT_APP
 #define CS_STRING "Odamex Client"
@@ -226,6 +229,130 @@ static CvarView GetSortedCvarView()
 	return view;
 }
 
+/**
+ * @brief Serialize a single JSON value to a compact, one-line string with no
+ *        trailing newline, for embedding in hand-ordered output.
+ */
+static std::string JSONScalar(const Json::Value& value)
+{
+	Json::FastWriter writer;
+	writer.omitEndingLineFeed();
+	return writer.write(value);
+}
+
+/**
+ * @brief Render cvar information as a JSON object string.
+ *
+ * This is because jsoncpp serializes objects in alphabetical order,
+ * so to get a custom order, we must do it by hand.
+ *
+ * @param cvar Cvar to read.
+ * 
+ * @param indent Indentation string for the object's braces. Fields are
+ * indented one further level (3 spaces).
+ * 
+ * @return The serialized object, or an empty string for cvars that have no
+ * representable type.
+ */
+static std::string JSONCvarObject(const cvar_t& cvar, const std::string& indent)
+{
+	// Type string and whether the cvar carries a numeric range.
+	const char* typestr = NULL;
+	bool numeric = false;
+	switch (cvar.type())
+	{
+	case CVARTYPE_BOOL:
+		typestr = "bool";
+		break;
+	case CVARTYPE_BYTE:
+	case CVARTYPE_WORD:
+	case CVARTYPE_INT:
+		typestr = "number";
+		numeric = true;
+		break;
+	case CVARTYPE_FLOAT:
+		typestr = "float";
+		numeric = true;
+		break;
+	case CVARTYPE_STRING:
+		typestr = "string";
+		break;
+	default:
+		return "";
+	}
+
+	// Default value, typed to match the cvar.
+	Json::Value defval;
+	switch (cvar.type())
+	{
+	case CVARTYPE_BOOL:
+		defval = atoi(cvar.getDefault().c_str()) != 0;
+		break;
+	case CVARTYPE_BYTE:
+	case CVARTYPE_WORD:
+	case CVARTYPE_INT:
+		defval = atoi(cvar.getDefault().c_str());
+		break;
+	case CVARTYPE_FLOAT:
+		defval = atof(cvar.getDefault().c_str());
+		break;
+	case CVARTYPE_STRING:
+		defval = cvar.getDefault();
+		break;
+	default:
+		break;
+	}
+
+	// Flags as an array of string names.
+	Json::Value flags(Json::arrayValue);
+	if (cvar.flags() & CVAR_USERINFO)
+		flags.append("USERINFO");
+	if (cvar.flags() & CVAR_SERVERINFO)
+		flags.append("SERVERINFO");
+	if (cvar.flags() & CVAR_NOSET)
+		flags.append("NOSET");
+	if (cvar.flags() & CVAR_LATCH)
+		flags.append("LATCH");
+	if (cvar.flags() & CVAR_UNSETTABLE)
+		flags.append("UNSETTABLE");
+	if (cvar.flags() & CVAR_NOENABLEDISABLE)
+		flags.append("NOENABLEDISABLE");
+	if (cvar.flags() & CVAR_SERVERARCHIVE)
+		flags.append("SERVERARCHIVE");
+	if (cvar.flags() & CVAR_CLIENTARCHIVE)
+		flags.append("CLIENTARCHIVE");
+
+	// Emit fields in a fixed order: name, type, helptext, min, max, default,
+	// flags. min/max are only present for numeric cvars with a bound set.
+	const std::string field = indent + "   ";
+	std::string out;
+	out += indent + "{\n";
+	out += field + "\"name\" : " + JSONScalar(Json::Value(cvar.name())) + ",\n";
+	out += field + "\"type\" : " + JSONScalar(Json::Value(typestr)) + ",\n";
+	out += field + "\"helptext\" : " + JSONScalar(Json::Value(cvar.helptext())) + ",\n";
+
+	if (numeric && cvar.getMinValue() != -FLT_MAX)
+	{
+		Json::Value minv = (cvar.type() == CVARTYPE_FLOAT)
+		                       ? Json::Value(static_cast<double>(cvar.getMinValue()))
+		                       : Json::Value(static_cast<int>(cvar.getMinValue()));
+		out += field + "\"min\" : " + JSONScalar(minv) + ",\n";
+	}
+
+	if (numeric && cvar.getMaxValue() != FLT_MAX)
+	{
+		Json::Value maxv = (cvar.type() == CVARTYPE_FLOAT)
+		                       ? Json::Value(static_cast<double>(cvar.getMaxValue()))
+		                       : Json::Value(static_cast<int>(cvar.getMaxValue()));
+		out += field + "\"max\" : " + JSONScalar(maxv) + ",\n";
+	}
+
+	out += field + "\"default\" : " + JSONScalar(defval) + ",\n";
+	out += field + "\"flags\" : " + JSONScalar(flags) + "\n";
+	out += indent + "}";
+	return out;
+}
+
 BEGIN_COMMAND(cvardoc)
 {
 	std::string buffer;
@@ -297,3 +424,70 @@ BEGIN_COMMAND(cvardoc)
 	PrintFmt("Wrote {} bytes to \"{}\"\n", bytes, path);
 }
 END_COMMAND(cvardoc)
+
+BEGIN_COMMAND(cvardocjson)
+{
+	std::string path = M_GetWriteDir();
+	if (!M_IsPathSep(path.back()))
+	{
+		path += PATHSEP;
+	}
+
+#ifdef CLIENT_APP
+	path += "odamex_cvardoc.json";
+#elif defined(SERVER_APP)
+	path += "odasrv_cvardoc.json";
+#elif defined(TEST_APP)
+	path += "odagtest_cvardoc.json";
+#endif
+
+	// Try and open a file in our write directory.
+	FILE* fh = fopen(path.c_str(), "wt+");
+	if (fh == NULL)
+	{
+		PrintFmt("error: Could not open \"{}\" for writing.\n", path);
+		return;
+	}
+
+	// Build the cvar objects, each hand-ordered (array elements indent two
+	// levels under the document root).
+	std::vector<std::string> entries;
+	CvarView view = GetSortedCvarView();
+	for (const auto& cvar : view)
+	{
+		std::string obj = JSONCvarObject(*cvar, "      ");
+		if (obj.empty())
+			continue;
+		entries.push_back(obj);
+	}
+
+	// jsoncpp serializes object keys alphabetically, so we assemble the whole
+	// document by hand to keep the metadata first and the cvars array last.
+	std::string buffer;
+	buffer += "{\n";
+	buffer += fmt::sprintf("   \"schema_version\" : %d,\n", 1);
+	buffer += fmt::sprintf("   \"odamex_version\" : %s,\n",
+	                       Json::valueToQuotedString(DOTVERSIONSTR));
+	buffer += fmt::sprintf("   \"odamex_commithash\" : %s,\n",
+	                       Json::valueToQuotedString(GitHash()));
+	buffer += fmt::sprintf("   \"odamex_branchname\" : %s,\n",
+	                       Json::valueToQuotedString(GitBranch()));
+	buffer += "   \"cvars\" :\n";
+	buffer += "   [\n";
+	for (size_t i = 0; i < entries.size(); i++)
+	{
+		buffer += entries[i];
+		buffer += (i + 1 < entries.size()) ? ",\n" : "\n";
+	}
+	buffer += "   ]\n";
+	buffer += "}\n";
+
+	fwrite(buffer.data(), sizeof(char), buffer.size(), fh);
+
+	long bytes = ftell(fh);
+	fclose(fh);
+
+	// Success!
+	PrintFmt("Wrote {} bytes to \"{}\"\n", bytes, path);
+}
+END_COMMAND(cvardocjson)

--- a/documentation/cvardoc.schema-v1.json
+++ b/documentation/cvardoc.schema-v1.json
@@ -49,7 +49,7 @@
         "type": {
           "description": "Value type of the cvar.",
           "type": "string",
-          "enum": ["bool", "number", "float", "string"]
+          "enum": ["boolean", "integer", "number", "string"]
         },
         "helptext": {
           "description": "Human-readable description of the cvar.",
@@ -57,14 +57,14 @@
         },
         "default": {
           "description": "Default value, typed according to the cvar's type.",
-          "type": ["boolean", "number", "string"]
+          "type": ["boolean", "integer", "number", "string"]
         },
         "min": {
-          "description": "Minimum value; present only for 'number' and 'float' cvars that have a lower bound.",
+          "description": "Minimum value; present only for 'integer' and 'number' cvars that have a lower bound.",
           "type": "number"
         },
         "max": {
-          "description": "Maximum value; present only for 'number' and 'float' cvars that have an upper bound.",
+          "description": "Maximum value; present only for 'integer' and 'number' cvars that have an upper bound.",
           "type": "number"
         },
         "flags": {
@@ -88,7 +88,7 @@
       },
       "allOf": [
         {
-          "if": { "properties": { "type": { "const": "bool" } } },
+          "if": { "properties": { "type": { "const": "boolean" } } },
           "then": {
             "properties": { "default": { "type": "boolean" } },
             "not": { "anyOf": [{ "required": ["min"] }, { "required": ["max"] }] }
@@ -102,13 +102,13 @@
           }
         },
         {
-          "if": { "properties": { "type": { "const": "number" } } },
+          "if": { "properties": { "type": { "const": "integer" } } },
           "then": {
             "properties": { "default": { "type": "integer" } }
           }
         },
         {
-          "if": { "properties": { "type": { "const": "float" } } },
+          "if": { "properties": { "type": { "const": "number" } } },
           "then": {
             "properties": { "default": { "type": "number" } }
           }

--- a/documentation/cvardoc.schema-v1.json
+++ b/documentation/cvardoc.schema-v1.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://odamex.net/schemas/cvardoc.schema-v1.json",
+  "title": "Odamex CVAR Documentation",
+  "description": "Schema for the JSON produced by the 'cvardocjson' console command, which dumps every registered console variable.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "odamex_version",
+    "odamex_commithash",
+    "odamex_branchname",
+    "cvars"
+  ],
+  "properties": {
+    "schema_version": {
+      "description": "Version of this document format.",
+      "type": "integer",
+      "const": 1
+    },
+    "odamex_version": {
+      "description": "Odamex version in major.minor.patch form.",
+      "type": "string"
+    },
+    "odamex_commithash": {
+      "description": "Git commit hash of the build, or an empty string.",
+      "type": "string"
+    },
+    "odamex_branchname": {
+      "description": "Git branch name of the build, or an empty string.",
+      "type": "string"
+    },
+    "cvars": {
+      "description": "All registered console variables, sorted by name.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/cvar" }
+    }
+  },
+  "$defs": {
+    "cvar": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "helptext", "default", "flags"],
+      "properties": {
+        "name": {
+          "description": "Name of the console variable.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Value type of the cvar.",
+          "type": "string",
+          "enum": ["bool", "number", "float", "string"]
+        },
+        "helptext": {
+          "description": "Human-readable description of the cvar.",
+          "type": "string"
+        },
+        "default": {
+          "description": "Default value, typed according to the cvar's type.",
+          "type": ["boolean", "number", "string"]
+        },
+        "min": {
+          "description": "Minimum value; present only for 'number' and 'float' cvars that have a lower bound.",
+          "type": "number"
+        },
+        "max": {
+          "description": "Maximum value; present only for 'number' and 'float' cvars that have an upper bound.",
+          "type": "number"
+        },
+        "flags": {
+          "description": "Behavioral flags set on the cvar.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "USERINFO",
+              "SERVERINFO",
+              "NOSET",
+              "LATCH",
+              "UNSETTABLE",
+              "NOENABLEDISABLE",
+              "SERVERARCHIVE",
+              "CLIENTARCHIVE"
+            ]
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "bool" } } },
+          "then": {
+            "properties": { "default": { "type": "boolean" } },
+            "not": { "anyOf": [{ "required": ["min"] }, { "required": ["max"] }] }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "string" } } },
+          "then": {
+            "properties": { "default": { "type": "string" } },
+            "not": { "anyOf": [{ "required": ["min"] }, { "required": ["max"] }] }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "number" } } },
+          "then": {
+            "properties": { "default": { "type": "integer" } }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "float" } } },
+          "then": {
+            "properties": { "default": { "type": "number" } }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The `cvardocjson` command is a new command for Odamex to print out a json file containing a dictionary of cvars, their names, defaults, min and max's (if a number) help text and flags, if any. It is heavily inspired by the `cvardoc` command, hence its name.

The reason to do this is for external programs to have a dictionary of cvars, for example a future version of Odalaunch, so cvars on servers can have descriptions rather than just the name.

This would help any effort to create a "create server" dialog, and let server hosts make better judgements about what to configure. Or something that'd open an Odamex configuration file, to better know what its reading.

The code is a little funky because `jsoncpp` only seems to allow you to serialize in alphanumeric order only, and to get a custom order that makes a little more sense, you seem to have to craft the file yourself.

I also created a json schema file for this document. It should be updated if the json schema of this command is ever changed.