### PR TITLE
[BUGFIX] P_ActivateMobj clearing all of flags2

### DIFF
--- a/common/p_things.cpp
+++ b/common/p_things.cpp
@@ -305,7 +305,7 @@ bool P_ActivateMobj (AActor *mobj, AActor *activator)
 {
 	if (mobj->flags & MF_COUNTKILL)
 	{
-		mobj->flags2 &= !(MF2_DORMANT | MF2_INVULNERABLE);
+		mobj->flags2 &= ~(MF2_DORMANT | MF2_INVULNERABLE);
 		return true;
 	}
 	else


### PR DESCRIPTION
It's suppose to only clear DORMANT and INVULNERABLE.