### PR TITLE
Add +FLOATBOB support

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -517,7 +517,16 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 
 	P_ClearId(netid);
 
-	AActor* mo = new AActor(base.pos.x, base.pos.y, base.pos.z, type);
+	const bool floatbob = (mobjinfo[type].flags2 & MF2_FLOATBOB);
+	// Spawn on the floor first so special1 can store the bob center offset.
+	AActor* mo = new AActor(base.pos.x, base.pos.y, floatbob ? ONFLOORZ : base.pos.z, type);
+	if (floatbob)
+	{
+		mo->UnlinkFromWorld();
+		mo->z = base.pos.z;
+		mo->special1 = mo->z - mo->floorz;
+		mo->LinkToWorld();
+	}
 	mo->baseline         = base;
 	mo->updatedDuringTic = gametic;
 	mo->mobjtic          = msg->timebase_tic();
@@ -550,6 +559,8 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 			mo->ceilingz = P_CeilingHeight(mo);
 			mo->dropoffz = mo->floorz;
 			mo->floorsector = mo->subsector->sector;
+			if (floatbob)
+				mo->special1 = mo->z - mo->floorz;
 		}
 	}
 
@@ -1133,6 +1144,8 @@ static void CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg)
 	else
 	{
 		CL_MoveThing(mo, update.pos.x, update.pos.y, update.pos.z);
+		if ((flags & baseline_t::POSZ) && (mo->flags2 & MF2_FLOATBOB))
+			mo->special1 = mo->z - mo->floorz;
 		mo->angle = update.angle;
 		mo->momx = update.mom.x;
 		mo->momy = update.mom.y;

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -843,6 +843,18 @@ static bool PIT_CheckThing (AActor *thing)
 		         (tmthing->flags & MF_SOLID || (demoplayback || !co_boomphys)));
 }
 
+// Odamex does not have ZDoom's later "acts like a bridge" flag.  Keep this
+// local to the +FLOATBOB bridge check so other special things are not affected.
+static bool P_IsBridgeMobj(const AActor* thing)
+{
+	return thing &&
+	       (thing->type == MT_BRIDGE ||
+	        thing->type == MT_BRIDGE32 ||
+	        thing->type == MT_BRIDGE16 ||
+	        thing->type == MT_BRIDGE8 ||
+	        thing->type == MT_ZDOOMBRIDGE);
+}
+
 // This routine checks for Lost Souls trying to be spawned		// phares
 // across 1-sided lines, impassible lines, or "monsters can't	//   |
 // cross" lines. Draw an imaginary line between the PE			//   V
@@ -901,6 +913,9 @@ bool PIT_CheckOnmobjZ (AActor *thing)
 
 	// [RH] Corpses and specials don't block moves
 	if (thing->flags & (MF_CORPSE|MF_SPECIAL))
+		return true;
+
+	if ((tmthing->flags & MF_SPECIAL) && !P_IsBridgeMobj(thing))
 		return true;
 
 	// Don't clip against self
@@ -1138,6 +1153,8 @@ AActor *P_CheckOnmobj (AActor *thing)
 	bool good;
 
 	oldz = thing->z;
+	if (thing->flags2 & MF2_FLOATBOB)
+		thing->z = thing->floorz + thing->special1; // test from the bob center
 	P_FakeZMovement (thing);
 	good = P_TestMobjZ (thing);
 	thing->z = oldz;
@@ -1153,7 +1170,8 @@ bool P_TestMobjZ (AActor *actor)
 	if (actor->flags & MF_NOCLIP)
 		return true;
 
-	if (!(actor->flags & MF_SOLID))
+	if (!(actor->flags & MF_SOLID) &&
+	    !((actor->flags & MF_SPECIAL) && (actor->flags2 & MF2_FLOATBOB)))
 		return true;
 
 	tmx = x = actor->x;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -624,6 +624,43 @@ fixed_t P_CalculateMinMom(const AActor *mo)
 }
 
 //
+// Floating item bobbing
+//
+// [RV] +FLOATBOB actors use the common ZDoom offset table.  
+// special1 stores the center offset from the floor.
+// The table supplies the visual bob.
+//
+static constexpr fixed_t FloatBobOffsets[64] =
+{
+	0, 51389, 102283, 152192,
+	200636, 247147, 291278, 332604,
+	370727, 405280, 435929, 462380,
+	484378, 501712, 514213, 521763,
+	524287, 521763, 514213, 501712,
+	484378, 462380, 435929, 405280,
+	370727, 332604, 291278, 247147,
+	200636, 152192, 102283, 51389,
+	-1, -51390, -102284, -152193,
+	-200637, -247148, -291279, -332605,
+	-370728, -405281, -435930, -462381,
+	-484380, -501713, -514215, -521764,
+	-524288, -521764, -514214, -501713,
+	-484379, -462381, -435930, -405280,
+	-370728, -332605, -291279, -247148,
+	-200637, -152193, -102284, -51389
+};
+
+static fixed_t P_FloatBobOffset(const AActor* mo)
+{
+	return FloatBobOffsets[(mo->rndindex + level.time) & 63];
+}
+
+static fixed_t P_FloatBobCenterZ(const AActor* mo)
+{
+	return mo->floorz + mo->special1;
+}
+
+//
 // P_MoveActor
 //
 // Tries to move an actor based on its momentum while performing
@@ -682,13 +719,15 @@ void P_MoveActor(AActor *mo)
 		return;		// actor was destroyed
 
 	if (mo->flags2 & MF2_FLOATBOB)
-	{ // Floating item bobbing motion (special1 is height)
-		mo->z = mo->floorz + mo->special1;
+	{
+		mo->z = P_FloatBobCenterZ(mo) + P_FloatBobOffset(mo);
 	}
-	if ((mo->z != mo->floorz) || mo->momz || BlockingMobj)
+	if (mo->momz || BlockingMobj ||
+	    (mo->z != mo->floorz &&
+	     (!(mo->flags2 & MF2_FLOATBOB) || P_FloatBobCenterZ(mo) != mo->floorz)))
 	{
 		// Handle Z momentum and gravity
-		if (P_AllowPassover() && (mo->flags2 & MF2_PASSMOBJ))
+		if (P_AllowPassover() && ((mo->flags2 & MF2_PASSMOBJ) || (mo->flags & MF_SPECIAL)))
 		{
 			if (!(onmo = P_CheckOnmobj(mo)))
 			{
@@ -715,7 +754,15 @@ void P_MoveActor(AActor *mo)
 						mo->player->deltaviewheight =
 						    (VIEWHEIGHT - mo->player->viewheight) >> 3;
 					}
-					mo->z = onmo->z + onmo->height;
+					if (mo->flags2 & MF2_FLOATBOB)
+					{
+						mo->special1 = onmo->z + onmo->height - mo->floorz;
+						mo->z = P_FloatBobCenterZ(mo) + P_FloatBobOffset(mo);
+					}
+					else
+					{
+						mo->z = onmo->z + onmo->height;
+					}
 				}
 
 				mo->flags2 |= MF2_ONMOBJ;
@@ -738,7 +785,8 @@ void P_MoveActor(AActor *mo)
 		// killough 9/12/98: objects fall off ledges if they are hanging off
 		// slightly push off of ledge if hanging more than halfway off
 		// [RH] Be more restrictive to avoid pushing monsters/players down steps
-		if (!(mo->flags & MF_NOGRAVITY) && (mo->z > mo->dropoffz) && P_AllowDropOff())
+		if (!(mo->flags & MF_NOGRAVITY) && !(mo->flags2 & MF2_FLOATBOB) &&
+			(mo->z > mo->dropoffz) && P_AllowDropOff())
 		{
 			P_ApplyTorque(mo); // Apply torque
 		}
@@ -2864,8 +2912,7 @@ void P_RespawnSpecials (void)
 		mo->z -= mthing.z << FRACBITS;
 
 	if (mo->flags2 & MF2_FLOATBOB)
-	{ // Seed random starting index for bobbing motion
-		mo->health = M_Random();
+	{
 		mo->special1 = mthing.z << FRACBITS;
 	}
 
@@ -3331,8 +3378,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 	mobj->spawnpoint = mthing;
 
 	if (mobj->flags2 & MF2_FLOATBOB)
-	{ // Seed random starting index for bobbing motion
-		mobj->health = M_Random();
+	{
 		mobj->special1 = mthing.z << FRACBITS;
 	}
 
@@ -3545,7 +3591,7 @@ void P_SetMobjBaseline(AActor& mo)
 
 	mo.baseline.pos.x = mo.x;
 	mo.baseline.pos.y = mo.y;
-	mo.baseline.pos.z = mo.z;
+	mo.baseline.pos.z = (mo.flags2 & MF2_FLOATBOB) ? P_FloatBobCenterZ(&mo) : mo.z;
 	mo.baseline.mom.x = mo.momx;
 	mo.baseline.mom.y = mo.momy;
 	mo.baseline.mom.z = mo.momz;
@@ -3574,7 +3620,8 @@ uint32_t P_GetMobjBaselineFlags(const AActor& mo)
 	{
 		flags |= baseline_t::POSY;
 	}
-	if (mo.baseline.pos.z != mo.z)
+	const fixed_t z = (mo.flags2 & MF2_FLOATBOB) ? P_FloatBobCenterZ(&mo) : mo.z;
+	if (mo.baseline.pos.z != z)
 	{
 		flags |= baseline_t::POSZ;
 	}

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -405,7 +405,8 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 	}
 	if (bflags & baseline_t::POSZ)
 	{
-		apos->set_z(mo->z);
+		// Send the bob center, not the per-tic visual offset.
+		apos->set_z((mo->flags2 & MF2_FLOATBOB) ? mo->floorz + mo->special1 : mo->z);
 	}
 	if (bflags & baseline_t::ANGLE)
 	{
@@ -648,7 +649,8 @@ odaproto::svc::UpdateMobj SVC_UpdateMobj(const AActor& mobj)
 	}
 	if (flags & baseline_t::POSZ)
 	{
-		pos->set_z(mobj.z);
+		// Send the bob center, not the per-tic visual offset.
+		pos->set_z((mobj.flags2 & MF2_FLOATBOB) ? mobj.floorz + mobj.special1 : mobj.z);
 	}
 	if (flags & baseline_t::ANGLE)
 	{


### PR DESCRIPTION
Implement +FLOATBOB support, per #979. Thanks to @Acts19quiz for the great writeup on that issue and test wad.
This is a simple PR but does a few things. 

It adds the ZDoom floatbob offset table (which appears to be the same throughout ZDaemon and Skulltag both in code and through visual inspection) and applies the visual bob _locally_ from a stable center Z, rather than treating the bob as real movement every tic. It keeps network traffic minimal by syncing the bob center when needed instead of transmitting the per-tic visual Z offset. This was done because a prior attempt at implementing this resulted in the server spamming the clients with an update on every tic.

Some additional precautions were added based on the #979 writeup regarding when a +FLOATBOB thing is sitting on bridge things. This was necessary because well known wads like Cybercrime 3 place these objects on thing bridges. Unlike later ZDoom (Skulltag, Zandronum, etc), Odamex doesn't have explicit “acts like a bridge” flag, so this keeps the bridge check local to known bridge mobj types instead of adding a broader flag change.

Tested with +FLOATBOB items on solid ground and bridge things, and verified that non-FLOATBOB items on bridge things still behave normally. Tested with Cybercrime3 and the test wad from #979.