### PR TITLE
Fix view jitter when netdemo is paused

### DIFF
--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -828,7 +828,7 @@ void R_SetupFrame (player_t *player)
 		memset (scalelightfixed, 0, MAXLIGHTSCALE*sizeof(*scalelightfixed));
 	}
 
-	if (use_localview && !::localview.skippitch)
+	if ((use_localview && !::localview.skippitch) || netdemo.isPaused())
 	{
 		R_ViewShear(clamp(camera->pitch - ::localview.pitch, -ANG(32), ANG(56)));
 	}


### PR DESCRIPTION
This fixes a jitter that happens sometimes when a netdemo is paused. Basically we don't want to interpolate the view shear when the demo is paused.

Test by watching the attached netdemo with 12.2.1 (your FPS needs to be > 35 to see the stutter), pause the demo while the player is flying around. If you dont see the stutter, step forward 1 tic until you do (right arrow). Playback with change to see the fix

Also you need to change the extension from txt to odd because of github reasons

[stutter.txt](https://github.com/user-attachments/files/29443622/stutter.txt)



