### PR TITLE
Make USE_SANITIZE_ADDRESS available when building with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,20 +136,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS "${CMAKE_EXPORT_COMPILE_COMMANDS}" CACHE BOOL
   FORCE)
 
 # Global compile options as shown in a GUI.
+option(USE_SANITIZE_THREAD "Turn on Thread Sanitizer in Debug builds." OFF)
 if(NOT MSVC)
-  set(USE_COLOR_DIAGNOSTICS ON CACHE BOOL
-    "Force the use of color diagnostics, necessary to get color output with Ninja.")
-  set(USE_STATIC_STDLIB OFF CACHE BOOL
-    "Statically link against the C and C++ Standard Library.")
-  set(USE_SANITIZE_ADDRESS OFF CACHE BOOL
-    "Turn on Address Sanitizer in Debug builds.")
-  set(USE_SANITIZE_THREAD OFF CACHE BOOL
-    "Turn on Thread Sanitizer in Debug builds.")
+  option(USE_COLOR_DIAGNOSTICS "Force the use of color diagnostics, necessary to get color output with Ninja." ON)
+  option(USE_STATIC_STDLIB "Statically link against the C and C++ Standard Library." OFF)
+  option(USE_SANITIZE_ADDRESS "Turn on Address Sanitizer in Debug builds." OFF)
   if(USE_SANITIZE_ADDRESS AND USE_SANITIZE_THREAD)
     message(FATAL_ERROR "USE_SANITIZE_ADDRESS and USE_SANITIZE_THREAD are mutually exclusive options.")
   endif()
-  set(USE_SANITIZE_UNDEFINED OFF CACHE BOOL
-    "Turn on Undefined Behavior Sanitizer in Debug builds.")
+  option(USE_SANITIZE_UNDEFINED "Turn on Undefined Behavior Sanitizer in Debug builds." OFF)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES SunOS )

--- a/cmake/modules/OdamexTargetSettings.cmake
+++ b/cmake/modules/OdamexTargetSettings.cmake
@@ -35,6 +35,9 @@ function(odamex_target_settings _TARGET)
     target_compile_definitions("${_TARGET}" PRIVATE
       $<$<CONFIG:Debug>:ODAMEX_DEBUG> _CRT_SECURE_NO_WARNINGS)
     target_compile_options("${_TARGET}" PRIVATE /MP)
+    if(USE_SANITIZE_ADDRESS)
+      target_compile_options("${_TARGET}" PRIVATE /fsanitize=address)
+    endif()
   else()
     target_compile_definitions("${_TARGET}" PRIVATE
       $<$<CONFIG:Debug>:ODAMEX_DEBUG>)
@@ -100,7 +103,11 @@ function(odamex_target_settings _TARGET)
 
   # Add link options - checked link options need at least 3.18.
   if(MSVC)
-    target_link_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
+    if(USE_SANITIZE_ADDRESS)
+      target_link_options("${_TARGET}" PRIVATE /INCREMENTAL:NO)
+    else()
+      target_link_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
+    endif()
     target_link_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/LTCG>)
   endif()
 


### PR DESCRIPTION
MSVC has supported ASan since Visual Studio 2019 version 16.9