### PR TITLE
Fix netdemo not closing / HOM crash when starting a new game from a paused netdemo

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -359,7 +359,7 @@ void Host_EndGame(const char *msg)
 
 void CL_QuitNetGame2(const netQuitReason_e reason, const char* file, const int line)
 {
-	if(connected)
+	if(connected && !simulated_connection)
 	{
 		SZ_Clear(&net_buffer);
 		MSG_WriteMarker(&net_buffer, clc_disconnect);
@@ -411,7 +411,7 @@ void CL_QuitNetGame2(const netQuitReason_e reason, const char* file, const int l
 	if (netdemo.isRecording())
 		netdemo.stopRecording();
 
-	if (netdemo.isPlaying())
+	if (netdemo.isPlaying() || netdemo.isPaused())
 		netdemo.stopPlaying();
 
 	demoplayback = false;


### PR DESCRIPTION
If you play a netdemo, pause it, then hit escape and start a new game, you will see the bug. This fixes that