### PR TITLE
[BUGFIX] SpawnSpotFacing always facing angle 0

### DIFF
--- a/common/actor.h
+++ b/common/actor.h
@@ -538,7 +538,7 @@ public:
 	// Thing being chased/attacked for tracers.
 	AActorPtr		tracer;
 	byte			special;		// special
-	byte			args[5];		// special arguments
+	std::array<byte, 5> args;		// special arguments
 
 	AActor			*inext, *iprev;	// Links to other mobjs in same bucket
 

--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -43,6 +43,7 @@
 #include "infomap.h"
 #include "p_mobj.h"
 #include "r_sky.h"
+#include "c_effect.h"
 
 #if defined(SERVER_APP)
 #include "sv_main.h"
@@ -1818,6 +1819,36 @@ void DLevelScript::StartSoundSequence(sector_t* sec, int index)
 
 EXTERN_CVAR(sv_nomonsters)
 
+namespace
+{
+
+std::optional<std::pair<byte, uint32_t>> GetFountainSpawnInfo(const char* mobjstr)
+{
+	const auto make_return = [](const uint32_t fountaintype) {
+		return std::pair<byte, uint32_t>({ fountaintype >> FX_FOUNTAINSHIFT, fountaintype });
+	};
+	switch (OUtil::CONST_HASH_NO_CASE(mobjstr)) {
+		case OUtil::CONST_HASH_NO_CASE("YellowParticleFountain"):
+			return make_return(FX_YELLOWFOUNTAIN);
+		case OUtil::CONST_HASH_NO_CASE("RedParticleFountain"):
+			return make_return(FX_REDFOUNTAIN);
+		case OUtil::CONST_HASH_NO_CASE("BlueParticleFountain"):
+			return make_return(FX_BLUEFOUNTAIN);
+		case OUtil::CONST_HASH_NO_CASE("GreenParticleFountain"):
+			return make_return(FX_GREENFOUNTAIN);
+		case OUtil::CONST_HASH_NO_CASE("PurpleParticleFountain"):
+			return make_return(FX_PURPLEFOUNTAIN);
+		case OUtil::CONST_HASH_NO_CASE("BlackParticleFountain"):
+			return make_return(FX_BLACKFOUNTAIN);
+		case OUtil::CONST_HASH_NO_CASE("WhiteParticleFountain"):
+			return make_return(FX_WHITEFOUNTAIN);
+		default:
+			return std::nullopt;
+	}
+}
+
+}
+
 // TODO: deduplicate these and the similar functions in P_Interaction
 int DLevelScript::DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, angle_t angle, bool force)
 {
@@ -1825,7 +1856,14 @@ int DLevelScript::DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, an
 	if (typestr == nullptr)
 		return 0;
 
-	const mobjtype_t info = P_INameToMobj(typestr);
+	mobjtype_t info = P_INameToMobj(typestr);
+	std::optional<std::pair<byte, uint32_t>> fountain_info;
+	if (info == MT_NULL)
+	{
+		fountain_info = GetFountainSpawnInfo(typestr);
+		if (fountain_info)
+			info = MT_FOUNTAIN;
+	}
 
 	int spawncount = 0;
 
@@ -1837,6 +1875,11 @@ int DLevelScript::DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, an
 		{
 			if (force || P_TestMobjLocation(actor))
 			{
+				if (fountain_info)
+				{
+					actor->args[0] = fountain_info->first;
+					actor->effects = fountain_info->second;
+				}
 				actor->angle = angle;
 				actor->tid = tid;
 				actor->AddToHash();
@@ -1876,9 +1919,16 @@ void DLevelScript::DoSpawnProjectile(int tid, int type, angle_t angle, fixed_t s
 	if (typestr == nullptr)
 		return;
 
-	const auto info = P_INameToMobj(typestr);
+	auto info = P_INameToMobj(typestr);
+	std::optional<std::pair<byte, uint32_t>> fountain_info;
 	if (info == MT_NULL)
-		return;
+	{
+		fountain_info = GetFountainSpawnInfo(typestr);
+		if (fountain_info)
+			info = MT_FOUNTAIN;
+		else
+			return;
+	}
 
 	if ((mobjinfo[info].flags & MF_COUNTKILL) && sv_nomonsters)
 		return;
@@ -1904,6 +1954,11 @@ void DLevelScript::DoSpawnProjectile(int tid, int type, angle_t angle, fixed_t s
 			}
 			else
 				mobj->flags |= MF_NOGRAVITY;
+			if (fountain_info)
+			{
+				mobj->args[0] = fountain_info->first;
+				mobj->effects = fountain_info->second;
+			}
 			mobj->target = spot->ptr();
 			mobj->angle = angle;
 			mobj->momx = FixedMul(speed, finecosine[angle>>ANGLETOFINESHIFT]);

--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -1819,7 +1819,7 @@ void DLevelScript::StartSoundSequence(sector_t* sec, int index)
 EXTERN_CVAR(sv_nomonsters)
 
 // TODO: deduplicate these and the similar functions in P_Interaction
-int DLevelScript::DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, int angle, bool force)
+int DLevelScript::DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, angle_t angle, bool force)
 {
 	const char* typestr = level.behavior->LookupString(type);
 	if (typestr == nullptr)
@@ -1837,7 +1837,7 @@ int DLevelScript::DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, in
 		{
 			if (force || P_TestMobjLocation(actor))
 			{
-				actor->angle = BYTEANGLE(angle);
+				actor->angle = angle;
 				actor->tid = tid;
 				actor->AddToHash();
 				actor->flags |= MF_DROPPED;  // Don't respawn
@@ -1858,7 +1858,7 @@ int DLevelScript::DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, in
 	return spawncount;
 }
 
-int DLevelScript::DoSpawnSpot(int type, int spot, int tid, std::optional<int> angle, bool force)
+int DLevelScript::DoSpawnSpot(int type, int spot, int tid, std::optional<angle_t> angle, bool force)
 {
 	FActorIterator iterator(spot);
 	AActor* aspot;
@@ -1905,7 +1905,7 @@ void DLevelScript::DoSpawnProjectile(int tid, int type, angle_t angle, fixed_t s
 			else
 				mobj->flags |= MF_NOGRAVITY;
 			mobj->target = spot->ptr();
-			mobj->angle = BYTEANGLE(angle);
+			mobj->angle = angle;
 			mobj->momx = FixedMul(speed, finecosine[angle>>ANGLETOFINESHIFT]);
 			mobj->momy = FixedMul(speed, finesine[angle>>ANGLETOFINESHIFT]);
 			mobj->momz = vspeed;
@@ -3409,22 +3409,22 @@ void DLevelScript::RunScript ()
 			break;
 
 		case PCD_SPAWN:
-			STACK(6) = DoSpawn (STACK(6), STACK(5), STACK(4), STACK(3), STACK(2), STACK(1), false);
+			STACK(6) = DoSpawn (STACK(6), STACK(5), STACK(4), STACK(3), STACK(2), BYTEANGLE(STACK(1)), false);
 			sp -= 5;
 			break;
 
 		case PCD_SPAWNDIRECT:
-			PushToStack (DoSpawn (pc[0], pc[1], pc[2], pc[3], pc[4], pc[5], false));
+			PushToStack (DoSpawn (pc[0], pc[1], pc[2], pc[3], pc[4], BYTEANGLE(pc[5]), false));
 			pc += 6;
 			break;
 
 		case PCD_SPAWNSPOT:
-			STACK(4) = DoSpawnSpot (STACK(4), STACK(3), STACK(2), STACK(1), false);
+			STACK(4) = DoSpawnSpot (STACK(4), STACK(3), STACK(2), BYTEANGLE(STACK(1)), false);
 			sp -= 3;
 			break;
 
 		case PCD_SPAWNSPOTDIRECT:
-			PushToStack (DoSpawnSpot (pc[0], pc[1], pc[2], pc[3], false));
+			PushToStack (DoSpawnSpot (pc[0], pc[1], pc[2], BYTEANGLE(pc[3]), false));
 			pc += 4;
 			break;
 
@@ -3434,7 +3434,7 @@ void DLevelScript::RunScript ()
 			break;
 
 		case PCD_SPAWNPROJECTILE:
-			DoSpawnProjectile(STACK(7), STACK(6), STACK(5), SPEED(STACK(4)), SPEED(STACK(3)), STACK(2), STACK(1));
+			DoSpawnProjectile(STACK(7), STACK(6), BYTEANGLE(STACK(5)), SPEED(STACK(4)), SPEED(STACK(3)), STACK(2), STACK(1));
 			sp -= 7;
 			break;
 
@@ -4122,7 +4122,7 @@ auto DLevelScript::CallFunction(const int scriptnum, const int func, const nonst
 
 		case CF_SPAWNSPOTFORCED:
 			CHECK_MIN_ARGS(4);
-			return DoSpawnSpot(args[0], args[1], args[2], args[3], true);
+			return DoSpawnSpot(args[0], args[1], args[2], BYTEANGLE(args[3]), true);
 
 		case CF_SPAWNSPOTFACINGFORCED:
 			CHECK_MIN_ARGS(3);
@@ -4130,7 +4130,7 @@ auto DLevelScript::CallFunction(const int scriptnum, const int func, const nonst
 
 		case CF_SPAWNFORCED:
 			CHECK_MIN_ARGS(4);
-			return DoSpawn(args[0], args[1], args[2], args[3], args.size() > 4 ? args[4] : 0, args.size() > 5 ? args[5] : 0, true);
+			return DoSpawn(args[0], args[1], args[2], args[3], args.size() > 4 ? args[4] : 0, args.size() > 5 ? BYTEANGLE(args[5]) : 0, true);
 
 		case CF_SQRT:
 			CHECK_MIN_ARGS(1);

--- a/common/p_acs.h
+++ b/common/p_acs.h
@@ -565,8 +565,8 @@ protected:
 	static int CountPlayers ();
 	static void SetLineTexture (int lineid, int side, int position, int name);
 
-	static int DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, int angle, bool force);
-	static int DoSpawnSpot(int type, int spot, int tid, std::optional<int> angle, bool force);
+	static int DoSpawn(int type, fixed_t x, fixed_t y, fixed_t z, int tid, angle_t angle, bool force);
+	static int DoSpawnSpot(int type, int spot, int tid, std::optional<angle_t> angle, bool force);
 	static void DoSpawnProjectile(int tid, int type, angle_t angle, fixed_t speed, fixed_t vspeed, bool gravity, int newtid);
 
 	static void SetLineBlocking(int lineid, int flags);

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -130,13 +130,12 @@ AActor::AActor()
       height(0), momx(0), momy(0), momz(0), validcount(0), type(MT_UNKNOWNTHING),
       info(NULL), tics(0), state(NULL), damage(0), flags(0), flags2(0),
       flags3(0), oflags(0), statusflags(0), special1(0), special2(0), health(0), movedir(0), movecount(0), visdir(0),
-      reactiontime(0), threshold(0), player(NULL), lastlook(0), special(0), inext(NULL),
+      reactiontime(0), threshold(0), player(NULL), lastlook(0), special(0), args(), inext(NULL),
       iprev(NULL), translation(translationref_t()), translucency(0), waterlevel(0),
       gear(0), onground(false), touching_sectorlist(NULL), deadtic(0), oldframe(0),
       rndindex(0), friend_playerid(0), friend_teamid(TEAM_NONE), pursuecount(0), strafecount(0),
       netid(0), tid(0), baseline(), baseline_set(false), bmapnode(this)
 {
-	memset(args, 0, sizeof(args));
 	self.init(this);
 }
 
@@ -154,7 +153,7 @@ AActor::AActor(const AActor& other)
       special1(other.special1), special2(other.special2),
       health(other.health), movedir(other.movedir), movecount(other.movecount),
       visdir(other.visdir), reactiontime(other.reactiontime), threshold(other.threshold),
-      player(other.player), lastlook(other.lastlook), special(other.special),
+      player(other.player), lastlook(other.lastlook), special(other.special), args(other.args),
       inext(other.inext), iprev(other.iprev), translation(other.translation),
       translucency(other.translucency), waterlevel(other.waterlevel), gear(other.gear),
       onground(other.onground), touching_sectorlist(other.touching_sectorlist),
@@ -165,7 +164,6 @@ AActor::AActor(const AActor& other)
       netid(other.netid), tid(other.tid),
       baseline_set(false), bmapnode(other.bmapnode)
 {
-	memcpy(args, other.args, sizeof(args));
 	memcpy(&baseline, &other.baseline, sizeof(baseline));
 	self.init(this);
 }
@@ -236,8 +234,8 @@ AActor &AActor::operator= (const AActor &other)
     netid = other.netid;
     tid = other.tid;
     special = other.special;
+	args = other.args;
 
-    memcpy(args, other.args, sizeof(args));
     bmapnode = other.bmapnode;
     memcpy(&baseline, &other.baseline, sizeof(baseline));
     baseline_set = other.baseline_set;
@@ -258,7 +256,7 @@ AActor::AActor(fixed_t ix, fixed_t iy, fixed_t iz, int32_t itype)
       height(0), momx(0), momy(0), momz(0), validcount(0), type(itype),
       info(NULL), tics(0), state(NULL), damage(0), flags(0), flags2(0), flags3(0), oflags(0),
       statusflags(0), special1(0), special2(0), health(0), movedir(0), movecount(0), visdir(0),
-      reactiontime(0), threshold(0), player(NULL), lastlook(0), special(0), inext(NULL),
+      reactiontime(0), threshold(0), player(NULL), lastlook(0), special(0), args(), inext(NULL),
       iprev(NULL), translation(translationref_t()), translucency(0), waterlevel(0),
       gear(0), onground(false), touching_sectorlist(NULL), deadtic(0), oldframe(0),
       rndindex(0), friend_playerid(0), friend_teamid(TEAM_NONE), pursuecount(0), strafecount(0),
@@ -332,7 +330,6 @@ AActor::AActor(fixed_t ix, fixed_t iy, fixed_t iz, int32_t itype)
 	}
 
 	spawnpoint.type = 0;
-	memset(args, 0, sizeof(args));
 }
 
 
@@ -3148,7 +3145,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 
 	// [RH] Set the thing's special
 	mobj->special = mthing.special;
-	memcpy (mobj->args, mthing.args, sizeof(mobj->args));
+	std::copy(std::begin(mthing.args), std::end(mthing.args), mobj->args.begin());
 
 	// [RH] If it's an ambient sound, activate it
 	if (type == MT_AMBIENT)


### PR DESCRIPTION
Also allows spawning of particle fountains from the ACS spawn functions. Since they're all the same mobjtype, it required a special case in DoSpawn(Projectile).