### PR TITLE
[BUGFIX] Midtex Gap

### DIFF
--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -792,7 +792,7 @@ void R_DrawSkyBoxes()
 			else
 			{
 				ceilingclip[i] = pl->top[i];
-				floorclip[i] = pl->bottom[i];
+				floorclip[i] = pl->bottom[i] + 1;
 			}
 		}
 

--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -802,6 +802,7 @@ void R_DrawSkyBoxes()
 		ds_p->x2 = viewwidth - 1;
 		ds_p->silhouette = SIL_BOTH;
 		ds_p->midposts = NULL;
+		ds_p->midscales = NULL;
 		ds_p->curline = NULL;
 
 		// [RK] Allocate full width clip arrays.

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -45,6 +45,7 @@
 // a pool of bytes allocated for sprite clipping arrays
 Pool<tallpost_t*> masked_midposts_pool(4096);
 Pool<int> sprclip_pool(4096);
+Pool<fixed_t> midscales_pool(4096);
 
 // OPTIMIZE: closed two sided lines as single sided
 
@@ -96,10 +97,7 @@ extern fixed_t FocalLengthY;
 extern float yfoc;
 
 static tallpost_t** masked_midposts;
-
-// scale at the masked seg's endpoint columns, for per-column interpolation
-static fixed_t sprinvyscale1, sprinvyscale2;
-static int sprscalex1, sprscalex2;
+static const fixed_t* masked_midscales;
 
 EXTERN_CVAR(r_clipmaskedspecial)
 
@@ -200,13 +198,8 @@ static inline void R_BlastMaskedSegColumn(void (*drawfunc)())
 	// can be off enough that by accumulation, it draws a row with no data.
 	// Your midtex gap! :)
 	//
-	// Instead of using the scalestep, we calculate spryscale
-	// via interpolation of the two endpoint scales.
-	if (sprscalex2 > sprscalex1)
-		spryscale = sprinvyscale1 + fixed_t(int64_t(dcol.x - sprscalex1) *
-			(sprinvyscale2 - sprinvyscale1) / (sprscalex2 - sprscalex1));
-	else
-		spryscale = sprinvyscale1;
+	// Instead we get spryscale from a value precalculated in R_StoreWallRange.
+	spryscale = masked_midscales[dcol.x];
 
 	if (post != NULL && spryscale > 0)
 	{
@@ -689,11 +682,7 @@ void R_RenderMaskedSegRange(drawseg_t* ds, int x1, int x2)
 		lightnum <  0 ? scalelight[0] : scalelight[lightnum];
 
 	masked_midposts = ds->midposts;
-
-	sprscalex1 = ds->x1;
-	sprscalex2 = ds->x2;
-	sprinvyscale1 = R_TexInvScaleY(ds->scale1, texnum);
-	sprinvyscale2 = R_TexInvScaleY(ds->scale2, texnum);
+	masked_midscales = ds->midscales;
 
 	rw_lightstep = ds->lightstep;
 	rw_light = ds->light + (x1 - ds->x1) * rw_lightstep;
@@ -883,6 +872,7 @@ void R_StoreWallRange(int start, int stop)
 	//	and decide if floor / ceiling marks are needed
 	midtexture = toptexture = bottomtexture = maskedtexture = 0;
 	ds_p->midposts = NULL;
+	ds_p->midscales = NULL;
 
 	if (!backsector)
 	{
@@ -1053,6 +1043,20 @@ void R_StoreWallRange(int start, int stop)
 			// masked midtexture
 			maskedtexture = texturetranslation[sidedef->midtexture];
 			ds_p->midposts = masked_midposts = masked_midposts_pool.alloc(count) - start;
+
+			// save the per-column scales, pre-scaled into the
+			// midtexture's y-scale space, for the masked pass
+			fixed_t* midscales = midscales_pool.alloc(count) - start;
+			if (texturescaley[maskedtexture] == FRACUNIT)
+			{
+				memcpy(midscales + start, wallscalex + start, count * sizeof(*midscales));
+			}
+			else
+			{
+				for (int x = start; x <= stop; x++)
+					midscales[x] = R_TexInvScaleY(wallscalex[x], maskedtexture);
+			}
+			ds_p->midscales = midscales;
 		}
 
 		// [SL] additional fix for sky hack
@@ -1150,6 +1154,7 @@ void R_ClearOpenings()
 {
 	masked_midposts_pool.clear();
 	sprclip_pool.clear();
+	midscales_pool.clear();
 }
 
 VERSION_CONTROL (r_segs_cpp, "$Id$")

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -97,6 +97,10 @@ extern float yfoc;
 
 static tallpost_t** masked_midposts;
 
+// scale at the masked seg's endpoint columns, for per-column interpolation
+static fixed_t sprinvyscale1, sprinvyscale2;
+static int sprscalex1, sprscalex2;
+
 EXTERN_CVAR(r_clipmaskedspecial)
 
 //
@@ -190,24 +194,41 @@ static inline void R_BlastMaskedSegColumn(void (*drawfunc)())
 {
 	tallpost_t* post = dcol.post;
 
+	// R_PrepWall uses floats to calculate scale1 and scale2, which left
+	// the scalestep values vulnerable to floating-point rounding errors.
+	// If a wall is tall enough and a resolution big enough, the scalestep
+	// can be off enough that by accumulation, it draws a row with no data.
+	// Your midtex gap! :)
+	//
+	// Instead of using the scalestep, we calculate spryscale
+	// via interpolation of the two endpoint scales.
+	if (sprscalex2 > sprscalex1)
+		spryscale = sprinvyscale1 + fixed_t(int64_t(dcol.x - sprscalex1) *
+			(sprinvyscale2 - sprinvyscale1) / (sprscalex2 - sprscalex1));
+	else
+		spryscale = sprinvyscale1;
+
 	if (post != NULL && spryscale > 0)
 	{
-		sprtopscreen = centeryfrac - FixedMul(dcol.texturemid, spryscale);
+		// R_FillWallHeightArray uses centery and so should we.
+		// Otherwise we can have textures drawing at different
+		// heights when mouselook is on.
+		sprtopscreen = (centery << FRACBITS) - FixedMul(dcol.texturemid, spryscale);
 		dcol.iscale = 0xffffffffu / (unsigned)spryscale;
 
 		while (!post->end())
 		{
 			// calculate unclipped screen coordinates for post
-			const int topscreen = sprtopscreen + spryscale * post->topdelta + 1;
+			const int topscreen = sprtopscreen + spryscale * post->topdelta;
 
-			dcol.yl = (topscreen + FRACUNIT) >> FRACBITS;
+			dcol.yl = topscreen >> FRACBITS;
 			dcol.yh = (topscreen + spryscale * post->length) >> FRACBITS;
 
-			dcol.yl = MAX(dcol.yl, mceilingclip[dcol.x] + 1);
+			dcol.yl = MAX(dcol.yl, MAX(mceilingclip[dcol.x], 0));
 			dcol.yh = MIN(dcol.yh, mfloorclip[dcol.x] - 1);
 
 			dcol.texturefrac = dcol.texturemid - (post->topdelta << FRACBITS)
-				+ (dcol.yl * dcol.iscale) - FixedMul(centeryfrac - FRACUNIT, dcol.iscale);
+				+ (dcol.yl * dcol.iscale) - FixedMul((centery << FRACBITS) - FRACUNIT, dcol.iscale);
 
 			if (dcol.texturefrac < 0)
 			{
@@ -235,8 +256,6 @@ static inline void R_BlastMaskedSegColumn(void (*drawfunc)())
 
 		masked_midposts[dcol.x] = NULL;
 	}
-
-	spryscale += rw_scalestep;
 }
 
 //
@@ -671,8 +690,10 @@ void R_RenderMaskedSegRange(drawseg_t* ds, int x1, int x2)
 
 	masked_midposts = ds->midposts;
 
-	rw_scalestep = R_TexInvScaleY(ds->scalestep, texnum);
-	spryscale = R_TexInvScaleY(ds->scale1, texnum) + (x1 - ds->x1) * rw_scalestep;
+	sprscalex1 = ds->x1;
+	sprscalex2 = ds->x2;
+	sprinvyscale1 = R_TexInvScaleY(ds->scale1, texnum);
+	sprinvyscale2 = R_TexInvScaleY(ds->scale2, texnum);
 
 	rw_lightstep = ds->lightstep;
 	rw_light = ds->light + (x1 - ds->x1) * rw_lightstep;

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -151,16 +151,16 @@ void R_BlastSpriteColumn(void (*drawfunc)())
 	while (!post->end())
 	{
 		// calculate unclipped screen coordinates for post
-		int topscreen = sprtopscreen + spryscale * post->topdelta + 1;
+		const int topscreen = sprtopscreen + spryscale * post->topdelta;
 
-		dcol.yl = (topscreen + FRACUNIT) >> FRACBITS;
+		dcol.yl = topscreen >> FRACBITS;
 		dcol.yh = (topscreen + spryscale * post->length) >> FRACBITS;
 
-		dcol.yl = MAX(dcol.yl, mceilingclip[dcol.x] + 1);
+		dcol.yl = MAX(dcol.yl, MAX(mceilingclip[dcol.x], 0));
 		dcol.yh = MIN(dcol.yh, mfloorclip[dcol.x] - 1);
 
 		dcol.texturefrac = dcol.texturemid - (post->topdelta << FRACBITS)
-			+ (dcol.yl * dcol.iscale) - FixedMul(centeryfrac - FRACUNIT, dcol.iscale);
+			+ (dcol.yl * dcol.iscale) - FixedMul((centery << FRACBITS) - FRACUNIT, dcol.iscale);
 
 		if (dcol.texturefrac < 0)
 		{
@@ -313,7 +313,7 @@ void R_DrawVisSprite (vissprite_t *vis, int x1, int x2)
 	dcol.iscale = 0xffffffffu / (unsigned)vis->yscale;
 	dcol.texturemid = vis->texturemid;
 	spryscale = vis->yscale;
-	sprtopscreen = centeryfrac - FixedMul(dcol.texturemid, spryscale);
+	sprtopscreen = (centery << FRACBITS) - FixedMul(dcol.texturemid, spryscale);
 
 	// [SL] set up the array that indicates which patch column to use for each screen column
 	fixed_t colfrac = vis->startfrac;
@@ -1234,7 +1234,7 @@ void R_DrawParticle(vissprite_t* vis)
 {
 	// Don't bother clipping each individual column
 	int x1 = vis->x1, x2 = vis->x2;
-	int y1 = MAX(vis->y1, MAX(mceilingclip[x1] + 1, mceilingclip[x2] + 1));
+	int y1 = MAX(vis->y1, MAX(mceilingclip[x1], mceilingclip[x2]));
 	int y2 = MIN(vis->y2, MIN(mfloorclip[x1] - 1, mfloorclip[x2] - 1));
 
 	dspan.x1 = vis->x1;

--- a/common/r_data.cpp
+++ b/common/r_data.cpp
@@ -591,9 +591,20 @@ void R_InitTextures()
 		char *name_p = names+4;
 
 		numpatches = LELONG ( *((int *)names) );
-		first_tx = W_CheckNumForName("TX_START") + 1;
-		const int last_tx  = W_CheckNumForName("TX_END") - 1;
-		tx_numtextures = last_tx - first_tx + 1;
+
+		// Put a guard here in case one of the pair is missing.
+		const int tx_startlump = W_CheckNumForName("TX_START");
+		const int tx_endlump = W_CheckNumForName("TX_END");
+		if (tx_startlump != -1 && tx_endlump != -1 && tx_endlump > tx_startlump)
+		{
+			first_tx = tx_startlump + 1;
+			tx_numtextures = tx_endlump - tx_startlump - 1;
+		}
+		else
+		{
+			first_tx = 0;
+			tx_numtextures = 0;
+		}
 
 		patchlookup.resize(numpatches);
 

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -598,10 +598,15 @@ struct drawseg_t
     int				silhouette;
 
     // Pointers to lists for sprite clipping,
-    //  all three adjusted so [x1] is first value.
+    //  all adjusted so [x1] is first value.
     int*			sprtopclip;
     int*			sprbottomclip;
 	tallpost_t**	midposts;
+
+	// per-column scales for the masked midtexture, in texture y-scale
+	// space; saved from wallscalex so the masked pass draws with the same
+	// scales R_PrepWall gave the wall tiers
+	fixed_t*		midscales;
 };
 
 


### PR DESCRIPTION
This PR was meant for the midtex gap, but the unlocking of knowledge on why it failed in the way it did allowed me to fix other bugs. This PR fixes #1567, #1028, and also fixes a bug I found with WADs with missing TX_ markers -- the -1 in W_CheckNumForName was messing it up a bit so I added a guard for it.

Now for the info you've all been waiting for! The midtex gap was caused by 4 things that I found:

1. R_BlastMaskedSegColumn had a legit off-by-one FRACUNIT when calculating dcol.yl.
2. MAX(mceilingclip[dcol.x], 0)) does the same thing mceilingclip[dcol.x] + 1) does (i.e. make it 0, never make it -1 which is what that array starts at) but does it in a way that allows every column on the screen to be drawn.
3. sprtopscreen/dcol.texturefrac use centeryfrac instead of centery which is what R_PrepWall uses, which can cause the midtexture to draw higher or lower a tiny (but noticeable, at least the debugger says) amount.
4. This had a lot to do with it as well, but R_PrepWall was creating scale1/scale2 values using a float, while being truncated to a fixed-point number to get the colfrac. This allowed the render function R_BlastMaskedSegColumn to become out of sync with what R_PrepWall prepared for midposts and what was drawn for R_BlastMaskedSegColumn, creating a gap. I tried an expensive calculation to match these up but it was too slow so instead I simply copied wallscalex when it was available to use for drawing midtex. It's separated by whether or not the texture has Y scaling, that should be tested.

I tried to also apply these changes to the Sprite blaster/particle draw function as well as they all had these foundational issues but less chance for them to pop up I suppose. Should make the sprite more accurate at least.

Also fixed is the Skybox HOM issue, now that I know floorclip should be 0 instead of -1 to end the clip.

Also mentioned at the beginning, I fixed an issue with TX_ markers as maps without TX_ markers had texture 3 overwritten, and luckily I had a test WAD where an animated sky frame was texture 3 so it flashed a texture and gave a huge clue.