### PR TITLE
Don't give verbose errors for every wad search directory that can't be found

### DIFF
--- a/client/src/cl_download.cpp
+++ b/client/src/cl_download.cpp
@@ -310,20 +310,20 @@ static StringTokens GetDownloadDirs()
 	StringTokens dirs;
 
 	// Add all of the sources.
-	D_AddSearchDir(dirs, cl_waddownloaddir.cstring(), PATHLISTSEPCHAR);
-	dirs.push_back(M_GetDownloadDir());
+	D_AddSearchDir(dirs, cl_waddownloaddir.str());
+	D_AddSearchDir(dirs, M_GetDownloadDir());
 
 	// These folders should only work on PC versions
 #ifndef GCONSOLE
-	D_AddSearchDir(dirs, Args.CheckValue("-waddir"), PATHLISTSEPCHAR);
-	D_AddSearchDir(dirs, getenv("DOOMWADDIR"), PATHLISTSEPCHAR);
-	D_AddSearchDir(dirs, getenv("DOOMWADPATH"), PATHLISTSEPCHAR);
+	D_AddSearchDirList(dirs, Args.CheckValue("-waddir"));
+	D_AddSearchDir(dirs, getenv("DOOMWADDIR"));
+	D_AddSearchDirList(dirs, getenv("DOOMWADPATH"));
 #endif
 
-	D_AddSearchDir(dirs, waddirs.cstring(), PATHLISTSEPCHAR);
+	D_AddSearchDirList(dirs, waddirs.str());
 
 #ifdef __SWITCH__
-	dirs.push_back("./wads");
+	D_AddSearchDir(dirs, "./wads");
 #endif
 
 	dirs.push_back(M_GetCWD());

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -283,30 +283,71 @@ void D_InitializeDoomObjectTables()
 	);
 }
 
-//
-// D_AddSearchDir
-// denis - Split a new directory string using the separator and append results to the output
-//
-void D_AddSearchDir(std::vector<std::string> &dirs, const char *dir, const char separator)
+void D_AddSearchDir(std::vector<std::string>& dirs, const char* newdir, missing_dir_policy_t policy)
 {
-	if(!dir)
+	if (!newdir)
+		return;
+
+	D_AddSearchDir(dirs, std::string{newdir}, policy);
+}
+
+void D_AddSearchDir(std::vector<std::string>& dirs, std::string newdir, missing_dir_policy_t policy)
+{
+	if (newdir.empty())
+		return;
+
+	M_ExpandHomeDir(newdir);
+	newdir = M_CleanPath(newdir);
+	if (M_DirectoryExists(newdir))
+	{
+		dirs.push_back(newdir);
+	}
+	else if (policy == missing_dir_policy_t::WARN ||
+		(policy == missing_dir_policy_t::DEV_WARN && (::developer || ::devparm)))
+	{
+		PrintFmt(PRINT_WARNING, "{}: search directory \"{}\" not found\n", __FUNCTION__, newdir);
+	}
+}
+
+//
+// D_AddSearchDirList
+// denis - Split a new directory string using the path list separator and append results to the output
+//
+void D_AddSearchDirList(std::vector<std::string> &dirs, const char *newdirs, missing_dir_policy_t policy)
+{
+	if (!newdirs)
+		return;
+
+	D_AddSearchDirList(dirs, std::string{newdirs}, policy);
+}
+
+void D_AddSearchDirList(std::vector<std::string> &dirs, std::string newdirs, missing_dir_policy_t policy)
+{
+	if(newdirs.empty())
 		return;
 
 	// search through dwd
-	std::stringstream ss(dir);
+	std::stringstream ss{newdirs};
 	std::string segment;
 
 	while(!ss.eof())
 	{
-		std::getline(ss, segment, separator);
+		std::getline(ss, segment, PATHLISTSEPCHAR);
 
 		if(!segment.length())
 			continue;
 
 		M_ExpandHomeDir(segment);
 		segment = M_CleanPath(segment);
-
-		dirs.push_back(segment);
+		if (M_DirectoryExists(segment))
+		{
+			dirs.push_back(segment);
+		}
+		else if (policy == missing_dir_policy_t::WARN ||
+			(policy == missing_dir_policy_t::DEV_WARN && (::developer || ::devparm)))
+		{
+			PrintFmt(PRINT_WARNING, "{}: search directory \"{}\" not found\n", __FUNCTION__, segment);
+		}
 	}
 }
 
@@ -315,11 +356,9 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 {
 	#if defined(_WIN32)
 
-	const char separator = ';';
-
 	// Doom 95
 	{
-		for (auto& uninstallval : uninstall_values)
+		for (const auto& uninstallval : uninstall_values)
 		{
 			char* val;
 			char* path;
@@ -341,7 +380,7 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 				path = unstr + strlen(uninstaller_string);
 
 				const char* cpath = path;
-				D_AddSearchDir(dirs, cpath, separator);
+				D_AddSearchDir(dirs, cpath);
 			}
 		}
 	}
@@ -356,7 +395,7 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 			{
 				const std::string subpath = fmt::format("{}\\{}", install_path, dir);
 
-				D_AddSearchDir(dirs, subpath.c_str(), separator);
+				D_AddSearchDir(dirs, subpath);
 			}
 
 			M_Free(install_path);
@@ -373,7 +412,7 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 			{
 				const std::string subpath = fmt::format("{}\\{}", install_path, dir);
 
-				D_AddSearchDir(dirs, subpath.c_str(), separator);
+				D_AddSearchDir(dirs, subpath);
 			}
 
 			M_Free(install_path);
@@ -386,7 +425,7 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 
 		if (doom_plus_doom2_path != nullptr)
 		{
-			D_AddSearchDir(dirs, doom_plus_doom2_path, separator);
+			D_AddSearchDir(dirs, doom_plus_doom2_path);
 			M_Free(doom_plus_doom2_path);
 		}
 
@@ -394,7 +433,7 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 
 		if (doom_path != nullptr)
 		{
-			D_AddSearchDir(dirs, doom_path, separator);
+			D_AddSearchDir(dirs, doom_path);
 			M_Free(doom_path);
 		}
 
@@ -404,8 +443,8 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 		{
 			const std::string full_doom2_path = fmt::format("{}\\{}", doom2_path, "doom2");
 			const std::string master_levels_path = fmt::format("{}\\{}", doom2_path, "master\\wads");
-			D_AddSearchDir(dirs, full_doom2_path.c_str(), separator);
-			D_AddSearchDir(dirs, master_levels_path.c_str(), separator);
+			D_AddSearchDir(dirs, full_doom2_path);
+			D_AddSearchDir(dirs, master_levels_path);
 			M_Free(doom2_path);
 		}
 
@@ -415,44 +454,42 @@ void D_AddPlatformSearchDirs(std::vector<std::string> &dirs)
 		{
 			const std::string plutonia_path = fmt::format("{}\\{}", final_doom_path, "Plutonia");
 			const std::string tnt_path = fmt::format("{}\\{}", final_doom_path, "TNT");
-			D_AddSearchDir(dirs, plutonia_path.c_str(), separator);
-			D_AddSearchDir(dirs, tnt_path.c_str(), separator);
+			D_AddSearchDir(dirs, plutonia_path);
+			D_AddSearchDir(dirs, tnt_path);
 			M_Free(final_doom_path);
 		}
 	}
 
 	// DOS Doom via DEICE
-	D_AddSearchDir(dirs, "\\doom2", separator);    // Doom II
-	D_AddSearchDir(dirs, "\\plutonia", separator); // Final Doom
-	D_AddSearchDir(dirs, "\\tnt", separator);
-	D_AddSearchDir(dirs, "\\doom_se", separator);  // Ultimate Doom
-	D_AddSearchDir(dirs, "\\doom", separator);     // Shareware / Registered Doom
-	D_AddSearchDir(dirs, "\\dooms", separator);    // Shareware versions
-	D_AddSearchDir(dirs, "\\doomsw", separator);
+	D_AddSearchDir(dirs, "\\doom2");    // Doom II
+	D_AddSearchDir(dirs, "\\plutonia"); // Final Doom
+	D_AddSearchDir(dirs, "\\tnt");
+	D_AddSearchDir(dirs, "\\doom_se");  // Ultimate Doom
+	D_AddSearchDir(dirs, "\\doom");     // Shareware / Registered Doom
+	D_AddSearchDir(dirs, "\\dooms");    // Shareware versions
+	D_AddSearchDir(dirs, "\\doomsw");
 
 	#elif defined(UNIX)
 
-	const char separator = ':';
-
 	#if defined(INSTALL_PREFIX) && defined(INSTALL_DATADIR)
-	D_AddSearchDir(dirs, INSTALL_PREFIX "/" INSTALL_DATADIR "/odamex", separator);
-	D_AddSearchDir(dirs, INSTALL_PREFIX "/" INSTALL_DATADIR "/games/odamex", separator);
+	D_AddSearchDir(dirs, INSTALL_PREFIX "/" INSTALL_DATADIR "/odamex", missing_dir_policy_t::DEV_WARN);
+	D_AddSearchDir(dirs, INSTALL_PREFIX "/" INSTALL_DATADIR "/games/odamex", missing_dir_policy_t::DEV_WARN);
 	#endif
 	// Search the maintainer-directed data directory for WADs
 	#if defined(ODAMEX_INSTALL_DATADIR)
-	D_AddSearchDir(dirs, ODAMEX_INSTALL_DATADIR, separator);
+	D_AddSearchDir(dirs, ODAMEX_INSTALL_DATADIR, missing_dir_policy_t::DEV_WARN);
 	#endif
 
-	D_AddSearchDir(dirs, "/usr/share/doom", separator);
-	D_AddSearchDir(dirs, "/usr/share/games/doom", separator);
-	D_AddSearchDir(dirs, "/usr/local/share/games/doom", separator);
-	D_AddSearchDir(dirs, "/usr/local/share/doom", separator);
+	D_AddSearchDir(dirs, "/usr/share/doom", missing_dir_policy_t::DEV_WARN);
+	D_AddSearchDir(dirs, "/usr/share/games/doom", missing_dir_policy_t::DEV_WARN);
+	D_AddSearchDir(dirs, "/usr/local/share/games/doom", missing_dir_policy_t::DEV_WARN);
+	D_AddSearchDir(dirs, "/usr/local/share/doom", missing_dir_policy_t::DEV_WARN);
 	// Flatpak sandbox default directories
 	// (Since you need to pass envvars to a Flatpak)
-	D_AddSearchDir(dirs, "/run/host/usr/share/doom", separator);
-	D_AddSearchDir(dirs, "/run/host/usr/share/games/doom", separator);
-	D_AddSearchDir(dirs, "/run/host/usr/local/share/games/doom", separator);
-	D_AddSearchDir(dirs, "/run/host/usr/local/share/doom", separator);
+	D_AddSearchDir(dirs, "/run/host/usr/share/doom", missing_dir_policy_t::DEV_WARN);
+	D_AddSearchDir(dirs, "/run/host/usr/share/games/doom", missing_dir_policy_t::DEV_WARN);
+	D_AddSearchDir(dirs, "/run/host/usr/local/share/games/doom", missing_dir_policy_t::DEV_WARN);
+	D_AddSearchDir(dirs, "/run/host/usr/local/share/doom", missing_dir_policy_t::DEV_WARN);
 
 	#endif
 }

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -203,7 +203,7 @@ static registry_value_t gog_final_doom =
 	"path",
 };
 
-static char *GetRegistryString(registry_value_t *reg_val)
+static char *GetRegistryString(const registry_value_t *reg_val)
 {
 	HKEY key = 0;
 	DWORD len = 0;

--- a/common/d_main.h
+++ b/common/d_main.h
@@ -60,7 +60,17 @@ void D_DisplayTicker(void);
 // [RH] Set this to something to draw an icon during the next screen refresh.
 extern const char *D_DrawIcon;
 
-void D_AddSearchDir(std::vector<std::string> &dirs, const char *dir, const char separator);
+enum struct missing_dir_policy_t
+{
+    SILENT,
+    WARN,
+    DEV_WARN,
+};
+
+void D_AddSearchDir(std::vector<std::string> &dirs, const char *newdir, missing_dir_policy_t policy = missing_dir_policy_t::SILENT);
+void D_AddSearchDir(std::vector<std::string> &dirs, std::string newdir, missing_dir_policy_t policy = missing_dir_policy_t::SILENT);
+void D_AddSearchDirList(std::vector<std::string> &dirs, const char *newdirs, missing_dir_policy_t policy = missing_dir_policy_t::SILENT);
+void D_AddSearchDirList(std::vector<std::string> &dirs, std::string newdirs, missing_dir_policy_t policy = missing_dir_policy_t::SILENT);
 void D_AddPlatformSearchDirs(std::vector<std::string>& dirs);
 void D_LoadResolvedPatches(bool reloadStrings = false);
 std::string D_CleanseFileName(const std::string &filename, const std::string &ext = "");

--- a/common/m_fileio.cpp
+++ b/common/m_fileio.cpp
@@ -194,6 +194,18 @@ bool M_FileExistsExt(const std::string& filename, const char* ext)
 	return false;
 }
 
+/**
+ * @brief Checks to see whether a file exists and is a directory or not
+ *
+ * @param filename Filename to check.
+ */
+bool M_DirectoryExists(const std::string& path)
+{
+	// Returns false on errors
+	std::error_code ec;
+	return fs::is_directory(path, ec);
+}
+
 //
 // M_WriteFile
 //

--- a/common/m_fileio.h
+++ b/common/m_fileio.h
@@ -39,6 +39,7 @@ std::string M_GetCWD();
 int64_t M_FileLength (FILE *f);
 bool M_FileExists(const std::string& filename);
 bool M_FileExistsExt(const std::string& filename, const char* ext);
+bool M_DirectoryExists(const std::string& filename);
 
 bool M_WriteFile(std::string filename, void *source, size_t length);
 size_t M_ReadFile(std::string filename, byte **buffer);

--- a/common/m_resfile.cpp
+++ b/common/m_resfile.cpp
@@ -238,13 +238,13 @@ std::vector<std::string> M_FileSearchDirs()
 	std::vector<std::string> dirs;
 
 	// [cSc] Add cl_waddownloaddir as default path
-	D_AddSearchDir(dirs, ::cl_waddownloaddir.cstring(), PATHLISTSEPCHAR);
-	D_AddSearchDir(dirs, ::Args.CheckValue("-waddir"), PATHLISTSEPCHAR);
-	D_AddSearchDir(dirs, getenv("DOOMWADDIR"), PATHLISTSEPCHAR);
-	D_AddSearchDir(dirs, getenv("DOOMWADPATH"), PATHLISTSEPCHAR);
-	D_AddSearchDir(dirs, ::waddirs.cstring(), PATHLISTSEPCHAR);
-	dirs.push_back(M_CleanPath(M_GetUserDir() + PATHSEP "downloads"));
-	dirs.push_back(M_CleanPath(M_GetBinaryDir() + PATHSEP "downloads"));
+	D_AddSearchDir(dirs, ::cl_waddownloaddir.str(), missing_dir_policy_t::WARN);
+	D_AddSearchDirList(dirs, ::Args.CheckValue("-waddir"), missing_dir_policy_t::WARN);
+	D_AddSearchDir(dirs, getenv("DOOMWADDIR"), missing_dir_policy_t::WARN);
+	D_AddSearchDirList(dirs, getenv("DOOMWADPATH"), missing_dir_policy_t::WARN);
+	D_AddSearchDirList(dirs, ::waddirs.str(), missing_dir_policy_t::WARN);
+	D_AddSearchDir(dirs, M_CleanPath(M_GetUserDir() + PATHSEP "downloads"));
+	D_AddSearchDir(dirs, M_CleanPath(M_GetBinaryDir() + PATHSEP "downloads"));
 	dirs.push_back(M_GetUserDir());
 	dirs.push_back(M_GetCWD());
 	dirs.push_back(M_GetBinaryDir());


### PR DESCRIPTION
This is based on the work manc did in the odaheretic-prologue branch. There's still some other things holding that up from getting merged, but I figured it would be good to go ahead and get this QoL change in.

When 11.1.0 moved to using std::filesystem, it changed the behavior of searching wad directories so that instead of silently skipping missing directories, it would print out the messages from caught filesystem exceptions. This results in lots of verbose errors that confuse users and make them think there's something wrong:
<img width="1905" height="618" alt="image" src="https://github.com/user-attachments/assets/d139fe1f-fbba-45cd-8c80-03bad991b1e8" />

Now these are silenced when adding wad search paths, unless they're user provided paths, in which case a clearer warning is printed

<img width="873" height="436" alt="image" src="https://github.com/user-attachments/assets/c026d7db-2f8e-42fa-8c43-df4e4464a5da" />