### PR TITLE
Apply bossaction linespecials using a copy of line 0

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -3608,7 +3608,9 @@ void A_BossDeath(AActor *actor)
 					continue;
 				}
 
-				line_t ld;
+				// De-facto UMAPINFO standard interpretation: activate the bossaction linespecial
+				// as though it's associated with line 0.
+				line_t ld = lines[0];
 
 				if (map_format.getZDoom())
 				{


### PR DESCRIPTION
This brings Odamex in line with other source ports' interpretation of the UMAPINFO standard, as discussed in the Discord oda-development channel.

More urgently, it resolves a crash experienced in NT2F map22, where a bossaction has a linespecial of `27074`, which calls for a change of floor texture.  Because there is no *explicit* line associated with that special (nor does the standard allow for one), it's a matter of interpretation as to which sector's texture to source for the target tagged sector.  After discussing with Elf Alchemist, the common but undocumented approach is to use a copy of line 0 as the special's starting point.  So now we do that here, and this should avoid any additional undefined behavior owing to linespecials that require information from actual, real lines.