### PR TITLE
[BUGFIX] Multiple HOM/Fake Flat fixes across the engine

### DIFF
--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -458,23 +458,24 @@ void R_AddLine (const seg_t *line)
 
 	dcol.color = ((line - segs) & 31) * 4;	// [RH] Color if not texturing line
 
-	// translate the line seg endpoints from world-space to camera-space
-	// and store in (t1.x, t1.y) and (t2.x, t2.y)
-	v2fixed_t t1, t2;
-	R_RotatePoint(line->v1->x - viewx, line->v1->y - viewy, ANG90 - viewangle, t1.x, t1.y);
-	R_RotatePoint(line->v2->x - viewx, line->v2->y - viewy, ANG90 - viewangle, t2.x, t2.y);
+	// translate the line seg endpoints from world-space to camera-space,
+	// keeping full 64-bit precision (t1, t2) so distant walls on huge maps
+	// (Planisphere 2) do not lose precision.
+	v2fixed64_t t1, t2;
+	R_RotatePoint64(int64_t(line->v1->x) - viewx, int64_t(line->v1->y) - viewy, ANG90 - viewangle, t1.x, t1.y);
+	R_RotatePoint64(int64_t(line->v2->x) - viewx, int64_t(line->v2->y) - viewy, ANG90 - viewangle, t2.x, t2.y);
 
 	// Clip the line seg to the viewing window
 	int32_t lclip, rclip;
-	if (!R_ClipLineToFrustum(&t1, &t2, NEARCLIP, lclip, rclip))
+	if (!R_ClipLineToFrustum64(t1, t2, NEARCLIP, lclip, rclip))
 		return;
 
 	// apply the view frustum clipping to t1 & t2
-	R_ClipLine(&t1, &t2, lclip, rclip, &t1, &t2);
+	R_ClipLine64(t1, t2, lclip, rclip, t1, t2);
 
 	// project the line endpoints to determine which columns the line seg occupies
-	int x1 = R_ProjectPointX(t1.x, t1.y);
-	int x2 = R_ProjectPointX(t2.x, t2.y) - 1;
+	int x1 = R_ProjectPointX64(t1.x, t1.y);
+	int x2 = R_ProjectPointX64(t2.x, t2.y) - 1;
 	if (!R_CheckProjectionX(x1, x2))
 		return;
 
@@ -490,7 +491,11 @@ void R_AddLine (const seg_t *line)
 	static sector_t tempsec;
 	backsector = line->backsector ? R_FakeFlat(line->backsector, &tempsec, NULL, NULL, true) : NULL;
 
-	R_PrepWall(w1.x, w1.y, w2.x, w2.y, t1.y, t2.y, x1, x2);
+	// Clamp the max scaling distance to prevent an overflow
+	static constexpr int64_t maxwalldist = int64_t(16384) * FRACUNIT;
+	const fixed_t d1 = static_cast<fixed_t>(t1.y > maxwalldist ? maxwalldist : t1.y);
+	const fixed_t d2 = static_cast<fixed_t>(t2.y > maxwalldist ? maxwalldist : t2.y);
+	R_PrepWall(w1.x, w1.y, w2.x, w2.y, d1, d2, x1, x2);
 
 	// [SL] Check for single-sided line, closed doors or other scenarios that
 	// would make this line seg solid.
@@ -607,8 +612,10 @@ static bool R_CheckBBox(const fixed_t *bspcoord)
 
 	// translate the bounding box vertices from world-space to camera-space
 	// and store in (t1.x, t1.y) and (t2.x, t2.y)
-	R_RotatePoint(xl - viewx, yl - viewy, ANG90 - viewangle, t1.x, t1.y);
-	R_RotatePoint(xh - viewx, yh - viewy, ANG90 - viewangle, t2.x, t2.y);
+	// if we scale it down here, don't let it cull any bsp subtrees
+	if (R_RotatePointSafe(int64_t(xl) - viewx, int64_t(yl) - viewy, ANG90 - viewangle, t1.x, t1.y) ||
+	    R_RotatePointSafe(int64_t(xh) - viewx, int64_t(yh) - viewy, ANG90 - viewangle, t2.x, t2.y))
+		return true;
 
 	v2fixed_t box_pts[4][2];
 	// top line of box

--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -447,6 +447,51 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 
 
 //
+// R_CheckClippedSegForFakeFlat
+//
+// We clip lines within NEARCLIP of the viewpoint, but these lines
+// may be needed to run R_FakeFlat.
+//
+// Check the clipped  segs for being within NEARCLIP of the view
+// point and if so, run R_FakeFlat on them
+//
+static void R_CheckClippedSegForFakeFlat(const seg_t* line)
+{
+	if (r_fakingunderwater || !line->backsector || !line->backsector->heightsec)
+		return;
+
+	// segs entirely behind the view plane cannot occupy the view
+	v2fixed64_t t1, t2;
+	R_RotatePoint64(int64_t(line->v1->x) - viewx, int64_t(line->v1->y) - viewy, ANG90 - viewangle, t1.x, t1.y);
+	R_RotatePoint64(int64_t(line->v2->x) - viewx, int64_t(line->v2->y) - viewy, ANG90 - viewangle, t2.x, t2.y);
+	if (t1.y < 0 && t2.y < 0)
+		return;
+
+	// is the view point within NEARCLIP of the seg?
+	const double dx = double(int64_t(line->v2->x) - line->v1->x);
+	const double dy = double(int64_t(line->v2->y) - line->v1->y);
+	const double px = double(int64_t(viewx) - line->v1->x);
+	const double py = double(int64_t(viewy) - line->v1->y);
+
+	const double len2 = dx * dx + dy * dy;
+	double u = len2 > 0.0 ? (px * dx + py * dy) / len2 : 0.0;
+	u = u < 0.0 ? 0.0 : (u > 1.0 ? 1.0 : u);
+
+	const double ex = px - u * dx;
+	const double ey = py - u * dy;
+
+	if (ex * ex + ey * ey >= double(NEARCLIP) * double(NEARCLIP))
+		return;
+
+	// let R_FakeFlat run the deep water window checks, considering the
+	// entire width of the view since the rejected seg has no column range
+	static sector_t tempsec;
+	rw_start = 0;
+	rw_stop = viewwidth - 1;
+	R_FakeFlat(line->backsector, &tempsec, NULL, NULL, true);
+}
+
+//
 // R_AddLine
 // Clips the given segment
 // and adds any visible pieces to the line list.
@@ -457,7 +502,11 @@ void R_AddLine (const seg_t *line)
 
 	// skip this line if it's not facing the camera
 	if (R_PointOnSegSide(viewx, viewy, line) != 0)
+	{
+		// a seg passing exactly through the view point is also rejected here
+		R_CheckClippedSegForFakeFlat(line);
 		return;
+	}
 
 	dcol.color = ((line - segs) & 31) * 4;	// [RH] Color if not texturing line
 
@@ -471,7 +520,10 @@ void R_AddLine (const seg_t *line)
 	// Clip the line seg to the viewing window
 	int32_t lclip, rclip;
 	if (!R_ClipLineToFrustum64(t1, t2, NEARCLIP, lclip, rclip))
+	{
+		R_CheckClippedSegForFakeFlat(line);
 		return;
+	}
 
 	// apply the view frustum clipping to t1 & t2
 	R_ClipLine64(t1, t2, lclip, rclip, t1, t2);
@@ -480,7 +532,10 @@ void R_AddLine (const seg_t *line)
 	int x1 = R_ProjectPointX64(t1.x, t1.y);
 	int x2 = R_ProjectPointX64(t2.x, t2.y) - 1;
 	if (!R_CheckProjectionX(x1, x2))
+	{
+		R_CheckClippedSegForFakeFlat(line);
 		return;
+	}
 
 	rw_start = x1;
 	rw_stop = x2;

--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -234,7 +234,9 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 
 	sector_t* heightsec = viewsector->heightsec;
 
-	bool underwater = r_fakingunderwater ||
+	// Gate r_fakingunderwater to only apply to heightsecs with
+	// possible deep water, since it applies to every heightsec in frame.
+	bool underwater = (r_fakingunderwater && s->floorheight > sec->floorheight) ||
 		(heightsec && viewz <= P_FloorHeight(viewx, viewy, heightsec));
 	bool doorunderwater = false;
 	int diffTex = (s->MoreFlags & SECF_CLIPFAKEPLANES);
@@ -302,7 +304,8 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 	// Only works if you cannot see the top surface of any deep water
 	// sectors at the same time.
 
-	if (back && !r_fakingunderwater && curline->frontsector->heightsec == NULL)
+	if (back && !r_fakingunderwater && curline->frontsector->heightsec == NULL &&
+		s->floorheight > sec->floorheight)
 	{
 		fixed_t fcz1 = P_CeilingHeight(curline->v1->x, curline->v1->y, frontsector);
 		fixed_t fcz2 = P_CeilingHeight(curline->v2->x, curline->v2->y, frontsector);

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -149,7 +149,22 @@ IWindowSurface* R_GetRenderingSurface()
 //
 int R_PointOnSide(fixed_t x, fixed_t y, fixed_t xl, fixed_t yl, fixed_t xh, fixed_t yh)
 {
-	return int64_t(xh - xl) * (y - yl) - int64_t(yh - yl) * (x - xl) >= 0;
+	int64_t dx = int64_t(xh) - xl;
+	int64_t dy = int64_t(yh) - yl;
+	int64_t px = int64_t(x) - xl;
+	int64_t py = int64_t(y) - yl;
+
+	static constexpr int64_t limit = int64_t(1) << 31;
+	if (dx >= limit || dx < -limit || dy >= limit || dy < -limit ||
+	    px >= limit || px < -limit || py >= limit || py < -limit)
+	{
+		dx >>= FRACBITS;
+		dy >>= FRACBITS;
+		px >>= FRACBITS;
+		py >>= FRACBITS;
+	}
+
+	return dx * py - dy * px >= 0;
 }
 
 //
@@ -189,7 +204,23 @@ int R_PointOnSegSide(fixed_t x, fixed_t y, const seg_t *line)
 //
 bool R_PointOnLine(fixed_t x, fixed_t y, fixed_t xl, fixed_t yl, fixed_t xh, fixed_t yh)
 {
-	return int64_t(xh - xl) * (y - yl) - int64_t(yh - yl) * (x - xl) == 0;
+	// 64-bit deltas for the same reason as R_PointOnSide above
+	int64_t dx = int64_t(xh) - xl;
+	int64_t dy = int64_t(yh) - yl;
+	int64_t px = int64_t(x) - xl;
+	int64_t py = int64_t(y) - yl;
+
+	static constexpr int64_t limit = int64_t(1) << 31;
+	if (dx >= limit || dx < -limit || dy >= limit || dy < -limit ||
+	    px >= limit || px < -limit || py >= limit || py < -limit)
+	{
+		dx >>= FRACBITS;
+		dy >>= FRACBITS;
+		px >>= FRACBITS;
+		py >>= FRACBITS;
+	}
+
+	return dx * py - dy * px == 0;
 }
 
 
@@ -279,6 +310,53 @@ void R_RotatePoint(fixed_t x, fixed_t y, angle_t ang, fixed_t &tx, fixed_t &ty)
 
 	tx = FixedMul(x, finecosine[index]) - FixedMul(y, finesine[index]);
 	ty = FixedMul(x, finesine[index]) + FixedMul(y, finecosine[index]);
+}
+
+//
+// R_RotatePointSafe
+//
+// Rotates world space into camera space, but has special provisions to
+// keep the calculation 64-bit and to rescale the result if it is too large
+// to fit in a fixed_t.
+//
+// R_RotatePoint takes 16.16 fixed point as input, but it can overflow if it
+// tries to rotate world space in a sightline longer than ~32767 fracunits.
+//
+// Returns true if the result had to be rescaled.
+//
+bool R_RotatePointSafe(int64_t x, int64_t y, angle_t ang, fixed_t &tx, fixed_t &ty)
+{
+	int index = ang >> ANGLETOFINESHIFT;
+
+	// same operations as FixedMul, kept in 64 bits
+	int64_t tx64 = ((x * finecosine[index]) >> FRACBITS) - ((y * finesine[index]) >> FRACBITS);
+	int64_t ty64 = ((x * finesine[index]) >> FRACBITS) + ((y * finecosine[index]) >> FRACBITS);
+
+	// Max distance for fixed_t (16.16 fixed point)
+	static constexpr int64_t limit = (int64_t(1) << 30) - 1;
+	const int64_t mag = MAX<int64_t>(tx64 < 0 ? -tx64 : tx64, ty64 < 0 ? -ty64 : ty64);
+	if (mag <= limit)
+	{
+		tx = static_cast<fixed_t>(tx64);
+		ty = static_cast<fixed_t>(ty64);
+		return false;
+	}
+
+	// Max rescale instead of overflow.
+	// This only kicks in if the x/y to rotate is larger than ~131,000 fracunits.
+	// The maximum possible sightline in a 16-bit coordinate map is ~56636 fracunits.
+	if (mag > INT64_MAX / limit)
+	{
+		const double scale = static_cast<double>(limit) / static_cast<double>(mag);
+		tx = static_cast<fixed_t>(tx64 * scale);
+		ty = static_cast<fixed_t>(ty64 * scale);
+	}
+	else
+	{
+		tx = static_cast<fixed_t>(tx64 * limit / mag);
+		ty = static_cast<fixed_t>(ty64 * limit / mag);
+	}
+	return true;
 }
 
 //
@@ -397,6 +475,106 @@ bool R_ClipLineToFrustum(const v2fixed_t* v1, const v2fixed_t* v2, fixed_t clipd
 	return true;
 }
 
+//
+// 64-bit camera-space clipping/projection.
+//
+// These mirror R_RotatePoint / R_ClipLine / R_ClipLineToFrustum /
+// R_ProjectPointX exactly, but keep the camera-space coordinates in 64 bits
+// instead of squeezing them into a fixed_t.
+//
+static inline int64_t R_iMul30(int64_t a, int64_t b) { return (a * b) >> 30; }
+static inline int64_t R_iDiv30(int64_t a, int64_t b) { return (a << 30) / b; }
+static inline int64_t R_iMulFrac(int64_t a, int64_t b) { return (a * b) >> FRACBITS; }
+
+void R_RotatePoint64(int64_t x, int64_t y, angle_t ang, int64_t& tx, int64_t& ty)
+{
+	const int index = ang >> ANGLETOFINESHIFT;
+	tx = ((x * finecosine[index]) >> FRACBITS) - ((y * finesine[index]) >> FRACBITS);
+	ty = ((x * finesine[index]) >> FRACBITS) + ((y * finecosine[index]) >> FRACBITS);
+}
+
+void R_ClipLine64(const v2fixed64_t& in1, const v2fixed64_t& in2,
+                  int32_t lclip, int32_t rclip,
+                  v2fixed64_t& out1, v2fixed64_t& out2)
+{
+	// Capture inputs into locals first so this is safe when an output aliases
+	// an input (R_AddLine calls it as R_ClipLine64(t1, t2, ..., t1, t2)).
+	const int64_t dx = in2.x - in1.x;
+	const int64_t dy = in2.y - in1.y;
+	const int64_t x = in1.x;
+	const int64_t y = in1.y;
+	out1.x = x + R_iMul30(lclip, dx);
+	out2.x = x + R_iMul30(rclip, dx);
+	out1.y = y + R_iMul30(lclip, dy);
+	out2.y = y + R_iMul30(rclip, dy);
+}
+
+bool R_ClipLineToFrustum64(const v2fixed64_t& v1, const v2fixed64_t& v2, int64_t clipdist,
+                           int32_t& lclip, int32_t& rclip)
+{
+	static constexpr int32_t CLIPUNIT = 1 << 30;
+	v2fixed64_t p1 = v1, p2 = v2;
+
+	lclip = 0;
+	rclip = CLIPUNIT;
+
+	// Clip portions of the line that are behind the view plane
+	if (p1.y < clipdist)
+	{
+		if (p2.y < clipdist)
+			return false;
+		lclip = static_cast<int32_t>(R_iDiv30(clipdist - p1.y, p2.y - p1.y));
+	}
+
+	if (p2.y < clipdist)
+		rclip = static_cast<int32_t>(R_iDiv30(clipdist - p1.y, p2.y - p1.y));
+
+	const int32_t unclipped_amount = rclip - lclip;
+
+	// apply the clipping against the 'y = clipdist' plane to p1 & p2
+	R_ClipLine64(v1, v2, lclip, rclip, p1, p2);
+
+	const int64_t yc1 = R_iMulFrac(fovtan, p1.y);
+	const int64_t yc2 = R_iMulFrac(fovtan, p2.y);
+
+	// is the entire line off the left side or the right side of the screen?
+	if ((p1.x < -yc1 && p2.x < -yc2) || (p1.x > yc1 && p2.x > yc2))
+		return false;
+
+	// is the left vertex off the left side of the screen?
+	if (p1.x < -yc1)
+	{
+		const int64_t den = p2.x - p1.x + yc2 - yc1;
+		if (den == 0)
+			return false;
+		const int32_t t = static_cast<int32_t>(R_iDiv30(-yc1 - p1.x, den));
+		lclip += static_cast<int32_t>(R_iMul30(t, unclipped_amount));
+	}
+
+	// is the right vertex off the right side of the screen?
+	if (p2.x > yc2)
+	{
+		const int64_t den = p2.x - p1.x - yc2 + yc1;
+		if (den == 0)
+			return false;
+		const int32_t t = static_cast<int32_t>(R_iDiv30(yc1 - p1.x, den));
+		rclip -= static_cast<int32_t>(R_iMul30(CLIPUNIT - t, unclipped_amount));
+	}
+
+	if (lclip > rclip)
+		return false;
+
+	return true;
+}
+
+int R_ProjectPointX64(int64_t x, int64_t y)
+{
+	if (y > 0)
+		return FIXED2INT(centerxfrac + int64_t(FocalLengthX) * x / y);
+	else
+		return centerx;
+}
+
 
 //
 // R_ProjectPointX
@@ -470,8 +648,8 @@ void R_DrawLine(const v3fixed_t* inpt1, const v3fixed_t* inpt2, byte color)
 {
 	// convert from world-space to camera-space
 	v3fixed_t pt1, pt2;
-	R_RotatePoint(inpt1->x - viewx, inpt1->y - viewy, ANG90 - viewangle, pt1.x, pt1.y);
-	R_RotatePoint(inpt2->x - viewx, inpt2->y - viewy, ANG90 - viewangle, pt2.x, pt2.y);
+	R_RotatePointSafe(int64_t(inpt1->x) - viewx, int64_t(inpt1->y) - viewy, ANG90 - viewangle, pt1.x, pt1.y);
+	R_RotatePointSafe(int64_t(inpt2->x) - viewx, int64_t(inpt2->y) - viewy, ANG90 - viewangle, pt2.x, pt2.y);
 	pt1.z = inpt1->z - viewz;
 	pt2.z = inpt2->z - viewz;
 

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -404,75 +404,10 @@ void R_ClipLine(const vertex_t* in1, const vertex_t* in2,
 //
 bool R_ClipLineToFrustum(const v2fixed_t* v1, const v2fixed_t* v2, fixed_t clipdist, int32_t& lclip, int32_t& rclip)
 {
-	static constexpr int32_t CLIPUNIT = 1 << 30;
-	v2fixed_t p1 = *v1, p2 = *v2;
-
-	lclip = 0;
-	rclip = CLIPUNIT;
-
-	// Clip portions of the line that are behind the view plane
-	if (p1.y < clipdist)
-	{
-		// reject the line entirely if the whole thing is behind the view plane.
-		if (p2.y < clipdist)
-			return false;
-
-		// clip the line at the point where p1.y == clipdist
-		lclip = FixedDiv30(clipdist - p1.y, p2.y - p1.y);
-	}
-
-	if (p2.y < clipdist)
-	{
-		// clip the line at the point where p2.y == clipdist
-		rclip = FixedDiv30(clipdist - p1.y, p2.y - p1.y);
-	}
-
-	int32_t unclipped_amount = rclip - lclip;
-
-	// apply the clipping against the 'y = clipdist' plane to p1 & p2
-	R_ClipLine(v1, v2, lclip, rclip, &p1, &p2);
-
-	// [SL] A note on clipping to the screen edges:
-	// With a 90-degree FOV, if p1.x < -p1.y, then the left point
-	// is off the left side of the screen. Similarly, if p2.x > p2.y,
-	// then the right point is off the right side of the screen.
-	// We use yc1 and yc2 instead of p1.y and p2.y because they are
-	// adjusted to work with the current FOV rather than just 90-degrees.
-	fixed_t yc1 = FixedMul(fovtan, p1.y);
-	fixed_t yc2 = FixedMul(fovtan, p2.y);
-
-	// is the entire line off the left side or the right side of the screen?
-	if ((p1.x < -yc1 && p2.x < -yc2) || (p1.x > yc1 && p2.x > yc2))
-		return false;
-
-	// is the left vertex off the left side of the screen?
-	if (p1.x < -yc1)
-	{
-		// clip line at left edge of the screen
-		fixed_t den = p2.x - p1.x + yc2 - yc1;
-		if (den == 0)
-			return false;
-
-		int32_t t = FixedDiv30(-yc1 - p1.x, den);
-		lclip += FixedMul30(t, unclipped_amount);
-	}
-
-	// is the right vertex off the right side of the screen?
-	if (p2.x > yc2)
-	{
-		// clip line at right edge of the screen
-		fixed_t den = p2.x - p1.x - yc2 + yc1;
-		if (den == 0)
-			return false;
-
-		int32_t t = FixedDiv30(yc1 - p1.x, den);
-		rclip -= FixedMul30(CLIPUNIT - t, unclipped_amount);
-	}
-
-	if (lclip > rclip)
-		return false;
-
-	return true;
+	// With high user FOVs, we have to make this a 64-bit calculation.
+	const v2fixed64_t p1(v1->x, v1->y);
+	const v2fixed64_t p2(v2->x, v2->y);
+	return R_ClipLineToFrustum64(p1, p2, clipdist, lclip, rclip);
 }
 
 //

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -976,8 +976,16 @@ void R_StoreWallRange(int start, int stop)
 				   (frontsector->floor_angle + frontsector->base_floor_angle)
 				;
 
+			// Sky hack
+			// MBF sky transfers split the visplane in 2, so in order for sky
+			// transfer skyhack to work, we need to identify both sectors' sky
+			const bool ceilingskyhack =
+				R_IsSkyFlat(frontsector->ceilingpic) && R_IsSkyFlat(backsector->ceilingpic) &&
+				frontsector->sky == backsector->sky;
+
 			markceiling =
-				  !P_IdenticalPlanes(&backsector->ceilingplane, &frontsector->ceilingplane)
+				  (!ceilingskyhack &&
+				   !P_IdenticalPlanes(&backsector->ceilingplane, &frontsector->ceilingplane))
 				|| backsector->lightlevel != frontsector->lightlevel
 				|| backsector->ceilingpic != frontsector->ceilingpic
 
@@ -1002,13 +1010,6 @@ void R_StoreWallRange(int start, int stop)
 				|| (backsector->ceiling_angle + backsector->base_ceiling_angle) !=
 				   (frontsector->ceiling_angle + frontsector->base_ceiling_angle)
 				;
-
-			// Sky hack
-			// MBF sky transfers split the visplane in 2, so in order for sky
-			// transfer skyhack to work, we need to identify both sectors' sky
-			markceiling = markceiling &&
-				(!R_IsSkyFlat(frontsector->ceilingpic) || !R_IsSkyFlat(backsector->ceilingpic) ||
-				 frontsector->sky != backsector->sky);
 		}
 
 

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -980,11 +980,10 @@ void R_StoreWallRange(int start, int stop)
 			// MBF sky transfers split the visplane in 2, so in order for sky
 			// transfer skyhack to work, we need to identify both sectors' sky
 			const bool ceilingskyhack =
-				R_IsSkyFlat(frontsector->ceilingpic) && R_IsSkyFlat(backsector->ceilingpic) &&
-				frontsector->sky == backsector->sky;
+				!R_IsSkyFlat(frontsector->ceilingpic) || !R_IsSkyFlat(backsector->ceilingpic);
 
 			markceiling =
-				  (!ceilingskyhack &&
+				  (ceilingskyhack &&
 				   !P_IdenticalPlanes(&backsector->ceilingplane, &frontsector->ceilingplane))
 				|| backsector->lightlevel != frontsector->lightlevel
 				|| backsector->ceilingpic != frontsector->ceilingpic

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -1004,8 +1004,11 @@ void R_StoreWallRange(int start, int stop)
 				;
 
 			// Sky hack
+			// MBF sky transfers split the visplane in 2, so in order for sky
+			// transfer skyhack to work, we need to identify both sectors' sky
 			markceiling = markceiling &&
-				(!R_IsSkyFlat(frontsector->ceilingpic) || !R_IsSkyFlat(backsector->ceilingpic));
+				(!R_IsSkyFlat(frontsector->ceilingpic) || !R_IsSkyFlat(backsector->ceilingpic) ||
+				 frontsector->sky != backsector->sky);
 		}
 
 

--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -353,7 +353,9 @@ static vissprite_t* R_GenerateVisSprite(const sector_t* sector, int fakeside,
 	// translate the sprite edges from world-space to camera-space
 	// and store in t1 & t2
 	fixed_t tx, ty, t1xold;
-	R_RotatePoint(x - viewx, y - viewy, ANG90 - viewangle, tx, ty);
+	// too far from the camera to draw anyway if its distance is greater than ~32767 fracunits.
+	if (R_RotatePointSafe(int64_t(x) - viewx, int64_t(y) - viewy, ANG90 - viewangle, tx, ty))
+		return NULL;
 
 	v2fixed_t t1, t2;
 	if (flip)

--- a/common/r_main.h
+++ b/common/r_main.h
@@ -145,12 +145,17 @@ R_PointToDist
   fixed_t	y );
 
 int R_ProjectPointX(fixed_t x, fixed_t y);
+int R_ProjectPointX64(int64_t x, int64_t y);
 int R_ProjectPointY(fixed_t z, fixed_t y);
 bool R_CheckProjectionX(int &x1, int &x2);
 bool R_CheckProjectionY(int &y1, int &y2);
 
 void R_RotatePoint(fixed_t x, fixed_t y, angle_t ang, fixed_t &tx, fixed_t &ty);
+bool R_RotatePointSafe(int64_t x, int64_t y, angle_t ang, fixed_t &tx, fixed_t &ty);
+void R_RotatePoint64(int64_t x, int64_t y, angle_t ang, int64_t& tx, int64_t& ty);
 bool R_ClipLineToFrustum(const v2fixed_t* v1, const v2fixed_t* v2, fixed_t clipdist, int32_t& lclip, int32_t& rclip);
+bool R_ClipLineToFrustum64(const v2fixed64_t& v1, const v2fixed64_t& v2, int64_t clipdist,
+						   int32_t& lclip, int32_t& rclip);
 
 void R_ClipLine(const v2fixed_t* in1, const v2fixed_t* in2,
 				int32_t lclip, int32_t rclip,
@@ -158,6 +163,9 @@ void R_ClipLine(const v2fixed_t* in1, const v2fixed_t* in2,
 void R_ClipLine(const vertex_t* in1, const vertex_t* in2,
 				int32_t lclip, int32_t rclip,
 				v2fixed_t* out1, v2fixed_t* out2);
+void R_ClipLine64(const v2fixed64_t& in1, const v2fixed64_t& in2,
+				  int32_t lclip, int32_t rclip,
+				  v2fixed64_t& out1, v2fixed64_t& out2);
 
 subsector_t*
 R_PointInSubsector


### PR DESCRIPTION
This PR should fix the following issues:

#980, #751, #1489

I'll go thru the fixes:

1. R_RotatePoint was overflowing on Planisphere 2, so I made the calculation 64-bit. However, the WAD still had HOMs when you viewed a large portion of the map, which ended up being R_ClipLine/R_ClipLineToFrustum overflowing. Fixed, although the framerate isn't the best, Planisphere 2 should be playable on Odamex with no HOMs.
2. When a transfer heights is visible onscreen in ZDoom ports, `r_fakingunderwater` is set across the renderer for that frame, which will treat all transfer heights (heightsec) sectors to display as deep water, causing the bug in D2IRO.wad map02. We add a check to these deep water sectors if r_fakingunderwater is 1, to see if they're really deep water sectors. This fixes D2IRO.wad map02 with no regressions that I can tell.
There's more fixes to be had, prueba_t.wad map03 having a lift that views both above and below a fake flat floor, causing issues, but I can't reliably fix that without portal column functionality and turning r_fakingunderwater into non-hack functionality. This issue pre-existed before the changes here. It causes issues in GZDoom's software renderer as well.
3. Sky transfer visplanes are different from regular sky visplanes, which caused HOMs in hellcinerator.wad map15 and bitter.wad map08. I borrowed the ZDoom 1.23b33 code for this.
4. Segs that intersect with the viewpoint + NEARCLIP (2 fracunits from camera) get clipped, however, we need those segs to determine if a backsector is deep water, which we just clipped, creating a HOM effect if you are viewing into the sector, clipping the seg that lets you know its deep water, but not being in the deep water sector itself. (#980)
5. Turning on high fovs in maps with huge outdoor spaces can sometimes cause a calculation in R_ClipLineToFrustum to overflow. (`ycx = FixedMul(fovtan, px.y)`) I figure making this function a 64-bit calculation is the best move to handle all FOVs with no fuss.