### PR TITLE
Make sure that only the periodic "background" UpdateMobjs can re-sync mode

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1088,11 +1088,11 @@ static void CL_UserInfo(const odaproto::svc::UserInfo* msg)
 	CL_CheckDisplayPlayer();
 }
 
-static void CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg)
+static AActor* CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg)
 {
 	AActor* mo = P_FindThingById(msg->actor().netid());
-	if (!mo)
-		return;
+	if (not mo)
+		return mo;
 
 	mo->updatedDuringTic = gametic;
 
@@ -1192,6 +1192,16 @@ static void CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg)
 		mo->tracer = tracer->ptr();
 	else
 		mo->tracer = AActor::AActorPtr();
+
+	return mo;
+}
+
+static void CL_UpdateMobjWithMode(const odaproto::svc::UpdateMobjWithMode* msg)
+{
+	AActor* mo = CL_UpdateMobj(& msg->update());
+
+	if (not mo)
+		return;
 
 	const MobjModeEnum mode = static_cast<MobjModeEnum>(msg->mode());
 	if (mode != mo->mode)
@@ -3503,6 +3513,7 @@ parseError_e CL_ProcessCommand(const ParseResultType& parsedCommand)
 		SV_MSG(svc_removemobj, CL_RemoveMobj, odaproto::svc::RemoveMobj);
 		SV_MSG(svc_userinfo, CL_UserInfo, odaproto::svc::UserInfo);
 		SV_MSG(svc_updatemobj, CL_UpdateMobj, odaproto::svc::UpdateMobj);
+		SV_MSG(svc_updatemobjwithmode, CL_UpdateMobjWithMode, odaproto::svc::UpdateMobjWithMode);
 		SV_MSG(svc_spawnplayer, CL_SpawnPlayer, odaproto::svc::SpawnPlayer);
 		SV_MSG(svc_damageplayer, CL_DamagePlayer, odaproto::svc::DamagePlayer);
 		SV_MSG(svc_killmobj, CL_KillMobj, odaproto::svc::KillMobj);

--- a/client/src/cl_stubs.cpp
+++ b/client/src/cl_stubs.cpp
@@ -62,6 +62,7 @@ void SV_TouchSpecial(AActor& special, player_t& player) {}
 void SV_UpdateFrags(player_t &player) {}
 void SV_UpdateMobj(AActor* mo) {}
 void SV_UpdateMobjBestEffort(AActor* mo) {}
+void SV_UpdateMobjReliable(AActor* mo) {}
 void SV_UpdateMobjState(const AActor* mo) {}
 void SV_UpdateMonsterRespawnCount() {}
 void SV_WakeupMobj(const AActor* mo, bool mustPlaySeeSound) {};

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -981,6 +981,7 @@ static void InitNetMessageFormats()
 	MSG_INFO(svc_removemobj);
 	MSG_INFO(svc_userinfo);
 	MSG_INFO(svc_updatemobj);
+	MSG_INFO(svc_updatemobjwithmode);
 	MSG_INFO(svc_spawnplayer);
 	MSG_INFO(svc_damageplayer);
 	MSG_INFO(svc_killmobj);

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -231,6 +231,7 @@ enum msg_t
 	svc_removemobj,
 	svc_userinfo,
 	svc_updatemobj,
+	svc_updatemobjwithmode,
 	svc_spawnplayer,
 	svc_damageplayer,
 	svc_killmobj,

--- a/common/msg_map.cpp
+++ b/common/msg_map.cpp
@@ -75,6 +75,7 @@ static void InitMap()
 	MapProto(svc_removemobj, odaproto::svc::RemoveMobj::descriptor());
 	MapProto(svc_userinfo, odaproto::svc::UserInfo::descriptor());
 	MapProto(svc_updatemobj, odaproto::svc::UpdateMobj::descriptor());
+	MapProto(svc_updatemobjwithmode, odaproto::svc::UpdateMobjWithMode::descriptor());
 	MapProto(svc_spawnplayer, odaproto::svc::SpawnPlayer::descriptor());
 	MapProto(svc_damageplayer, odaproto::svc::DamagePlayer::descriptor());
 	MapProto(svc_killmobj, odaproto::svc::KillMobj::descriptor());

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -2544,9 +2544,7 @@ void P_DamageMobj(AActor *target, const AActor *inflictor, AActor *source, int d
 		}
 		if (clientsNeedUpdate and not clientsWereUpdated)
 		{
-			// We use Reliable transport for the subsequent UpdateMobj so that we don't inadvertently wind
-			// up with disordered mid-tic updates that really needed to be sandwiched between other updates.
-			SV_UpdateMobjReliable(target);
+			SV_UpdateMobj(target);
 		}
 	}
 	else

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -90,6 +90,7 @@ void SV_SendKillMobj(const AActor *source, const AActor *target, const AActor *i
 void SV_SendDamagePlayer(player_t *player, const AActor* inflictor, int healthDamage, int armorDamage);
 void SV_SendDamageMobj(AActor *target, int pain);
 void SV_UpdateMobj(AActor* mo);
+void SV_UpdateMobjReliable(AActor* mo);
 void PickupMessage(const AActor *toucher, const char *message);
 void WeaponPickupMessage(const AActor *toucher, const weapontype_t &Weapon);
 
@@ -2490,12 +2491,14 @@ void P_DamageMobj(AActor *target, const AActor *inflictor, AActor *source, int d
 			}
 		}
 
+        bool clientsNeedUpdate = false;
 		if (!player)
 		{
 			SV_SendDamageMobj(target, pain);
+			clientsNeedUpdate = true;
 		}
 
-		bool clientWasUpdated = false;
+		bool clientsWereUpdated = false;
 
 		if (pain < target->info->painchance &&
 		    !(target->flags & MF_SKULLFLY) &&
@@ -2503,7 +2506,7 @@ void P_DamageMobj(AActor *target, const AActor *inflictor, AActor *source, int d
 		{
 			target->flags |= MF_JUSTHIT;	// fight back!
 			const auto painResult = P_SetMobjState(target, target->info->painstate);
-			clientWasUpdated = (painResult == SetMobStateResultEnum::SUCCESSFUL_AND_CLIENTS_UPDATED);
+			clientsWereUpdated = (painResult == SetMobStateResultEnum::SUCCESSFUL_AND_CLIENTS_UPDATED);
 		}
 
 		target->reactiontime = 0;			// we're awake now...
@@ -2536,12 +2539,14 @@ void P_DamageMobj(AActor *target, const AActor *inflictor, AActor *source, int d
 				&& target->info->seestate != S_NULL)
 			{
 				const auto seeResult = P_SetMobjState(target, target->info->seestate);
-				clientWasUpdated = clientWasUpdated or seeResult == SetMobStateResultEnum::SUCCESSFUL_AND_CLIENTS_UPDATED;
+				clientsWereUpdated = clientsWereUpdated or seeResult == SetMobStateResultEnum::SUCCESSFUL_AND_CLIENTS_UPDATED;
 			}
-			if (not clientWasUpdated)
-			{
-				SV_UpdateMobj(target);
-			}
+		}
+		if (clientsNeedUpdate and not clientsWereUpdated)
+		{
+			// We use Reliable transport for the subsequent UpdateMobj so that we don't inadvertently wind
+			// up with disordered mid-tic updates that really needed to be sandwiched between other updates.
+			SV_UpdateMobjReliable(target);
 		}
 	}
 	else

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -2491,7 +2491,7 @@ void P_DamageMobj(AActor *target, const AActor *inflictor, AActor *source, int d
 			}
 		}
 
-        bool clientsNeedUpdate = false;
+		bool clientsNeedUpdate = false;
 		if (!player)
 		{
 			SV_SendDamageMobj(target, pain);

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -626,10 +626,8 @@ odaproto::svc::UserInfo SVC_UserInfo(const player_t& player, int64_t time)
 /**
  * @brief Update mobj data on the client compared to the baseline.
  */
-odaproto::svc::UpdateMobj SVC_UpdateMobj(const AActor& mobj)
+static void FillUpdateMobj(odaproto::svc::UpdateMobj& msg, const AActor& mobj)
 {
-	odaproto::svc::UpdateMobj msg;
-
 	uint32_t flags = P_GetMobjBaselineFlags(mobj);
 	msg.set_flags(flags);
 
@@ -688,10 +686,23 @@ odaproto::svc::UpdateMobj SVC_UpdateMobj(const AActor& mobj)
 	{
 		mom->set_z(mobj.momz);
 	}
+}
+
+odaproto::svc::UpdateMobj SVC_UpdateMobj(const AActor& mobj)
+{
+	odaproto::svc::UpdateMobj msg;
+	FillUpdateMobj(msg, mobj);
+	return msg;
+}
+
+odaproto::svc::UpdateMobjWithMode SVC_UpdateMobjWithMode(const AActor& mobj)
+{
+    odaproto::svc::UpdateMobjWithMode msg;
+
+    FillUpdateMobj(* msg.mutable_update(), mobj);
 
 	msg.set_mode(static_cast<odaproto::svc::MobjModeEnum>(mobj.mode));
-
-	return msg;
+    return msg;
 }
 
 EXTERN_CVAR(sv_sharekeys);

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -697,12 +697,12 @@ odaproto::svc::UpdateMobj SVC_UpdateMobj(const AActor& mobj)
 
 odaproto::svc::UpdateMobjWithMode SVC_UpdateMobjWithMode(const AActor& mobj)
 {
-    odaproto::svc::UpdateMobjWithMode msg;
+	odaproto::svc::UpdateMobjWithMode msg;
 
-    FillUpdateMobj(* msg.mutable_update(), mobj);
+	FillUpdateMobj(* msg.mutable_update(), mobj);
 
 	msg.set_mode(static_cast<odaproto::svc::MobjModeEnum>(mobj.mode));
-    return msg;
+	return msg;
 }
 
 EXTERN_CVAR(sv_sharekeys);

--- a/common/svc_message.h
+++ b/common/svc_message.h
@@ -97,6 +97,7 @@ odaproto::svc::ExplodeMissile SVC_ExplodeMissile(const AActor& mobj);
 odaproto::svc::RemoveMobj SVC_RemoveMobj(const AActor& mobj);
 odaproto::svc::UserInfo SVC_UserInfo(const player_t& player, int64_t time);
 odaproto::svc::UpdateMobj SVC_UpdateMobj(const AActor& mobj);
+odaproto::svc::UpdateMobjWithMode SVC_UpdateMobjWithMode(const AActor& mobj);
 odaproto::svc::SpawnPlayer SVC_SpawnPlayer(const player_t& player, int tic);
 odaproto::svc::DamagePlayer SVC_DamagePlayer(const player_t& player, const AActor *inflictor, int health, int armor, int destinationClientTicOfValidity);
 odaproto::svc::KillMobj SVC_KillMobj(const AActor* source, const AActor* target, const AActor* inflictor,

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -164,7 +164,7 @@ message UpdateMobj
 message UpdateMobjWithMode
 {
 	UpdateMobj   update = 1;
-	MobjModeEnum mode   = 3;
+	MobjModeEnum mode   = 2;
 }
 
 // svc_spawnplayer

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -157,8 +157,14 @@ enum MobjModeEnum
 message UpdateMobj
 {
 	uint32 flags = 1;
-	Actor actor = 2;
-	MobjModeEnum mode = 3;
+	Actor  actor = 2;
+}
+
+// svc_updatemobjwithmode
+message UpdateMobjWithMode
+{
+	UpdateMobj   update = 1;
+	MobjModeEnum mode   = 3;
 }
 
 // svc_spawnplayer

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3108,7 +3108,7 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 	                                     sortedMobjIter->distanceSquared < HYPER_AWARENESS_CUTOFF_SQUARED;
 	if (isHyperAware)
 	{
-		MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobj(*mo));
+		MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobjWithMode(*mo));
 	}
 	else
 	{
@@ -3147,7 +3147,7 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 					break;
 
 				default:
-					MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobj(*mo));
+					MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobjWithMode(*mo));
 					break;
 			}
 		}
@@ -3293,7 +3293,7 @@ void SV_UpdateMonsters(player_t& player, AActor *mo)
 				break;
 
 			default:
-				MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobj(*mo));
+				MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobjWithMode(*mo));
 				break;
 		}
 	}
@@ -3720,7 +3720,7 @@ void SV_WriteCommandsForPlayer(player_t& player)
 			// Now in this case we're okay with *potentially* going overbudget or behind-by-one tic,
 			// because the player has a mobj that's multiple seconds out of date.  Being a even little
 			// late is better than that.
-			MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_UpdateMobj(*sortedMobjIter->actorPtr));
+			MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_UpdateMobjWithMode(*sortedMobjIter->actorPtr));
 			player.requestedNetIdUpdate = 0;
 		}
 	}

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3154,7 +3154,14 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 	}
 }
 
-static void ImmediateUpdateMobj(AActor& mobj, bool reliableIsAllowed)
+enum class TransportEnum
+{
+	AUTO,
+	BEST_EFFORT,
+	RELIABLE
+};
+
+static void ImmediateUpdateMobj(AActor& mobj, TransportEnum transport)
 {
 	// Don't use this function to update players.
 	if (mobj.player)
@@ -3166,6 +3173,12 @@ static void ImmediateUpdateMobj(AActor& mobj, bool reliableIsAllowed)
 	{
 		if (player.ingame() and SV_IsPlayerAllowedToSee(player, &mobj))
 		{
+			MessageQueue& fullAwareQueue = transport == TransportEnum::AUTO or
+			                               transport == TransportEnum::RELIABLE ? player.client.messenger.ReliableBuf() :
+			                                                                      player.client.messenger.NetBuf();
+			MessageQueue& semiAwareQueue = transport == TransportEnum::AUTO or
+			                               transport == TransportEnum::BEST_EFFORT ? player.client.messenger.NetBuf() :
+			                                                                         player.client.messenger.ReliableBuf();
 			switch (mobj.playersAware.Get(player.id))
 			{
 				case AwarenessEnum::NOT_AWARE:         [[ fallthrough ]];
@@ -3175,14 +3188,13 @@ static void ImmediateUpdateMobj(AActor& mobj, bool reliableIsAllowed)
 				case AwarenessEnum::ALWAYS_AWARE:      [[ fallthrough ]];
 				case AwarenessEnum::FULLY_AWARE:
 					mobj.updatedDuringTic = gametic;
-					MSG_WriteSVC(reliableIsAllowed ? player.client.messenger.ReliableBuf()
-					                               : player.client.messenger.NetBuf(),
-					             message);
+					MSG_WriteSVC(fullAwareQueue, message);
 					break;
 
 				case AwarenessEnum::SEMI_AWARE:
 					mobj.updatedDuringTic = gametic;
-					MSG_WriteSVC(player.client.messenger.NetBuf(), message);
+					MSG_WriteSVC(semiAwareQueue, message);
+					break;
 			}
 		}
 	}
@@ -3191,13 +3203,19 @@ static void ImmediateUpdateMobj(AActor& mobj, bool reliableIsAllowed)
 // Update the given actors data immediately, using standard Reliable and Best-effort transports as appropriate.
 void SV_UpdateMobj(AActor* mo)
 {
-	ImmediateUpdateMobj(*mo, true);
+	ImmediateUpdateMobj(*mo, TransportEnum::AUTO);
 }
 
 // Update the given actors data immediately, ONLY using Best-effort transport.
 void SV_UpdateMobjBestEffort(AActor* mo)
 {
-	ImmediateUpdateMobj(*mo, false);
+	ImmediateUpdateMobj(*mo, TransportEnum::BEST_EFFORT);
+}
+
+// Update the given actors data immediately, ONLY using Reliable transport.
+void SV_UpdateMobjReliable(AActor* mo)
+{
+	ImmediateUpdateMobj(*mo, TransportEnum::RELIABLE);
 }
 
 void SV_WakeupMobj(const AActor* mo, bool mustPlaySeeSound)
@@ -3261,7 +3279,7 @@ void SV_UpdateMonsters(player_t& player, AActor *mo)
 	if ((gametic+mo->netid) % 7)
 		return;
 
-	// Avoid sending more than one Update Mobj per tic for any missile.
+	// Avoid sending more than one Update Mobj per tic for any monsters.
 	// Here we check to see if an update went out during the "meat" of the tic, which is complete at this point.
 	if (mo->updatedDuringTic == gametic)
 		return;
@@ -5120,15 +5138,6 @@ void SV_SendDamageMobj(AActor *target, int pain)
 		if (SV_IsPlayerAllowedToSee(player, target))
 		{
 			MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_DamageMobj(target, pain));
-
-			// If we're letting the client gradually forget about this mobj, don't bother with
-			// a mobj update.  Also, don't bother if it's another player, because other players
-			// get updated with a special message.
-			if (target->playersAware.Get(player.id) != AwarenessEnum::BARELY_AWARE and not target->player)
-			{
-				target->updatedDuringTic = gametic;
-				MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobj(*target));
-			}
 		}
 	}
 }

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3173,12 +3173,10 @@ static void ImmediateUpdateMobj(AActor& mobj, TransportEnum transport)
 	{
 		if (player.ingame() and SV_IsPlayerAllowedToSee(player, &mobj))
 		{
-			MessageQueue& fullAwareQueue = transport == TransportEnum::AUTO or
-			                               transport == TransportEnum::RELIABLE ? player.client.messenger.ReliableBuf() :
-			                                                                      player.client.messenger.NetBuf();
-			MessageQueue& semiAwareQueue = transport == TransportEnum::AUTO or
-			                               transport == TransportEnum::BEST_EFFORT ? player.client.messenger.NetBuf() :
-			                                                                         player.client.messenger.ReliableBuf();
+			MessageQueue& fullAwareQueue = transport == TransportEnum::BEST_EFFORT ? player.client.messenger.NetBuf()
+			                                                                       : player.client.messenger.ReliableBuf();
+			MessageQueue& semiAwareQueue = transport == TransportEnum::RELIABLE ? player.client.messenger.ReliableBuf()
+                                                                                : player.client.messenger.NetBuf();
 			switch (mobj.playersAware.Get(player.id))
 			{
 				case AwarenessEnum::NOT_AWARE:         [[ fallthrough ]];

--- a/tests/unit-tests/src/t_stubs.cpp
+++ b/tests/unit-tests/src/t_stubs.cpp
@@ -102,6 +102,7 @@ void SV_PreservePlayer(player_t &player) {}
 void SV_BroadcastSector(int sectornum) {}
 void SV_UpdateMobj(AActor* mo) {}
 void SV_UpdateMobjBestEffort(AActor* mo) {}
+void SV_UpdateMobjReliable(AActor* mo) {}
 void SV_UpdateMobjState(const AActor* mo) {}
 void SV_WakeupMobj(const AActor* mo, bool mustPlaySeeSound) {};
 


### PR DESCRIPTION
This partially addresses a ghost-creation issue where an out-of-order best-effort vs. reliable update can change a mobj's mode from a DEATH mode to anything else.

The bug can create ghosts if a reliable KillMobj arrives before a best-effort UpdateMobj from the same frame.  This is more likely to actually happen if the mobj changed state during `P_DamageMobj` in the same tic in which it was killed (i.e. multiple players shooting something at the same time), and there's latency jitter on the same tic that the monster is killed.  It's unlikely in terms of absolute numbers, as in, one in thousands, but that becomes *relatively likely*, statistically speaking, as monster count and player count scale, especially for players that have international packet routes.

The second half of this fix is in an upcoming PR that adds packet-level timestamps and rejection of mobj updates that pre-date the most recent reliable mobj update.