### PR TITLE
Check against proper VC redist version in Windows installer

### DIFF
--- a/ci/stage-inno-setup-and-run.ps1
+++ b/ci/stage-inno-setup-and-run.ps1
@@ -156,12 +156,15 @@ function CompileSetup {
         Remove-Item -Force -Recurse -Path "${OutputDir}"
     }
 
+    $VCRedistVersion = (Get-Item "${OutX64}\redist\vc_redist.x64.exe").VersionInfo.ProductVersion
+
     New-Item  -Force -ItemType "directory" -Path "${OutputDir}"
     # Generate installer
     ISCC.exe "${CurrentDir}\installer\windows\odamex.iss" `
         /DOdamexVersion=${OdamexVersion} `
         /DOdamexTestSuffix=${OdamexTestSuffix} `
         /DSourcePath=${CurrentDir} `
+        /DVCRedistVersion=${VCRedistVersion} `
         /O${OutputDir}
 }
 

--- a/installer/windows/odamex.iss
+++ b/installer/windows/odamex.iss
@@ -345,7 +345,7 @@ begin
 end;
 
 
-function VC2017RedistNeedsInstall(Platform: String): Boolean;
+function VCRedistNeedsInstall(Platform: String): Boolean;
 var
   Version: String;
   KeyLocation: String;
@@ -355,9 +355,9 @@ begin
        KeyLocation, 'Version',
        Version) then
   begin
-    // Is the installed version at least 14.40?
+    // Is the installed version new enough?
     Log('VC Redist Version check : found ' + Version);
-    Result := (CompareVersion(Version, 'v14.40.33810.0')>0);
+    Result := (CompareVersion(Version, {#VCRedistVersion})>0);
   end
   else
   begin
@@ -374,13 +374,13 @@ end;
 Filename: "{tmp}\VC_redist.x64.exe"; \
   StatusMsg: "Installing VC++ Runtime"; \
   Parameters: "/install /passive /norestart"; \
-  Check: VC2017RedistNeedsInstall('x64') and Is64BitInstallMode; \
+  Check: VCRedistNeedsInstall('x64') and Is64BitInstallMode; \
   Flags: waituntilterminated
 
 Filename: "{tmp}\VC_redist.x86.exe"; \
   StatusMsg: "Installing VC++ Runtime"; \
   Parameters: "/install /passive /norestart"; \
-  Check: VC2017RedistNeedsInstall('x86') and (not Is64BitInstallMode); \
+  Check: VCRedistNeedsInstall('x86') and (not Is64BitInstallMode); \
   Flags: waituntilterminated
 
 Filename: {app}\odalaunch.exe; Description: {cm:LaunchProgram,Odalaunch}; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
#1799 Made sure we include an updated version of the VC++ redistributables, but it turns out that the installer has a hardcoded version check that means it might fail to update the redistributable in certain cases. This PR makes it so that the version is read from the fetched redist installer, and that is the version checked against when the Odamex installer runs.