### PR TITLE
Multiple netcode fixes for mobj state update ordering

### DIFF
--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -1029,15 +1029,14 @@ void G_Ticker (void)
 					break;
 			}
 
-			// If we're here it's because we need to accept a message right away.
-
-			const MessageResultEnum nonReliableResult = CL_AcceptNetMessage();
-			if (nonReliableResult == MessageResultEnum::ABORT)
+			// If we're here it's because we need to accept messages right away.
+			const MessageResultEnum immediateResult = CL_ProcessCurrentAvailableMessages();
+			if (immediateResult == MessageResultEnum::ABORT)
 				return;
 		}
 
 		// With all the latest packets received, process the reliable message in proper sequence.
-		const MessageResultEnum reliableResult = CL_ProcessCurrentReliableMessages();
+		const MessageResultEnum reliableResult = CL_ProcessCurrentAvailableMessages();
 		if (reliableResult == MessageResultEnum::ABORT)
 			return;
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1998,11 +1998,6 @@ void CL_TryToConnect(uint32_t server_token)
 
 		CL_SendUserInfo(netBuf); // send userinfo
 
-		// [SL] The "rate" CVAR has been deprecated. Now just send a hard-coded
-		// maximum rate that the server will ignore.
-		constexpr int rate = 0xFFFF;
-		MSG_WriteLong(&netBuf, rate);
-
 		MSG_WriteString(&netBuf, connectpasshash.c_str());
 
 		NET_SendPacket(netBuf, serveraddr);

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2072,7 +2072,7 @@ MessageResultEnum CL_AcceptNetMessage()
 	return MessageResultEnum::DEFER;
 }
 
-MessageResultEnum CL_ProcessCurrentReliableMessages()
+MessageResultEnum CL_ProcessCurrentAvailableMessages()
 {
 	auto result = CL_AcceptNetMessage();
 	while (result == MessageResultEnum::ACCEPT)

--- a/client/src/cl_main.h
+++ b/client/src/cl_main.h
@@ -71,7 +71,7 @@ bool CL_PrepareConnect();
 void CL_ParseCommands(void);
 MessageResultEnum CL_ReadPacketHeader();
 MessageResultEnum CL_AcceptNetMessage();
-MessageResultEnum CL_ProcessCurrentReliableMessages();
+MessageResultEnum CL_ProcessCurrentAvailableMessages();
 void CL_SendCmd(void);
 void CL_SaveCmd(void);
 void CL_MoveThing(AActor *mobj, fixed_t x, fixed_t y, fixed_t z);

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1088,11 +1088,16 @@ static void CL_UserInfo(const odaproto::svc::UserInfo* msg)
 	CL_CheckDisplayPlayer();
 }
 
-static AActor* CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg)
+static AActor* CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg, AActor* mo = nullptr)
 {
-	AActor* mo = P_FindThingById(msg->actor().netid());
 	if (not mo)
-		return mo;
+	{
+		mo = P_FindThingById(msg->actor().netid());
+		if (not mo)
+		{
+			return mo;
+		}
+	}
 
 	mo->updatedDuringTic = gametic;
 
@@ -1198,7 +1203,7 @@ static AActor* CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg)
 
 static void CL_UpdateMobjWithMode(const odaproto::svc::UpdateMobjWithMode* msg)
 {
-	AActor* mo = CL_UpdateMobj(& msg->update());
+	AActor* mo = P_FindThingById(msg->update().actor().netid());
 
 	if (not mo)
 		return;
@@ -1241,6 +1246,10 @@ static void CL_UpdateMobjWithMode(const odaproto::svc::UpdateMobjWithMode* msg)
 		}
 		mo->tics = msg->tics();
 	}
+
+	// Now apply the update mobj, on the off chance that a mode change caused
+	// us to mispredict the fine-grained position, momentum, angle, etc.
+	CL_UpdateMobj(& msg->update(), mo);
 }
 
 //

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -333,7 +333,8 @@ static void CL_MovePlayer(const odaproto::svc::MovePlayer* msg)
 
 	// Mark the gametic this update arrived in for prediction code
 	p.tic = gametic;
-	p.mo->updatedDuringLocalTic = gametic;
+	p.mo->updatedDuringLocalTic  = gametic;
+	p.mo->updatedDuringServerTic = ::messenger.GetCurrentReceivedPacketSequenceNumber();
 
 	// GhostlyDeath -- Servers will never send updates on spectators
 	if (p.spectator && (&p != &consoleplayer()))
@@ -527,9 +528,10 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 		mo->special1 = mo->z - mo->floorz;
 		mo->LinkToWorld();
 	}
-	mo->baseline         = base;
-	mo->updatedDuringLocalTic = gametic;
-	mo->mobjtic          = msg->timebase_tic();
+	mo->baseline               = base;
+	mo->updatedDuringLocalTic  = gametic;
+	mo->updatedDuringServerTic = ::messenger.GetCurrentReceivedPacketSequenceNumber();
+	mo->mobjtic                = msg->timebase_tic();
 
 	P_SetThingId(mo, netid);
 
@@ -1099,6 +1101,7 @@ static AActor* CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg, AActor* mo = 
 		}
 	}
 
+	mo->updatedDuringServerTic = ::messenger.GetCurrentReceivedPacketSequenceNumber();
 	mo->updatedDuringLocalTic = gametic;
 
 	uint32_t flags = msg->flags();
@@ -1208,6 +1211,20 @@ static void CL_UpdateMobjWithMode(const odaproto::svc::UpdateMobjWithMode* msg)
 	if (not mo)
 		return;
 
+	// Special handling: If we get a best-effort / order-not-guaranteed UpdateMobj, make sure that
+	//                   we're not going backwards with it!  This avoids rare ghosts.
+	const int currentSequence = ::messenger.GetCurrentReceivedPacketSequenceNumber();
+	if (currentSequence < 0)
+	{
+		const int baseSequence = std::abs(mo->updatedDuringServerTic);
+		const int newSequence  = -currentSequence;
+
+		if (newSequence < baseSequence)
+		{
+			return;
+		}
+	}
+
 	const MobjModeEnum mode = static_cast<MobjModeEnum>(msg->mode());
 	if (mode != mo->mode)
 	{
@@ -1281,7 +1298,8 @@ static void CL_SpawnPlayer(const odaproto::svc::SpawnPlayer* msg)
 
 	mobj->momx = mobj->momy = mobj->momz = 0;
 
-	mobj->updatedDuringLocalTic = gametic;
+	mobj->updatedDuringServerTic = ::messenger.GetCurrentReceivedPacketSequenceNumber();
+	mobj->updatedDuringLocalTic  = gametic;
 	mobj->credibility.Lionize();
 
 	// set color translations for player sprites
@@ -1497,6 +1515,7 @@ static void CL_KillMobj(const odaproto::svc::KillMobj* msg)
 		target->momy = msg->target_mom().y();
 		target->momz = msg->target_mom().z();
 
+		target->updatedDuringServerTic = ::messenger.GetCurrentReceivedPacketSequenceNumber();
 		target->updatedDuringLocalTic = gametic;
 	}
 
@@ -1540,7 +1559,8 @@ static void CL_RaiseMobj(const odaproto::svc::RaiseMobj* msg)
 	corpsehit->momy = msg->corpse().mom().y();
 	corpsehit->momz = msg->corpse().mom().z();
 
-	corpsehit->updatedDuringLocalTic = gametic;
+	corpsehit->updatedDuringServerTic = ::messenger.GetCurrentReceivedPacketSequenceNumber();
+	corpsehit->updatedDuringLocalTic  = gametic;
 
 	mobjinfo_t* info = corpsehit->info;
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -333,7 +333,7 @@ static void CL_MovePlayer(const odaproto::svc::MovePlayer* msg)
 
 	// Mark the gametic this update arrived in for prediction code
 	p.tic = gametic;
-	p.mo->updatedDuringTic = gametic;
+	p.mo->updatedDuringLocalTic = gametic;
 
 	// GhostlyDeath -- Servers will never send updates on spectators
 	if (p.spectator && (&p != &consoleplayer()))
@@ -528,7 +528,7 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 		mo->LinkToWorld();
 	}
 	mo->baseline         = base;
-	mo->updatedDuringTic = gametic;
+	mo->updatedDuringLocalTic = gametic;
 	mo->mobjtic          = msg->timebase_tic();
 
 	P_SetThingId(mo, netid);
@@ -1099,7 +1099,7 @@ static AActor* CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg, AActor* mo = 
 		}
 	}
 
-	mo->updatedDuringTic = gametic;
+	mo->updatedDuringLocalTic = gametic;
 
 	uint32_t flags = msg->flags();
 
@@ -1281,7 +1281,7 @@ static void CL_SpawnPlayer(const odaproto::svc::SpawnPlayer* msg)
 
 	mobj->momx = mobj->momy = mobj->momz = 0;
 
-	mobj->updatedDuringTic = gametic;
+	mobj->updatedDuringLocalTic = gametic;
 	mobj->credibility.Lionize();
 
 	// set color translations for player sprites
@@ -1497,7 +1497,7 @@ static void CL_KillMobj(const odaproto::svc::KillMobj* msg)
 		target->momy = msg->target_mom().y();
 		target->momz = msg->target_mom().z();
 
-		target->updatedDuringTic = gametic;
+		target->updatedDuringLocalTic = gametic;
 	}
 
 	target->health = health;
@@ -1540,7 +1540,7 @@ static void CL_RaiseMobj(const odaproto::svc::RaiseMobj* msg)
 	corpsehit->momy = msg->corpse().mom().y();
 	corpsehit->momz = msg->corpse().mom().z();
 
-	corpsehit->updatedDuringTic = gametic;
+	corpsehit->updatedDuringLocalTic = gametic;
 
 	mobjinfo_t* info = corpsehit->info;
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1235,6 +1235,11 @@ static void CL_UpdateMobjWithMode(const odaproto::svc::UpdateMobjWithMode* msg)
 			default:
 				break;
 		}
+		if (mo->state->statenum != msg->state())
+		{
+			P_SetMobjState(mo, msg->state());
+		}
+		mo->tics = msg->tics();
 	}
 }
 

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -32,6 +32,7 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 	const PacketHeaderType header {io_rawBuf};
 
 	m_immediateReceiveBuffer.clear();
+	m_immediateReceiveSequenceNumber = 0;
 
 	if (m_sender.GetMode() == SequenceSender::CRITICAL_FAILURE)
 	{
@@ -89,6 +90,7 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 	if (bestEffortSize > 0)
 	{
 		m_immediateReceiveBuffer.WriteChunk(io_rawBuf.ReadChunk(bestEffortSize), bestEffortSize);
+		m_immediateReceiveSequenceNumber = header.sequence;
 		return MessageResultEnum::ACCEPT;
 	}
 
@@ -107,12 +109,15 @@ bool OdaMessenger::NextReceivedPacket(buf_t& io_rawBuf)
 	const int receivedReliableSequenceNumber = m_receiver.NextPacket(io_rawBuf);
 	if (receivedReliableSequenceNumber >= 0)
 	{
+		m_currentReceivedPacketSequenceNumber = receivedReliableSequenceNumber;
 		return true;
 	}
 
 	if (m_immediateReceiveBuffer.size())
 	{
 		io_rawBuf.swap(m_immediateReceiveBuffer);
+		m_currentReceivedPacketSequenceNumber = m_immediateReceiveSequenceNumber;
+		m_immediateReceiveSequenceNumber = 0;
 		m_immediateReceiveBuffer.clear();
 		return true;
 	}

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -31,6 +31,8 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 {
 	const PacketHeaderType header {io_rawBuf};
 
+	m_immediateReceiveBuffer.clear();
+
 	if (m_sender.GetMode() == SequenceSender::CRITICAL_FAILURE)
 	{
 		return MessageResultEnum::ABORT;
@@ -82,9 +84,11 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 			ack.WriteLong(header.sequence);
 		}
 	}
-	if (io_rawBuf.BytesLeftToRead() > 0)
+
+	const size_t bestEffortSize = io_rawBuf.BytesLeftToRead();
+	if (bestEffortSize > 0)
 	{
-		m_quickTurnaroundReceiveBuffer = &io_rawBuf;
+		m_immediateReceiveBuffer.WriteChunk(io_rawBuf.ReadChunk(bestEffortSize), bestEffortSize);
 		return MessageResultEnum::ACCEPT;
 	}
 
@@ -98,13 +102,21 @@ bool OdaMessenger::NextReceivedPacket(buf_t& io_rawBuf)
 		return false;
 	}
 
-	if (m_quickTurnaroundReceiveBuffer)
+	// Do the reliable traffic first because it's possible or even likely for a reliable mobj update
+	// (or critical event) to be followed up by an UpdateMobj that includes post-physics dynamics.
+	const int receivedReliableSequenceNumber = m_receiver.NextPacket(io_rawBuf);
+	if (receivedReliableSequenceNumber >= 0)
 	{
-		io_rawBuf.swap(*m_quickTurnaroundReceiveBuffer);
-		m_quickTurnaroundReceiveBuffer = nullptr;
 		return true;
 	}
-	return m_receiver.NextPacket(io_rawBuf) >= 0;
+
+	if (m_immediateReceiveBuffer.size())
+	{
+		io_rawBuf.swap(m_immediateReceiveBuffer);
+		m_immediateReceiveBuffer.clear();
+		return true;
+	}
+	return false;
 }
 
 void OdaMessenger::HandleAcks(buf_t& io_rawBuf)

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -89,6 +89,10 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 	const size_t bestEffortSize = io_rawBuf.BytesLeftToRead();
 	if (bestEffortSize > 0)
 	{
+		if (bestEffortSize > m_immediateReceiveBuffer.maxsize())
+		{
+			m_immediateReceiveBuffer.resize(bestEffortSize + 1);    // +1 because that's what buf_t needs...
+		}
 		m_immediateReceiveBuffer.WriteChunk(io_rawBuf.ReadChunk(bestEffortSize), bestEffortSize);
 		m_immediateReceiveSequenceNumber = header.sequence;
 		return MessageResultEnum::ACCEPT;

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -179,7 +179,7 @@ class OdaMessenger
 		MessageQueue m_outgoingNonReliableQueue;
 		MessageQueue m_outgoingHighNonReliableQueue;
 
-		buf_t* m_quickTurnaroundReceiveBuffer { nullptr };
+		buf_t m_immediateReceiveBuffer { MAX_UDP_PACKET };
 
 		int m_maxPacketsPerRetransmission   { DEFAULT_RETRANSMISSIONS_PER_TIC };
 		int m_retransmitDelayInTics         { 0 };

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -155,6 +155,8 @@ class OdaMessenger
 		int GetReliableOverloadCount() const { return m_reliableOverloadCount; }
 		int GetTicBudget() const             { return m_perTicBudget; }
 
+		int GetCurrentReceivedPacketSequenceNumber() const { return m_currentReceivedPacketSequenceNumber; }
+
 	protected:
 
 		size_t PackAsReliable  (Packet& io_packet, const buf_t& messageBuf);
@@ -179,7 +181,9 @@ class OdaMessenger
 		MessageQueue m_outgoingNonReliableQueue;
 		MessageQueue m_outgoingHighNonReliableQueue;
 
-		buf_t m_immediateReceiveBuffer { MAX_UDP_PACKET };
+		buf_t m_immediateReceiveBuffer              { MAX_UDP_PACKET };
+		int   m_immediateReceiveSequenceNumber      { 0 };
+		int   m_currentReceivedPacketSequenceNumber { 0 };
 
 		int m_maxPacketsPerRetransmission   { DEFAULT_RETRANSMISSIONS_PER_TIC };
 		int m_retransmitDelayInTics         { 0 };

--- a/common/actor.h
+++ b/common/actor.h
@@ -632,7 +632,9 @@ public:
 
 	// Server: The tic on which this mobj was sent an UpdateMobj.
 	// Client: the tic on which this mobj received an UpdateMobj.
-	int updatedDuringTic;
+	int updatedDuringLocalTic;
+
+	int updatedDuringServerTic;
 
 	// Server:  The tic on which this mobj was actually spawned. Used to for determining correct initial
 	//          state and rnd index to send to clients.  *Not communicated to the client.*

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -346,9 +346,9 @@ inline void CredibilityState::Update(const AActor& mobj)
 #ifdef CLIENT_APP
     if (not serverside)     // But we still need to check in case we're in single-player.
     {
-        if (mobj.updatedDuringTic >= 0 and m_credibility != CredibilityEnum::ALWAYS_CREDIBLE)
+        if (mobj.updatedDuringLocalTic >= 0 and m_credibility != CredibilityEnum::ALWAYS_CREDIBLE)
         {
-            const int ticsSinceAuthoritativeUpdate = gametic - mobj.updatedDuringTic;
+            const int ticsSinceAuthoritativeUpdate = gametic - mobj.updatedDuringLocalTic;
 
             if (ticsSinceAuthoritativeUpdate == 0)
             {
@@ -412,8 +412,8 @@ AActor::AActor()
       iprev(NULL), translation(translationref_t()), translucency(0), waterlevel(0),
       gear(0), onground(false), touching_sectorlist(NULL), deadtic(0), rndindex(0),
       spawnRndindex(0), friend_playerid(0), friend_teamid(TEAM_NONE), pursuecount(0), strafecount(0),
-      netid(0), tid(0), baseline(), baseline_set(false), mode(MobjModeEnum::SPAWN), updatedDuringTic(-1), spawnTic(gametic),
-      mobjtic(gametic), bmapnode(this)
+      netid(0), tid(0), baseline(), baseline_set(false), mode(MobjModeEnum::SPAWN), updatedDuringLocalTic(-1),
+      updatedDuringServerTic(-1), spawnTic(gametic), mobjtic(gametic), bmapnode(this)
 {
 	args.fill(0);
 	self.init(this);
@@ -441,7 +441,8 @@ AActor::AActor(const AActor& other)
       deadtic(other.deadtic), rndindex(other.rndindex), spawnRndindex(other.spawnRndindex),
       friend_playerid(other.friend_playerid), friend_teamid(other.friend_teamid),
       pursuecount(other.pursuecount), strafecount(other.strafecount), netid(other.netid), tid(other.tid),
-      baseline_set(false), mode(other.mode), updatedDuringTic(other.updatedDuringTic), spawnTic(other.spawnTic),
+      baseline_set(false), mode(other.mode), updatedDuringLocalTic(other.updatedDuringLocalTic),
+      updatedDuringServerTic(other.updatedDuringServerTic), spawnTic(other.spawnTic),
       mobjtic(other.mobjtic), credibility {other.credibility}, bmapnode(other.bmapnode)
 {
 	memcpy(&baseline, &other.baseline, sizeof(baseline));
@@ -524,11 +525,12 @@ AActor &AActor::operator= (const AActor &other)
     memcpy(&baseline, &other.baseline, sizeof(baseline));
     baseline_set = other.baseline_set;
 
-    mode             = other.mode;
-    updatedDuringTic = other.updatedDuringTic;
-    spawnTic         = other.spawnTic;
-    mobjtic          = other.mobjtic;
-    credibility      = other.credibility;
+    mode                    = other.mode;
+    updatedDuringLocalTic   = other.updatedDuringLocalTic;
+    updatedDuringServerTic  = other.updatedDuringServerTic;
+    spawnTic                = other.spawnTic;
+    mobjtic                 = other.mobjtic;
+    credibility             = other.credibility;
 
     return *this;
 }
@@ -550,8 +552,8 @@ AActor::AActor(fixed_t ix, fixed_t iy, fixed_t iz, int32_t itype)
       iprev(NULL), translation(translationref_t()), translucency(0), waterlevel(0),
       gear(0), onground(false), touching_sectorlist(NULL), deadtic(0), rndindex(0),
       spawnRndindex(0), friend_playerid(0), friend_teamid(TEAM_NONE), pursuecount(0), strafecount(0),
-      netid(0), tid(0), baseline(), baseline_set(false), mode(MobjModeEnum::SPAWN), updatedDuringTic(-1),
-      spawnTic(gametic), mobjtic(gametic), bmapnode(this)
+      netid(0), tid(0), baseline(), baseline_set(false), mode(MobjModeEnum::SPAWN), updatedDuringLocalTic(-1),
+      updatedDuringServerTic(-1), spawnTic(gametic), mobjtic(gametic), bmapnode(this)
 {
 	// Fly!!! fix it in P_RespawnSpecial
 	const auto it = ::mobjinfo.find(itype);
@@ -1321,7 +1323,8 @@ void AActor::Serialize (FArchive &arc)
 			<< rndindex
 			<< spawnRndindex
 			<< mode
-			<< updatedDuringTic
+			<< updatedDuringLocalTic
+			<< updatedDuringServerTic
 			<< spawnTic
 			<< mobjtic
 			<< credibility;
@@ -1411,7 +1414,8 @@ void AActor::Serialize (FArchive &arc)
 			>> rndindex
 			>> spawnRndindex
 			>> mode
-			>> updatedDuringTic
+			>> updatedDuringLocalTic
+			>> updatedDuringServerTic
 			>> spawnTic
 			>> mobjtic
 			>> credibility;

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -630,7 +630,6 @@ static void FillUpdateMobj(odaproto::svc::UpdateMobj& msg, const AActor& mobj)
 {
 	uint32_t flags = P_GetMobjBaselineFlags(mobj);
 	msg.set_flags(flags);
-	msg.set_server_tic(gametic);
 
 	odaproto::Actor* act = msg.mutable_actor();
 	odaproto::Vec3* pos = act->mutable_pos();

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -630,6 +630,7 @@ static void FillUpdateMobj(odaproto::svc::UpdateMobj& msg, const AActor& mobj)
 {
 	uint32_t flags = P_GetMobjBaselineFlags(mobj);
 	msg.set_flags(flags);
+	msg.set_server_tic(gametic);
 
 	odaproto::Actor* act = msg.mutable_actor();
 	odaproto::Vec3* pos = act->mutable_pos();

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -702,6 +702,9 @@ odaproto::svc::UpdateMobjWithMode SVC_UpdateMobjWithMode(const AActor& mobj)
 	FillUpdateMobj(* msg.mutable_update(), mobj);
 
 	msg.set_mode(static_cast<odaproto::svc::MobjModeEnum>(mobj.mode));
+	msg.set_state(mobj.state->statenum);
+	msg.set_tics (mobj.tics);
+
 	return msg;
 }
 

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -165,6 +165,8 @@ message UpdateMobjWithMode
 {
 	UpdateMobj   update = 1;
 	MobjModeEnum mode   = 2;
+	uint32       state  = 3;
+	uint32       tics   = 4;
 }
 
 // svc_spawnplayer

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -156,8 +156,9 @@ enum MobjModeEnum
 // svc_updatemobj
 message UpdateMobj
 {
-	uint32 flags = 1;
-	Actor  actor = 2;
+	uint32 flags      = 1;
+	Actor  actor      = 2;
+	uint32 server_tic = 3;
 }
 
 // svc_updatemobjwithmode

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -156,9 +156,8 @@ enum MobjModeEnum
 // svc_updatemobj
 message UpdateMobj
 {
-	uint32 flags      = 1;
-	Actor  actor      = 2;
-	uint32 server_tic = 3;
+	uint32 flags = 1;
+	Actor  actor = 2;
 }
 
 // svc_updatemobjwithmode

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3180,12 +3180,12 @@ static void ImmediateUpdateMobj(AActor& mobj, TransportEnum transport)
 
 				case AwarenessEnum::ALWAYS_AWARE:      [[ fallthrough ]];
 				case AwarenessEnum::FULLY_AWARE:
-					mobj.updatedDuringTic = gametic;
+					mobj.updatedDuringLocalTic = gametic;
 					MSG_WriteSVC(fullAwareQueue, message);
 					break;
 
 				case AwarenessEnum::SEMI_AWARE:
-					mobj.updatedDuringTic = gametic;
+					mobj.updatedDuringLocalTic = gametic;
 					MSG_WriteSVC(semiAwareQueue, message);
 					break;
 			}
@@ -3293,7 +3293,7 @@ void SV_UpdateAvatars(player_t& player)
 	{
 		if (voodooInfo.mobj and ((voodooInfo.mobj->netid + gametic) % 7) == 0)
 		{
-			voodooInfo.mobj->updatedDuringTic = gametic;    // Avoid a potential duplicate send.
+			voodooInfo.mobj->updatedDuringLocalTic = gametic;    // Avoid a potential duplicate send.
 			MSG_WriteSVC(player.client.messenger.HighBuf(), SVC_UpdateMobj(*voodooInfo.mobj));
 		}
 	}
@@ -5197,13 +5197,13 @@ void SV_ExplodeMissile(AActor *mo)
 
 			case AwarenessEnum::ALWAYS_AWARE:  [[ fallthrough ]];      // See everything.
 			case AwarenessEnum::FULLY_AWARE:
-				mo->updatedDuringTic = gametic;
+				mo->updatedDuringLocalTic = gametic;
 				MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_UpdateMobj(*mo));
 				MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_ExplodeMissile(*mo));
 				break;
 
 			case AwarenessEnum::SEMI_AWARE:                            // See an explosion, maybe even in the correct position.
-				mo->updatedDuringTic = gametic;
+				mo->updatedDuringLocalTic = gametic;
 				MSG_WriteSVC(player.client.messenger.NetBuf(), SVC_UpdateMobj(*mo));
 				MSG_WriteSVC(player.client.messenger.ReliableBuf(), SVC_ExplodeMissile(*mo));
 				break;

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3092,11 +3092,6 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 	if (!(mo->flags & MF_MISSILE) || mo->flags & MF_SKULLFLY)
 		return;
 
-	// Avoid sending more than one Update Mobj per tic for any missile.
-	// Here we check to see if an update went out during the "meat" of the tic, which is complete at this point.
-	if (mo->updatedDuringTic == gametic)
-		return;
-
 	// 64 units feels about right to prevent barely-dodged missiles from floating in front of the player's face
 	// when in a high-lag ~200 msec ping situation.
 	constexpr int HYPER_AWARENESS_CUTOFF_SQUARED = 64 * 64;
@@ -3275,11 +3270,6 @@ void SV_UpdateMonsters(player_t& player, AActor *mo)
 
 	// update monster position every 7 tics
 	if ((gametic+mo->netid) % 7)
-		return;
-
-	// Avoid sending more than one Update Mobj per tic for any monsters.
-	// Here we check to see if an update went out during the "meat" of the tic, which is complete at this point.
-	if (mo->updatedDuringTic == gametic)
 		return;
 
 	if (mo->target and SV_IsPlayerAllowedToSee(player, mo))


### PR DESCRIPTION
This PR includes the following fixes:

1. If a mobj is scheduled for a regular, post-dynamics UpdateMobj, always send it, even if we already queued up a Reliable UpdateMobj from earlier in the same tic.
1. When receiving a packet with both Reliable and Best-Effort sections, process the Reliable section first (as long as we aren't waiting on a prior packet in the reliable sequence).  This helps avoid the case where if case 1 above applies, we don't see a mobj "glitch backwards."
2. Ensure that stale best-effort UpdateMobj receptions cannot overwrite more current updates that were previously received.  (this needs yet to be applied to Reliable updates.
3. Add State and Tics to UpdateMobjWithMode so that if a mobj needs to have its mode resynched with the server, it also advances to the correct state and tic within that state IF the that state doesn't just directly follow from a one-off run of the mode state transition.  We also check to make sure we're not going to inadvertently trigger a double-action.
4. When the above re-synch happens, make sure that we do it BEFORE applying the post-dynamics UpdateMobj data.  This fixes an issue where the client winds up with mobjs that desynch due to being based on mid-tic mobj state rather than "final" state in the server tic.