### PR TITLE
Client-only:  Predict weapon pickups only for consoleplayer

### DIFF
--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -1388,8 +1388,12 @@ void P_TouchSpecialThing(AActor& special, AActor& toucher)
 	if (delta > toucher.height || delta < lowerbound)
 		return;
 
-	// Only allow clients to predict touching weapons, not health, armor, etc
-	if (!serverside && (!cl_predictpickup || !P_SpecialIsWeapon(special)))
+	// Only allow clients to predict touching weapons, not health, armor, etc.
+	// Furthermore, they can only predict for themselves, no one else.
+	if (not serverside && not  (cl_predictpickup
+	                            and P_SpecialIsWeapon(special)
+	                            and toucher.player
+	                            and toucher.player->id == consoleplayer_id))
 		return;
 
 	// [Blair] Execute ZDoom thing specials on items that are picked up.


### PR DESCRIPTION
Odamex performs client-side prediction of weapon pickups.  Unfortunately that carries the risk of mispredictions.  If a misprediction happens for the local player, we roll it back.  If a mispredicted pickup happens due to predicted remote player motion, then the "false pickup" sticks.  When that happens, if it's a dropped weapon, its mobj is destroyed, effectively becoming completely invisible to the player even though it's still actually there on the server, and in any case, there's a false audio cue.

Instead of introducing new infrastructure or enhancing the existing rollback feature, the simplest, most error-proof solution is to stop predicting weapon pickups for remote players.  This brings weapon pickups in line with remote player armor, health, powerups, and other pickups.  The drawback is that a client's perception of other players' weapon pickups is potentially delayed by a few tics (approx half the ping time).

Before:

https://github.com/user-attachments/assets/eeba129b-47f2-4607-9fca-cd2778975330

After:


https://github.com/user-attachments/assets/86161067-07fc-429c-94c1-08a4a7ab5cbb

