### PR TITLE
[BUGFIX] `exec` and `-config` not searching relative paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,11 +136,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS "${CMAKE_EXPORT_COMPILE_COMMANDS}" CACHE BOOL
   FORCE)
 
 # Global compile options as shown in a GUI.
-option(USE_SANITIZE_THREAD "Turn on Thread Sanitizer in Debug builds." OFF)
+option(USE_SANITIZE_ADDRESS "Turn on Address Sanitizer in Debug builds." OFF)
 if(NOT MSVC)
   option(USE_COLOR_DIAGNOSTICS "Force the use of color diagnostics, necessary to get color output with Ninja." ON)
   option(USE_STATIC_STDLIB "Statically link against the C and C++ Standard Library." OFF)
-  option(USE_SANITIZE_ADDRESS "Turn on Address Sanitizer in Debug builds." OFF)
+  option(USE_SANITIZE_THREAD "Turn on Thread Sanitizer in Debug builds." OFF)
   if(USE_SANITIZE_ADDRESS AND USE_SANITIZE_THREAD)
     message(FATAL_ERROR "USE_SANITIZE_ADDRESS and USE_SANITIZE_THREAD are mutually exclusive options.")
   endif()

--- a/common/c_dispatch.cpp
+++ b/common/c_dispatch.cpp
@@ -412,7 +412,13 @@ BEGIN_COMMAND (exec)
 	static std::vector<std::string> exec_stack;
 	static std::vector<bool>	tag_stack;
 
-	std::string found = M_FindUserFileName(argv[1], ".cfg");
+	// TODO: clean this up into a clearer ordering of search directories
+	// CWD, M_FindUserFileName, -cfgdir, ODAMEX_INSTALL_DATADIR, M_GetBinaryDir
+	// the last two are so that config-sample can always be easily exec'd
+	// not sure where exactly -cfgdir should be in the priority, it could be argued
+	// that it should be above user directory and/or CWD
+	std::string found = M_FileExists(argv[1]) ?
+		M_CleanPath(argv[1]) : M_FindUserFileName(argv[1], ".cfg");
 	if (found.empty())
 	{
 		const char* cfgdir = Args.CheckValue("-cfgdir");

--- a/common/c_dispatch.h
+++ b/common/c_dispatch.h
@@ -86,10 +86,10 @@ protected:
 		public: \
 			Cmd_##n () : DConsoleCommand (#n) {} \
 			Cmd_##n (const char *name) : DConsoleCommand (name) {} \
-			void Run (uint32_t key = 0)
+			void Run ([[maybe_unused]] uint32_t key = 0)
 
 #define END_COMMAND(n)		}; \
-	static Cmd_##n Cmd_instance##n;
+	namespace { Cmd_##n Cmd_instance##n; }
 
 class DConsoleAlias : public DConsoleCommand
 {

--- a/common/info.cpp
+++ b/common/info.cpp
@@ -3947,7 +3947,7 @@ mobjinfo_t doom_mobjinfo[::NUMMOBJTYPES] = {
 	0,		// flags3
 	NULL, // ripsound
 	MT_NULL,		// droppeditem
-	"$TAG_AMMOROCKETS",
+	"$AMMO_ROCKETS",
 	},
 
 	{		// MT_MISC19
@@ -3988,7 +3988,7 @@ mobjinfo_t doom_mobjinfo[::NUMMOBJTYPES] = {
 	0,		// flags3
 	NULL, // ripsound
 	MT_NULL,		// droppeditem
-	"$TAG_AMMOROCKETS",
+	"$AMMO_ROCKETS",
 	},
 
 	{		// MT_MISC20
@@ -4029,7 +4029,7 @@ mobjinfo_t doom_mobjinfo[::NUMMOBJTYPES] = {
 	0,		// flags3
 	NULL, // ripsound
 	MT_NULL,		// droppeditem
-	"$TAG_AMMOCELLS",
+	"$AMMO_CELLS",
 	},
 
 	{		// MT_MISC21
@@ -4070,7 +4070,7 @@ mobjinfo_t doom_mobjinfo[::NUMMOBJTYPES] = {
 	0,		// flags3
 	NULL, // ripsound
 	MT_NULL,		// droppeditem
-	"$TAG_AMMOCELLS",
+	"$AMMO_CELLS",
 	},
 
 	{		// MT_MISC22

--- a/common/m_fileio.cpp
+++ b/common/m_fileio.cpp
@@ -57,7 +57,7 @@ std::string M_JoinPath(std::string_view path1, std::string_view path2)
 */
 void M_ExpandHomeDir(std::string& path)
 {
-	if (!path.length())
+	if (path.empty())
 		return;
 
 	if (path[0] != '~')
@@ -95,7 +95,8 @@ std::string M_FindUserFileName(const std::string& file, const char* ext)
 	{
 		return found;
 	}
-	else if (ext != NULL)
+
+	if (ext != nullptr)
 	{
 		found = M_GetUserFileName(std::string(file) + ext);
 		if (M_FileExists(found))
@@ -395,11 +396,13 @@ std::string M_GetUserFileName(const std::string& file)
 	std::string path = file;
 	return M_CleanPath(path);
 #else
-	fs::path path(file);
+	std::string expanded(file);
+	M_ExpandHomeDir(expanded);
+	fs::path path(expanded);
 	// Is absolute path?  If so, stop here.
 	if (path.is_absolute())
 	{
-		return file;
+		return expanded;
 	}
 
 	// Is this an explicitly relative path?  If so, stop here.
@@ -408,7 +411,8 @@ std::string M_GetUserFileName(const std::string& file)
 	{
 		return file;
 	}
-	else if (fileLen >= 3 && file[0] == '.' && file[1] == '.' && M_IsPathSep(file[2]))
+
+	if (fileLen >= 3 && file[0] == '.' && file[1] == '.' && M_IsPathSep(file[2]))
 	{
 		return file;
 	}

--- a/common/m_resfile.cpp
+++ b/common/m_resfile.cpp
@@ -134,7 +134,10 @@ bool OWantFile::make(OWantFile& out, const std::string& file, const ofile_t type
 	std::string extension;
 	M_ExtractFileExtension(basename, extension);
 
-	out.m_wantedpath = file;
+	std::string expanded(file);
+	M_ExpandHomeDir(expanded);
+
+	out.m_wantedpath = expanded;
 	out.m_wantedtype = type;
 	out.m_basename = basename;
 	out.m_extension = extension;
@@ -162,7 +165,10 @@ bool OWantFile::makeWithHash(OWantFile& out, const std::string& file, const ofil
 	std::string extension;
 	M_ExtractFileExtension(basename, extension);
 
-	out.m_wantedpath = file;
+	std::string expanded(file);
+	M_ExpandHomeDir(expanded);
+
+	out.m_wantedpath = expanded;
 	out.m_wantedtype = type;
 	out.m_wantedMD5 = hash;
 	out.m_basename = basename;

--- a/common/m_resfile.cpp
+++ b/common/m_resfile.cpp
@@ -320,16 +320,6 @@ bool M_ResolveWantedFile(OResFile& out, const OWantFile& wanted)
 	return false;
 }
 
-static bool ScanIWADCmp(const scannedIWAD_t& a, const scannedIWAD_t& b)
-{
-	return a.id->weight < b.id->weight;
-}
-
-static bool ScanPWADCmp(const scannedPWAD_t& a, const scannedPWAD_t& b)
-{
-	return StdStringToLower(a.filename) < StdStringToLower(b.filename);
-}
-
 /**
  * @brief Scan all file search directories for IWAD files.
  */
@@ -369,7 +359,10 @@ std::vector<scannedIWAD_t> M_ScanIWADs()
 	}
 
 	// Sort the results by weight.
-	std::sort(rvo.begin(), rvo.end(), ScanIWADCmp);
+	std::sort(rvo.begin(), rvo.end(),
+		[](const scannedIWAD_t& a, const scannedIWAD_t& b) {
+			return a.id->weight < b.id->weight;
+		});
 
 	return rvo;
 }
@@ -421,7 +414,10 @@ std::vector<scannedPWAD_t> M_ScanPWADs()
 	}
 
 	// Sort the results alphabetically
-	std::sort(rvo.begin(), rvo.end(), ScanPWADCmp);
+	std::sort(rvo.begin(), rvo.end(),
+		[](const scannedPWAD_t& a, const scannedPWAD_t& b){
+			return StdStringToLower(a.filename) < StdStringToLower(b.filename);
+		});
 
 	return rvo;
 }

--- a/common/m_resfile.h
+++ b/common/m_resfile.h
@@ -92,34 +92,34 @@ class OWantFile
 	/**
 	 * @brief Get the original "wanted" path.
 	 */
-	const std::string& getWantedPath() const { return m_wantedpath; }
+	[[nodiscard]] const std::string& getWantedPath() const { return m_wantedpath; }
 
 	/**
 	 * @brief Get the original "wanted" path.
 	 */
-	ofile_t getWantedType() const { return m_wantedtype; }
+	[[nodiscard]] ofile_t getWantedType() const { return m_wantedtype; }
 
 	/**
 	 * @brief Get the assumed hash of the file, or an empty string if there
 	 *        is no hash.
 	 */
-	const OMD5Hash& getWantedMD5() const { return m_wantedMD5; }
+	[[nodiscard]] const OMD5Hash& getWantedMD5() const { return m_wantedMD5; }
 
 	/**
 	 * @brief Get the base filename of the resource, with no directory.
 	 */
-	const std::string& getBasename() const { return m_basename; }
+	[[nodiscard]] const std::string& getBasename() const { return m_basename; }
 
 	/**
 	 * @brief Get the extension of the resource.
 	 */
-	const std::string& getExt() const { return m_extension; }
+	[[nodiscard]] const std::string& getExt() const { return m_extension; }
 
 	static bool make(OWantFile& out, const std::string& file, const ofile_t type);
 	static bool makeWithHash(OWantFile& out, const std::string& file, const ofile_t type,
 	                         const OMD5Hash& hash);
 };
-typedef std::vector<OWantFile> OWantFiles;
+using OWantFiles = std::vector<OWantFile>;
 
 struct fileIdentifier_t;
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -719,7 +719,7 @@ static void P_DoNewChaseDir(AActor* actor, fixed_t deltax, fixed_t deltay)
 	int tdir;
 	dirtype_t olddir = (dirtype_t)actor->movedir;
 
-	dirtype_t turnaround = turnaround = opposite[olddir];
+	dirtype_t turnaround = opposite[olddir];
 
 	if (deltax > 10 * FRACUNIT)
 		d[1] = DI_EAST;

--- a/common/version.h
+++ b/common/version.h
@@ -108,7 +108,7 @@ public:
 	file_version(const char *uid, const char *id, const char *p, int l, const char *t, const char *d);
 };
 
-#define VERSION_CONTROL(uid, id) static file_version file_version_unique_##uid(#uid, id, __FILE__, __LINE__, __TIME__, __DATE__);
+#define VERSION_CONTROL(uid, id) namespace { file_version file_version_unique_##uid(#uid, id, __FILE__, __LINE__, __TIME__, __DATE__); }
 
 const char* GitHash();
 const char* GitBranch();


### PR DESCRIPTION
Before 11.1.0, `exec` and `-config` would search the CWD if the path given was a relative path. 11.1.0 unintentionally changed this so that it would require an explicitly relative path starting with `./` or `../`. This PR restores the old behavior and also makes `M_FindUserFileName`/`M_GetUserFileName` and `OWantFile` constructors perform tilde expansion, which fixes most cases of tildes not being expanded in file paths.