### PR TITLE
Fix psprite state and player color when using netff or netrew in a netdemo

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1674,15 +1674,6 @@ void NetDemo::readSnapshotData(std::vector<byte>& buf)
 	else
 		displayplayer_id = cid;
 
-	// setup psprites and restore player colors
-	for (auto& player : players)
-	{
-		P_SetupPsprites(player);
-		R_BuildPlayerTranslation(player.id, CL_GetPlayerColor(player));
-	}
-
-	R_CopyTranslationRGB (0, consoleplayer_id);
-
 	// Link the CTF flag actors to CTFdata[i].actor
 	TThinkerIterator<AActor> flagiterator;
 	while ( (mo = flagiterator.Next() ) )


### PR DESCRIPTION
During a netff or netrew, these setup functions are overwriting the correct state that was just set from P_SerializePlayers(). To test just make a demo run around shooting a weapon during a snapshot, play it back and see the difference compared to 12.2.1 (ETA - you should have screen wipe style set to None in Display settings to see the fix). Also I don't see any reason to be messing with the player colors here, removing that fixes #956