### PR TITLE
Point the avatar in its map-specified angle, like most other mapthings mobs

### DIFF
--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3544,6 +3544,7 @@ void P_SpawnAvatars()
 
 		// Assign spawnpoint so that it gets archived and can be matched back up with voodoostarts after deserialization.
 		voodoo.mobj->spawnpoint = voodoo.mapThing;
+		voodoo.mobj->angle      = ANG45 * (voodoo.mapThing.angle/45);
 		voodoo.mobj->credibility.Lionize();
 	}
 }


### PR DESCRIPTION
Effectively just cosmetic.  I'm sure there are some wads out there that count on the visual impact of seeing a voodoo doll / avatar looking in a particular direction, though.  This fixes those cases.