### PR TITLE
Clipboard improvements

### DIFF
--- a/client/sdl/i_system.cpp
+++ b/client/sdl/i_system.cpp
@@ -426,11 +426,13 @@ void I_BaseWarning(const std::string& warningtext)
 // [EB] 20 Mar 2026 - Got rid of all platform specific code
 // Now that we dropped SDL1 support, we can fully rely on SDL for this
 //
-std::string I_GetClipboardText()
+std::string I_GetClipboardText(bool use_primary_selection)
 {
 #if defined(SDL20) || defined(SDL3)
-	char* textp = SDL_GetClipboardText();
-	auto textpExit = nonstd::make_scope_exit([&]() { SDL_free(textp); });
+	const auto driver = I_GetVideoDriverName();
+	const bool driver_supports_primary = driver == "wayland" || driver == "x11";
+	char* textp = use_primary_selection && driver_supports_primary ? SDL_GetPrimarySelectionText() : SDL_GetClipboardText();
+	const auto textpExit = nonstd::make_scope_exit([&]() { SDL_free(textp); });
 
 	if (NULL == textp)
 	{

--- a/client/sdl/i_system.cpp
+++ b/client/sdl/i_system.cpp
@@ -426,12 +426,16 @@ void I_BaseWarning(const std::string& warningtext)
 // [EB] 20 Mar 2026 - Got rid of all platform specific code
 // Now that we dropped SDL1 support, we can fully rely on SDL for this
 //
-std::string I_GetClipboardText(bool use_primary_selection)
+std::string I_GetClipboardText([[maybe_unused]] bool use_primary_selection)
 {
 #if defined(SDL20) || defined(SDL3)
-	const auto driver = I_GetVideoDriverName();
-	const bool driver_supports_primary = driver == "wayland" || driver == "x11";
-	char* textp = use_primary_selection && driver_supports_primary ? SDL_GetPrimarySelectionText() : SDL_GetClipboardText();
+	#if SDL_VERSION_ATLEAST(2, 26, 0)
+		const auto driver = I_GetVideoDriverName();
+		const bool driver_supports_primary = driver == "wayland" || driver == "x11";
+		char* textp = use_primary_selection && driver_supports_primary ? SDL_GetPrimarySelectionText() : SDL_GetClipboardText();
+	#else
+		char* textp = SDL_GetClipboardText();
+	#endif
 	const auto textpExit = nonstd::make_scope_exit([&]() { SDL_free(textp); });
 
 	if (NULL == textp)

--- a/client/sdl/i_system.h
+++ b/client/sdl/i_system.h
@@ -111,7 +111,7 @@ bool I_IsHeadless();
 
 void I_FinishClockCalibration ();
 
-std::string I_GetClipboardText();
+std::string I_GetClipboardText(bool use_primary_selection = false);
 
 /**
  * @brief Show an error message box.

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -2208,6 +2208,17 @@ static bool C_HandleKey(const event_t* ev)
 		return true;
 	}
 
+	if (KeysAlt)
+	{
+		// Paste from primary selection - add each character to command line
+ 		if (tolower(ev->data1) == 'v')
+		{
+			CmdLine.insertString(I_GetClipboardText(true));
+			TabCycleClear();
+		}
+		return true;
+	}
+
 	if (keytext)
 	{
 		// Add keypress to command line

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -2042,8 +2042,9 @@ static bool C_HandleKey(const event_t* ev)
 			return true;
 		}
 	case OKEY_MOUSE2:
+	case OKEY_MOUSE3:
 		// Paste from clipboard - add each character to command line
-		CmdLine.insertString(I_GetClipboardText());
+		CmdLine.insertString(I_GetClipboardText(ch == OKEY_MOUSE3));
 		CmdCompletions.clear();
 		TabCycleClear();
 		return true;

--- a/odalaunch/src/lst_servers.cpp
+++ b/odalaunch/src/lst_servers.cpp
@@ -117,9 +117,6 @@ void LstOdaServerList::OnCopyAddress(wxCommandEvent& event)
 
 	if(wxTheClipboard->Open())
 	{
-#ifdef __WXGTK__
-		wxTheClipboard->UsePrimarySelection(true);
-#endif
 		wxTheClipboard->SetData(new wxTextDataObject(li.m_text));
 		wxTheClipboard->Close();
 	}


### PR DESCRIPTION
Middle click paste support has been reintroduced after being removed by #1851. When running under X11 or Wayland (and the SDL version is 2.26.0 or later) it now pastes from the primary selection instead of the clipboard. Additionally, the ALT+V shortcut has been introduced to paste from the primary selection as well. Right click and CTRL+V paste from the clipboard always.

Prior to #1658, CTRL+V and middle click both pasted from the primary selection on X11 (and crashed Odamex on Wayland...). Because of this, Odalaunch's "Copy Server Address" context item copied to the primary selection. Now that this PR brings full support for pasting from either one, Odalaunch now copies to the clipboard, as that is what is usually expected when explicitly copying.