### PR TITLE
[BUGFIX] Odalpapi NET_ReportError never includes file/line/function on GCC/Clang

### DIFF
--- a/odalpapi/net_error.cpp
+++ b/odalpapi/net_error.cpp
@@ -154,7 +154,7 @@ void _ReportError(const char* file, int line, const char* func,
 #endif
 }
 
-#if _MSC_VER < 1400
+#if defined(_MSC_VER) && _MSC_VER < 1400
 void NET_ReportError(const char* fmt, ...)
 {
 	va_list ap;

--- a/odalpapi/net_error.h
+++ b/odalpapi/net_error.h
@@ -32,7 +32,7 @@ namespace odalpapi
 
 void _ReportError(const char* file, int line, const char* func,
                   const char* fmt, ...);
-#if (_MSC_VER < 1400) // __VA_ARGS__ not supported by older ANSI C++
+#if defined(_MSC_VER) && (_MSC_VER < 1400) // __VA_ARGS__ not supported by older ANSI C++
 	void NET_ReportError(const char* fmt, ...);
 #else
 	#define NET_ReportError(...) \


### PR DESCRIPTION
Fixes the errors always saying `[:0] BufferedSocket::()`.