### PR TITLE
Update vc++ redist urls

### DIFF
--- a/ci/win-release-x64.ps1
+++ b/ci/win-release-x64.ps1
@@ -140,7 +140,7 @@ function CopyFilesX64 {
         -Destination "${X64Dir}\"
 
     # Get VC++ Redist
-    Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "${X64Dir}\redist\vc_redist.x64.exe"
+    Invoke-WebRequest -Uri "https://aka.ms/vc14/vc_redist.x64.exe" -OutFile "${X64Dir}\redist\vc_redist.x64.exe"
 }
 
 function OutputsX64 {

--- a/ci/win-release-x86.ps1
+++ b/ci/win-release-x86.ps1
@@ -140,7 +140,7 @@ function CopyFilesX86 {
         -Destination "${X86Dir}\"
 
     # Get VC++ Redist
-    Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x86.exe" -OutFile "${X86Dir}\redist\vc_redist.x86.exe"
+    Invoke-WebRequest -Uri "https://aka.ms/vc14/vc_redist.x86.exe" -OutFile "${X86Dir}\redist\vc_redist.x86.exe"
 }
 
 function OutputsX86 {


### PR DESCRIPTION
The old urls have stopped being updated and currently point to v14.44.35211. The downloads have been reorganized and the new urls currently download v14.51.36247. With the GitHub Actions switching to VS2026, I'm pretty sure we should be including v14.50 or later.