### PR TITLE
Fix red pain incorrectly showing when switching to a remote player's POV with spynext 

### DIFF
--- a/client/src/cl_pred.cpp
+++ b/client/src/cl_pred.cpp
@@ -209,6 +209,24 @@ static void CL_PredictSpying()
 }
 
 //
+// CL_PredictRemotePlayers
+//
+//
+static void CL_PredictRemotePlayers()
+{
+	for (auto& player : players)
+	{
+		if (player.ingame() 
+			&& player.mo 
+			&& player.id != consoleplayer_id   // handled in CL_PredictWorld
+			&& player.id != displayplayer_id)  // handled in CL_PredictSpying
+		{
+			P_BumpPlayerCounters(player);
+		}
+	}
+}
+
+//
 // CL_PredictSpectator
 //
 //
@@ -274,6 +292,8 @@ void CL_PredictWorld(void)
 
 	if (consoleplayer_id != displayplayer_id)
 		CL_PredictSpying();
+
+	CL_PredictRemotePlayers();
 
 	// [SL] 2012-03-10 - Spectators can predict their position without server
 	// correction.  Handle them as a special case and leave.

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -104,6 +104,7 @@ void P_PlayerThink (player_t& player);
 void P_SetPlayerPowerupStatuses(player_t& player, nonstd::span<const int, NUMPOWERS> powers);
 bool P_AreTeammates(const player_t& a, const player_t& b);
 bool P_CanSpy(player_t &viewer, player_t &other, bool demo = false);
+void P_BumpPlayerCounters(player_t& player);
 
 //
 // P_MOBJ

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -1077,8 +1077,7 @@ void P_PlayerThink (player_t& player)
 		player.powers[pw_invulnerability]--;
 
 	if (player.powers[pw_invisibility])
-		if (! --player.powers[pw_invisibility] )
-			player.mo->flags &= ~MF_SHADOW;
+		player.powers[pw_invisibility]--;
 
 	if (player.powers[pw_infrared])
 		player.powers[pw_infrared]--;
@@ -1096,12 +1095,13 @@ void P_PlayerThink (player_t& player)
 		player.bonuscount--;
 
 	if (player.hazardcount)
-	{
 		player.hazardcount--;
-		if (!(::level.time % player.hazardinterval) &&
-		    player.hazardcount > 16 * TICRATE)
-			P_DamageMobj(player.mo, NULL, NULL, 5);
-	}
+
+	if (not player.powers[pw_invisibility] )
+		player.mo->flags &= ~MF_SHADOW;
+
+	if (player.hazardcount && not (::level.time % player.hazardinterval) && player.hazardcount > 16 * TICRATE)
+		P_DamageMobj(player.mo, NULL, NULL, 5);
 
 	// Handling colormaps.
 	if (displayplayer().powers[pw_invulnerability])

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -902,6 +902,36 @@ void P_SwitchSpyOnNoLives(const player_t& player)
 	}
 }
 
+void P_BumpPlayerCounters(player_t& player)
+{
+	// Counters, time dependent power ups.
+
+	// Strength counts up to diminish fade.
+	if (player.powers[pw_strength])
+		player.powers[pw_strength]++;
+
+	if (player.powers[pw_invulnerability])
+		player.powers[pw_invulnerability]--;
+
+	if (player.powers[pw_invisibility])
+		player.powers[pw_invisibility]--;
+
+	if (player.powers[pw_infrared])
+		player.powers[pw_infrared]--;
+
+	if (player.powers[pw_ironfeet])
+		player.powers[pw_ironfeet]--;
+
+	if (player.damagecount)
+		player.damagecount--;
+
+	if (player.bonuscount)
+		player.bonuscount--;
+
+	if (player.hazardcount)
+		player.hazardcount--;
+}
+
 void P_SetPlayerPowerupStatuses(player_t& player, nonstd::span<const int, NUMPOWERS> powers)
 {
 	if (!player.mo)
@@ -1067,38 +1097,13 @@ void P_PlayerThink (player_t& player)
 	// cycle psprites
 	P_MovePsprites (player);
 
-	// Counters, time dependent power ups.
+	P_BumpPlayerCounters(player);
 
-	// Strength counts up to diminish fade.
-	if (player.powers[pw_strength])
-		player.powers[pw_strength]++;
-
-	if (player.powers[pw_invulnerability])
-		player.powers[pw_invulnerability]--;
-
-	if (player.powers[pw_invisibility])
-		player.powers[pw_invisibility]--;
-
-	if (player.powers[pw_infrared])
-		player.powers[pw_infrared]--;
-
-	if (player.powers[pw_ironfeet])
-		player.powers[pw_ironfeet]--;
+	if (not player.powers[pw_invisibility])
+		player.mo->flags &= ~MF_SHADOW;
 
 	// For offline/chase cam
 	P_SetPlayerPowerupStatuses(player, player.powers);
-
-	if (player.damagecount)
-		player.damagecount--;
-
-	if (player.bonuscount)
-		player.bonuscount--;
-
-	if (player.hazardcount)
-		player.hazardcount--;
-
-	if (not player.powers[pw_invisibility] )
-		player.mo->flags &= ~MF_SHADOW;
 
 	if (player.hazardcount && not (::level.time % player.hazardinterval) && player.hazardcount > 16 * TICRATE)
 		P_DamageMobj(player.mo, NULL, NULL, 5);


### PR DESCRIPTION
This fixes #1767 which stems from V_DoPaletteEffects - because remote players' damagecount is not predicted (say after the svc_damageplayer message comes in).  Initially I was calling the entire P_PlayerThink for every remote player but that led to the dreaded lift sound bug.  Predicting the counters should be perfectly safe though

Test with this demo (switch to odd extension) and switch to the damaged player after red pain should have gone away
[red.txt](https://github.com/user-attachments/files/29522803/red.txt)
