### PR TITLE
[BUGFIX] Odalaunch crashes when multiple launched clients running at the same time are closed

### DIFF
--- a/odalaunch/src/dlg_main.cpp
+++ b/odalaunch/src/dlg_main.cpp
@@ -156,9 +156,6 @@ dlgMain::dlgMain(wxWindow* parent, wxWindowID id)
 	wxIcon MainIcon;
 	bool GetListOnStart, LoadChatOnLS, CheckForUpdates;
 
-	// Allows us to auto-refresh the list due to the client not being run
-	m_ClientIsRunning = false;
-
 	// Loads the frame from the xml resource file
 	wxXmlResource::Get()->LoadFrame(this, parent, "dlgMain");
 
@@ -722,9 +719,13 @@ void dlgMain::OnTimer(wxTimerEvent& event)
 // Called when the odamex client process terminates
 void dlgMain::OnProcessTerminate(wxProcessEvent& event)
 {
-	m_ClientIsRunning = false;
+	const int pid = event.GetPid();
 
-	delete m_Process;
+    auto it = m_Processes.find(pid);
+    if (it != m_Processes.end())
+	{
+		m_Processes.erase(it);
+	}
 }
 
 // Posts a message from the main thread to the monitor thread
@@ -1506,12 +1507,17 @@ void dlgMain::LaunchGame(const wxString& Address, const wxString& ODX_Path,
 	}
 
 	// Redirect I/O of child process under non-windows platforms
-	m_Process = new wxProcess(this, wxPROCESS_REDIRECT);
-
-	m_ClientIsRunning = true;
-
-	if(wxExecute(CmdLine, wxEXEC_ASYNC, m_Process) <= 0)
-		wxMessageBox(wxString::Format(MsgStr, BinName.c_str()));
+	auto proc = std::make_unique<wxProcess>(this, wxPROCESS_REDIRECT);
+	const auto pid = wxExecute(CmdLine, wxEXEC_ASYNC, proc.get());
+	if(pid <= 0)
+	{
+		wxMessageBox(wxString::Format(MsgStr, BinName));
+	}
+	else
+	{
+		// for some reason exExecute returns a long but wxProcessEvent::GetPid returns an int
+		m_Processes.emplace(static_cast<int>(pid), std::move(proc));
+	}
 }
 
 

--- a/odalaunch/src/dlg_main.h
+++ b/odalaunch/src/dlg_main.h
@@ -49,6 +49,7 @@
 
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 #include "query_thread.h"
 #include "net_packet.h"
@@ -124,9 +125,9 @@ protected:
 	wxInt32 FindServer(wxString);
 	wxInt32 GetSelectedServerArrayIndex();
 
-	bool ClientIsRunning()
+	bool ClientIsRunning() const
 	{
-		return m_ClientIsRunning;
+		return !m_Processes.empty();
 	};
 
 	void LaunchGame(const wxString& Address, const wxString& ODX_Path,
@@ -144,10 +145,9 @@ protected:
 	wxSearchCtrl* m_SrchCtrlGlobal;
 
 	wxStatusBar* m_StatusBar;
-	wxProcess* m_Process;
+	std::unordered_map<int, std::unique_ptr<wxProcess>> m_Processes;
 
 	bool m_UpdateCheckWasAutomatic = false;
-	bool m_ClientIsRunning;
 
 	OdaInfoBar *InfoBar;
 


### PR DESCRIPTION
Previously it would only remember the most recently spawned process, and try to `delete` the pointer to that `wxProcess` for each client closed. Now every process is tracked in a map, looking up the correct one by the pid obtained from the `wxProcessEvent`