### PR TITLE
Fix timing issues leading to severe tracer mispredictions

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1878,10 +1878,10 @@ bool CL_Connect()
 	messenger = OdaMessenger();
 	messenger.SetMaxRate(20);               // FIXME: total guess.
 	messenger.SetPacketsPerRetransmit(10);  // To align with the size of the traditional cmd buffer.
-    messenger.SetRetransmitDelay(0);        // This causes an immediate retransmit to relieve the risk of
-                                            // packet loss on commands from the client.  Reliability comes
-                                            // at the cost of _potential_ additionald latency, and the
-                                            // slight increase in packets/tic is worth latency mitigation...
+	messenger.SetRetransmitDelay(0);        // This causes an immediate retransmit to relieve the risk of
+	                                        // packet loss on commands from the client.  Reliability comes
+	                                        // at the cost of _potential_ additionald latency, and the
+	                                        // slight increase in packets/tic is worth latency mitigation...
 	// Rewind!
 	// CL_Connect is only called after we already know that the sequence is 0, so we can just let
 	// the messenger do its thing.

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -519,8 +519,9 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 	P_ClearId(netid);
 
 	AActor* mo = new AActor(base.pos.x, base.pos.y, base.pos.z, type);
-	mo->baseline = base;
+	mo->baseline         = base;
 	mo->updatedDuringTic = gametic;
+	mo->mobjtic          = msg->lifetime_tic();
 
 	P_SetThingId(mo, netid);
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -509,9 +509,8 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 
 	// Read other fields
 
-	uint32_t netid = msg->current().netid();
+	uint32_t netid  = msg->current().netid();
 	mobjtype_t type = static_cast<mobjtype_t>(msg->current().type());
-	statenum_t state = static_cast<statenum_t>(msg->current().statenum());
 
 	if (!mobjinfo.contains(type))
 		return;
@@ -638,9 +637,15 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 			mo->tics = 1;
 	}
 
-    if(state >= S_NULL && states.contains(state))
+	statenum_t statenum = static_cast<statenum_t>(msg->current().statenum());
+
+    if(statenum >= S_NULL && states.contains(statenum))
 	{
-		P_SetMobjState(mo, state);
+		P_SetMobjState(mo, statenum);
+
+		const int32_t tics = msg->current().tics();
+		mo->tics = tics ? tics : -1;
+
 	}
 
 	if (serverside && mo->flags & MF_COUNTKILL)

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -520,7 +520,7 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 	AActor* mo = new AActor(base.pos.x, base.pos.y, base.pos.z, type);
 	mo->baseline         = base;
 	mo->updatedDuringTic = gametic;
-	mo->mobjtic          = msg->lifetime_tic();
+	mo->mobjtic          = msg->timebase_tic();
 
 	P_SetThingId(mo, netid);
 
@@ -639,13 +639,13 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 
 	statenum_t statenum = static_cast<statenum_t>(msg->current().statenum());
 
-    if(statenum >= S_NULL && states.contains(statenum))
+	if (statenum >= S_NULL && states.contains(statenum))
 	{
 		P_SetMobjState(mo, statenum);
 
+		// Set animation tic to ensure that the initial state is consistent with the server.
 		const int32_t tics = msg->current().tics();
 		mo->tics = tics ? tics : -1;
-
 	}
 
 	if (serverside && mo->flags & MF_COUNTKILL)

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -56,6 +56,7 @@ void SV_ExplodeMissile(AActor *mo) {}
 void SV_PreservePlayer(player_t &player) {}
 void SV_BroadcastSector(int sectornum) {}
 void SV_UpdateMobj(AActor* mo) {}
+void SV_UpdateMobjBestEffort(AActor* mo) {}
 void SV_UpdateMobjState(const AActor* mo) {}
 
 void CTF_RememberFlagPos(const mapthing2_t& mthing) {}

--- a/common/actor.h
+++ b/common/actor.h
@@ -478,6 +478,7 @@ public:
 	~AActor () override;
 
 	void RunThink () override;
+	void PostThink() override;
 
     // Info for drawing: position.
     fixed_t		x;
@@ -616,6 +617,11 @@ public:
 	int updatedDuringTic;
 
 	int spawnTic;
+
+	//
+	// Client:  The monotonic "gametic" for this mobj - use this to perform mobj-internal timed operations
+	//          so that the predictions occur with the same order and delay that they do on the server.
+	int mobjtic;
 
 	CredibilityState credibility;
 

--- a/common/actor.h
+++ b/common/actor.h
@@ -616,6 +616,8 @@ public:
 	// Client: the tic on which this mobj received an UpdateMobj.
 	int updatedDuringTic;
 
+	// Server:  The tic on which this mobj was actually spawned. Used to for determining correct initial
+	//          state and rnd index to send to clients.  *Not communicated to the client.*
 	int spawnTic;
 
 	//

--- a/common/dthinker.cpp
+++ b/common/dthinker.cpp
@@ -267,7 +267,10 @@ void DThinker::RunThinkers ()
 	while (currentthinker)
 	{
 		if (!IndependentThinker(currentthinker))
+		{
 			currentthinker->RunThink();
+			currentthinker->PostThink();
+		}
 		currentthinker = currentthinker->m_Next;
 	}
 	END_STAT (ThinkCycles);

--- a/common/dthinker.h
+++ b/common/dthinker.h
@@ -63,6 +63,7 @@ public:
 	void Destroy () override;
 	~DThinker () override;
 	virtual void RunThink () {}
+	virtual void PostThink () {}
 
 	void *operator new (size_t size);
 	void operator delete (void *block);

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -117,6 +117,7 @@ void A_Fall (AActor *actor);
 void SV_UpdateMonsterRespawnCount();
 void SV_SendRaiseMobj(const AActor* source, const AActor* corpse);
 void SV_UpdateMobj(AActor* mo);
+void SV_UpdateMobjBestEffort(AActor* mo);
 void SV_Sound(const AActor* mo, byte channel, const char* name, byte attenuation);
 void SV_SpawnMobj(AActor* mobj);
 void SV_BroadcastNoiseAlert(const sector_t& sector);
@@ -2130,15 +2131,6 @@ void A_Tracer (AActor *actor)
 	if (demogametic & 3)
 		return;
 
-	// Because of how tricky it can be to keep the client-side predicted Tracer turns in
-	// a good-looking sync with the server, we opt to NOT predict the turns.  We still
-	// predict the linear motion, though.  The server will tell us when the missile is
-	// supposed to turn and also update position accordingly.
-//	if (not serverside)
-//	{
-//		return;
-//	}
-
 	if (serverside)
 	{
 		// spawn a puff of smoke behind the rocket
@@ -2201,6 +2193,21 @@ void A_Tracer (AActor *actor)
 		actor->momz -= FRACUNIT/8;
 	else
 		actor->momz += FRACUNIT/8;
+
+	if (serverside)
+	{
+		// Please note that it's very intentional that we do the best effort update here
+		// and still do the MT_TRACER check in the standard UpdateMobj missile checks on
+		// the server.  TLDR:  Just because something's an MT_TRACER doesn't necessarily
+		// mean it's going to run A_Tracer and vice versa.  We want to make sure that in
+		// all events, we send an appropriately-scheduled update, and in the worst case,
+		// we coincide this update with the check, which effectively skips the duplicate
+		// update.  One might think its a duplicated capability, but it's not really.
+		//
+		// This specific call is required to make sure we get elevated-rate updates for
+		// non-MT_TRACER mobjs that use A_Tracer.
+		SV_UpdateMobjBestEffort(actor);
+	}
 }
 
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2124,19 +2124,29 @@ void A_Tracer (AActor *actor)
 
 	// denis - demogametic must be 0-based, but from start of entire demo,
 	// not just this level!
+
 	extern int demostartgametic;
-	int demogametic = gametic - demostartgametic;
+	int demogametic = actor->mobjtic - demostartgametic;
 	if (demogametic & 3)
 		return;
 
-	// spawn a puff of smoke behind the rocket
-	if(serverside)
+	// Because of how tricky it can be to keep the client-side predicted Tracer turns in
+	// a good-looking sync with the server, we opt to NOT predict the turns.  We still
+	// predict the linear motion, though.  The server will tell us when the missile is
+	// supposed to turn and also update position accordingly.
+//	if (not serverside)
+//	{
+//		return;
+//	}
+
+	if (serverside)
 	{
+		// spawn a puff of smoke behind the rocket
 		P_SpawnTracerPuff(actor->x, actor->y, actor->z);
 
 		AActor* th = new AActor (actor->x - actor->momx,
-						 actor->y - actor->momy,
-						 actor->z, MT_SMOKE);
+		                         actor->y - actor->momy,
+		                         actor->z, MT_SMOKE);
 
 		th->momz = FRACUNIT;
 		th->tics -= P_Random (th)&3;
@@ -2152,9 +2162,9 @@ void A_Tracer (AActor *actor)
 
 	// change angle
 	angle_t exact = P_PointToAngle (actor->x,
-							 actor->y,
-							 dest->x,
-							 dest->y);
+	                                actor->y,
+	                                dest->x,
+	                                dest->y);
 
 	if (exact != actor->angle)
 	{
@@ -2179,7 +2189,7 @@ void A_Tracer (AActor *actor)
 
 	// change slope
 	fixed_t dist = P_AproxDistance (dest->x - actor->x,
-							dest->y - actor->y);
+	                                dest->y - actor->y);
 
 	dist = dist / actor->info->speed;
 

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -200,7 +200,8 @@ AActor::AActor()
       iprev(NULL), translation(translationref_t()), translucency(0), waterlevel(0),
       gear(0), onground(false), touching_sectorlist(NULL), deadtic(0), rndindex(0),
       spawnRndindex(0), friend_playerid(0), friend_teamid(TEAM_NONE), pursuecount(0), strafecount(0),
-      netid(0), tid(0), baseline(), baseline_set(false), updatedDuringTic(-1), spawnTic(gametic), bmapnode(this)
+      netid(0), tid(0), baseline(), baseline_set(false), updatedDuringTic(-1), spawnTic(gametic),
+      mobjtic(gametic), bmapnode(this)
 {
 	args.fill(0);
 	self.init(this);
@@ -228,7 +229,7 @@ AActor::AActor(const AActor& other)
       friend_playerid(other.friend_playerid), friend_teamid(other.friend_teamid),
       pursuecount(other.pursuecount), strafecount(other.strafecount), netid(other.netid), tid(other.tid),
       baseline_set(false), updatedDuringTic(other.updatedDuringTic), spawnTic(other.spawnTic),
-      credibility {other.credibility}, bmapnode(other.bmapnode)
+      mobjtic(other.mobjtic), credibility {other.credibility}, bmapnode(other.bmapnode)
 {
 	memcpy(&baseline, &other.baseline, sizeof(baseline));
 	self.init(this);
@@ -308,6 +309,7 @@ AActor &AActor::operator= (const AActor &other)
 
     updatedDuringTic = other.updatedDuringTic;
     spawnTic         = other.spawnTic;
+    mobjtic          = other.mobjtic;
     credibility      = other.credibility;
 
     return *this;
@@ -331,7 +333,7 @@ AActor::AActor(fixed_t ix, fixed_t iy, fixed_t iz, int32_t itype)
       gear(0), onground(false), touching_sectorlist(NULL), deadtic(0), rndindex(0),
       spawnRndindex(0), friend_playerid(0), friend_teamid(TEAM_NONE), pursuecount(0), strafecount(0),
       netid(0), tid(0), baseline(), baseline_set(false), updatedDuringTic(-1), spawnTic(gametic),
-      bmapnode(this)
+      mobjtic(gametic), bmapnode(this)
 {
 	// Fly!!! fix it in P_RespawnSpecial
 	const auto it = ::mobjinfo.find(itype);
@@ -816,6 +818,11 @@ void P_TestActorMovement(AActor *mo, fixed_t tryx, fixed_t tryy, fixed_t tryz,
 	backup.toActor(mo);
 }
 
+void AActor::PostThink()
+{
+	++mobjtic;
+}
+
 //
 // P_MobjThinker
 //
@@ -1023,6 +1030,7 @@ void AActor::Serialize (FArchive &arc)
 			<< spawnRndindex
 			<< updatedDuringTic
 			<< spawnTic
+			<< mobjtic
 			<< credibility;
 
 		// NOTE(jsd): This is pretty awful right here:
@@ -1111,6 +1119,7 @@ void AActor::Serialize (FArchive &arc)
 			>> spawnRndindex
 			>> updatedDuringTic
 			>> spawnTic
+			>> mobjtic
 			>> credibility;
 
 		tracer.init(tmptracer);

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -444,20 +444,27 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 		amom->set_z(mo->momz);
 	}
 
-	cur->set_type(mo->type);
-	cur->set_netid(mo->netid);
+	// Now set the basic current info.
 
-	// denis - sending state fixes monster ghosts appearing under doors
+	cur->set_type    (mo->type);
+	cur->set_netid   (mo->netid);
 	cur->set_statenum(mo->state->statenum);
 
-    // Tics can never be left at 0, because 0 means to proceed to the next state
-    // immediately before returning control back out of the state-advance code.
-    // Therefore we co-opt the zero / default state to mean -1, which is the
-    // "do not animate" value.
-    if (mo->tics > 0)
-    {
+	// Please note that we send the current gametic as the client's initial timebase for mobj-
+	// internal timing.  This ensures that any timed events for this mobj from this point
+	// forward are using the same timebase as the server.  Example:  whether or not A_Tracer
+	// does any actual tracing logic.
+	//
+	msg.set_timebase_tic(gametic);
+
+	// Animation state rics can never be left at 0, because 0 means to proceed to the next state
+	// immediately before returning control back out of the state-advance code.  Therefore we
+	// co-opt the zero / default state to mean -1, which is the "do not animate" value.
+	//
+	if (mo->tics > 0)
+	{
 		cur->set_tics(mo->tics);
-    }
+	}
 
 	// Special case:  Did we get spawned in earlier on this tic?  If so, there are some instances
 	// where a mobj spawns in via dehacked SpawnObject, but its frames / state sequencing is such
@@ -508,11 +515,6 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 		spawnFlags |= SVC_SM_OFLAGS;
 		cur->set_oflags(mo->oflags);
 	}
-
-	// Please note that we send the current gametic as the client's mobj-lifetime side timer tic value.
-	// this ensures that any timed events for this mobj from this point forward are using the same
-	// timebase as the server.
-	msg.set_lifetime_tic(gametic);
 
 	// animating corpses
 	if ((mo->flags & MF_CORPSE) && mo->state->statenum != S_GIBS)

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -499,6 +499,11 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 		cur->set_oflags(mo->oflags);
 	}
 
+	// Please note that we send the current gametic as the client's mobj-lifetime side timer tic value.
+	// this ensures that any timed events for this mobj from this point forward are using the same
+	// timebase as the server.
+	msg.set_lifetime_tic(gametic);
+
 	// animating corpses
 	if ((mo->flags & MF_CORPSE) && mo->state->statenum != S_GIBS)
 	{

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -450,6 +450,15 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 	// denis - sending state fixes monster ghosts appearing under doors
 	cur->set_statenum(mo->state->statenum);
 
+    // Tics can never be left at 0, because 0 means to proceed to the next state
+    // immediately before returning control back out of the state-advance code.
+    // Therefore we co-opt the zero / default state to mean -1, which is the
+    // "do not animate" value.
+    if (mo->tics > 0)
+    {
+		cur->set_tics(mo->tics);
+    }
+
 	// Special case:  Did we get spawned in earlier on this tic?  If so, there are some instances
 	// where a mobj spawns in via dehacked SpawnObject, but its frames / state sequencing is such
 	// that multiple states and special actions take effect in the very first RunThink operation.
@@ -463,6 +472,7 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 		// those cases where they AREN'T the same value that we're really after here.
 		cur->set_statenum(mo->info->spawnstate);
 		cur->set_rndindex(mo->spawnRndindex);
+		cur->set_tics    (states[mo->info->spawnstate].tics);
 	}
 
 	if (mo->type == MT_FOUNTAIN)

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -75,15 +75,16 @@ message UpdatePing
 	int32 ping = 2;
 }
 
-// svc_spawnmobj, svc_mobjinfo, svc_corpse
+// svc_spawnmobj
 message SpawnMobj
 {
-	Actor baseline = 1;
-	uint32 baseline_flags = 2;
-	Actor current = 3;
-	uint32 spawn_flags = 4;
-	uint32 target_netid = 5;
-	repeated int32 args = 6;
+	Actor           baseline        = 1;
+	uint32          baseline_flags  = 2;
+	Actor           current         = 3;
+	uint32          spawn_flags     = 4;
+	uint32          target_netid    = 5;
+	repeated int32  args            = 6;
+	uint32          lifetime_tic    = 7;
 }
 
 // svc_disconnectclient

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -84,7 +84,7 @@ message SpawnMobj
 	uint32          spawn_flags     = 4;
 	uint32          target_netid    = 5;
 	repeated int32  args            = 6;
-	uint32          lifetime_tic    = 7;
+	uint32          timebase_tic    = 7;
 }
 
 // svc_disconnectclient

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3119,8 +3119,9 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 		// Revenant tracers and Mancubus fireballs need to be updated more often (and custom tracers)
 		const bool needsMoreFrequentUpdates = (mo->type == MT_TRACER || mo->type == MT_FATSHOT || mo->flags2 & MF2_SEEKERMISSILE);
 
-		const int  divisor = needsMoreFrequentUpdates ? 5 : 30;
-		const int  phase   = (gametic + mo->netid) % divisor;
+		const int divisor   = needsMoreFrequentUpdates ? 4 : 30;
+		const int updateTic = mo->type == MT_TRACER ? mo->mobjtic - 1 : gametic + mo->netid;
+		const int phase     = updateTic % divisor;
 
 		// Does this mobj have a scheduled update now?
 		if (phase == 0)
@@ -3133,6 +3134,7 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 
 				default:
 					MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobj(*mo));
+					break;
 			}
 		}
 	}

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3128,6 +3128,11 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 		// a rate divisor of 4 and the frame count being the mobjtic value that it had on this tic.
 		// In other words, we subtract 1 because the mobjtic was incremented after RunThink.
 
+		// On top of all that, we have to make this check anyway because if something's an MT_TRACER,
+		// but has been specially dehacked to use a thinker routine other than A_Tracer, we want to
+		// ensure that it still gets an appropriately-scheduled, elevated update cycle.  Please note
+		// that there's a counter-part check in A_Tracer that covers the opposite case.
+
 		const int updateTic = mo->type == MT_TRACER ? mo->mobjtic - 1       // rev shot?  update right away.
 		                                            : gametic + mo->netid;  // Anything else?  Be fair with the bandwidth.
 		const int divisor   = needsMoreFrequentUpdates ? 4 : 30;
@@ -3149,18 +3154,19 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 	}
 }
 
-// Update the given actors data immediately.
-void SV_UpdateMobj(AActor* mo)
+static void ImmediateUpdateMobj(AActor& mobj, bool reliableIsAllowed)
 {
 	// Don't use this function to update players.
-	if (mo->player)
+	if (mobj.player)
 		return;
+
+	auto message = SVC_UpdateMobj(mobj);
 
 	for (auto& player : players)
 	{
-		if (player.ingame() and SV_IsPlayerAllowedToSee(player, mo))
+		if (player.ingame() and SV_IsPlayerAllowedToSee(player, &mobj))
 		{
-			switch (mo->playersAware.Get(player.id))
+			switch (mobj.playersAware.Get(player.id))
 			{
 				case AwarenessEnum::NOT_AWARE:         [[ fallthrough ]];
 				case AwarenessEnum::BARELY_AWARE:
@@ -3168,16 +3174,30 @@ void SV_UpdateMobj(AActor* mo)
 
 				case AwarenessEnum::ALWAYS_AWARE:      [[ fallthrough ]];
 				case AwarenessEnum::FULLY_AWARE:
-					mo->updatedDuringTic = gametic;
-					MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_UpdateMobj(*mo));
+					mobj.updatedDuringTic = gametic;
+					MSG_WriteSVC(reliableIsAllowed ? player.client.messenger.ReliableBuf()
+					                               : player.client.messenger.NetBuf(),
+					             message);
 					break;
 
 				case AwarenessEnum::SEMI_AWARE:
-					mo->updatedDuringTic = gametic;
-					MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobj(*mo));
+					mobj.updatedDuringTic = gametic;
+					MSG_WriteSVC(player.client.messenger.NetBuf(), message);
 			}
 		}
 	}
+}
+
+// Update the given actors data immediately, using standard Reliable and Best-effort transports as appropriate.
+void SV_UpdateMobj(AActor* mo)
+{
+	ImmediateUpdateMobj(*mo, true);
+}
+
+// Update the given actors data immediately, ONLY using Best-effort transport.
+void SV_UpdateMobjBestEffort(AActor* mo)
+{
+	ImmediateUpdateMobj(*mo, false);
 }
 
 // Update the given actors state immediately.

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3116,14 +3116,23 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 		if (mo->type == MT_PLASMA)
 			return;
 
-		// Revenant tracers and Mancubus fireballs need to be updated more often (and custom tracers)
-		const bool needsMoreFrequentUpdates = (mo->type == MT_TRACER || mo->type == MT_FATSHOT || mo->flags2 & MF2_SEEKERMISSILE);
+		// Revenant tracers, seekers, and Mancubus fireballs need to be updated more often.
+		const bool needsMoreFrequentUpdates = (mo->type  == MT_TRACER
+		                                    or mo->type  == MT_FATSHOT
+		                                    or mo->flags2 & MF2_SEEKERMISSILE);
 
+		// There's special knowledge about Revenant tracers here.  We try hard to keep their
+		// server->client updates such that client-visible behavior is as vanilla-like as possible.
+		// Specifically we send out their updates immediately after the A_Tracer logic should have
+		// run and applied (if it's going to apply - see the funky timing logic there).  This means
+		// a rate divisor of 4 and the frame count being the mobjtic value that it had on this tic.
+		// In other words, we subtract 1 because the mobjtic was incremented after RunThink.
+
+		const int updateTic = mo->type == MT_TRACER ? mo->mobjtic - 1       // rev shot?  update right away.
+		                                            : gametic + mo->netid;  // Anything else?  Be fair with the bandwidth.
 		const int divisor   = needsMoreFrequentUpdates ? 4 : 30;
-		const int updateTic = mo->type == MT_TRACER ? mo->mobjtic - 1 : gametic + mo->netid;
 		const int phase     = updateTic % divisor;
 
-		// Does this mobj have a scheduled update now?
 		if (phase == 0)
 		{
 			switch (awarenessLevel)
@@ -5144,28 +5153,28 @@ void SV_ExplodeMissile(AActor *mo)
 {
 	for (auto& player : players)
 	{
-        switch (mo->playersAware.Get(player.id))
-        {
-            case AwarenessEnum::NOT_AWARE:                             // See nothing.
+		switch (mo->playersAware.Get(player.id))
+		{
+			case AwarenessEnum::NOT_AWARE:                             // See nothing.
 				break;
 
-            case AwarenessEnum::ALWAYS_AWARE:  [[ fallthrough ]];      // See everything.
-            case AwarenessEnum::FULLY_AWARE:
+			case AwarenessEnum::ALWAYS_AWARE:  [[ fallthrough ]];      // See everything.
+			case AwarenessEnum::FULLY_AWARE:
 				mo->updatedDuringTic = gametic;
 				MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_UpdateMobj(*mo));
 				MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_ExplodeMissile(*mo));
 				break;
 
-            case AwarenessEnum::SEMI_AWARE:                            // See an explosion, maybe even in the correct position.
+			case AwarenessEnum::SEMI_AWARE:                            // See an explosion, maybe even in the correct position.
 				mo->updatedDuringTic = gametic;
 				MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobj(*mo));
 				MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_ExplodeMissile(*mo));
 				break;
 
-            case AwarenessEnum::BARELY_AWARE:                          // See an explosion, almost certainly in the wrong position.
+			case AwarenessEnum::BARELY_AWARE:                          // See an explosion, almost certainly in the wrong position.
 				MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_ExplodeMissile(*mo));
 				break;
-        }
+		}
 	}
 }
 

--- a/tests/unit-tests/src/t_stubs.cpp
+++ b/tests/unit-tests/src/t_stubs.cpp
@@ -101,6 +101,7 @@ void SV_SendPlayerInfo(player_t &player) {}
 void SV_PreservePlayer(player_t &player) {}
 void SV_BroadcastSector(int sectornum) {}
 void SV_UpdateMobj(AActor* mo) {}
+void SV_UpdateMobjBestEffort(AActor* mo) {}
 void SV_UpdateMobjState(const AActor* mo) {}
 
 void CTF_RememberFlagPos(const mapthing2_t& mthing) {}


### PR DESCRIPTION
### Overview

This PR updates the server timing logic so that all `MT_TRACER`s and any other kind of mobj that goes through the `A_Tracer` state action are updated from server to client on the tic that a direction or angle change was applied.

Additionally, it updates the mobj infrastructure so that the client performs its A_Tracer prediction on the same *relative* tic as the server.  This ensures that the 4-tic cadence of tracer actions is consistent and doesn't jitter, except when actual network jitter occurs.

### Details

Huge credit to Gobolt for identifying the underlying mechanism of this bug.

The A_Tracer action has a modulus-4 check (micro-optimized as a bitwise AND 3) against the tic number as to whether or not it should actually do anything.  If this action is scheduled to run at ***any*** major frame, it creates the possibility that the check will never pass, leading to some missiles being tracers and some not.  (Since Revenants schedule the action with a 2-tic major frame, this happens with their shots.)

The major problem comes from the tic value being checked for the tracer action being different between client and server.  The end result is that one treats the missile as a tracer and the other does not.  This can cause severe visible stutters on any revenant rocket, regardless of whether the client sees it as a tracer or not.  The effect is especially bad on dehacked tracers where a non-`MT_TRACER` mobj is sent through the `A_Tracer` state action, where the misprediction is allowed to stick for up to 30 tics.

### The fix

The fix is to:

1. Increase the standard UpdateMobj rate for `MT_TRACER`S to be 4-tic interval (8.75 Hz) instead of 5-tic (7 Hz),
2. Add an explicit best-effort UpdateMobj on tics that `A_Tracer` runs, to coincide with (thus skip) the standard check,
3. Communicate the mobj's client timebase tic from the server upon spawn so that clients can predict the tracer action accurately and consistently with the server.

Furthermore, the communication of the timebase in theory allows the client to keep any future major-frame-and-phased predictions consistent with the server.

### PLEASE NOTE - upcoming optimization and lower-level protocol update

Because this adds a tic value to the SpawnMobj, thus increasing the bandwidth burden on already-heavily-loaded servers, and in conjunction with other messages that have the same needs, this provides the impetus for finally going in and adding two new fields to the *packet* header:

- Originator tic  (the sender's tic that an outgoing packet's data was valid - i.e. `gametic`)
- Receiver tic of validity  (the sender's most-recently-received tic from the message's destination at the time that the outgoing data was generated - i.e. `player.tic` or `lastsvgametic`)

And retire / slim-down / repurpose the svc_servergametic message as a health status and metrics message.