### PR TITLE
[FEATURE] Mouse Driven Menu

### DIFF
--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -424,7 +424,7 @@ static void I_ApplyInputMode(EInputMode mode)
 	else if (mode == INPUT_MODE_UI)
 		input_subsystem->grabInputForUI();
 	else
-	input_subsystem->releaseInput();
+		input_subsystem->releaseInput();
 }
 
 
@@ -859,6 +859,8 @@ static int I_GetEventRepeaterKey(const event_t* ev)
 		button == OKEY_LSHIFT || button == OKEY_LCTRL || button == OKEY_LALT ||
 		button == OKEY_RSHIFT || button == OKEY_RCTRL || button == OKEY_RALT ||
 		button == OKEY_NUMLOCK)
+		return 0;
+	else if (button >= OKEY_MOUSE1 && button <= OKEY_MWHEELRIGHT)
 		return 0;
 	else if (button >= OKEY_HAT1 && button <= OKEY_HAT8)
 		return button;

--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -55,9 +55,20 @@
 bool tab_keydown = false;	// [ML] Actual status of tab key
 #endif
 
+EXTERN_CVAR(ui_mouse)
+
 static IInputSubsystem* input_subsystem = NULL;
 
 static bool nomouse = false;
+
+enum EInputMode
+{
+	INPUT_MODE_RELEASED,
+	INPUT_MODE_UI,
+	INPUT_MODE_GAME
+};
+
+static EInputMode current_input_mode = INPUT_MODE_RELEASED;
 
 KeyNameTable key_names;
 
@@ -341,16 +352,17 @@ static bool I_CanRepeat()
 
 
 //
-// I_CanGrab
+// I_GetDesiredInputMode
 //
-// Returns true if the input (mouse & keyboard) can be grabbed in
-// the current game state.
+// Returns how the mouse should be handled in the current game state:
+// captured for gameplay, freed but still delivering buttons for the menu and
+// console, or shut off entirely.
 //
-static bool I_CanGrab()
+static EInputMode I_GetDesiredInputMode()
 {
 	#ifdef GCONSOLE
-	return true;
-	#endif
+	return INPUT_MODE_GAME;
+	#else
 
 	extern bool configuring_controls;
 	extern constate_e ConsoleState;
@@ -359,45 +371,59 @@ static bool I_CanGrab()
 
 	// If the window doesn't have the focus, don't grab
 	if (!I_GetWindow()->isFocused())
-		return false;
+		return INPUT_MODE_RELEASED;
+
+	const bool console_active = ConsoleState == c_down || ConsoleState == c_falling ||
+	                            ConsoleState == c_fallfull;
+
+	const bool attract_active = gamestate == GS_DEMOSCREEN || gamestate == GS_FINALE ||
+	                            ((gamestate == GS_LEVEL || gamestate == GS_INTERMISSION) &&
+	                             demoplayback);
+
+	const bool ui_active = menuactive || console_active || attract_active;
+	if (ui_active && !configuring_controls)
+	{
+		if (nomouse || ui_mouse.asInt() == 0)
+			return INPUT_MODE_RELEASED;
+		return INPUT_MODE_UI;
+	}
 
 	// If the window is full screen and has only one monitor, always grab
 	if (I_GetWindow()->isFullScreen() && I_GetMonitorCount() <= 1)
-		return true;
+		return INPUT_MODE_GAME;
 
 	if (nomouse)
-		return false;
+		return INPUT_MODE_RELEASED;
 
 	// Always grab when configuring controllers in the menu
 	if (configuring_controls)
-		return true;
+		return INPUT_MODE_GAME;
 
 	// If paused, in the menu or in the console, don't grab
 	if (menuactive || ConsoleState == c_down || paused)
-		return false;
+		return INPUT_MODE_RELEASED;
 
 	// If playing the game, always grab
 	if ((gamestate == GS_LEVEL || gamestate == GS_INTERMISSION) && !demoplayback)
-		return true;
+		return INPUT_MODE_GAME;
 
-	return false;
+	return INPUT_MODE_RELEASED;
+	#endif
 }
 
 
 //
-// I_GrabInput
+// I_ApplyInputMode
 //
-static void I_GrabInput()
+static void I_ApplyInputMode(EInputMode mode)
 {
-	input_subsystem->grabInput();
-}
+	current_input_mode = mode;
 
-
-//
-// I_UngrabInput
-//
-static void I_UngrabInput()
-{
+	if (mode == INPUT_MODE_GAME)
+		input_subsystem->grabInput();
+	else if (mode == INPUT_MODE_UI)
+		input_subsystem->grabInputForUI();
+	else
 	input_subsystem->releaseInput();
 }
 
@@ -412,10 +438,7 @@ static void I_UngrabInput()
 //
 void I_ForceUpdateGrab()
 {
-	if (I_CanGrab())
-		I_GrabInput();
-	else
-		I_UngrabInput();
+	I_ApplyInputMode(I_GetDesiredInputMode());
 }
 
 
@@ -436,10 +459,9 @@ static void I_UpdateGrab()
 	prev_fullscreen = fullscreen;
 
 	// check if the window focus changed (or menu/console status changed)
-	if (!input_subsystem->isInputGrabbed() && I_CanGrab())
-		I_GrabInput();
-	else if (input_subsystem->isInputGrabbed() && !I_CanGrab())
-		I_UngrabInput();
+	const EInputMode desired = I_GetDesiredInputMode();
+	if (desired != current_input_mode)
+		I_ApplyInputMode(desired);
 #endif
 }
 
@@ -620,7 +642,7 @@ void STACK_ARGS I_ShutdownInput()
 {
 	input_subsystem->disableTextEntry();
 
-	I_UngrabInput();
+	I_ApplyInputMode(INPUT_MODE_RELEASED);
 
 	delete input_subsystem;
 	input_subsystem = NULL;

--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -466,6 +466,43 @@ static void I_UpdateGrab()
 }
 
 
+//
+// I_GetUIMousePosition
+//
+bool I_GetUIMousePosition(int& x, int& y)
+{
+	if (current_input_mode != INPUT_MODE_UI)
+		return false;
+
+	int window_x, window_y;
+	SDL_GetMouseState(&window_x, &window_y);
+
+	return I_WindowToSurfaceCoords(window_x, window_y, x, y);
+}
+
+
+//
+// I_IsUIMouseButtonDown
+//
+bool I_IsUIMouseButtonDown(int button)
+{
+	if (current_input_mode != INPUT_MODE_UI)
+		return false;
+
+	const uint32_t state = SDL_GetMouseState(NULL, NULL);
+
+	switch (button)
+	{
+	case OKEY_MOUSE1:	return (state & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0;
+	case OKEY_MOUSE2:	return (state & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
+	case OKEY_MOUSE3:	return (state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0;
+	case OKEY_MOUSE4:	return (state & SDL_BUTTON(SDL_BUTTON_X1)) != 0;
+	case OKEY_MOUSE5:	return (state & SDL_BUTTON(SDL_BUTTON_X2)) != 0;
+	default:			return false;
+	}
+}
+
+
 CVAR_FUNC_IMPL(use_joystick)
 {
 	if (var == 0.0f)

--- a/client/sdl/i_input.h
+++ b/client/sdl/i_input.h
@@ -48,6 +48,9 @@ int I_GetKeyFromName(const std::string& name);
 void I_GetEvents(bool mouseOnly);
 
 
+bool I_GetUIMousePosition(int& x, int& y);
+bool I_IsUIMouseButtonDown(int button);
+
 // ============================================================================
 //
 // IInputDevice abstract base class interface

--- a/client/sdl/i_input.h
+++ b/client/sdl/i_input.h
@@ -64,6 +64,9 @@ public:
 	virtual void resume() = 0;
 	virtual void reset() = 0;
 
+	virtual void resumeUI()
+	{	resume();	}
+
 	virtual void gatherEvents() = 0;
 	virtual bool hasEvent() const = 0;
 	virtual void getEvent(event_t* ev) = 0;
@@ -113,6 +116,9 @@ public:
 
 	virtual void grabInput() = 0;
 	virtual void releaseInput() = 0;
+
+	virtual void grabInputForUI()
+	{	releaseInput();	}
 
 	virtual bool isInputGrabbed() const
 	{	return false;	}

--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -541,7 +541,8 @@ void ISDL20MouseInputDevice::gatherEvents()
 				ev.type = ev_keydown;
 				int direction = 1;
 				#if SDL_VERSION_ATLEAST(2, 0, 4)
-				if (sdl_ev.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
+				// Only allow flipped mousewheel directions when in UI mode.
+				if (!mUIMode && sdl_ev.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
 					direction = -1;
 				#endif
 

--- a/client/sdl/i_input_sdl20.cpp
+++ b/client/sdl/i_input_sdl20.cpp
@@ -360,7 +360,7 @@ void ISDL20KeyboardInputDevice::getEvent(event_t* ev)
 // ISDL20MouseInputDevice::ISDL20MouseInputDevice
 //
 ISDL20MouseInputDevice::ISDL20MouseInputDevice(int id) :
-	mActive(false)
+	mActive(false), mUIMode(false)
 {
 	reset();
 }
@@ -414,10 +414,45 @@ void ISDL20MouseInputDevice::reset()
 void ISDL20MouseInputDevice::pause()
 {
 	mActive = false;
+	mUIMode = false;
 	SDL_EventState(SDL_MOUSEMOTION, SDL_IGNORE);
 	SDL_EventState(SDL_MOUSEBUTTONDOWN, SDL_IGNORE);
 	SDL_EventState(SDL_MOUSEBUTTONUP, SDL_IGNORE);
 	SDL_SetRelativeMouseMode(SDL_FALSE);
+}
+
+
+//
+// ISDL20MouseInputDevice::enableEvents
+//
+// Enables delivery of SDL mouse events, optionally capturing the pointer for
+// relative motion.
+//
+void ISDL20MouseInputDevice::enableEvents(bool relative)
+{
+	if (relative)
+	{
+		// [RV] Always use relative mouse mode and
+		// force unscaled relative motion across supported SDL versions
+		SDL_SetRelativeMouseMode(SDL_TRUE);
+
+		#if SDL_VERSION_ATLEAST(2, 0, 14)
+			SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_SCALING, "0", SDL_HINT_OVERRIDE);
+		#endif
+
+		#if SDL_VERSION_ATLEAST(2, 26, 0)
+			SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE, "0", SDL_HINT_OVERRIDE);
+		#endif
+	}
+	else
+	{
+		// Let the cursor move freely so the OS cursor tracks the UI.
+		SDL_SetRelativeMouseMode(SDL_FALSE);
+	}
+
+	SDL_EventState(SDL_MOUSEMOTION, SDL_ENABLE);
+	SDL_EventState(SDL_MOUSEBUTTONDOWN, SDL_ENABLE);
+	SDL_EventState(SDL_MOUSEBUTTONUP, SDL_ENABLE);
 }
 
 
@@ -432,23 +467,26 @@ void ISDL20MouseInputDevice::pause()
 void ISDL20MouseInputDevice::resume()
 {
 	mActive = true;
+	mUIMode = false;
 	reset();
 
-	// [RV] Always use relative mouse mode and
-	// force unscaled relative motion across supported SDL versions
-	SDL_SetRelativeMouseMode(SDL_TRUE);
+	enableEvents(true);
+}
 
-	#if SDL_VERSION_ATLEAST(2, 0, 14)
-		SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_SCALING, "0", SDL_HINT_OVERRIDE);
-	#endif
 
-	#if SDL_VERSION_ATLEAST(2, 26, 0)
-		SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE, "0", SDL_HINT_OVERRIDE);
-	#endif
+//
+// ISDL20MouseInputDevice::resumeUI
+//
+// Enables input for driving menus and the console. The pointer is left
+// uncaptured so the OS cursor remains visible and positioned by the user.
+//
+void ISDL20MouseInputDevice::resumeUI()
+{
+	mActive = true;
+	mUIMode = true;
+	reset();
 
-	SDL_EventState(SDL_MOUSEMOTION, SDL_ENABLE);
-	SDL_EventState(SDL_MOUSEBUTTONDOWN, SDL_ENABLE);
-	SDL_EventState(SDL_MOUSEBUTTONUP, SDL_ENABLE);
+	enableEvents(false);
 }
 
 //
@@ -485,7 +523,7 @@ void ISDL20MouseInputDevice::gatherEvents()
 		}
 	}
 
-	if (movement_event.data2 || movement_event.data3)
+	if (!mUIMode && (movement_event.data2 || movement_event.data3))
 		mEvents.push(movement_event);
 
 	// Retrieve mouse button and wheel events from SDL and post
@@ -1052,6 +1090,18 @@ void ISDL20InputSubsystem::releaseInput()
 	IInputDevice* device = getMouseInputDevice();
 	if (device)
 		device->pause();
+}
+
+
+//
+// ISDL20InputSubsystem::grabInputForUI
+//
+void ISDL20InputSubsystem::grabInputForUI()
+{
+	mInputGrabbed = false;
+	IInputDevice* device = getMouseInputDevice();
+	if (device)
+		device->resumeUI();
 }
 
 #endif	// SDL20

--- a/client/sdl/i_input_sdl20.h
+++ b/client/sdl/i_input_sdl20.h
@@ -92,6 +92,7 @@ public:
 
 	virtual void pause();
 	virtual void resume();
+	virtual void resumeUI();
 	virtual void reset();
 
 	virtual void gatherEvents();
@@ -104,7 +105,11 @@ public:
 	virtual void flushEvents();
 
 private:
+	void enableEvents(bool relative);
+
 	bool			mActive;
+
+	bool			mUIMode;
 
 	typedef std::queue<event_t> EventQueue;
 	EventQueue		mEvents;
@@ -167,6 +172,7 @@ public:
 
 	virtual void grabInput();
 	virtual void releaseInput();
+	virtual void grabInputForUI();
 
 	virtual bool isInputGrabbed() const
 	{	return mInputGrabbed;	}

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -1111,6 +1111,44 @@ int I_GetSurfaceHeight()
 
 
 //
+// I_WindowToSurfaceCoords
+//
+// Translates a point in window coordinates to the same point in the
+// surface that draws to the window.
+//
+// Returns true if the function was able to translate the position.
+//
+bool I_WindowToSurfaceCoords(int window_x, int window_y, int& surface_x, int& surface_y)
+{
+	if (!I_VideoInitialized() || I_GetWindow() == nullptr)
+		return false;
+
+	int x, y;
+	if (!I_GetWindow()->windowToSurfaceCoords(window_x, window_y, x, y))
+		return false;
+
+	// The surface everything draws to may be a matted sub-surface centered
+	// inside the window's surface, so shift into its coordinate space.
+	const IWindowSurface* window_surface = I_GetWindow()->getPrimarySurface();
+	const IWindowSurface* draw_surface = I_GetPrimarySurface();
+
+	if (window_surface == nullptr || draw_surface == nullptr)
+		return false;
+
+	x -= (window_surface->getWidth() - draw_surface->getWidth()) / 2;
+	y -= (window_surface->getHeight() - draw_surface->getHeight()) / 2;
+
+	if (x < 0 || x >= draw_surface->getWidth() || y < 0 || y >= draw_surface->getHeight())
+		return false;
+
+	surface_x = x;
+	surface_y = y;
+
+	return true;
+}
+
+
+//
 // I_IsProtectedReslotuion
 //
 // [ML] If this is 320x200 or 640x400, the resolutions

--- a/client/sdl/i_video.h
+++ b/client/sdl/i_video.h
@@ -76,6 +76,8 @@ int I_GetVideoBitDepth();
 int I_GetSurfaceWidth();
 int I_GetSurfaceHeight();
 
+bool I_WindowToSurfaceCoords(int window_x, int window_y, int& surface_x, int& surface_y);
+
 bool I_IsProtectedResolution(const IWindowSurface* surface = I_GetPrimarySurface());
 bool I_IsProtectedResolution(int width, int height);
 bool I_IsWideResolution(int width, int height);
@@ -421,6 +423,8 @@ public:
 
 	virtual void startRefresh() { }
 	virtual void finishRefresh() { }
+	virtual bool windowToSurfaceCoords(int window_x, int window_y, int& surface_x, int& surface_y) const
+	{	return false;	}
 };
 
 
@@ -523,6 +527,9 @@ public:
 
 	virtual void startRefresh() { }
 	virtual void finishRefresh() { }
+
+	virtual bool windowToSurfaceCoords(int window_x, int window_y, int& surface_x, int& surface_y) const
+	{	return false;	}
 
 	virtual void setWindowTitle(const std::string& caption = "") { }
 	virtual void setWindowIcon() { }

--- a/client/sdl/i_video_sdl20.cpp
+++ b/client/sdl/i_video_sdl20.cpp
@@ -28,6 +28,7 @@
 #include "i_sdl.h"
 #include <stdlib.h>
 #include <cassert>
+#include <cmath>
 
 #include <algorithm>
 #include <functional>
@@ -364,6 +365,56 @@ void ISDL20TextureWindowSurfaceManager::finishRefresh()
 		SDL_RenderCopy(mSDLRenderer, mSDLTexture, NULL, NULL);
 
 	SDL_RenderPresent(mSDLRenderer);
+}
+
+
+//
+// ISDL20TextureWindowSurfaceManager::windowToSurfaceCoords
+//
+// Inverts the transformation the finishRefresh() function applies when
+// presenting the texture:
+// 
+// window pixels -> renderer logical coordinates -> surface pixels.
+//
+bool ISDL20TextureWindowSurfaceManager::windowToSurfaceCoords(
+		int window_x, int window_y, int& surface_x, int& surface_y) const
+{
+	if (mSDLRenderer == nullptr)
+		return false;
+
+	// Undo the letterboxing/scaling applied by SDL_RenderSetLogicalSize.
+	float logical_x, logical_y;
+
+	// Do people even sub in old SDL.dlls anymore?
+	#if SDL_VERSION_ATLEAST(2, 0, 18)
+		SDL_RenderWindowToLogical(mSDLRenderer, window_x, window_y, &logical_x, &logical_y);
+	#else
+		SDL_Rect viewport;
+		float scale_x, scale_y;
+		SDL_RenderGetViewport(mSDLRenderer, &viewport);
+		SDL_RenderGetScale(mSDLRenderer, &scale_x, &scale_y);
+		if (scale_x <= 0.0f || scale_y <= 0.0f)
+			return false;
+		logical_x = window_x / scale_x - viewport.x;
+		logical_y = window_y / scale_y - viewport.y;
+	#endif
+
+	// Undo the destination rectangle the texture is blitted into.
+	// 
+	// When not pillarboxing, the logical size is the surface size
+	// and this is a no-op.
+	if (mDrawLogicalRect)
+	{
+		if (mLogicalRect.w <= 0 || mLogicalRect.h <= 0)
+			return false;
+		logical_x = (logical_x - mLogicalRect.x) * mWidth / static_cast<float>(mLogicalRect.w);
+		logical_y = (logical_y - mLogicalRect.y) * mHeight / static_cast<float>(mLogicalRect.h);
+	}
+
+	surface_x = static_cast<int>(std::floor(logical_x));
+	surface_y = static_cast<int>(std::floor(logical_y));
+
+	return surface_x >= 0 && surface_x < mWidth && surface_y >= 0 && surface_y < mHeight;
 }
 
 

--- a/client/sdl/i_video_sdl20.h
+++ b/client/sdl/i_video_sdl20.h
@@ -98,6 +98,8 @@ public:
 	virtual void startRefresh();
 	virtual void finishRefresh();
 
+	virtual bool windowToSurfaceCoords(int window_x, int window_y, int& surface_x, int& surface_y) const;
+
 private:
 	ISDL20Window*			mWindow;
 	SDL_Renderer*			mSDLRenderer;
@@ -190,6 +192,13 @@ public:
 
 	virtual void startRefresh();
 	virtual void finishRefresh();
+
+	virtual bool windowToSurfaceCoords(int window_x, int window_y, int& surface_x, int& surface_y) const
+	{
+		if (mSurfaceManager)
+			return mSurfaceManager->windowToSurfaceCoords(window_x, window_y, surface_x, surface_y);
+		return false;
+	}
 
 	virtual void lockSurface();
 	virtual void unlockSurface();

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -76,6 +76,8 @@ static bool				cursoron = false;
 static int				ConBottom = 0;
 static int RowAdjust = 0;
 
+static const int		CONSOLE_WHEEL_LINES = 3;
+
 int			ConBottomStep; // Console fall/raise bottom pixels at the end of the tic, for interp purposes
 
 int			CursorTicker, ScrollState = 0;
@@ -2039,7 +2041,7 @@ static bool C_HandleKey(const event_t* ev)
 			TabCycleClear();
 			return true;
 		}
-	case OKEY_MOUSE3:
+	case OKEY_MOUSE2:
 		// Paste from clipboard - add each character to command line
 		CmdLine.insertString(I_GetClipboardText());
 		CmdCompletions.clear();
@@ -2095,6 +2097,24 @@ static bool C_HandleKey(const event_t* ev)
 			else
 				// Start scrolling console buffer down
 				ScrollState = SCROLLDN;
+			return true;
+		}
+		else if (ch == OKEY_MWHEELUP)
+		{
+			// Scroll the console buffer up a few lines at a time
+			if (static_cast<int>(ConRows) > static_cast<int>(ConBottom / ConCharSize))
+			{
+				RowAdjust += CONSOLE_WHEEL_LINES;
+				if (RowAdjust > static_cast<int>(ConRows - ConBottom / ConCharSize))
+					RowAdjust = ConRows - ConBottom / ConCharSize;
+			}
+			return true;
+		}
+		else if (ch == OKEY_MWHEELDOWN)
+		{
+			RowAdjust -= CONSOLE_WHEEL_LINES;
+			if (RowAdjust < 0)
+				RowAdjust = 0;
 			return true;
 		}
 		else if (Key_IsLeftKey(ch, NumLockEnabled))

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -270,6 +270,9 @@ CVAR_RANGE_FUNC_DECL(ui_transgreen, "0", "",
 
 CVAR_RANGE_FUNC_DECL(ui_transblue, "0", "",
 					CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 255.0f)
+
+CVAR(				ui_mouse, "1", "Navigate the menus and console with the mouse",
+					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 // Init settings
 // -------------
 

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -2546,6 +2546,9 @@ void M_Ticker()
 
 	if (menuactive)
 	{
+		if (OptionsActive)
+			M_OptUpdateMouseItem();
+		else
 			M_UpdateMouseItem();
 	}
 

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -2067,6 +2067,51 @@ static void M_SetPlayerColorFromMouse(int item, int mouse_x);
 
 
 //
+// M_MouseOverEditField
+//
+// Returns true if the cursor is over the text field currently being edited, so
+// that clicking it can commit the entry the same way pressing Enter does.
+//
+static bool M_MouseOverEditField()
+{
+	if (ui_mouse.asInt() == 0)
+		return false;
+
+	// Origin and length of the box drawn by M_DrawSaveLoadBorder for the
+	// field currently being edited.
+	int box_x, box_y, len;
+
+	if (genStringEnter == oldmenustring_t::SAVEGAME)
+	{
+		box_x = LoadDef.x;
+		box_y = LoadDef.y + LINEHEIGHT * saveSlot;
+		len = 24;
+	}
+	else if (genStringEnter == oldmenustring_t::PLAYERNAME)
+	{
+		box_x = PSetupDef.x + 56;
+		box_y = PSetupDef.y;
+		len = MAXPLAYERNAME + 1;
+	}
+	else
+	{
+		return false;
+	}
+
+	int mouse_x, mouse_y;
+	if (!I_GetUIMousePosition(mouse_x, mouse_y))
+		return false;
+
+	const int x1 = screen->getCleanX(box_x - 8);
+	const int x2 = screen->getCleanX(box_x + len * 8 + 8);
+	const int y1 = screen->getCleanY(box_y);
+	const int y2 = screen->getCleanY(box_y + LINEHEIGHT);
+
+	return mouse_x >= x1 && mouse_x < x2 && mouse_y >= y1 && mouse_y < y2;
+}
+
+
+//
 // M_UpdateMouseItem
 //
 // Moves the menu cursor to whatever the mouse is hovering over.
@@ -2239,15 +2284,20 @@ bool M_Responder (event_t* ev)
 				savegamestrings[saveSlot][saveCharIndex] = 0;
 			}
 		}
-		else if (Key_IsCancelKey(ch))
+		else if (Key_IsCancelKey(ch) ||
+		         (ui_mouse.asInt() != 0 && ch == OKEY_MOUSE2))
 		{
+			// Escape, or a right click, cancels the entry and restores the
+			// previous text.
 			if (genStringEnter == oldmenustring_t::SAVEGAME)
 				M_ClearMenus();
 			genStringEnter = oldmenustring_t::NONE;
 			M_StringCopy(&savegamestrings[saveSlot][0], saveOldString, SAVESTRINGSIZE);
 		}
-		else if (Key_IsAcceptKey(ch))
+		else if (Key_IsAcceptKey(ch) ||
+		         (ch == OKEY_MOUSE1 && M_MouseOverEditField()))
 		{
+			// Enter, or a click on the field being edited, commits the entry.
 			if (genStringEnter == oldmenustring_t::SAVEGAME)
 				M_ClearMenus();
 			genStringEnter = oldmenustring_t::NONE;

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -209,8 +209,12 @@ enum
 	MSGBUTTON_NONE = -1
 };
 
+// Surface-space bounds of each confirmation button. The buttons are stacked
+// vertically, so each has its own Y range.
 static int MessageButtonX1[2], MessageButtonX2[2];
-static int MessageButtonY1 = 0, MessageButtonY2 = 0;
+static int MessageButtonY1[2], MessageButtonY2[2];
+
+static int messageSelection = MSGBUTTON_NO;
 
 static void M_DrawMessageButtons(int y);
 
@@ -1859,6 +1863,7 @@ void M_StartMessage (const char *string, void (*routine)(int), bool input)
 	messageString = string;
 	messageRoutine = routine;
 	messageNeedsInput = input;
+	messageSelection = MSGBUTTON_NO;
 	menuactive = true;
 }
 
@@ -1971,20 +1976,18 @@ static int M_GetMessageButton()
 	if (ui_mouse.asInt() == 0 || !messageToPrint || !messageNeedsInput)
 		return MSGBUTTON_NONE;
 
-	// Nothing has been drawn yet this session
-	if (MessageButtonY2 <= MessageButtonY1)
-		return MSGBUTTON_NONE;
-
 	int mouse_x, mouse_y;
 	if (!I_GetUIMousePosition(mouse_x, mouse_y))
 		return MSGBUTTON_NONE;
 
-	if (mouse_y < MessageButtonY1 || mouse_y >= MessageButtonY2)
-		return MSGBUTTON_NONE;
-
 	for (int button = 0; button < 2; button++)
 	{
-		if (mouse_x >= MessageButtonX1[button] && mouse_x < MessageButtonX2[button])
+		// A zero-height range means the button hasn't been drawn yet
+		if (MessageButtonY2[button] <= MessageButtonY1[button])
+			continue;
+
+		if (mouse_x >= MessageButtonX1[button] && mouse_x < MessageButtonX2[button] &&
+		    mouse_y >= MessageButtonY1[button] && mouse_y < MessageButtonY2[button])
 			return button;
 	}
 
@@ -2001,27 +2004,62 @@ static int M_GetMessageButton()
 static void M_DrawMessageButtons(int y)
 {
 	static const char* labels[2] = { "YES", "NO" };
-	static const int SPACING = 24;
+	// Draw order
+	static const int order[2] = {MSGBUTTON_YES, MSGBUTTON_NO};
 
-	const int widths[2] = { V_StringWidth(labels[0]), V_StringWidth(labels[1]) };
-	const int total = widths[0] + SPACING + widths[1];
 	const int height = W_ResolvePatchHandle(hu_font[0])->height();
+	const patch_t* cursor = W_CachePatch("LITLCURS");
+	const int cursor_gap = 4;
+	const int line_step = height + 2;
 
-	const int hovered = M_GetMessageButton();
-
-	int x = 160 - total / 2;
-	for (int button = 0; button < 2; button++)
+	for (int row = 0; row < 2; row++)
 	{
-		screen->DrawTextCleanMove(button == hovered ? CR_GREY : CR_RED, x, y, labels[button]);
+		const int button = order[row];
+		const int w = V_StringWidth(labels[button]);
+		const int bx = 160 - w / 2;			// each label centered
+		const int by = y + row * line_step;
 
-		MessageButtonX1[button] = screen->getCleanX(x);
-		MessageButtonX2[button] = screen->getCleanX(x + widths[button]);
+		screen->DrawTextCleanMove(CR_RED, bx, by, labels[button]);
 
-		x += widths[button] + SPACING;
+		MessageButtonX1[button] = screen->getCleanX(bx);
+		MessageButtonX2[button] = screen->getCleanX(bx + w);
+		MessageButtonY1[button] = screen->getCleanY(by);
+		MessageButtonY2[button] = screen->getCleanY(by + height);
+
+		if (button == messageSelection && skullAnimCounter < 6)
+			screen->DrawPatchClean(cursor, bx + w + cursor_gap, by);
 	}
+}
 
-	MessageButtonY1 = screen->getCleanY(y);
-	MessageButtonY2 = screen->getCleanY(y + height);
+
+//
+// M_UpdateMessageSelection
+//
+// Moves the confirmation selection to whatever button the mouse hovers over.
+// Leaves it untouched when the pointer is off the buttons so keyboard choices
+// aren't fought by a resting cursor.
+//
+static void M_UpdateMessageSelection()
+{
+	static int prev_mouse_x = -1, prev_mouse_y = -1;
+
+	int mouse_x, mouse_y;
+	if (!I_GetUIMousePosition(mouse_x, mouse_y))
+		return;
+
+	const bool moved = (mouse_x != prev_mouse_x || mouse_y != prev_mouse_y);
+	prev_mouse_x = mouse_x;
+	prev_mouse_y = mouse_y;
+
+	if (!moved)
+		return;
+
+	const int button = M_GetMessageButton();
+	if (button != MSGBUTTON_NONE && button != messageSelection)
+	{
+		messageSelection = button;
+		S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+	}
 }
 
 
@@ -2237,6 +2275,16 @@ bool M_Responder (event_t* ev)
 	{
 		int answer = 0;
 
+		const bool buttons_shown = ui_mouse.asInt() != 0 && messageNeedsInput;
+
+		if (buttons_shown && (Key_IsUpKey(ch, numlock) || Key_IsDownKey(ch, numlock) ||
+		                      Key_IsLeftKey(ch, numlock) || Key_IsRightKey(ch, numlock)))
+		{
+			messageSelection = (messageSelection == MSGBUTTON_YES) ? MSGBUTTON_NO : MSGBUTTON_YES;
+			S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+			return true;
+		}
+
 		if (ui_mouse.asInt() != 0 && (ch == OKEY_MOUSE1 || ch == OKEY_MOUSE2))
 		{
 			if (!messageNeedsInput)
@@ -2256,6 +2304,10 @@ bool M_Responder (event_t* ev)
 
 				answer = (button == MSGBUTTON_YES) ? 'y' : 'n';
 			}
+		}
+		else if (buttons_shown && Key_IsAcceptKey(ch))
+		{
+			answer = (messageSelection == MSGBUTTON_YES) ? 'y' : 'n';
 		}
 		else if (messageNeedsInput &&
 		    (!(ch2 == ' ' || Key_IsMenuKey(ch) || Key_IsYesKey(ch) || Key_IsNoKey(ch) ||
@@ -2492,7 +2544,7 @@ void M_Drawer()
 
 		V_FreeBrokenLines (lines);
 
-		if (messageNeedsInput)
+		if (messageNeedsInput && ui_mouse.asInt() != 0)
 			M_DrawMessageButtons(y + ch->height());
 	}
 	else if (menuactive)
@@ -2616,7 +2668,9 @@ void M_Ticker()
 		skullAnimCounter = 8;
 	}
 
-	if (menuactive)
+	if (messageToPrint && messageNeedsInput && ui_mouse.asInt() != 0)
+		M_UpdateMessageSelection();
+	else if (menuactive)
 	{
 		if (OptionsActive)
 			M_OptUpdateMouseItem();

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -197,6 +197,11 @@ static IWindowSurface* fire_surface;
 static constexpr int fire_surface_width = 72;
 static constexpr int fire_surface_height = 77;
 
+static int PSetupSliderX1 = 0;
+static int PSetupSliderX2 = 0;
+
+static int PSetupDragItem = -1;
+
 enum
 {
 	MSGBUTTON_YES = 0,
@@ -1628,6 +1633,9 @@ static void M_PlayerSetupDrawer()
 			const int x = V_StringWidth("Green") + 8 + PSetupDef.x;
 			const argb_t playercolor = V_GetColorFromString(cl_color);
 
+			PSetupSliderX1 = screen->getCleanX(x + SLIDER_TRACK_X);
+			PSetupSliderX2 = screen->getCleanX(x + SLIDER_TRACK_X + SLIDER_TRACK_WIDTH);
+
 			M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*5, 0.0f, 255.0f, playercolor.getr(), 0.0f);
 			M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*6, 0.0f, 255.0f, playercolor.getg(), 0.0f);
 			M_DrawSlider(x, PSetupDef.y + LINEHEIGHT*7, 0.0f, 255.0f, playercolor.getb(), 0.0f);
@@ -2015,6 +2023,11 @@ static void M_DrawMessageButtons(int y)
 	MessageButtonY1 = screen->getCleanY(y);
 	MessageButtonY2 = screen->getCleanY(y + height);
 }
+
+
+static void M_SetPlayerColorFromMouse(int item, int mouse_x);
+
+
 //
 // M_UpdateMouseItem
 //
@@ -2023,6 +2036,11 @@ static void M_DrawMessageButtons(int y)
 static void M_UpdateMouseItem()
 {
 	static int prev_mouse_x = -1, prev_mouse_y = -1;
+
+	// Drop any drag whose button was released or whose menu went away
+	if (PSetupDragItem != -1 &&
+	    (currentMenu != &PSetupDef || !I_IsUIMouseButtonDown(OKEY_MOUSE1)))
+		PSetupDragItem = -1;
 
 	int mouse_x, mouse_y;
 	if (!I_GetUIMousePosition(mouse_x, mouse_y))
@@ -2035,6 +2053,14 @@ static void M_UpdateMouseItem()
 	if (!moved)
 		return;
 
+	// A drag keeps hold of the slider it started on, so sliding off the row
+	// vertically doesn't hand the drag to a neighbour.
+	if (PSetupDragItem != -1)
+	{
+		M_SetPlayerColorFromMouse(PSetupDragItem, mouse_x);
+		return;
+	}
+
 	const int item = M_GetMouseItem();
 	if (item != -1 && item != itemOn)
 	{
@@ -2045,6 +2071,33 @@ static void M_UpdateMouseItem()
 
 
 //
+// M_SetPlayerColorFromMouse
+//
+// Jumps a player color slider to the position the slider was
+// clicked at.
+//
+static void M_SetPlayerColorFromMouse(int item, int mouse_x)
+{
+	if (PSetupSliderX2 <= PSetupSliderX1)
+		return;
+
+	float dist = static_cast<float>(mouse_x - PSetupSliderX1) / static_cast<float>(PSetupSliderX2 - PSetupSliderX1);
+	dist = clamp(dist, 0.0f, 1.0f);
+
+	const int part = clamp(static_cast<int>(dist * 255.0f + 0.5f), 0, 255);
+
+	argb_t color = V_GetColorFromString(cl_color);
+
+	if (item == playerred)
+		color.setr(part);
+	else if (item == playergreen)
+		color.setg(part);
+	else
+		color.setb(part);
+
+	SendNewColor(color.getr(), color.getg(), color.getb());
+}
+
 
 //
 // M_ActivateItem
@@ -2274,7 +2327,26 @@ bool M_Responder (event_t* ev)
 			if (item != -1)
 			{
 				itemOn = item;
+
+				// The player setup colour sliders jump to where they were
+				// clicked instead of nudging a single step.
+				int mouse_x, mouse_y;
+				const bool colorslider = currentMenu == &PSetupDef &&
+				                         (item == playerred || item == playergreen ||
+				                          item == playerblue);
+
+				if (colorslider && I_GetUIMousePosition(mouse_x, mouse_y))
+				{
+					M_SetPlayerColorFromMouse(item, mouse_x);
+					S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+
+					// Keep following the pointer until the button is released
+					PSetupDragItem = item;
+				}
+				else
+				{
 					M_ActivateItem(item);
+				}
 			}
 			return true;
 		}

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -57,6 +57,10 @@
 #include "m_fileio.h"
 
 EXTERN_CVAR(g_resetinvonexit)
+EXTERN_CVAR(ui_mouse)
+
+bool I_GetUIMousePosition(int& x, int& y);
+bool I_IsUIMouseButtonDown(int button);
 
 // temp for screenblocks (0-9)
 int 				screenSize;
@@ -192,6 +196,18 @@ bool M_DemoNoPlay;
 static IWindowSurface* fire_surface;
 static constexpr int fire_surface_width = 72;
 static constexpr int fire_surface_height = 77;
+
+enum
+{
+	MSGBUTTON_YES = 0,
+	MSGBUTTON_NO = 1,
+	MSGBUTTON_NONE = -1
+};
+
+static int MessageButtonX1[2], MessageButtonX2[2];
+static int MessageButtonY1 = 0, MessageButtonY2 = 0;
+
+static void M_DrawMessageButtons(int y);
 
 static void M_PauseSound(void)
 {
@@ -1873,6 +1889,189 @@ int M_StringHeight(char* string)
 //
 
 //
+// M_GetMouseItem
+//
+// Returns the index of the item in the current old-style menu underneath the
+// mouse cursor, or -1 if the cursor isn't over a selectable item.
+//
+static int M_GetMouseItem()
+{
+
+	if (ui_mouse.asInt() == 0 || currentMenu == nullptr)
+		return -1;
+
+	// These states take over the whole menu and have nothing to click on.
+	if (messageToPrint || genStringEnter != oldmenustring_t::NONE)
+		return -1;
+
+	int mouse_x, mouse_y;
+	if (!I_GetUIMousePosition(mouse_x, mouse_y))
+		return -1;
+
+	for (int i = 0; i < currentMenu->numitems; i++)
+	{
+		const oldmenuitem_t& item = currentMenu->menuitems[i];
+		if (item.status == -1)
+			continue;
+
+		int width = 0;
+		if (item.name[0])
+		{
+			width = W_CachePatch(item.name)->width();
+		}
+		else if (item.textname[0])
+		{
+			V_SetFont("BIGFONT");
+			width = V_StringWidth(item.textname);
+			V_SetFont("SMALLFONT");
+		}
+		else
+		{
+			// The item carries no label of its own.
+			// The row still occupies its usual slot,
+			// so make the rest of the line clickable.
+			width = 320 - currentMenu->x - 8;
+		}
+
+		if (width <= 0)
+			continue;
+
+		// The hitbox starts at the cursor rather than the label so that the
+		// gap the skull occupies is still clickable.
+		const int y = currentMenu->y + i * LINEHEIGHT;
+		const int x1 = screen->getCleanX(currentMenu->x + SKULLXOFF);
+		const int x2 = screen->getCleanX(currentMenu->x + width);
+		const int y1 = screen->getCleanY(y);
+		const int y2 = screen->getCleanY(y + LINEHEIGHT);
+
+		if (mouse_x >= x1 && mouse_x < x2 && mouse_y >= y1 && mouse_y < y2)
+			return i;
+	}
+
+	return -1;
+}
+
+
+//
+// M_GetMessageButton
+//
+// Returns which of the confirmation prompt's buttons the cursor is over:
+// MSGBUTTON_YES, MSGBUTTON_NO, or MSGBUTTON_NONE.
+//
+static int M_GetMessageButton()
+{
+	if (ui_mouse.asInt() == 0 || !messageToPrint || !messageNeedsInput)
+		return MSGBUTTON_NONE;
+
+	// Nothing has been drawn yet this session
+	if (MessageButtonY2 <= MessageButtonY1)
+		return MSGBUTTON_NONE;
+
+	int mouse_x, mouse_y;
+	if (!I_GetUIMousePosition(mouse_x, mouse_y))
+		return MSGBUTTON_NONE;
+
+	if (mouse_y < MessageButtonY1 || mouse_y >= MessageButtonY2)
+		return MSGBUTTON_NONE;
+
+	for (int button = 0; button < 2; button++)
+	{
+		if (mouse_x >= MessageButtonX1[button] && mouse_x < MessageButtonX2[button])
+			return button;
+	}
+
+	return MSGBUTTON_NONE;
+}
+
+
+//
+// M_DrawMessageButtons
+//
+// Draws clickable YES and NO buttons underneath a confirmation prompt and
+// records where they landed so the responder can hit-test against them.
+//
+static void M_DrawMessageButtons(int y)
+{
+	static const char* labels[2] = { "YES", "NO" };
+	static const int SPACING = 24;
+
+	const int widths[2] = { V_StringWidth(labels[0]), V_StringWidth(labels[1]) };
+	const int total = widths[0] + SPACING + widths[1];
+	const int height = W_ResolvePatchHandle(hu_font[0])->height();
+
+	const int hovered = M_GetMessageButton();
+
+	int x = 160 - total / 2;
+	for (int button = 0; button < 2; button++)
+	{
+		screen->DrawTextCleanMove(button == hovered ? CR_GREY : CR_RED, x, y, labels[button]);
+
+		MessageButtonX1[button] = screen->getCleanX(x);
+		MessageButtonX2[button] = screen->getCleanX(x + widths[button]);
+
+		x += widths[button] + SPACING;
+	}
+
+	MessageButtonY1 = screen->getCleanY(y);
+	MessageButtonY2 = screen->getCleanY(y + height);
+}
+//
+// M_UpdateMouseItem
+//
+// Moves the menu cursor to whatever the mouse is hovering over.
+//
+static void M_UpdateMouseItem()
+{
+	static int prev_mouse_x = -1, prev_mouse_y = -1;
+
+	int mouse_x, mouse_y;
+	if (!I_GetUIMousePosition(mouse_x, mouse_y))
+		return;
+
+	const bool moved = (mouse_x != prev_mouse_x || mouse_y != prev_mouse_y);
+	prev_mouse_x = mouse_x;
+	prev_mouse_y = mouse_y;
+
+	if (!moved)
+		return;
+
+	const int item = M_GetMouseItem();
+	if (item != -1 && item != itemOn)
+	{
+		itemOn = item;
+		S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+	}
+}
+
+
+//
+
+//
+// M_ActivateItem
+//
+// Performs the action for a menu item, as though it had been selected with
+// the accept key.
+//
+static void M_ActivateItem(int item)
+{
+	if (!currentMenu->menuitems[item].routine || !currentMenu->menuitems[item].status)
+		return;
+
+	currentMenu->lastOn = item;
+	if (currentMenu->menuitems[item].status == 2)
+	{
+		currentMenu->menuitems[item].routine(1);		// right arrow
+		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+	}
+	else
+	{
+		currentMenu->menuitems[item].routine(item);
+		S_Sound(CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+	}
+}
+
+
+//
 // M_Responder
 //
 bool M_Responder (event_t* ev)
@@ -1983,7 +2182,29 @@ bool M_Responder (event_t* ev)
 	// Take care of any messages that need input
 	if (messageToPrint)
 	{
-		if (messageNeedsInput &&
+		int answer = 0;
+
+		if (ui_mouse.asInt() != 0 && (ch == OKEY_MOUSE1 || ch == OKEY_MOUSE2))
+		{
+			if (!messageNeedsInput)
+			{
+				// "Press any key" messages are dismissed by any click
+				answer = ' ';
+			}
+			else if (ch == OKEY_MOUSE2)
+			{
+				answer = 'n';
+			}
+			else
+			{
+				const int button = M_GetMessageButton();
+				if (button == MSGBUTTON_NONE)
+					return true;
+
+				answer = (button == MSGBUTTON_YES) ? 'y' : 'n';
+			}
+		}
+		else if (messageNeedsInput &&
 		    (!(ch2 == ' ' || Key_IsMenuKey(ch) || Key_IsYesKey(ch) || Key_IsNoKey(ch) ||
 			(isascii(ch2) && (toupper(ch2) == 'N' || toupper(ch2) == 'Y')))))
 			return true;
@@ -1992,7 +2213,9 @@ bool M_Responder (event_t* ev)
 		messageToPrint = 0;
 		if (messageRoutine)
 		{
-			if (ch == '\0' && ch2 != '\0')
+			if (answer)
+				messageRoutine(answer);
+			else if (ch == '\0' && ch2 != '\0')
 				messageRoutine(ch2);
 			else
 				messageRoutine(ch);
@@ -2019,6 +2242,17 @@ bool M_Responder (event_t* ev)
 			AddCommandString("menu_main");
 			return true;
 		}
+
+		const bool attract = gamestate == GS_DEMOSCREEN || gamestate == GS_FINALE ||
+		                     ((gamestate == GS_LEVEL || gamestate == GS_INTERMISSION) &&
+		                      demoplayback);
+
+		if (ui_mouse.asInt() != 0 && attract && (ch == OKEY_MOUSE1 || ch == OKEY_MOUSE2))
+		{
+			AddCommandString("menu_main");
+			return true;
+		}
+
 		return false;
 	}
 
@@ -2028,6 +2262,26 @@ bool M_Responder (event_t* ev)
 		if(!strcmp(cmd, "menu_main"))
 		{
 			M_ClearMenus();
+			return true;
+		}
+	}
+
+	if (ui_mouse.asInt() != 0)
+	{
+		if (ch == OKEY_MOUSE1)
+		{
+			const int item = M_GetMouseItem();
+			if (item != -1)
+			{
+				itemOn = item;
+					M_ActivateItem(item);
+			}
+			return true;
+		}
+		else if (ch == OKEY_MOUSE2)
+		{
+			currentMenu->lastOn = itemOn;
+			M_PopMenuStack();
 			return true;
 		}
 	}
@@ -2078,21 +2332,7 @@ bool M_Responder (event_t* ev)
 		}
 		else if (Key_IsAcceptKey(ch))
 		{
-			if (currentMenu->menuitems[itemOn].routine &&
-				currentMenu->menuitems[itemOn].status)
-			{
-				currentMenu->lastOn = itemOn;
-				if (currentMenu->menuitems[itemOn].status == 2)
-				{
-					currentMenu->menuitems[itemOn].routine(1);		// right arrow
-					S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
-				}
-				else
-				{
-					currentMenu->menuitems[itemOn].routine(itemOn);
-					S_Sound(CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
-				}
-			}
+			M_ActivateItem(itemOn);
 			return true;
 		}
 		else if (Key_IsCancelKey(ch))
@@ -2179,6 +2419,9 @@ void M_Drawer()
 		}
 
 		V_FreeBrokenLines (lines);
+
+		if (messageNeedsInput)
+			M_DrawMessageButtons(y + ch->height());
 	}
 	else if (menuactive)
 	{
@@ -2299,6 +2542,11 @@ void M_Ticker()
 	{
 		whichSkull ^= 1;
 		skullAnimCounter = 8;
+	}
+
+	if (menuactive)
+	{
+			M_UpdateMouseItem();
 	}
 
 	if (currentMenu == &PSetupDef)

--- a/client/src/m_menu.h
+++ b/client/src/m_menu.h
@@ -30,6 +30,9 @@
 #define LINEHEIGHT	16
 #define SKULLXOFF	-32
 
+#define SLIDER_TRACK_X		5
+#define SLIDER_TRACK_WIDTH	78
+
 //
 // MENUS
 //

--- a/client/src/m_menu.h
+++ b/client/src/m_menu.h
@@ -65,6 +65,9 @@ void M_OptResponder (event_t *ev);
 // [RH] Draw options menu
 void M_OptDrawer (void);
 
+// Move the options menu selection to whatever the mouse is hovering over
+void M_OptUpdateMouseItem();
+
 // [RH] Initialize options menu
 void M_OptInit (void);
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -29,6 +29,8 @@
 
 #include "odamex.h"
 
+#include <cmath>
+
 #include "gstrings.h"
 #include "minilzo.h"
 
@@ -234,6 +236,21 @@ void M_ClearMenus (void);
 static bool CanScrollUp;
 static bool CanScrollDown;
 static int VisBottom;
+
+EXTERN_CVAR(ui_mouse)
+
+#define MAX_OPT_MOUSE_ROWS	32
+
+struct optmouserow_t
+{
+	int		item;		// index into CurrentMenu->items
+	int		y1, y2;		// surface pixel bounds of the row
+};
+
+static optmouserow_t	OptMouseRows[MAX_OPT_MOUSE_ROWS];
+static int				OptMouseRowCount = 0;
+
+static const int		OPT_WHEEL_LINES = 3;
 
 value_t YesNo[2] = {
 	{ 0.0, "No" },
@@ -1712,12 +1729,22 @@ void M_OptDrawer (void)
 	y = 15 + title->height();
 	ytop = y + CurrentMenu->scrolltop * 8;
 
+	OptMouseRowCount = 0;
+
 	for (i = 0; i < CurrentMenu->numitems && y <= 192 - theight; i++, y += 8)	// TIJ
 	{
 		if (i == CurrentMenu->scrolltop)
 			i += CurrentMenu->scrollpos;
 
 		item = CurrentMenu->items + i;
+
+		if (OptMouseRowCount < MAX_OPT_MOUSE_ROWS)
+		{
+			optmouserow_t& row = OptMouseRows[OptMouseRowCount++];
+			row.item = i;
+			row.y1 = screen->getCleanY(y);
+			row.y2 = screen->getCleanY(y + 8);
+		}
 
 		if (item->type == screenres)
 		{
@@ -1938,6 +1965,175 @@ void M_OptDrawer (void)
 		screen->DrawPatchClean (W_CachePatch ("LITLDN"), 3, 190);
 }
 
+//
+// M_OptItemSelectable
+//
+// Matches the item types the up/down key handlers skip over.
+//
+static bool M_OptItemSelectable(const menuitem_t* item)
+{
+	switch (item->type)
+	{
+	case redtext:
+	case whitetext:
+	case yellowtext:
+	case orangetext:
+		return false;
+	case screenres:
+		return item->b.res1 != NULL;
+	default:
+		return true;
+	}
+}
+
+
+//
+// M_OptRowUnderMouse
+//
+// Returns an index into OptMouseRows, or -1 if the cursor isn't over a row.
+//
+static int M_OptRowUnderMouse(int mouse_y)
+{
+	for (int i = 0; i < OptMouseRowCount; i++)
+	{
+		if (mouse_y >= OptMouseRows[i].y1 && mouse_y < OptMouseRows[i].y2)
+			return i;
+	}
+
+	return -1;
+}
+
+
+//
+// M_OptScreenResColumn
+//
+// Returns which of the three resolution columns the cursor is over.
+//
+static int M_OptScreenResColumn(int mouse_x)
+{
+	for (int col = 2; col > 0; col--)
+	{
+		if (mouse_x >= screen->getCleanX(104 * col + 8))
+			return col;
+	}
+
+	return 0;
+}
+
+
+//
+// M_OptScroll
+//
+// Scrolls the visible portion of the menu without moving the selection.
+//
+static void M_OptScroll(int lines)
+{
+	if (lines < 0 && CanScrollUp)
+	{
+		CurrentMenu->scrollpos += lines;
+		if (CurrentMenu->scrollpos < 0)
+			CurrentMenu->scrollpos = 0;
+	}
+	else if (lines > 0 && CanScrollDown)
+	{
+		const int pagesize = VisBottom - CurrentMenu->scrollpos - CurrentMenu->scrolltop;
+		CurrentMenu->scrollpos += lines;
+		if (CurrentMenu->scrollpos + CurrentMenu->scrolltop + pagesize > CurrentMenu->numitems)
+			CurrentMenu->scrollpos = CurrentMenu->numitems - CurrentMenu->scrolltop - pagesize;
+	}
+}
+
+
+//
+// M_OptMouseClick
+//
+static void M_OptMouseClick(int mouse_x, int mouse_y)
+{
+	const int row = M_OptRowUnderMouse(mouse_y);
+	if (row == -1)
+		return;
+
+	const int index = OptMouseRows[row].item;
+	menuitem_t* item = CurrentMenu->items + index;
+
+	if (!M_OptItemSelectable(item))
+		return;
+
+	// The resolution list keeps its column in the item being left behind
+	if (CurrentMenu->items[CurrentItem].type == screenres && CurrentItem != index)
+		CurrentMenu->items[CurrentItem].a.selmode = -1;
+
+	CurrentItem = index;
+
+	if (item->type == screenres)
+		item->a.selmode = M_OptScreenResColumn(mouse_x);
+
+
+	bool cycles_value = false;
+	switch (item->type)
+	{
+	case discrete:
+	case cdiscrete:
+	case svdiscrete:
+	case bitflag:
+	case joyactive:
+		cycles_value = true;
+		break;
+	default:
+		break;
+	}
+
+	// Everything else behaves exactly as though the accept key was pressed.
+	event_t synth_ev(ev_keydown, cycles_value ? OKEY_RIGHTARROW : OKEY_ENTER, 0, 0, 0);
+	M_OptResponder(&synth_ev);
+}
+
+
+//
+// M_OptUpdateMouseItem
+//
+// Moves the selection to whatever the cursor is hovering over. Only acts when
+// the pointer actually moves so that a resting cursor doesn't fight the
+// keyboard.
+//
+void M_OptUpdateMouseItem()
+{
+	static int prev_mouse_x = -1, prev_mouse_y = -1;
+
+	if (ui_mouse.asInt() == 0 || WaitingForKey || WaitingForAxis)
+		return;
+
+	int mouse_x, mouse_y;
+	if (!I_GetUIMousePosition(mouse_x, mouse_y))
+		return;
+
+	const bool moved = (mouse_x != prev_mouse_x || mouse_y != prev_mouse_y);
+	prev_mouse_x = mouse_x;
+	prev_mouse_y = mouse_y;
+
+	if (!moved)
+		return;
+
+	const int row = M_OptRowUnderMouse(mouse_y);
+	if (row == -1)
+		return;
+
+	const int index = OptMouseRows[row].item;
+	if (index == CurrentItem || !M_OptItemSelectable(CurrentMenu->items + index))
+		return;
+
+	if (CurrentMenu->items[CurrentItem].type == screenres)
+		CurrentMenu->items[CurrentItem].a.selmode = -1;
+
+	CurrentItem = index;
+
+	if (CurrentMenu->items[CurrentItem].type == screenres)
+		CurrentMenu->items[CurrentItem].a.selmode = M_OptScreenResColumn(mouse_x);
+
+	S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+}
+
+
 void M_OptResponder (event_t *ev)
 {
 	menuitem_t *item;
@@ -2013,6 +2209,29 @@ void M_OptResponder (event_t *ev)
 				}
 			}
 		}
+		return;
+			}
+
+	if (ui_mouse.asInt() != 0 && ev->type == ev_keydown &&
+	    ch >= OKEY_MOUSE1 && ch <= OKEY_MWHEELRIGHT)
+	{
+		int mouse_x, mouse_y;
+
+		if (ch == OKEY_MOUSE2)
+		{
+			CurrentMenu->lastOn = CurrentItem;
+			M_PopMenuStack();
+			return;
+		}
+		else if (ch == OKEY_MWHEELUP)
+			M_OptScroll(-OPT_WHEEL_LINES);
+		else if (ch == OKEY_MWHEELDOWN)
+			M_OptScroll(OPT_WHEEL_LINES);
+		else if (ch == OKEY_MOUSE1 && I_GetUIMousePosition(mouse_x, mouse_y))
+			M_OptMouseClick(mouse_x, mouse_y);
+
+		if (CurrentMenu->refreshfunc)
+			(*CurrentMenu->refreshfunc)();
 		return;
 	}
 

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -252,6 +252,9 @@ static int				OptMouseRowCount = 0;
 
 static const int		OPT_WHEEL_LINES = 3;
 
+static int				OptDragItem = -1;
+static menu_t*			OptDragMenu = NULL;
+
 value_t YesNo[2] = {
 	{ 0.0, "No" },
 	{ 1.0, "Yes" }
@@ -2045,6 +2048,86 @@ static void M_OptScroll(int lines)
 
 
 //
+// M_OptSetSliderFromMouse
+//
+// Sets a slider to the value the cursor was clicked at.
+//
+static void M_OptSetSliderFromMouse(menuitem_t* item, int mouse_x)
+{
+	const int x = CurrentMenu->indent + 8;
+	const int track_x1 = screen->getCleanX(x + SLIDER_TRACK_X);
+	const int track_x2 = screen->getCleanX(x + SLIDER_TRACK_X + SLIDER_TRACK_WIDTH);
+
+	if (track_x2 <= track_x1)
+		return;
+
+	float dist = static_cast<float>(mouse_x - track_x1) / static_cast<float>(track_x2 - track_x1);
+	dist = clamp(dist, 0.0f, 1.0f);
+
+	if (item->type == slider)
+	{
+		float newval = item->b.leftval + dist * (item->c.rightval - item->b.leftval);
+
+		// Snap to the item's step so clicking produces the same set of values
+		// the arrow keys do.
+		if (item->d.step != 0.0f)
+		{
+			const float step = (item->c.rightval >= item->b.leftval) ? item->d.step : -item->d.step;
+			newval = item->b.leftval +
+			         step * std::floor((newval - item->b.leftval) / step + 0.5f);
+		}
+
+		if (item->b.leftval < item->c.rightval)
+			newval = clamp(newval, item->b.leftval, item->c.rightval);
+		else
+			newval = clamp(newval, item->c.rightval, item->b.leftval);
+
+		if (item->e.cfunc)
+			item->e.cfunc(item->a.cvar, newval);
+		else
+			item->a.cvar->Set(newval);
+	}
+	else
+	{
+		// Color component sliders move in steps of 17
+		int part = static_cast<int>(dist * 255.0f + 0.5f);
+		part = ((part + 0x08) / 0x11) * 0x11;
+		part = clamp(part, 0, 0xFF);
+
+		const char* oldcolor = item->a.cvar->cstring();
+		char newcolor[9];
+
+		if (strlen(oldcolor) == 8)
+			memcpy(newcolor, oldcolor, 9);
+		else
+			memcpy(newcolor, "00 00 00", 9);
+
+		char singlecolor[3];
+		snprintf(singlecolor, 3, "%02x", part);
+
+		if (item->type == redslider)
+			memcpy(newcolor, singlecolor, 2);
+		else if (item->type == greenslider)
+			memcpy(newcolor + 3, singlecolor, 2);
+		else if (item->type == blueslider)
+			memcpy(newcolor + 6, singlecolor, 2);
+
+		item->a.cvar->Set(newcolor);
+	}
+}
+
+
+//
+// M_OptItemIsSlider
+//
+static bool M_OptItemIsSlider(const menuitem_t* item)
+{
+	return item->type == slider || item->type == redslider ||
+	       item->type == greenslider || item->type == blueslider;
+}
+
+
+//
 // M_OptMouseClick
 //
 static void M_OptMouseClick(int mouse_x, int mouse_y)
@@ -2068,6 +2151,16 @@ static void M_OptMouseClick(int mouse_x, int mouse_y)
 	if (item->type == screenres)
 		item->a.selmode = M_OptScreenResColumn(mouse_x);
 
+	if (M_OptItemIsSlider(item))
+	{
+		M_OptSetSliderFromMouse(item, mouse_x);
+		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+
+		// Keep following the pointer until the button is released
+		OptDragItem = index;
+		OptDragMenu = CurrentMenu;
+		return;
+	}
 
 	bool cycles_value = false;
 	switch (item->type)
@@ -2103,6 +2196,12 @@ void M_OptUpdateMouseItem()
 	if (ui_mouse.asInt() == 0 || WaitingForKey || WaitingForAxis)
 		return;
 
+	if (OptDragItem != -1 &&
+	    (OptDragMenu != CurrentMenu || OptDragItem >= CurrentMenu->numitems ||
+	     !M_OptItemIsSlider(CurrentMenu->items + OptDragItem) ||
+	     !I_IsUIMouseButtonDown(OKEY_MOUSE1)))
+		OptDragItem = -1;
+
 	int mouse_x, mouse_y;
 	if (!I_GetUIMousePosition(mouse_x, mouse_y))
 		return;
@@ -2113,6 +2212,12 @@ void M_OptUpdateMouseItem()
 
 	if (!moved)
 		return;
+
+	if (OptDragItem != -1)
+	{
+		M_OptSetSliderFromMouse(CurrentMenu->items + OptDragItem, mouse_x);
+		return;
+	}
 
 	const int row = M_OptRowUnderMouse(mouse_y);
 	if (row == -1)
@@ -2210,7 +2315,7 @@ void M_OptResponder (event_t *ev)
 			}
 		}
 		return;
-			}
+	}
 
 	if (ui_mouse.asInt() != 0 && ev->type == ev_keydown &&
 	    ch >= OKEY_MOUSE1 && ch <= OKEY_MWHEELRIGHT)

--- a/common/v_video.h
+++ b/common/v_video.h
@@ -221,11 +221,13 @@ protected:
 	static vdrawfunc *m_Drawfuncs;
 	static vdrawsfunc *m_Drawsfuncs;
 
-private:
-	IWindowSurface*			mSurface;
-
+public:
+	// Maps a virtual 320x200 coordinate to a real screen coordinate.
 	int getCleanX(int x) const;
 	int getCleanY(int y) const;
+
+private:
+	IWindowSurface*			mSurface;
 };
 
 inline void DCanvas::DrawText (int normalcolor, int x, int y, const byte *string) const


### PR DESCRIPTION
This really took too long for us to adopt, so I'm glad to add it! This PR introduces a way to navigate the current menu system using a mouse only. Left click will change a toggle, or drag/set a slider, while right click mimics the ESC key (go back 1 level). Scroll wheel will scroll menus as you'd expect.

The real thing enabling this is the creation of "input modes" to determine when UI should receive input, and marshal said input. Previously, Odamex would discard mouse input for everything except the game.

I also created a function for Odamex to determine the x/y of where a user clicked a window transformed into the scaled/emulated surface it came from. I'm not entirely sure if it's 100% right but it seems to work alright.

I also took it upon myself to make the console part of this UI input mode to marshal mouse events to `C_Responder()`, and implement scrolling and pasting with mouse in the console. Right click will paste there. This resolves #1397.

The actual menu part is pretty simple, instead of a conventional "hittest" function like you'd expect in a window system, the menu and options simply put the x/y/height/width of an option in an array on creation, and enumerate these on menu click to see if any x/y of the click landed on any of these menu items.

I also added a "yes/no" mouseable button set to the "exit game" screen, ala UZDoom, to allow using the mouse there.

I stopped short of creating an onscreen keyboard (again ala UZDoom) but with these functions an enterprising dev would be able to whip that up in a short amount of time using these "psuedo-hittest" functions and the DIGFONT or similar to make the keyboard graphics. I also chose not to add a "back" button as we don't have a graphic for it.

This should tide us over until we can implement a real UI system in Odamex.