### PR TITLE
Add clang-tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,7 +49,7 @@ Checks: |
   # another one thats just noisy right now
   -readability-named-parameter,
   # we mostly use lowercase
-  readability-uppercase-literal-suffix,
+  -readability-uppercase-literal-suffix,
 CheckOptions:
   # Allow `if (pointer)`
   - key: readability-implicit-bool-conversion.AllowPointerConditions

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://www.schemastore.org/clang-tidy.json
+---
+Checks: |
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  modernize-*,
+  # this is really just style
+  -modernize-use-trailing-return-type,
+  # sometimes there are issues with the c++ versions of c headers
+  -modernize-deprecated-headers,
+  bugprone-*,
+  # we have too many of these that this will just end up noise
+  -bugprone-easily-swappable-parameters,
+  performance-*,
+  # this is just a little silly
+  -performance-enum-size
+  misc-*,
+  # again, so many of these that it's not worth it
+  -misc-non-private-member-variables-in-classes,
+  -misc-no-recursion,
+  cppcoreguidelines-macro-usage,
+  cppcoreguidelines-missing-std-forward,
+  cppcoreguidelines-prefer-member-initializer,
+  cppcoreguidelines-pro-type-const-cast,
+  cppcoreguidelines-pro-type-cstyle-cast,
+  cppcoreguidelines-pro-type-member-init,
+  cppcoreguidelines-pro-type-reinterpret-cast,
+  cppcoreguidelines-rvalue-reference-param-not-moved,
+  cppcoreguidelines-virtual-class-destructor,
+  google-default-arguments,
+  google-runtime-int,
+  readability-*,
+  # Our style guide says no braces for single line ifs is okay
+  -readability-braces-around-statements
+  -readability-identifier-length,
+  -readability-identifier-naming,
+  -readability-qualified-auto,
+  # who cares
+  -readability-avoid-const-params-in-decls,
+  # another one thats just noisy right now
+  -readability-named-parameter,
+CheckOptions:
+  # Allow `if (pointer)`
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: true
+  # Allow `if (integer)`
+  - key: readability-implicit-bool-conversion.AllowIntegerConditions
+    value: true
+  - key: cppcoreguidelines-rvalue-reference-param-not-moved.AllowPartialMove
+    value: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,11 @@ Checks: |
   misc-*,
   # again, so many of these that it's not worth it
   -misc-non-private-member-variables-in-classes,
+  # some annoying warnings about reasonable uses of recursion
   -misc-no-recursion,
+  # too many false positives
+  -misc-use-internal-linkage,
+  # cppcoreguidelines are a little too opinionated so lets whitelist instead of blacklist
   cppcoreguidelines-macro-usage,
   cppcoreguidelines-missing-std-forward,
   cppcoreguidelines-prefer-member-initializer,
@@ -32,6 +36,7 @@ Checks: |
   readability-*,
   # Our style guide says no braces for single line ifs is okay
   -readability-braces-around-statements
+  # another one that is lots of warnings right now
   -readability-identifier-length,
   -readability-identifier-naming,
   -readability-qualified-auto,
@@ -39,6 +44,8 @@ Checks: |
   -readability-avoid-const-params-in-decls,
   # another one thats just noisy right now
   -readability-named-parameter,
+  # we mostly use lowercase
+  readability-uppercase-literal-suffix,
 CheckOptions:
   # Allow `if (pointer)`
   - key: readability-implicit-bool-conversion.AllowPointerConditions

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,9 +35,11 @@ Checks: |
   google-runtime-int,
   readability-*,
   # Our style guide says no braces for single line ifs is okay
-  -readability-braces-around-statements
+  -readability-braces-around-statements,
+  # we have reasons to have sparsely initialized enums in a number of places
+  -readability-enum-initial-value,
   # the idea is cool, but its not really all that helpful
-  -readability-function-cognitive-complexity
+  -readability-function-cognitive-complexity,
   # another one that is lots of warnings right now
   -readability-identifier-length,
   -readability-identifier-naming,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,6 +36,8 @@ Checks: |
   readability-*,
   # Our style guide says no braces for single line ifs is okay
   -readability-braces-around-statements
+  # the idea is cool, but its not really all that helpful
+  -readability-function-cognitive-complexity
   # another one that is lots of warnings right now
   -readability-identifier-length,
   -readability-identifier-naming,
@@ -52,6 +54,8 @@ CheckOptions:
     value: true
   # Allow `if (integer)`
   - key: readability-implicit-bool-conversion.AllowIntegerConditions
+    value: true
+  - key: readability-implicit-bool-conversion.AllowLogicalOperatorConversions
     value: true
   - key: cppcoreguidelines-rvalue-reference-param-not-moved.AllowPartialMove
     value: true

--- a/common/c_cvars.h
+++ b/common/c_cvars.h
@@ -146,6 +146,8 @@ public:
 	[[nodiscard]] int asInt() const { return static_cast<int>(std::round(m_Value)); }
 	[[nodiscard]] bool asBool() const { return m_Value != 0; }
 
+	[[nodiscard]] explicit operator bool () const { return asBool(); }
+
 	inline void Callback (){ if (m_Callback) m_Callback (*this); }
 
 	void SetDefault (const char *value);

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -988,11 +988,11 @@ void AActor::Serialize (FArchive &arc)
 		}
 		spawnpoint.Serialize (arc);
 		baseline.Serialize(arc);
-		if (mobjinfo.find(type) == mobjinfo.end())
+		if (!mobjinfo.contains(type))
 		{
 			I_Error("AActor::Serialize: Unknown object type ({}) in saved game", type);
 		}
-		if (sprnames.find(sprite) == sprnames.end())
+		if (!sprnames.contains(sprite))
 		{
 			I_Error("AActor::Serialize: Unknown sprite ({}) in saved game", sprite);
 		}
@@ -1044,7 +1044,7 @@ bool P_SetMobjState(AActor *mobj, int32_t state, bool cl_update)
 
 	do
 	{
-		if (states.find(state) == states.end())
+		if (!states.contains(state))
 		{
 			I_Error("P_SetMobjState: State {} does not exist in state table.", state);
 		}


### PR DESCRIPTION
I tried to find a good balance between not being extremely noisy with warnings absolutely everywhere, but still fairly strict where it can be, to discourage bad practices/encourage continuing to modernize and clean up the codebase. Please feel free to provide feedback on any checks you think should be enabled/disabled differently from what I've done here.