### PR TITLE
Disable tracer turn client prediction

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -659,6 +659,11 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 	//              with the same state, anim tics, and mobjtic as the server would on the next
 	//              frame following the SpawnMobj command.
 	//
+	//                  Remember, there are functions like P_CheckMissileSpawn, which may have
+	//                  critically modified animation tics before even running through the first
+	//                  mobj's first think + action calls, and all of that precedes the creation
+	//                  of the SpawnMobj message.
+	//
 	//          2.  If the mobj truly spawned on the server in the same tic as the SpawnMobj,
 	//              any complete state transitions that took place on the mobj must take place
 	//              in this function as well.  That is, any spawn-time action functions due to

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -648,6 +648,24 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 			mo->tics = 1;
 	}
 
+	// FIXME: Rework the following block once we get the tic timestamping refactored and develop
+	//        a clear, easy-to-understand method of reconstructing the mobjs' post-spawned,
+	//        pre-tic state, including any "random tic adjustments" that P_CheckMissileSpawn
+	//        and other spawn-time functions may have applied.
+	//
+	//        Key, top-level requirements:
+	//
+	//          1.  When CL_SpawnMobj is complete, the mobj must proceed into the rest of the tic
+	//              with the same state, anim tics, and mobjtic as the server would on the next
+	//              frame following the SpawnMobj command.
+	//
+	//          2.  If the mobj truly spawned on the server in the same tic as the SpawnMobj,
+	//              any complete state transitions that took place on the mobj must take place
+	//              in this function as well.  That is, any spawn-time action functions due to
+	//              having a spawnstate tics duration of 1 or 0 must also run before we return
+	//              from CL_SpawnMobj.  This allows things like immediate sound effects and
+	//              secondary mobjs to work (think a noisy, instant gib spawner).
+
 	statenum_t statenum = static_cast<statenum_t>(msg->current().statenum());
 
 	if (statenum >= S_NULL && states.contains(statenum))

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2136,6 +2136,18 @@ void A_Tracer (AActor *actor)
 	//        may be a very-difficult-to-predict player mobj.  A precondition for this is
 	//        the gametic timestamping refactor, and it MAY require a more generic physical
 	//        rollback reconciliation approach and/or a fancy Kalman-style filter.
+	//
+	//        The main test case:  No Time 2 Freeze (NT2F.wad), map22.
+	//
+	//        The revenants spawn custom missile mobjs that are _not_ MT_TRACER, but still
+	//        go through A_Tracer as their main action function once every 2 tics, and
+	//        before the first RunThink.  Yet, as they are not MT_TRACER, they also get
+	//        less-frequent UpdateMobj messages if they randomly happen to not actually do
+	//        any tracing on the server, owing to ye olde revenant scheduling issue above.
+	//        In that case, if the client incorrectly predicts a turn, then the predicted
+	//        missile is allowed to stray pretty far afield before being corrected by
+	//        UpdateMobj.  When that happens, it is exceptionally jarring for any player
+	//        that sees it.  Whatever solution we arrive on must NOT be subject to that bug.
 	if (not serverside)
 		return;
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2131,6 +2131,14 @@ void A_Tracer (AActor *actor)
 	if (demogametic & 3)
 		return;
 
+	// FIXME: Remove the following once we REALLY understand the feasibility of a client-
+	//        side prediction of a tracer whose state depends on its target, which itself
+	//        may be a very-difficult-to-predict player mobj.  A precondition for this is
+	//        the gametic timestamping refactor, and it MAY require a more generic physical
+	//        rollback reconciliation approach and/or a fancy Kalman-style filter.
+	if (not serverside)
+		return;
+
 	if (serverside)
 	{
 		// spawn a puff of smoke behind the rocket


### PR DESCRIPTION
It turned out that there's a sneaky vanilla, server-side random animation tic adjustment that happens post-spawn but pre-think for missiles and other mobjs that can completely throw the tic-sequence-level prediction on the client side.  It's going to require a refactor of how we manage tic timestamping to get it right and have it be something easy-to-read and understand.  That's something we've wanted for a little while now, as we now have more messages in protobreak that feed into client-side rollbacks that need the timestamps, and are currently duplicated in those messages.

Here's an example of the worst-case misprediction that happens thanks to the randomly-offset tic:


https://github.com/user-attachments/assets/063a39f5-f55c-4f8a-9ec7-3a5a91f22af1

Here's the same with client-side A_Tracer turn/angle predictions disabled:


https://github.com/user-attachments/assets/1fa0294e-3c44-4273-b3e5-4a2a41b4f3d6

------

Please note that MBF21 tracers have never performed client-side turn predictions, and they look fine from the player's perspective.  This change simply brings the vanilla Doom A_Tracer in line with that approach.