### PR TITLE
Fix desynched healing animation for custom healers

### DIFF
--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -3037,7 +3037,8 @@ bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 					A_FaceTarget(actor);
 					actor->target = temp;
 
-					P_SetMobjState(actor, static_cast<statenum_t>(healstate));
+					// Force a client update because healstate might NOT be a "mode" for custom healers.
+					P_SetMobjState(actor, static_cast<statenum_t>(healstate), true);
 
 					if (!clientside)
 						SV_Sound(corpsehit, CHAN_BODY, SoundMap[healsound].c_str(), ATTN_IDLE);


### PR DESCRIPTION
A custom healer monster can have its healing phase be an ordinary animation, rather than setup as a "mode" transition state.  (NT2F's Diabolist is an example of such a monster.)  This creates the opportunity for the server-side monster to proceed into that phase without informing the client that it's doing so, thus allowing the client to continue predicting A_Chase motion while the server has the monster standing still and performing the heal operation.

This PR fixes that by always having the transition into the heal animation/states be communicated to the clients.