### PR TITLE
Fix for P_JustTeleported being true on odasrv startup

### DIFF
--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -192,7 +192,7 @@ void P_ClearJustTeleported()
 
 bool P_JustTeleported (AActor* thing)
 {
-	return teleportedThing == thing;
+	return thing != nullptr && teleportedThing == thing;
 }
 
 //

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -192,7 +192,7 @@ void P_ClearJustTeleported()
 
 bool P_JustTeleported (AActor* thing)
 {
-	return thing != nullptr && teleportedThing == thing;
+	return teleportedThing != nullptr && teleportedThing == thing;
 }
 
 //


### PR DESCRIPTION
Seeing a crash on odasrv when both of these are nullptr

<img width="786" height="397" alt="Screenshot from 2026-07-24 09-25-00" src="https://github.com/user-attachments/assets/4040db9d-49ec-40d3-9a5a-05917666e541" />
