### PR TITLE
Initial netdemo seek command

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -442,11 +442,11 @@ bool NetDemo::startPlaying(const std::string &filename)
 		return false;
 	}
 
-    if constexpr (TRY_LOADING_OLD_NETDEMOS)
-    {
-        PrintFmt(PRINT_WARNING, "Attempting to load a version {} netdemo...\n", header.id.version);
-    }
-    else if (header.id.version != NETDEMOVER)
+	if constexpr (TRY_LOADING_OLD_NETDEMOS)
+	{
+		PrintFmt(PRINT_WARNING, "Attempting to load a version {} netdemo...\n", header.id.version);
+	}
+	else if (header.id.version != NETDEMOVER)
 	{
 		std::string buffer;
 		const int latestVersion = LatestDemoVersion(header.id.version);
@@ -643,15 +643,22 @@ bool NetDemo::atSnapshotInterval()
 }
 
 
-void NetDemo::ticker()
+bool NetDemo::ticker()
 {
-	netdemotic++;
-	if (netdemotic == pause_netdemotic)
+	if (not isInPlayback())
+		return false;
+
+	if (isPlaying())
 	{
-		pause_netdemotic = 0;
-		pause();
-		::paused = true;
+		netdemotic++;
+		if (netdemotic == pause_netdemotic)
+		{
+			pause_netdemotic = 0;
+			pause();
+			::paused = true;
+		}
 	}
+	return true;
 }
 
 //
@@ -827,7 +834,8 @@ void NetDemo::readMessages(buf_t* netbuffer)
 	}
 
 	// read from the input file and put the data into netbuffer
-	gametic = tic;
+	gametic     = tic;
+	netdemotic  = gametic - header.starting_gametic;
 	readMessageBody(netbuffer, len);
 }
 
@@ -1132,7 +1140,7 @@ void NetDemo::prevTic()
 	if (!isPaused())
 		return;
 
-	seekGametic(gametic - 1);
+	seekNetdemotic(netdemotic - 1);
 }
 
 //

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -102,7 +102,7 @@ void NetDemo::cleanUp()
 {
 	if (isRecording())
 	{
-		stopRecording();	// Try to write any unwritten data
+		stopRecording();    // Try to write any unwritten data
 	}
 
 	// close all files
@@ -175,44 +175,44 @@ bool NetDemo::writeHeader()
 
 bool NetDemo::netdemo_header_id_t::Read(std::fstream& io_stream)
 {
-    if (io_stream.good())
-    {
-        return  M_ReadLE(io_stream, identifier)
-            and M_ReadLE(io_stream, version);
-    }
-    return false;
+	if (io_stream.good())
+	{
+		return  M_ReadLE(io_stream, identifier)
+		    and M_ReadLE(io_stream, version);
+	}
+	return false;
 }
 
 bool NetDemo::netdemo_header3_t::Read(std::fstream& io_stream)
 {
-    if (io_stream.good())
-    {
-        return  id.Read(io_stream)
-            and M_ReadLE(io_stream, compression)
-            and M_ReadLE(io_stream, snapshot_index_size)
-            and M_ReadLE(io_stream, snapshot_index_offset)
-            and M_ReadLE(io_stream, map_index_size)
-            and M_ReadLE(io_stream, map_index_offset)
-            and M_ReadLE(io_stream, snapshot_spacing)
-            and M_ReadLE(io_stream, starting_gametic)
-            and M_ReadLE(io_stream, ending_gametic)
-            and M_ReadLE(io_stream, reserved);
-    }
-    return false;
+	if (io_stream.good())
+	{
+		return  id.Read(io_stream)
+		    and M_ReadLE(io_stream, compression)
+		    and M_ReadLE(io_stream, snapshot_index_size)
+		    and M_ReadLE(io_stream, snapshot_index_offset)
+		    and M_ReadLE(io_stream, map_index_size)
+		    and M_ReadLE(io_stream, map_index_offset)
+		    and M_ReadLE(io_stream, snapshot_spacing)
+		    and M_ReadLE(io_stream, starting_gametic)
+		    and M_ReadLE(io_stream, ending_gametic)
+		    and M_ReadLE(io_stream, reserved);
+	}
+	return false;
 }
 
 bool NetDemo::netdemo_header4_t::Read(std::fstream& io_stream)
 {
-    if (io_stream.good())
-    {
-        return  id.Read(io_stream)
-            and M_ReadLE(io_stream, compression)
-            and M_ReadLE(io_stream, snapshot_spacing)
-            and M_ReadLE(io_stream, starting_gametic)
-            and M_ReadLE(io_stream, ending_gametic)
-            and M_ReadLE(io_stream, reserved);
-    }
-    return false;
+	if (io_stream.good())
+	{
+		return  id.Read(io_stream)
+		    and M_ReadLE(io_stream, compression)
+		    and M_ReadLE(io_stream, snapshot_spacing)
+		    and M_ReadLE(io_stream, starting_gametic)
+		    and M_ReadLE(io_stream, ending_gametic)
+		    and M_ReadLE(io_stream, reserved);
+	}
+	return false;
 }
 
 //
@@ -227,42 +227,42 @@ bool NetDemo::readHeader()
 	demofp.seekg(0, std::ios::beg);
 	const auto startingPosition = demofp.tellg();
 
-    netdemo_header_id_t headerId;
-    const bool headerIDOk = headerId.Read(demofp);
+	netdemo_header_id_t headerId;
+	const bool headerIDOk = headerId.Read(demofp);
 
-    if (not (headerIDOk
-             and headerId.identifier[0] == 'O'
-             and headerId.identifier[1] == 'D'
-             and headerId.identifier[2] == 'A'
-             and headerId.identifier[3] == 'D'))
-    {
-        return false;
-    }
+	if (not (headerIDOk
+	         and headerId.identifier[0] == 'O'
+	         and headerId.identifier[1] == 'D'
+	         and headerId.identifier[2] == 'A'
+	         and headerId.identifier[3] == 'D'))
+	{
+		return false;
+	}
 
-    header.id = headerId;
+	header.id = headerId;
 
-    if (header.id.version == NETDEMOVER)
-    {
-        demofp.seekg(startingPosition, std::ios::beg);
+	if (header.id.version == NETDEMOVER)
+	{
+		demofp.seekg(startingPosition, std::ios::beg);
 
-        return header.Read(demofp)
-                and demofp.tellg() - startingPosition == HEADER_SIZE;
-    }
+		return header.Read(demofp)
+		        and demofp.tellg() - startingPosition == HEADER_SIZE;
+	}
 
-    if (header.id.version == 3)
-    {
-        demofp.seekg(startingPosition, std::ios::beg);
+	if (header.id.version == 3)
+	{
+		demofp.seekg(startingPosition, std::ios::beg);
 
-        netdemo_header3_t header3;
+		netdemo_header3_t header3;
 
-        if (header3.Read(demofp)
-                and demofp.tellg() - startingPosition == HEADER_SIZE)
-        {
-            // Translate from 3 to NETDEMOVER
-            header.Import(header3);
-            return true;
-        }
-    }
+		if (header3.Read(demofp)
+		        and demofp.tellg() - startingPosition == HEADER_SIZE)
+		{
+			// Translate from 3 to NETDEMOVER
+			header.Import(header3);
+			return true;
+		}
+	}
 	return false;
 }
 

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1132,9 +1132,7 @@ void NetDemo::prevTic()
 	if (!isPaused())
 		return;
 
-	pause_netdemotic = netdemotic - 1;
-	state = oldstate;
-	::paused = false;
+	seekGametic(gametic - 1);
 }
 
 //

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -39,6 +39,7 @@
 #include "clc_message.h"
 #include "svc_message.h"
 #include "g_gametype.h"
+#include "g_game.h"
 
 #include "PacketHeaderType.h"
 
@@ -112,6 +113,7 @@ void NetDemo::cleanUp()
 	map_index.clear();
 	state = oldstate = NetDemo::st_stopped;
 	netdemotic = pause_netdemotic = last_map_tic = 0;
+	timingdemo = false;
 }
 
 /**
@@ -490,6 +492,7 @@ bool NetDemo::pause()
 {
 	if (isPlaying())
 	{
+		timingdemo = false;
 		oldstate = state;
 		state = NetDemo::st_paused;
 		return true;
@@ -1032,59 +1035,74 @@ void NetDemo::writeConnectionSequence(buf_t *netbuffer)
 }
 
 
-//
-// snapshotLookup()
-//
-//      Returns the snapshot that preceeds the ticnum parameter or returns
-//      NULL if the ticnum is out of bounds.
-//
-const NetDemo::netdemo_index_entry_t *NetDemo::snapshotLookup(int ticnum) const
+NetDemo::SnapshotVector::const_iterator NetDemo::lookupSnapshot(const SnapshotVector& i_vector, uint32_t gameticnum) const
 {
-	int index = (ticnum - header.starting_gametic) / header.snapshot_spacing - 1;
+    if (gameticnum < header.starting_gametic or
+        gameticnum > header.ending_gametic or
+        i_vector.empty())
+    {
+        return i_vector.end();
+    }
 
-	if (index >= snapshot_index.size())
-		return NULL;
+    auto iter = std::upper_bound(i_vector.begin(),
+                                 i_vector.end(),
+                                 gameticnum);
 
-	int mapindex = getCurrentMapIndex();
-	if (index < 0 || snapshot_index[index].ticnum < map_index[mapindex].ticnum)
-		return &map_index[mapindex];
+    // We know that the tic number is within the valid range and that there's at least one snapshot,
+    // but upper_bound will return end() if the tic number is between the start of the last snapshot
+    // and the ending_gametic.
+    //
+    // In any case, we want to return the element BEFORE the result of upper_bound, unless it's the
+    // very first element.
 
-	return &snapshot_index[index];
+    if (iter == i_vector.begin())
+    {
+        return iter;
+    }
+    return iter-1;
+}
+
+
+// getSnapshotForNetdemotic()
+//
+//      Returns the snapshot that preceeds the netdemoticnum parameter or returns
+//      snapshot_index.end() if the netdemoticnum is out of bounds.
+//
+NetDemo::SnapshotVector::const_iterator NetDemo::getSnapshotForNetdemotic(uint32_t i_netdemoticnum) const
+{
+    return lookupSnapshot(snapshot_index, header.starting_gametic + i_netdemoticnum);
+}
+
+// getSnapshotForGametic()
+//
+//      Returns the snapshot that preceeds the gameticnum parameter or returns
+//      snapshot_index.end() if the gameticnum is out of bounds.
+//
+NetDemo::SnapshotVector::const_iterator NetDemo::getSnapshotForGametic(uint32_t gameticnum) const
+{
+    return lookupSnapshot(snapshot_index, gameticnum);
 }
 
 //
-// getCurrentSnapshotIndex()
+// getCurrentSnapshotIter()
 //
-//      Returns the index into the snapshot_index vector that immediately
+//      Returns the iterator into the snapshot_index vector that immediately
 //      preceeds the current gametic.
 //
-int NetDemo::getCurrentSnapshotIndex() const
+NetDemo::SnapshotVector::const_iterator NetDemo::getCurrentSnapshotIter() const
 {
-	for (int i = 0; i < snapshot_index.size() - 1; i++)
-	{
-		if (static_cast<int>(snapshot_index[i + 1].ticnum) > gametic)
-			return i;
-	}
-
-	return snapshot_index.size() - 1;
+    return lookupSnapshot(snapshot_index, static_cast<uint32_t>(gametic));
 }
 
-
 //
-// getCurrentMapIndex()
+// getCurrentMapIter()
 //
-//      Returns the index into the map_index vector for the map that the
+//      Returns the iterator into the map_index vector for the map that the
 //      is currently being played.
 //
-int NetDemo::getCurrentMapIndex() const
+NetDemo::SnapshotVector::const_iterator NetDemo::getCurrentMapIter() const
 {
-	for (int i = 0; i < map_index.size() - 1; i++)
-	{
-		if (static_cast<int>(map_index[i + 1].ticnum) > gametic)
-			return i;
-	}
-
-	return map_index.size() - 1;
+    return lookupSnapshot(map_index, static_cast<uint32_t>(gametic));
 }
 
 //
@@ -1127,16 +1145,15 @@ void NetDemo::prevTic()
 //
 void NetDemo::nextSnapshot()
 {
-	if (snapshot_index.empty())
+	auto currentIter = getCurrentSnapshotIter();
+
+    if (currentIter   == snapshot_index.end() or
+        currentIter+1 == snapshot_index.end())
+    {
 		return;
+    }
 
-	int nextsnapindex = getCurrentSnapshotIndex() + 1;
-
-	// don't read past the last snapshot
-	if (nextsnapindex >= snapshot_index.size())
-		return;
-
-	readSnapshot(&snapshot_index[nextsnapindex]);
+	readSnapshot(currentIter+1);
 }
 
 
@@ -1148,15 +1165,17 @@ void NetDemo::nextSnapshot()
 //
 void NetDemo::prevSnapshot()
 {
-	if (snapshot_index.empty())
-		return;
+    auto iter = getCurrentSnapshotIter();
 
-	int prevsnapindex = getCurrentSnapshotIndex() - 1;
+    if (iter == snapshot_index.end())        // Unlikely, but validate it anyway.
+        return;
 
-	if (prevsnapindex < 0)
-		prevsnapindex = 0;
+    if (iter != snapshot_index.begin())
+    {
+        iter -= 1;
+    }
 
-	readSnapshot(&snapshot_index[prevsnapindex]);
+	readSnapshot(iter);
 }
 
 //
@@ -1167,16 +1186,16 @@ void NetDemo::prevSnapshot()
 //
 void NetDemo::nextMap()
 {
-	if (map_index.empty())
-		return;
+    auto iter = getCurrentMapIter();
+    if (iter == map_index.end())
+        return;
 
-	int nextmapindex = getCurrentMapIndex() + 1;
-	if (nextmapindex >= map_index.size())
-		return;
+    iter += 1;
 
-	const NetDemo::netdemo_index_entry_t *snap = &map_index[nextmapindex];
+    if (iter == map_index.end())
+        return;
 
-	readSnapshot(snap);
+    readSnapshot(iter);
 }
 
 //
@@ -1187,16 +1206,17 @@ void NetDemo::nextMap()
 //
 void NetDemo::prevMap()
 {
-	if (map_index.empty())
-		return;
+    auto iter = getCurrentMapIter();
 
-	int prevmapindex = getCurrentMapIndex() - 1;
-	if (prevmapindex < 0)
-		prevmapindex = 0;
+    if (iter == map_index.end())
+        return;
 
-	const NetDemo::netdemo_index_entry_t *snap = &map_index[prevmapindex];
+    if (iter != map_index.begin())
+    {
+        iter -= 1;
+    }
 
-	readSnapshot(snap);
+	readSnapshot(iter);
 }
 
 
@@ -1204,10 +1224,10 @@ void NetDemo::prevMap()
 // readSnapshot()
 //
 //
-void NetDemo::readSnapshot(const netdemo_index_entry_t *snap)
+bool NetDemo::readSnapshot(SnapshotVector::const_iterator snap)
 {
-	if (!isPlaying() || !snap)
-		return;
+	if (not isPlaying())
+		return false;
 
 	gametic = snap->ticnum;
 	int file_offset = snap->offset;
@@ -1219,7 +1239,7 @@ void NetDemo::readSnapshot(const netdemo_index_entry_t *snap)
 	if (!readMessageHeader(type, len, tic))
 	{
 		fatalError("Failed to read netdemo message header.");
-		return;
+		return false;
 	}
 
 	// Clear the snapshot buffer and read into it.
@@ -1230,11 +1250,12 @@ void NetDemo::readSnapshot(const netdemo_index_entry_t *snap)
 	if (demofp.gcount() < len)
 	{
 		fatalError("Unable to read snapshot from data file");
-		return;
+		return false;
 	}
 
 	readSnapshotData(snapbuf);
 	netdemotic = snap->ticnum - header.starting_gametic;
+	return true;
 }
 
 
@@ -1284,6 +1305,34 @@ const std::vector<int> NetDemo::getMapChangeTimes() const
 	return times;
 }
 
+bool NetDemo::seekGametic(int requestedGametic)
+{
+    if (not isInPlayback()
+        or requestedGametic < header.starting_gametic
+        or requestedGametic > header.ending_gametic)
+    {
+        return false;
+    }
+
+    auto snapshotIter = getSnapshotForGametic(requestedGametic);
+    if (snapshotIter == snapshot_index.end())
+        return false;
+
+    resume();
+    if (readSnapshot(snapshotIter))
+    {
+        timingdemo = true;
+        pause_netdemotic = requestedGametic - header.starting_gametic;
+        return true;
+    }
+    pause();
+    return false;
+}
+
+bool NetDemo::seekNetdemoTic(int requestedNetdemotic)
+{
+    return seekGametic(requestedNetdemotic + header.starting_gametic);
+}
 
 void NetDemo::writeMapChange()
 {

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1321,8 +1321,17 @@ bool NetDemo::seekGametic(int requestedGametic)
 	if (snapshotIter == snapshot_index.end())
 		return false;
 
+	// First, we have to be playing to load a snapshot.  Then we have to be playing to
+	// fast-forward to the requested tic.  If we fail, we just simply pause.
 	resume();
-	if (readSnapshot(snapshotIter))
+
+	auto currentSnapshotIter = getCurrentSnapshotIter();
+
+	// If we need to skip ahead more than one second's worth or go backwards, read the snapshot.
+	const bool isReadyToFF = requestedGametic < gametic or requestedGametic > gametic + TICRATE ?
+	                         readSnapshot(snapshotIter) :
+	                         true;
+	if (isReadyToFF)
 	{
 		timingdemo = true;
 		pause_netdemotic = requestedGametic - header.starting_gametic;

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1037,29 +1037,29 @@ void NetDemo::writeConnectionSequence(buf_t *netbuffer)
 
 NetDemo::SnapshotVector::const_iterator NetDemo::lookupSnapshot(const SnapshotVector& i_vector, uint32_t gameticnum) const
 {
-    if (gameticnum < header.starting_gametic or
-        gameticnum > header.ending_gametic or
-        i_vector.empty())
-    {
-        return i_vector.end();
-    }
+	if (gameticnum < header.starting_gametic or
+	    gameticnum > header.ending_gametic or
+	    i_vector.empty())
+	{
+		return i_vector.end();
+	}
 
-    auto iter = std::upper_bound(i_vector.begin(),
-                                 i_vector.end(),
-                                 gameticnum);
+	auto iter = std::upper_bound(i_vector.begin(),
+	                             i_vector.end(),
+	                             gameticnum);
 
-    // We know that the tic number is within the valid range and that there's at least one snapshot,
-    // but upper_bound will return end() if the tic number is between the start of the last snapshot
-    // and the ending_gametic.
-    //
-    // In any case, we want to return the element BEFORE the result of upper_bound, unless it's the
-    // very first element.
+	// We know that the tic number is within the valid range and that there's at least one snapshot,
+	// but upper_bound will return end() if the tic number is between the start of the last snapshot
+	// and the ending_gametic.
+	//
+	// In any case, we want to return the element BEFORE the result of upper_bound, unless it's the
+	// very first element.
 
-    if (iter == i_vector.begin())
-    {
-        return iter;
-    }
-    return iter-1;
+	if (iter == i_vector.begin())
+	{
+		return iter;
+	}
+	return iter-1;
 }
 
 
@@ -1070,7 +1070,7 @@ NetDemo::SnapshotVector::const_iterator NetDemo::lookupSnapshot(const SnapshotVe
 //
 NetDemo::SnapshotVector::const_iterator NetDemo::getSnapshotForNetdemotic(uint32_t i_netdemoticnum) const
 {
-    return lookupSnapshot(snapshot_index, header.starting_gametic + i_netdemoticnum);
+	return lookupSnapshot(snapshot_index, header.starting_gametic + i_netdemoticnum);
 }
 
 // getSnapshotForGametic()
@@ -1080,7 +1080,7 @@ NetDemo::SnapshotVector::const_iterator NetDemo::getSnapshotForNetdemotic(uint32
 //
 NetDemo::SnapshotVector::const_iterator NetDemo::getSnapshotForGametic(uint32_t gameticnum) const
 {
-    return lookupSnapshot(snapshot_index, gameticnum);
+	return lookupSnapshot(snapshot_index, gameticnum);
 }
 
 //
@@ -1091,7 +1091,7 @@ NetDemo::SnapshotVector::const_iterator NetDemo::getSnapshotForGametic(uint32_t 
 //
 NetDemo::SnapshotVector::const_iterator NetDemo::getCurrentSnapshotIter() const
 {
-    return lookupSnapshot(snapshot_index, static_cast<uint32_t>(gametic));
+	return lookupSnapshot(snapshot_index, static_cast<uint32_t>(gametic));
 }
 
 //
@@ -1102,7 +1102,7 @@ NetDemo::SnapshotVector::const_iterator NetDemo::getCurrentSnapshotIter() const
 //
 NetDemo::SnapshotVector::const_iterator NetDemo::getCurrentMapIter() const
 {
-    return lookupSnapshot(map_index, static_cast<uint32_t>(gametic));
+	return lookupSnapshot(map_index, static_cast<uint32_t>(gametic));
 }
 
 //
@@ -1147,11 +1147,11 @@ void NetDemo::nextSnapshot()
 {
 	auto currentIter = getCurrentSnapshotIter();
 
-    if (currentIter   == snapshot_index.end() or
-        currentIter+1 == snapshot_index.end())
-    {
+	if (currentIter   == snapshot_index.end() or
+	    currentIter+1 == snapshot_index.end())
+	{
 		return;
-    }
+	}
 
 	readSnapshot(currentIter+1);
 }
@@ -1165,15 +1165,15 @@ void NetDemo::nextSnapshot()
 //
 void NetDemo::prevSnapshot()
 {
-    auto iter = getCurrentSnapshotIter();
+	auto iter = getCurrentSnapshotIter();
 
-    if (iter == snapshot_index.end())        // Unlikely, but validate it anyway.
-        return;
+	if (iter == snapshot_index.end())        // Unlikely, but validate it anyway.
+		return;
 
-    if (iter != snapshot_index.begin())
-    {
-        iter -= 1;
-    }
+	if (iter != snapshot_index.begin())
+	{
+		iter -= 1;
+	}
 
 	readSnapshot(iter);
 }
@@ -1186,16 +1186,16 @@ void NetDemo::prevSnapshot()
 //
 void NetDemo::nextMap()
 {
-    auto iter = getCurrentMapIter();
-    if (iter == map_index.end())
-        return;
+	auto iter = getCurrentMapIter();
+	if (iter == map_index.end())
+		return;
 
-    iter += 1;
+	iter += 1;
 
-    if (iter == map_index.end())
-        return;
+	if (iter == map_index.end())
+		return;
 
-    readSnapshot(iter);
+	readSnapshot(iter);
 }
 
 //
@@ -1206,15 +1206,15 @@ void NetDemo::nextMap()
 //
 void NetDemo::prevMap()
 {
-    auto iter = getCurrentMapIter();
+	auto iter = getCurrentMapIter();
 
-    if (iter == map_index.end())
-        return;
+	if (iter == map_index.end())
+		return;
 
-    if (iter != map_index.begin())
-    {
-        iter -= 1;
-    }
+	if (iter != map_index.begin())
+	{
+		iter -= 1;
+	}
 
 	readSnapshot(iter);
 }
@@ -1307,31 +1307,31 @@ const std::vector<int> NetDemo::getMapChangeTimes() const
 
 bool NetDemo::seekGametic(int requestedGametic)
 {
-    if (not isInPlayback()
-        or requestedGametic < header.starting_gametic
-        or requestedGametic > header.ending_gametic)
-    {
-        return false;
-    }
+	if (not isInPlayback()
+	    or requestedGametic < header.starting_gametic
+	    or requestedGametic > header.ending_gametic)
+	{
+		return false;
+	}
 
-    auto snapshotIter = getSnapshotForGametic(requestedGametic);
-    if (snapshotIter == snapshot_index.end())
-        return false;
+	auto snapshotIter = getSnapshotForGametic(requestedGametic);
+	if (snapshotIter == snapshot_index.end())
+		return false;
 
-    resume();
-    if (readSnapshot(snapshotIter))
-    {
-        timingdemo = true;
-        pause_netdemotic = requestedGametic - header.starting_gametic;
-        return true;
-    }
-    pause();
-    return false;
+	resume();
+	if (readSnapshot(snapshotIter))
+	{
+		timingdemo = true;
+		pause_netdemotic = requestedGametic - header.starting_gametic;
+		return true;
+	}
+	pause();
+	return false;
 }
 
 bool NetDemo::seekNetdemoTic(int requestedNetdemotic)
 {
-    return seekGametic(requestedNetdemotic + header.starting_gametic);
+	return seekGametic(requestedNetdemotic + header.starting_gametic);
 }
 
 void NetDemo::writeMapChange()

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1354,7 +1354,7 @@ bool NetDemo::seekGametic(int requestedGametic)
 	return false;
 }
 
-bool NetDemo::seekNetdemoTic(int requestedNetdemotic)
+bool NetDemo::seekNetdemotic(int requestedNetdemotic)
 {
 	return seekGametic(requestedNetdemotic + header.starting_gametic);
 }

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1091,7 +1091,15 @@ NetDemo::SnapshotVector::const_iterator NetDemo::getSnapshotForGametic(uint32_t 
 	return lookupSnapshot(snapshot_index, gameticnum);
 }
 
+// getMapLoadSnapshotForGametic()
 //
+//      Returns the snapshot that loaded the map that is being played as of the given gametic.
+//      Returns map_index.end() if the gametic is out of bounds.
+NetDemo::SnapshotVector::const_iterator NetDemo::getMapLoadSnapshotForGametic(uint32_t gameticnum) const
+{
+	return lookupSnapshot(map_index, gameticnum);
+}
+
 // getCurrentSnapshotIter()
 //
 //      Returns the iterator into the snapshot_index vector that immediately
@@ -1330,6 +1338,16 @@ bool NetDemo::seekGametic(int requestedGametic)
 	// First, we have to be playing to load a snapshot.  Then we have to be playing to
 	// fast-forward to the requested tic.  If we fail, we just simply pause.
 	resume();
+
+	// If we're switching maps, then load the snapshot that walks the client through the
+	// proper map-change message sequence before we try to load the commanded snapshot.
+	// This avoids some glitches, including missing mobjs and mis-interpolations.
+	const auto currentMapLoadIter = getCurrentMapIter();
+	const auto destinationMapIter = getMapLoadSnapshotForGametic(requestedGametic);
+	if (currentMapLoadIter != destinationMapIter)
+	{
+		readSnapshot(destinationMapIter);
+	}
 
 	auto currentSnapshotIter = getCurrentSnapshotIter();
 

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1314,6 +1314,9 @@ bool NetDemo::seekGametic(int requestedGametic)
 		return false;
 	}
 
+	if (requestedGametic == gametic)
+		return true;
+
 	auto snapshotIter = getSnapshotForGametic(requestedGametic);
 	if (snapshotIter == snapshot_index.end())
 		return false;

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1327,14 +1327,27 @@ bool NetDemo::seekGametic(int requestedGametic)
 
 	auto currentSnapshotIter = getCurrentSnapshotIter();
 
-	// If we need to skip ahead more than one second's worth or go backwards, read the snapshot.
-	const bool isReadyToFF = requestedGametic < gametic or requestedGametic > gametic + TICRATE ?
-	                         readSnapshot(snapshotIter) :
-	                         true;
+	// We want to force a snapshot load if we need to skip backwards by any amount or if
+	// we're advancing to another snapshot, and the target is more than a second out.
+	// The only reason for the one second out is that we can just easily fast-forward
+	// 35 tics.  It's pretty arbitary really.
+	const bool mustLoadSnapshot = requestedGametic < gametic
+	                              or (snapshotIter != currentSnapshotIter
+	                                  and requestedGametic > gametic + TICRATE);
+
+	const bool isReadyToFF = mustLoadSnapshot ? readSnapshot(snapshotIter) : true;
+
 	if (isReadyToFF)
 	{
+		// FIXME:   If we try to pause at the very beginning of a snapshot, we get a horrible
+		//          view interpolation error.  Workaround: advance one tic.
+		if (requestedGametic == snapshotIter->ticnum)
+		{
+			requestedGametic += 1;
+		}
 		timingdemo = true;
 		pause_netdemotic = requestedGametic - header.starting_gametic;
+
 		return true;
 	}
 	pause();

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -42,6 +42,7 @@ public:
 	[[nodiscard]] int getSpacing() const { return header.snapshot_spacing; }
 
 	[[nodiscard]] int getNetdemotic() const { return netdemotic; }
+	[[nodiscard]] int getGametic() const    { return netdemotic + header.starting_gametic; }
 
 	void nextTic();
 	void prevTic();
@@ -50,7 +51,7 @@ public:
 	void nextMap();
 	void prevMap();
 
-	void ticker();
+	bool ticker();
 	[[nodiscard]] int calculateTimeElapsed() const;
 	[[nodiscard]] int calculateTotalTime() const;
 	[[nodiscard]] const std::vector<int> getMapChangeTimes() const;
@@ -85,15 +86,15 @@ private:
 		uint32_t        ticnum  { 0 };
 		std::streampos  offset  { 0 };  // offset in the demo file
 
-        auto operator<=>(const netdemo_index_entry_t& other) const
-        {
-            return ticnum <=> other.ticnum;
-        }
-        auto operator<=>(uint32_t otherTic) const
-        {
-            return ticnum <=> otherTic;
-        }
-    };
+		auto operator<=>(const netdemo_index_entry_t& other) const
+		{
+			return ticnum <=> other.ticnum;
+		}
+		auto operator<=>(uint32_t otherTic) const
+		{
+			return ticnum <=> otherTic;
+		}
+	};
 
 	void cleanUp();
 	void error(const std::string &message);

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -23,6 +23,8 @@ public:
 	bool stopRecording();
 	bool pause();
 	bool resume();
+	bool seekNetdemoTic(int requestedNetdemotic);
+	bool seekGametic(int requestedGametic);
 
 	void writeMessages();
 	void readMessages(buf_t* netbuffer);
@@ -80,21 +82,28 @@ private:
 	{
 		uint32_t        ticnum  { 0 };
 		std::streampos  offset  { 0 };  // offset in the demo file
-	};
+
+        auto operator<=>(const netdemo_index_entry_t& other) const
+        {
+            return ticnum <=> other.ticnum;
+        }
+        auto operator<=>(uint32_t otherTic) const
+        {
+            return ticnum <=> otherTic;
+        }
+    };
 
 	void cleanUp();
 	void error(const std::string &message);
 	void fatalError(const std::string &message);
 	void reset();
 
-	[[nodiscard]] const netdemo_index_entry_t *snapshotLookup(int ticnum) const;
 	void writeLauncherSequence(buf_t *netbuffer);
 	void writeConnectionSequence(buf_t *netbuffer);
 
 	void readSnapshotData(std::vector<byte>& buf);
 	void writeSnapshotData(std::vector<byte>& buf);
 
-	void readSnapshot(const netdemo_index_entry_t *snap);
 	void writeChunk(const byte *data, size_t size, netdemo_message_t type);
 	bool writeHeader();
 	bool readHeader();
@@ -103,8 +112,16 @@ private:
 
 	void populateMessageIndexes();
 
-	[[nodiscard]] int getCurrentSnapshotIndex() const;
-	[[nodiscard]] int getCurrentMapIndex() const;
+	using SnapshotVector = std::vector<netdemo_index_entry_t>;
+
+	[[nodiscard]] SnapshotVector::const_iterator getCurrentSnapshotIter  () const;
+	[[nodiscard]] SnapshotVector::const_iterator getCurrentMapIter       () const;
+	[[nodiscard]] SnapshotVector::const_iterator getSnapshotForGametic   (uint32_t gameticnum) const;
+	[[nodiscard]] SnapshotVector::const_iterator getSnapshotForNetdemotic(uint32_t netdemoticnum) const;
+
+	[[nodiscard]] SnapshotVector::const_iterator lookupSnapshot(const SnapshotVector& i_vector, uint32_t gameticnum) const;
+
+	bool readSnapshot(SnapshotVector::const_iterator snap);
 
 	void writeLocalCmd(buf_t *netbuffer) const;
 	bool readMessageHeader(netdemo_message_t &type, uint32_t &len, uint32_t &tic);
@@ -171,11 +188,11 @@ private:
 	std::string     filename{ };
 	std::fstream    demofp  { };
 
-	std::deque<buf_t>   captured {};
+	std::deque<buf_t> captured {};
 
-	netdemo_header4_t                  header        {};
-	std::vector<netdemo_index_entry_t> snapshot_index{};
-	std::vector<netdemo_index_entry_t> map_index     {};
+	netdemo_header4_t   header        {};
+	SnapshotVector      snapshot_index{};
+	SnapshotVector      map_index     {};
 
 	std::vector<byte>   snapbuf         { };
 	int                 netdemotic      { 0 };

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -23,7 +23,7 @@ public:
 	bool stopRecording();
 	bool pause();
 	bool resume();
-	bool seekNetdemoTic(int requestedNetdemotic);
+	bool seekNetdemotic(int requestedNetdemotic);
 	bool seekGametic(int requestedGametic);
 
 	void writeMessages();
@@ -40,6 +40,8 @@ public:
 	[[nodiscard]] bool isInPlayback() const { return isPlaying() or isPaused(); }
 
 	[[nodiscard]] int getSpacing() const { return header.snapshot_spacing; }
+
+	[[nodiscard]] int getNetdemotic() const { return netdemotic; }
 
 	void nextTic();
 	void prevTic();

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -117,10 +117,11 @@ private:
 
 	using SnapshotVector = std::vector<netdemo_index_entry_t>;
 
-	[[nodiscard]] SnapshotVector::const_iterator getCurrentSnapshotIter  () const;
-	[[nodiscard]] SnapshotVector::const_iterator getCurrentMapIter       () const;
-	[[nodiscard]] SnapshotVector::const_iterator getSnapshotForGametic   (uint32_t gameticnum) const;
-	[[nodiscard]] SnapshotVector::const_iterator getSnapshotForNetdemotic(uint32_t netdemoticnum) const;
+	[[nodiscard]] SnapshotVector::const_iterator getCurrentSnapshotIter      () const;
+	[[nodiscard]] SnapshotVector::const_iterator getCurrentMapIter           () const;
+	[[nodiscard]] SnapshotVector::const_iterator getSnapshotForGametic       (uint32_t gameticnum) const;
+	[[nodiscard]] SnapshotVector::const_iterator getSnapshotForNetdemotic    (uint32_t netdemoticnum) const;
+	[[nodiscard]] SnapshotVector::const_iterator getMapLoadSnapshotForGametic(uint32_t gameticnum) const;
 
 	[[nodiscard]] SnapshotVector::const_iterator lookupSnapshot(const SnapshotVector& i_vector, uint32_t gameticnum) const;
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -777,11 +777,14 @@ void CL_StepTics(unsigned int count)
 
 		G_Ticker ();
 
-		if (!netdemo.isPaused())
-			gametic++;
-
-		if (netdemo.isPlaying() && !netdemo.isPaused())
-			netdemo.ticker();
+		if (netdemo.ticker())
+		{
+			gametic = netdemo.getGametic();
+		}
+		else
+		{
+			++gametic;
+		}
 	}
 
 	DObject::EndFrame ();

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1416,16 +1416,16 @@ END_COMMAND(netprevmap)
 
 enum class SeekKindEnum
 {
-    NONE,
-    ABSOLUTE_NETDEMOTIC,
-    RELATIVE_NETDEMOTIC,
-    ABSOLUTE_GAMETIC,
+	NONE,
+	ABSOLUTE_NETDEMOTIC,
+	RELATIVE_NETDEMOTIC,
+	ABSOLUTE_GAMETIC,
 };
 
 struct SeekParseResult
 {
-    SeekKindEnum kind { SeekKindEnum::NONE };
-    int          tics { 0 };
+	SeekKindEnum kind { SeekKindEnum::NONE };
+	int          tics { 0 };
 };
 
 using TicsType = std::chrono::duration<uint32_t,
@@ -1433,92 +1433,92 @@ using TicsType = std::chrono::duration<uint32_t,
 
 uint32_t ParseTicsAsTimeFormat(const char* str, const char* format)
 {
-    TicsType           tics;
-    std::istringstream is {str};
-    is >> std::chrono::parse(format, tics);
-    if (not is.fail())
-    {
-        return tics.count();
-    }
-    return 0;
+	TicsType           tics;
+	std::istringstream is {str};
+	is >> std::chrono::parse(format, tics);
+	if (not is.fail())
+	{
+		return tics.count();
+	}
+	return 0;
 }
 
 uint32_t ParseTicsAsTime(const char* str)
 {
-    constexpr static auto formats =
-    {
-        "%H:%M:%S",
-        "%M:%S",
-    };
+	constexpr static auto formats =
+	{
+		"%H:%M:%S",
+		"%M:%S",
+	};
 
-    for (auto format : formats)
-    {
-        if (auto result = ParseTicsAsTimeFormat(str, format))
-        {
-            return result;
-        }
-    }
-    return 0;
+	for (auto format : formats)
+	{
+		if (auto result = ParseTicsAsTimeFormat(str, format))
+		{
+			return result;
+		}
+	}
+	return 0;
 }
 
 SeekParseResult ParseSeekValue(const char* valueStr)
 {
-    SeekParseResult result;
+	SeekParseResult result;
 
-    if (not valueStr)
-    {
-        return result;
-    }
+	if (not valueStr)
+	{
+		return result;
+	}
 
-    switch (*valueStr)
-    {
-        case 'g':       [[ fallthrough ]];
-        case 'G':
-            result.kind = SeekKindEnum::ABSOLUTE_GAMETIC;
-            ++valueStr;
-            break;
+	switch (*valueStr)
+	{
+		case 'g':       [[ fallthrough ]];
+		case 'G':
+			result.kind = SeekKindEnum::ABSOLUTE_GAMETIC;
+			++valueStr;
+			break;
 
-        case '+':       [[ fallthrough ]];
-        case '-':
-            result.kind = SeekKindEnum::RELATIVE_NETDEMOTIC;
-            break;
+		case '+':       [[ fallthrough ]];
+		case '-':
+			result.kind = SeekKindEnum::RELATIVE_NETDEMOTIC;
+			break;
 
-        default:
-            result.kind = SeekKindEnum::ABSOLUTE_NETDEMOTIC;
-            break;
-    }
+		default:
+			result.kind = SeekKindEnum::ABSOLUTE_NETDEMOTIC;
+			break;
+	}
 
-    char*      firstUnparsedPtr {nullptr};
-    const long intValue = std::strtol(valueStr, & firstUnparsedPtr, 0);
+	char*      firstUnparsedPtr {nullptr};
+	const long intValue = std::strtol(valueStr, & firstUnparsedPtr, 0);
 
-    if (intValue and firstUnparsedPtr and *firstUnparsedPtr != ':')
-    {
-        result.tics = (result.kind == SeekKindEnum::ABSOLUTE_GAMETIC ? std::abs(intValue) : intValue);
-        return result;
-    }
+	if (intValue and firstUnparsedPtr and *firstUnparsedPtr != ':')
+	{
+		result.tics = (result.kind == SeekKindEnum::ABSOLUTE_GAMETIC ? std::abs(intValue) : intValue);
+		return result;
+	}
 
-    // If we already determined that we have a relative indicator, record the sign
-    // and then skip it before trying to parse a time value.
-    const bool isNegative = *valueStr == '-';
+	// If we already determined that we have a relative indicator, record the sign
+	// and then skip it before trying to parse a time value.
+	const bool isNegative = *valueStr == '-';
 
-    if (result.kind == SeekKindEnum::RELATIVE_NETDEMOTIC)
-    {
-        ++valueStr;
-    }
+	if (result.kind == SeekKindEnum::RELATIVE_NETDEMOTIC)
+	{
+		++valueStr;
+	}
 
-    if (uint32_t timeParseResult = ParseTicsAsTime(valueStr))
-    {
-        result.tics = static_cast<int>(timeParseResult);
-        if (isNegative)
-        {
-            result.tics = -result.tics;
-        }
-    }
-    else
-    {
-        result.kind = SeekKindEnum::NONE;
-    }
-    return result;
+	if (uint32_t timeParseResult = ParseTicsAsTime(valueStr))
+	{
+		result.tics = static_cast<int>(timeParseResult);
+		if (isNegative)
+		{
+			result.tics = -result.tics;
+		}
+	}
+	else
+	{
+		result.kind = SeekKindEnum::NONE;
+	}
+	return result;
 }
 
 BEGIN_COMMAND(netseek)
@@ -1537,47 +1537,47 @@ BEGIN_COMMAND(netseek)
 		return;
 	}
 
-    const SeekParseResult parseResult = ParseSeekValue(argv[1]);
+	const SeekParseResult parseResult = ParseSeekValue(argv[1]);
 
-    DPrintFmt("Seek command: {} tics: {}\n",
-            parseResult.kind == SeekKindEnum::NONE ? "NONE" :
-            parseResult.kind == SeekKindEnum::ABSOLUTE_NETDEMOTIC ? "ABSOLUTE_NETDEMOTIC" :
-            parseResult.kind == SeekKindEnum::RELATIVE_NETDEMOTIC ? "RELATIVE_NETDEMOTIC" :
-            parseResult.kind == SeekKindEnum::ABSOLUTE_GAMETIC ? "ABSOLUTE_GAMETIC" :
-            "???",
-            parseResult.tics);
+	DPrintFmt("Seek command: {} tics: {}\n",
+	          parseResult.kind == SeekKindEnum::NONE ? "NONE" :
+	          parseResult.kind == SeekKindEnum::ABSOLUTE_NETDEMOTIC ? "ABSOLUTE_NETDEMOTIC" :
+	          parseResult.kind == SeekKindEnum::RELATIVE_NETDEMOTIC ? "RELATIVE_NETDEMOTIC" :
+	          parseResult.kind == SeekKindEnum::ABSOLUTE_GAMETIC ? "ABSOLUTE_GAMETIC" :
+	          "???",
+	          parseResult.tics);
 
-    switch (parseResult.kind)
-    {
-        case SeekKindEnum::NONE:
-            PrintFmt(PRINT_HIGH, "Cannot seek: cannot parse {}\n", argv[1]);
-            break;
+	switch (parseResult.kind)
+	{
+		case SeekKindEnum::NONE:
+			PrintFmt(PRINT_HIGH, "Cannot seek: cannot parse {}\n", argv[1]);
+			break;
 
-        case SeekKindEnum::ABSOLUTE_NETDEMOTIC:
-            if (not netdemo.seekNetdemotic(parseResult.tics))
-            {
-                PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid tic number\n", parseResult.tics);
-            }
-            break;
+		case SeekKindEnum::ABSOLUTE_NETDEMOTIC:
+			if (not netdemo.seekNetdemotic(parseResult.tics))
+			{
+				PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid tic number\n", parseResult.tics);
+			}
+			break;
 
-        case SeekKindEnum::RELATIVE_NETDEMOTIC:
-            if (not netdemo.seekNetdemotic(netdemo.getNetdemotic() + parseResult.tics))
-            {
-                PrintFmt(PRINT_HIGH, "Cannot seek: {}{}{} == {} is an invalid tic number\n",
-                         netdemo.getNetdemotic(),
-                         parseResult.tics < 0 ? " " : " +",
-                         parseResult.tics,
-                         netdemo.getNetdemotic() + parseResult.tics);
-            }
-            break;
+		case SeekKindEnum::RELATIVE_NETDEMOTIC:
+			if (not netdemo.seekNetdemotic(netdemo.getNetdemotic() + parseResult.tics))
+			{
+				PrintFmt(PRINT_HIGH, "Cannot seek: {}{}{} == {} is an invalid tic number\n",
+				         netdemo.getNetdemotic(),
+				         parseResult.tics < 0 ? " " : " +",
+				         parseResult.tics,
+				         netdemo.getNetdemotic() + parseResult.tics);
+			}
+			break;
 
-        case SeekKindEnum::ABSOLUTE_GAMETIC:
-            if (not netdemo.seekGametic(parseResult.tics))
-            {
-                PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid gametic number\n", parseResult.tics);
-            }
-            break;
-    }
+		case SeekKindEnum::ABSOLUTE_GAMETIC:
+			if (not netdemo.seekGametic(parseResult.tics))
+			{
+				PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid gametic number\n", parseResult.tics);
+			}
+			break;
+	}
 }
 END_COMMAND(netseek)
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1525,10 +1525,17 @@ BEGIN_COMMAND(netseek)
 {
 	if (argc <= 1)
 	{
-		PrintFmt(PRINT_HIGH, "netseek  <netdemo tic number>\n"
-		                     "netseek g<recorded gametic number>\n"
-		                     "netseek +<tics forward>\n"
-		                     "netseek -<tics backward>\n");
+		PrintFmt(PRINT_HIGH, "Absolute seek:\n"
+		                     "    netseek  <netdemo tic number>\n"
+		                     "    netseek g<recorded gametic number>\n"
+		                     "    netseek  <[hh:]mm:ss>\n"
+		                     "Relative seek forward:\n"
+		                     "    netseek +<tics>\n"
+		                     "    netseek +<[hh:]mm:ss>\n"
+		                     "Relative seek backward:\n"
+		                     "    netseek -<tics>\n"
+		                     "    netseek -<[hh:]mm:ss>\n"
+		        );
 		return;
 	}
 	if (not netdemo.isInPlayback())

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1540,7 +1540,7 @@ BEGIN_COMMAND(netseek)
 	}
 	if (not netdemo.isInPlayback())
 	{
-		PrintFmt(PRINT_HIGH, "Cannot seek because a netdemo isn't playing.  Use the 'netplay' command to start.\n");
+		PrintFmt(PRINT_WARNING, "Cannot seek because a netdemo isn't playing.  Use the 'netplay' command to start.\n");
 		return;
 	}
 
@@ -1557,20 +1557,20 @@ BEGIN_COMMAND(netseek)
 	switch (parseResult.kind)
 	{
 		case SeekKindEnum::NONE:
-			PrintFmt(PRINT_HIGH, "Cannot seek: cannot parse {}\n", argv[1]);
+			PrintFmt(PRINT_WARNING, "Cannot seek: cannot parse {}\n", argv[1]);
 			break;
 
 		case SeekKindEnum::ABSOLUTE_NETDEMOTIC:
 			if (not netdemo.seekNetdemotic(parseResult.tics))
 			{
-				PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid tic number\n", parseResult.tics);
+				PrintFmt(PRINT_WARNING, "Cannot seek: {} is an invalid tic number\n", parseResult.tics);
 			}
 			break;
 
 		case SeekKindEnum::RELATIVE_NETDEMOTIC:
 			if (not netdemo.seekNetdemotic(netdemo.getNetdemotic() + parseResult.tics))
 			{
-				PrintFmt(PRINT_HIGH, "Cannot seek: {}{}{} == {} is an invalid tic number\n",
+				PrintFmt(PRINT_WARNING, "Cannot seek: {}{}{} == {} is an invalid tic number\n",
 				         netdemo.getNetdemotic(),
 				         parseResult.tics < 0 ? " " : " +",
 				         parseResult.tics,
@@ -1581,7 +1581,7 @@ BEGIN_COMMAND(netseek)
 		case SeekKindEnum::ABSOLUTE_GAMETIC:
 			if (not netdemo.seekGametic(parseResult.tics))
 			{
-				PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid gametic number\n", parseResult.tics);
+				PrintFmt(PRINT_WARNING, "Cannot seek: {} is an invalid gametic number\n", parseResult.tics);
 			}
 			break;
 	}

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1539,6 +1539,14 @@ BEGIN_COMMAND(netseek)
 
     const SeekParseResult parseResult = ParseSeekValue(argv[1]);
 
+    DPrintFmt("Seek command: {} tics: {}\n",
+            parseResult.kind == SeekKindEnum::NONE ? "NONE" :
+            parseResult.kind == SeekKindEnum::ABSOLUTE_NETDEMOTIC ? "ABSOLUTE_NETDEMOTIC" :
+            parseResult.kind == SeekKindEnum::RELATIVE_NETDEMOTIC ? "RELATIVE_NETDEMOTIC" :
+            parseResult.kind == SeekKindEnum::ABSOLUTE_GAMETIC ? "ABSOLUTE_GAMETIC" :
+            "???",
+            parseResult.tics);
+
     switch (parseResult.kind)
     {
         case SeekKindEnum::NONE:

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1415,23 +1415,23 @@ END_COMMAND(netprevmap)
 
 BEGIN_COMMAND(netseek)
 {
-    if (argc <= 1)
-    {
-        PrintFmt(PRINT_HIGH, "netseek <absolute netdemo tic number>\n");
-        return;
-    }
-    if (not netdemo.isInPlayback())
-    {
-        PrintFmt(PRINT_HIGH, "Cannot seek because a netdemo isn't playing.  Use the 'netplay' command to start.\n");
-        return;
-    }
+	if (argc <= 1)
+	{
+		PrintFmt(PRINT_HIGH, "netseek <absolute netdemo tic number>\n");
+		return;
+	}
+	if (not netdemo.isInPlayback())
+	{
+		PrintFmt(PRINT_HIGH, "Cannot seek because a netdemo isn't playing.  Use the 'netplay' command to start.\n");
+		return;
+	}
 
-    const int requestedAbsoluteNetdemoTic = std::stoi(argv[1]);
+	const int requestedAbsoluteNetdemoTic = std::stoi(argv[1]);
 
-    if (not netdemo.seekNetdemoTic(requestedAbsoluteNetdemoTic))
-    {
-        PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid tic number\n", requestedAbsoluteNetdemoTic);
-    }
+	if (not netdemo.seekNetdemoTic(requestedAbsoluteNetdemoTic))
+	{
+		PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid tic number\n", requestedAbsoluteNetdemoTic);
+	}
 }
 END_COMMAND(netseek)
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -77,6 +77,7 @@
 #include "PlayerStateRoller.h"
 
 #include <bitset>
+#include <chrono>
 #include <ranges>
 #include <set>
 #include <sstream>
@@ -1413,11 +1414,117 @@ BEGIN_COMMAND(netprevmap)
 }
 END_COMMAND(netprevmap)
 
+enum class SeekKindEnum
+{
+    NONE,
+    ABSOLUTE_NETDEMOTIC,
+    RELATIVE_NETDEMOTIC,
+    ABSOLUTE_GAMETIC,
+};
+
+struct SeekParseResult
+{
+    SeekKindEnum kind { SeekKindEnum::NONE };
+    int          tics { 0 };
+};
+
+using TicsType = std::chrono::duration<uint32_t,
+                                       std::ratio<1, 35>>;
+
+uint32_t ParseTicsAsTimeFormat(const char* str, const char* format)
+{
+    TicsType           tics;
+    std::istringstream is {str};
+    is >> std::chrono::parse(format, tics);
+    if (not is.fail())
+    {
+        return tics.count();
+    }
+    return 0;
+}
+
+uint32_t ParseTicsAsTime(const char* str)
+{
+    constexpr static auto formats =
+    {
+        "%H:%M:%S",
+        "%M:%S",
+    };
+
+    for (auto format : formats)
+    {
+        if (auto result = ParseTicsAsTimeFormat(str, format))
+        {
+            return result;
+        }
+    }
+    return 0;
+}
+
+SeekParseResult ParseSeekValue(const char* valueStr)
+{
+    SeekParseResult result;
+
+    if (not valueStr)
+    {
+        return result;
+    }
+
+    switch (*valueStr)
+    {
+        case 'g':       [[ fallthrough ]];
+        case 'G':
+            result.kind = SeekKindEnum::ABSOLUTE_GAMETIC;
+            ++valueStr;
+            break;
+
+        case '+':       [[ fallthrough ]];
+        case '-':
+            result.kind = SeekKindEnum::RELATIVE_NETDEMOTIC;
+            break;
+
+        default:
+            result.kind = SeekKindEnum::ABSOLUTE_NETDEMOTIC;
+            break;
+    }
+
+    char*      firstUnparsedPtr {nullptr};
+    const long intValue = std::strtol(valueStr, & firstUnparsedPtr, 0);
+
+    if (intValue and firstUnparsedPtr and *firstUnparsedPtr != ':')
+    {
+        result.tics = (result.kind == SeekKindEnum::ABSOLUTE_GAMETIC ? std::abs(intValue) : intValue);
+        return result;
+    }
+
+    // If we already determined that we have a relative indicator, record the sign
+    // and then skip it before trying to parse a time value.
+    const bool isNegative = *valueStr == '-';
+
+    if (result.kind == SeekKindEnum::RELATIVE_NETDEMOTIC)
+    {
+        ++valueStr;
+    }
+
+    if (uint32_t timeParseResult = ParseTicsAsTime(valueStr))
+    {
+        result.tics = static_cast<int>(timeParseResult);
+    }
+    else
+    {
+        result.kind = SeekKindEnum::NONE;
+    }
+    return result;
+}
+
 BEGIN_COMMAND(netseek)
 {
 	if (argc <= 1)
 	{
-		PrintFmt(PRINT_HIGH, "netseek <absolute netdemo tic number>\n");
+		PrintFmt(PRINT_HIGH, "netseek  <netdemo tic number>\n"
+		                     "netseek g<recorded gametic number>\n"
+		                     "netseek +<tics forward>\n"
+		                     "netseek -<tics backward>\n");
 		return;
 	}
 	if (not netdemo.isInPlayback())
@@ -1426,12 +1533,39 @@ BEGIN_COMMAND(netseek)
 		return;
 	}
 
-	const int requestedAbsoluteNetdemoTic = std::stoi(argv[1]);
+    const SeekParseResult parseResult = ParseSeekValue(argv[1]);
 
-	if (not netdemo.seekNetdemoTic(requestedAbsoluteNetdemoTic))
-	{
-		PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid tic number\n", requestedAbsoluteNetdemoTic);
-	}
+    switch (parseResult.kind)
+    {
+        case SeekKindEnum::NONE:
+            PrintFmt(PRINT_HIGH, "Cannot seek: cannot parse {}\n", argv[1]);
+            break;
+
+        case SeekKindEnum::ABSOLUTE_NETDEMOTIC:
+            if (not netdemo.seekNetdemotic(parseResult.tics))
+            {
+                PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid tic number\n", parseResult.tics);
+            }
+            break;
+
+        case SeekKindEnum::RELATIVE_NETDEMOTIC:
+            if (not netdemo.seekNetdemotic(netdemo.getNetdemotic() + parseResult.tics))
+            {
+                PrintFmt(PRINT_HIGH, "Cannot seek: {} {}{} == {} is an invalid tic number\n",
+                         netdemo.getNetdemotic(),
+                         parseResult.tics < 0 ? '-' : '+',
+                         parseResult.tics,
+                         netdemo.getNetdemotic() + parseResult.tics);
+            }
+            break;
+
+        case SeekKindEnum::ABSOLUTE_GAMETIC:
+            if (not netdemo.seekGametic(parseResult.tics))
+            {
+                PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid gametic number\n", parseResult.tics);
+            }
+            break;
+    }
 }
 END_COMMAND(netseek)
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -79,6 +79,7 @@
 #include <bitset>
 #include <chrono>
 #include <ranges>
+#include <regex>
 #include <set>
 #include <sstream>
 
@@ -1433,35 +1434,30 @@ struct SeekParseResult
 };
 
 template <typename DurationType>
-auto ParseFormattedTimeAs(const char* str, const char* format)
-{
-	DurationType       tics;
-	std::istringstream is {str};
-	is >> std::chrono::parse(format, tics);
-	if (not is.fail())
-	{
-		return tics.count();
-	}
-	return typename DurationType::rep(0);
-}
-
-template <typename DurationType>
 auto ParseTimeAs(const char* str, bool isNegative)
 {
-	constexpr static auto formats =
-	{
-		"%H:%M:%S",
-		"%M:%S",
-	};
+	const static std::regex regexHMS { "(\\d+):(\\d+):(\\d+)" };
+	const static std::regex regexMS  { "(\\d+):(\\d+)" };
 
-	for (auto format : formats)
+	std::tm dateTime {};
+	std::cmatch match;
+	if (std::regex_match(str, match, regexHMS))
 	{
-		if (auto result = ParseFormattedTimeAs<DurationType>(str, format))
-		{
-			return isNegative ? -result : result;
-		}
+		std::from_chars(match[1].first, match[1].second, dateTime.tm_hour);
+		std::from_chars(match[2].first, match[2].second, dateTime.tm_min);
+		std::from_chars(match[3].first, match[3].second, dateTime.tm_sec);
 	}
-	return typename DurationType::rep(0);
+	else if (std::regex_match(str, match, regexMS))
+	{
+		std::from_chars(match[1].first, match[1].second, dateTime.tm_min);
+		std::from_chars(match[2].first, match[2].second, dateTime.tm_sec);
+	}
+
+	const auto ticks = (DurationType(std::chrono::hours   { dateTime.tm_hour }) +
+	                    DurationType(std::chrono::minutes { dateTime.tm_min  }) +
+	                    DurationType(std::chrono::seconds { dateTime.tm_sec  })).count();
+
+	return isNegative ? -ticks : ticks;
 }
 
 SeekParseResult ParseSeekValue(const char* valueStr)

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1509,6 +1509,10 @@ SeekParseResult ParseSeekValue(const char* valueStr)
     if (uint32_t timeParseResult = ParseTicsAsTime(valueStr))
     {
         result.tics = static_cast<int>(timeParseResult);
+        if (isNegative)
+        {
+            result.tics = -result.tics;
+        }
     }
     else
     {
@@ -1551,9 +1555,9 @@ BEGIN_COMMAND(netseek)
         case SeekKindEnum::RELATIVE_NETDEMOTIC:
             if (not netdemo.seekNetdemotic(netdemo.getNetdemotic() + parseResult.tics))
             {
-                PrintFmt(PRINT_HIGH, "Cannot seek: {} {}{} == {} is an invalid tic number\n",
+                PrintFmt(PRINT_HIGH, "Cannot seek: {}{}{} == {} is an invalid tic number\n",
                          netdemo.getNetdemotic(),
-                         parseResult.tics < 0 ? '-' : '+',
+                         parseResult.tics < 0 ? " " : " +",
                          parseResult.tics,
                          netdemo.getNetdemotic() + parseResult.tics);
             }

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1413,6 +1413,28 @@ BEGIN_COMMAND(netprevmap)
 }
 END_COMMAND(netprevmap)
 
+BEGIN_COMMAND(netseek)
+{
+    if (argc <= 1)
+    {
+        PrintFmt(PRINT_HIGH, "netseek <absolute netdemo tic number>\n");
+        return;
+    }
+    if (not netdemo.isInPlayback())
+    {
+        PrintFmt(PRINT_HIGH, "Cannot seek because a netdemo isn't playing.  Use the 'netplay' command to start.\n");
+        return;
+    }
+
+    const int requestedAbsoluteNetdemoTic = std::stoi(argv[1]);
+
+    if (not netdemo.seekNetdemoTic(requestedAbsoluteNetdemoTic))
+    {
+        PrintFmt(PRINT_HIGH, "Cannot seek: {} is an invalid tic number\n", requestedAbsoluteNetdemoTic);
+    }
+}
+END_COMMAND(netseek)
+
 //
 // CL_MoveThing
 //

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -1427,26 +1427,26 @@ enum class SeekKindEnum
 
 struct SeekParseResult
 {
-	SeekKindEnum kind { SeekKindEnum::NONE };
-	int          tics { 0 };
+	SeekKindEnum kind    { SeekKindEnum::NONE };
+	int          tics    { 0 };
+	bool         isExact { true };
 };
 
-using TicsType = std::chrono::duration<uint32_t,
-                                       std::ratio<1, 35>>;
-
-uint32_t ParseTicsAsTimeFormat(const char* str, const char* format)
+template <typename DurationType>
+auto ParseFormattedTimeAs(const char* str, const char* format)
 {
-	TicsType           tics;
+	DurationType       tics;
 	std::istringstream is {str};
 	is >> std::chrono::parse(format, tics);
 	if (not is.fail())
 	{
 		return tics.count();
 	}
-	return 0;
+	return typename DurationType::rep(0);
 }
 
-uint32_t ParseTicsAsTime(const char* str)
+template <typename DurationType>
+auto ParseTimeAs(const char* str, bool isNegative)
 {
 	constexpr static auto formats =
 	{
@@ -1456,12 +1456,12 @@ uint32_t ParseTicsAsTime(const char* str)
 
 	for (auto format : formats)
 	{
-		if (auto result = ParseTicsAsTimeFormat(str, format))
+		if (auto result = ParseFormattedTimeAs<DurationType>(str, format))
 		{
-			return result;
+			return isNegative ? -result : result;
 		}
 	}
-	return 0;
+	return typename DurationType::rep(0);
 }
 
 SeekParseResult ParseSeekValue(const char* valueStr)
@@ -1509,13 +1509,18 @@ SeekParseResult ParseSeekValue(const char* valueStr)
 		++valueStr;
 	}
 
-	if (uint32_t timeParseResult = ParseTicsAsTime(valueStr))
+	using TicsType = std::chrono::duration<int,
+	                                       std::ratio<1, TICRATE>>;
+
+	if (int timeParseResult = ParseTimeAs<TicsType>(valueStr, isNegative))
 	{
-		result.tics = static_cast<int>(timeParseResult);
-		if (isNegative)
-		{
-			result.tics = -result.tics;
-		}
+		result.tics = timeParseResult;
+	}
+	// Okay, direct-to-tics didn't work.  Try milliseconds and flooring it to tics.
+	else if (auto timeParseResult = ParseTimeAs<std::chrono::milliseconds>(valueStr, isNegative))
+	{
+		result.tics    = (timeParseResult * TICRATE) / 1000;
+		result.isExact = false;
 	}
 	else
 	{
@@ -1557,6 +1562,11 @@ BEGIN_COMMAND(netseek)
 	          "???",
 	          parseResult.tics);
 
+	if (parseResult.kind != SeekKindEnum::NONE and not parseResult.isExact)
+	{
+		PrintFmt(PRINT_WARNING, "Inexact seek: {} is not an exact tic.  Seeking to closest preceding tic...\n", argv[1]);
+	}
+
 	switch (parseResult.kind)
 	{
 		case SeekKindEnum::NONE:
@@ -1573,9 +1583,9 @@ BEGIN_COMMAND(netseek)
 		case SeekKindEnum::RELATIVE_NETDEMOTIC:
 			if (not netdemo.seekNetdemotic(netdemo.getNetdemotic() + parseResult.tics))
 			{
-				PrintFmt(PRINT_WARNING, "Cannot seek: {}{}{} == {} is an invalid tic number\n",
+				PrintFmt(PRINT_WARNING, "Cannot seek: {} {}{} == {} is an invalid tic number\n",
 				         netdemo.getNetdemotic(),
-				         parseResult.tics < 0 ? " " : " +",
+				         parseResult.tics < 0 ? "" : "+",
 				         parseResult.tics,
 				         netdemo.getNetdemotic() + parseResult.tics);
 			}


### PR DESCRIPTION
### Overview

This PR adds the `netseek` command, which supports the following modes of seeking:

```
Absolute seek:
    netseek  <netdemo tic number>
    netseek g<recorded gametic number>
    netseek  <[hh:]mm:ss>
Relative seek forward:
    netseek +<tics>
    netseek +<[hh:]mm:ss>
Relative seek backward:
    netseek -<tics>
    netseek -<[hh:]mm:ss>
```

This PR also changes the `NetDemo::prevTic` function to actually do a relative seek backwards one tic.

### Details

Tic-resolution seeking is based on loading the snapshot that directly precedes the requested tic and then playing back tics up to the requested tic, faster than realtime via `timingdemo`.

Snapshot seeking is based on the sorted nature of the snapshot and map index vectors.  Given a requested tic number, we rely on the binary-search of `std::upper_bound` on the index containers to rapidly select the snapshot to load.

Three attempts were made at parsing out "HH : MM : SS" strings:
- `std::chrono::parse` is the ideal solution and met all our needs when using MSVC 2026, however it's not supported on multiple CI build environments, including MacOS and some of the Linux environments.
- `std::get_time` was able to parse the strings, but not very well.  In particular, it could perform a partial parse and falsely indicate success.  In order to be successful with it, we'd have to second guess and verify its output, which would add some tedious and tricky code.
- `std::regex` meets our needs without being overly complex.  The main tradeoff for using it is that we don't easily parse partial-seconds, so that quality is dropped and punted until `std::chrono::parse` is more widely supported.  In the meantime, regex is plenty adequate and supported.  **This is the solution implemented in this PR.**

An off-by-one bug was discovered in the course of implementing netdemo seeking, and the resolution for it is to put `gametic` under direct control of the `NetDemo` class at all times while netdemo playback is active.  Please see `NetDemo::ticker()` and `CL_StepTics()` for these changes.

As of this PR, the client performs full rendering while seeking forward.  A subsequent PR will update the client to skip full rendering and instead show a "seeking..." screen of some sort.

### Examples

Relative and absolute timepoints:


https://github.com/user-attachments/assets/a6343178-2a33-4740-9453-61b3b222b139

Absolute netdemo tic number:

https://github.com/user-attachments/assets/194f836d-d8d3-4f28-a654-b5213079db4b

Relative tic numbers, including left arrow key `prevTic`:

https://github.com/user-attachments/assets/4002ba46-9de1-48f0-a53f-f7b5465d2457

More relative tic numbers:

https://github.com/user-attachments/assets/1d3c59c2-64cf-4aec-b47b-d3a1439ea15f

Seek across map transitions:  ~~PLEASE NOTE:  there is a snapshot-loading bug when skipping to a snapshot that's not the start-of-map snapshot.  This is being worked.~~  This is fixed as of commit https://github.com/odamex/odamex/pull/1862/commits/ad5ce4b209b66d672d44590e1d88e454a4b81044

https://github.com/user-attachments/assets/ae508f41-0f02-4382-a0a6-73a8ddfbb1f9

