### PR TITLE
Initial netdebug_automap

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -120,6 +120,8 @@ EXTERN_CVAR(am_ovscalewidth)
 EXTERN_CVAR(am_ovscaleheight)
 EXTERN_CVAR(am_ovlocation)
 
+EXTERN_CVAR(netdebug_automap)
+
 BEGIN_COMMAND(resetcustomcolors)
 {
 	am_backcolor = "00 00 3a";
@@ -1891,6 +1893,8 @@ void AM_drawCheatThing(const AActor* t)
 	angle_t rotate_angle = 0;
 	angle_t triangle_angle = tangle;
 
+	const fixed64_t radius = FIXED2FIXED64(t->radius);
+
 	if (am_rotate)
 	{
 		AM_rotatePoint(p);
@@ -1919,16 +1923,14 @@ void AM_drawCheatThing(const AActor* t)
 		{
 			const am_color_t key_color = AM_getKeyColor(t);
 
-			AM_drawLineCharacter(gameinfo.cheatKey, FIXED2FIXED64(t->radius), 0, key_color, p.x,
-			                     p.y);
+			AM_drawLineCharacter(gameinfo.cheatKey, radius, 0, key_color, p.x, p.y);
 		}
 	}
 	else
 	{
 		am_color_t color = gameinfo.currentAutomapColors.ThingColor;
 
-		AM_drawLineCharacter(thintriangle_guy, FIXED2FIXED64(t->radius), triangle_angle, color,
-		                     p.x, p.y);
+		AM_drawLineCharacter(thintriangle_guy, radius, triangle_angle, color, p.x, p.y);
 
 		if (t->flags & MF_MISSILE)
 		{
@@ -1951,8 +1953,16 @@ void AM_drawCheatThing(const AActor* t)
 				color = gameinfo.currentAutomapColors.ThingColor_NoCountMonster;
 		}
 
-		AM_drawLineCharacter(thinrectangle_guy, FIXED2FIXED64(t->radius), rotate_angle, color,
-		                     p.x, p.y);
+		AM_drawLineCharacter(thinrectangle_guy, radius, rotate_angle, color, p.x, p.y);
+	}
+
+	if (netdebug_automap)
+	{
+		screen->DrawTextStretched(CR_GREY,
+		                          CXMTOF(p.x - radius),
+		                          CYMTOF(p.y + radius) - V_LineHeight() * 2,
+		                          fmt::sprintf("%d", t->netid).c_str(),
+		                          2, 2);
 	}
 }
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -379,26 +379,36 @@ CVAR(cl_downloadsites,
      "with ZIP.",
      CVARTYPE_STRING, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE)
 
-CVAR_RANGE_FUNC_DECL(cl_interp, "1", "Interpolate enemy player positions",
-					CVARTYPE_INT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 4.0f)
+CVAR_RANGE_FUNC_DECL(cl_interp, "1",
+                    "Interpolate enemy player positions",
+                    CVARTYPE_INT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 4.0f)
 
-CVAR_RANGE(			cl_prednudge,	"0.70", "Smooth out collisions",
-					CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.05f, 1.0f)
+CVAR_RANGE(cl_prednudge, "0.70",
+            "Smooth out collisions",
+            CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.05f, 1.0f)
 
-CVAR(				cl_predictweapons, "1", "Draw weapon effects immediately",
-					CVARTYPE_BOOL, CVAR_USERINFO | CVAR_CLIENTARCHIVE)
+CVAR(cl_predictweapons, "1",
+    "Draw weapon effects immediately",
+    CVARTYPE_BOOL, CVAR_USERINFO | CVAR_CLIENTARCHIVE)
 
-CVAR(				cl_netgraph, "0", "Show a graph of network related statistics",
-					CVARTYPE_BOOL, CVAR_NULL)
+CVAR(cl_netgraph, "0",
+    "Show a graph of network related statistics",
+     CVARTYPE_BOOL, CVAR_NULL)
 
-CVAR(				cl_serverdownload, "1", "Enable or disable downloading game files and resources from the internet " \
-											"(see cl_downloadsites for more information)",
-					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
+CVAR(cl_serverdownload, "1",
+    "Enable or disable downloading game files and resources from the internet "
+    "(see cl_downloadsites for more information)",
+    CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
-CVAR(				cl_forcedownload, "0", "Forces the client to download the last WAD file when connecting " \
-											"to a server, even if the client already has that file " \
-											"(requires developer 1).",
-					CVARTYPE_BOOL, CVAR_NULL)
+CVAR(cl_forcedownload, "0",
+    "Forces the client to download the last WAD file when connecting "
+    "to a server, even if the client already has that file "
+    "(requires developer 1).",
+    CVARTYPE_BOOL, CVAR_NULL)
+
+CVAR(netdebug_automap, "0",
+    "Enables display of various netcode debugging information on the automap.  Requires iddt level 2 cheat.",
+    CVARTYPE_BOOL, CVAR_NULL)
 
 // Client Preferences
 // ------------------
@@ -772,7 +782,7 @@ CVAR(			r_drawflat, "0", "Disables all texturing of walls, floors and ceilings",
 CVAR(			r_clipmaskedspecial, "0", "Vertically clip masked midtextures when surrounding sectors have differing specials (mimics Hexen and DSDA-Doom behavior)",
 				CVARTYPE_BOOL, CVAR_NULL)
 
-CVAR(			r_thingsectorlight, "0", "Things are lit according to the average of the transferred light levels (mimics MBF behavior)",
+CVAR(			r_thingsectorlight, "0", "Things are lit according to the average of the transfered light levels (mimics MBF behavior)",
 				CVARTYPE_BOOL, CVAR_NULL)
 
 CVAR(           r_drawnetcredibility, "0", "Add a particle to each actor indicating how credible the client considers the actor's position",


### PR DESCRIPTION
This PR introduces a new debugging aid.  When cheats are enabled, and `iddt` level 2 is active, the `netdebug_automap` cvar can be toggled on to show mobj netids directly above their bounding boxes on the automap.