### PR TITLE
Fix Avatar-related multi-touches and exponential item respawns

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1866,7 +1866,7 @@ static void CL_TouchSpecial(const odaproto::svc::TouchSpecial* msg)
 	uint32_t id = msg->netid();
 	AActor* mo = P_FindThingById(id);
 
-    player_t& player = consoleplayer();
+	player_t& player = consoleplayer();
 	if (not player.mo)
 		return;
 
@@ -1877,30 +1877,34 @@ static void CL_TouchSpecial(const odaproto::svc::TouchSpecial* msg)
 		return;
 	}
 
-    // Do a switcheroo of the new state for the historical state at the time of the pickup
-    // so that we can run the actual P_GiveSpecial function and let it produce the result
-    // of the pickup *at that old point in time*.  With that result in hand, we undo the
-    // switcheroo and resolve the potentially-modified history.
+	// Do a switcheroo of the new state for the historical state at the time of the pickup
+	// so that we can run the actual P_GiveSpecial function and let it produce the result
+	// of the pickup *at that old point in time*.  With that result in hand, we undo the
+	// switcheroo and resolve the potentially-modified history.
 
-    const int oldTic = msg->player_tic();
-    auto optionalHistory = rollerState.GetStateAtTic(oldTic);
+	const int oldTic = msg->player_tic();
+	auto optionalHistory = rollerState.GetStateAtTic(oldTic);
 	const PlayerItemDataType currentClientSideState {player};
 
-    if (optionalHistory)
-    {
-        optionalHistory->get().ToPlayer(player);
-    }
+	if (optionalHistory)
+	{
+		optionalHistory->get().ToPlayer(player);
+	}
 
-	P_GiveSpecial(player, *mo);
+	const ItemEquipVal giveResult = P_GiveSpecial(player, *mo);
+	if (giveResult == IEV_EquipRemove)
+	{
+		mo->Destroy();
+	}
 
-    if (optionalHistory)
-    {
-        const PlayerItemDataType modifiedHistory {player};
+	if (optionalHistory)
+	{
+		const PlayerItemDataType modifiedHistory {player};
 
-        currentClientSideState.ToPlayer(player);
+		currentClientSideState.ToPlayer(player);
 
-        rollerState.Resolve(oldTic, modifiedHistory, player);
-    }
+		rollerState.Resolve(oldTic, modifiedHistory, player);
+	}
 }
 
 // ---------------------------------------------------------------------------------------------------------

--- a/client/src/cl_replay.cpp
+++ b/client/src/cl_replay.cpp
@@ -186,7 +186,11 @@ void ClientReplay::itemReplay()
 		const weapontype_t weapontype = P_NameToWeapon(weaponname);
 		const bool weaponSwitch = P_CheckSwitchWeapon(player, weapontype);
 
-		P_GiveSpecial(player, *mo);
+		const ItemEquipVal giveResult = P_GiveSpecial(player, *mo);
+		if (giveResult == IEV_EquipRemove)
+		{
+			mo->Destroy();
+		}
 
 		replayed = true;
 

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -870,10 +870,10 @@ void P_PickupSound(const AActor *ent, int channel, const char *name)
 		S_Sound(ent, channel, name, 1, ATTN_NONE);
 }
 
-void P_GiveSpecial(player_t& player, AActor& special)
+ItemEquipVal P_GiveSpecial(player_t& player, AActor& special)
 {
 	if (!player.mo)
-		return;
+		return IEV_NotEquipped;
 
 	AActor *toucher = player.mo;
 	enum class SpecialSound
@@ -1308,14 +1308,14 @@ void P_GiveSpecial(player_t& player, AActor& special)
 				if (teamInfo->FlagSocketSprite == special.sprite)
 				{
 					SV_SocketTouch(player, teamInfo->Team);
-					return;
+					return val;
 				}
 			}
 
 			if (!teamItemSuccess)
 			{
 				PrintFmt(PRINT_HIGH, "P_SpecialThing: Unknown gettable thing {}: {}\n", special.sprite, special.info->name);
-				return;
+				return val;
 			}
 		}
 	}
@@ -1327,7 +1327,7 @@ void P_GiveSpecial(player_t& player, AActor& special)
 	}
 
 	if (val == IEV_NotEquipped)
-		return;
+		return val;
 
 	//the player equipped/picked up an item
 	player.bonuscount = BONUSADD;
@@ -1335,9 +1335,6 @@ void P_GiveSpecial(player_t& player, AActor& special)
 
 	if (msg != NULL)
 		PickupMessage(toucher, GStrings(*msg));
-
-	if (val == IEV_EquipRemove)
-		special.Destroy();
 
 	const AActor *ent = player.mo;
 	switch (sound)
@@ -1356,6 +1353,7 @@ void P_GiveSpecial(player_t& player, AActor& special)
 	default:
 		OUtil::unreachable();
 	}
+	return val;
 }
 
 
@@ -1408,15 +1406,25 @@ void P_TouchSpecialThing(AActor& special, AActor& toucher)
 
 	if (toucher.type == MT_AVATAR)
 	{
+		bool mustBeDestroyed = false;
 		PlayersView pr = PlayerQuery().execute().players;
 		for (const auto& player : pr)
 		{
-			P_GiveSpecial(*player, special);
+			const ItemEquipVal giveResult = P_GiveSpecial(*player, special);
+			mustBeDestroyed = mustBeDestroyed or giveResult == IEV_EquipRemove;
+		}
+		if (mustBeDestroyed)
+		{
+			special.Destroy();
 		}
 	}
 	else if (toucher.player)
 	{
-		P_GiveSpecial(*toucher.player, special);
+		const ItemEquipVal giveResult = P_GiveSpecial(*toucher.player, special);
+		if (giveResult == IEV_EquipRemove)
+		{
+			special.Destroy();
+		}
 	}
 }
 

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -343,7 +343,9 @@ extern std::set<short>	movable_sectors;
 extern std::array<int, NUMAMMO> maxammo;
 extern std::array<int, NUMAMMO> clipammo;
 
-void P_GiveSpecial(player_t& player, AActor& special);
+[[ nodiscard("Please check for whether the mobj must be destroyed!!") ]]
+ItemEquipVal P_GiveSpecial(player_t& player, AActor& special);
+
 void P_TouchSpecialThing (AActor& special, AActor& toucher);
 
 void P_DamageMobj (AActor *target, const AActor *inflictor, AActor *source, int damage, int mod=0, int flags=0);

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -554,6 +554,9 @@ void P_ClearId(uint32_t id)
 //
 void AActor::Destroy ()
 {
+	if (WasDestroyed())
+		return;
+
 	SV_SendDestroyActor(this);
 
 	actor_by_netid.erase(netid);


### PR DESCRIPTION
This PR fixes two bugs associated with items being touched by Avatars:

1. **Exponential item respawns**:  When an item is touched by an Avatar in a game with N players in-game, the item is queued up for respawn N times.  And then once respawned, each copy of the item causes another N copies to be enqueued, leading to an exponential growth in the mobj count and touches.
2. **Premature RemoveMobj message**:  When an item is touched by an Avatar in a game with N players in-game, only the first player actually perceives the touch, all others desync.  The desync is that the server has actually applied the effects of the touch to all players, but their clients' local mobj was deleted via RemoveMobj before they could handle it via TouchSpecial.

The fix ultimately is to defer the touched-item removal until after *all* touch processing for it is complete.

An earlier fix for bug 1 above was to add a check at the top of `AActor::Destroy` that verifies that the mobj hasn't already been destroyed.  The ultimate fix makes this unnecessary, but the check remains because it's a fairly fundamental sanity-check to ensure that we don't go through one-time mobj removal more than once.  Also, the same check is already happening in the parent class's `Destroy` function, which is called at the bottom of `AActor::Destroy`, so this brings AActor up to step with its parent.