### PR TITLE
Ensure a mobj's first client-side tic uses the correct animation tic

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1878,10 +1878,10 @@ bool CL_Connect()
 	messenger = OdaMessenger();
 	messenger.SetMaxRate(20);               // FIXME: total guess.
 	messenger.SetPacketsPerRetransmit(10);  // To align with the size of the traditional cmd buffer.
-    messenger.SetRetransmitDelay(0);        // This causes an immediate retransmit to relieve the risk of
-                                            // packet loss on commands from the client.  Reliability comes
-                                            // at the cost of _potential_ additionald latency, and the
-                                            // slight increase in packets/tic is worth latency mitigation...
+	messenger.SetRetransmitDelay(0);        // This causes an immediate retransmit to relieve the risk of
+	                                        // packet loss on commands from the client.  Reliability comes
+	                                        // at the cost of _potential_ additionald latency, and the
+	                                        // slight increase in packets/tic is worth latency mitigation...
 	// Rewind!
 	// CL_Connect is only called after we already know that the sequence is 0, so we can just let
 	// the messenger do its thing.

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -509,9 +509,8 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 
 	// Read other fields
 
-	uint32_t netid = msg->current().netid();
+	uint32_t netid  = msg->current().netid();
 	mobjtype_t type = static_cast<mobjtype_t>(msg->current().type());
-	statenum_t state = static_cast<statenum_t>(msg->current().statenum());
 
 	if (!mobjinfo.contains(type))
 		return;
@@ -519,7 +518,7 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 	P_ClearId(netid);
 
 	AActor* mo = new AActor(base.pos.x, base.pos.y, base.pos.z, type);
-	mo->baseline = base;
+	mo->baseline         = base;
 	mo->updatedDuringTic = gametic;
 
 	P_SetThingId(mo, netid);
@@ -637,9 +636,15 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 			mo->tics = 1;
 	}
 
-    if(state >= S_NULL && states.contains(state))
+	statenum_t statenum = static_cast<statenum_t>(msg->current().statenum());
+
+    if(statenum >= S_NULL && states.contains(statenum))
 	{
-		P_SetMobjState(mo, state);
+		P_SetMobjState(mo, statenum);
+
+		const int32_t tics = msg->current().tics();
+		mo->tics = tics ? tics : -1;
+
 	}
 
 	if (serverside && mo->flags & MF_COUNTKILL)

--- a/common/actor.h
+++ b/common/actor.h
@@ -615,6 +615,8 @@ public:
 	// Client: the tic on which this mobj received an UpdateMobj.
 	int updatedDuringTic;
 
+	// Server:  The tic on which this mobj was actually spawned. Used to for determining correct initial
+	//          state and rnd index to send to clients.  *Not communicated to the client.*
 	int spawnTic;
 
 	CredibilityState credibility;

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -450,6 +450,15 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 	// denis - sending state fixes monster ghosts appearing under doors
 	cur->set_statenum(mo->state->statenum);
 
+    // Tics can never be left at 0, because 0 means to proceed to the next state
+    // immediately before returning control back out of the state-advance code.
+    // Therefore we co-opt the zero / default state to mean -1, which is the
+    // "do not animate" value.
+    if (mo->tics > 0)
+    {
+		cur->set_tics(mo->tics);
+    }
+
 	// Special case:  Did we get spawned in earlier on this tic?  If so, there are some instances
 	// where a mobj spawns in via dehacked SpawnObject, but its frames / state sequencing is such
 	// that multiple states and special actions take effect in the very first RunThink operation.
@@ -463,6 +472,7 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 		// those cases where they AREN'T the same value that we're really after here.
 		cur->set_statenum(mo->info->spawnstate);
 		cur->set_rndindex(mo->spawnRndindex);
+		cur->set_tics    (states[mo->info->spawnstate].tics);
 	}
 
 	if (mo->type == MT_FOUNTAIN)

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -75,7 +75,7 @@ message UpdatePing
 	int32 ping = 2;
 }
 
-// svc_spawnmobj, svc_mobjinfo, svc_corpse
+// svc_spawnmobj
 message SpawnMobj
 {
 	Actor baseline = 1;


### PR DESCRIPTION
While this does have an obvious cosmetic impact, it also is part of an overall solution to ensuring that mobj actions associated with animation state actually fire in the same sequence as they would from the spawn-point forward.