### PR TITLE
Run clang-tidy on PRs

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
-          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libfltk1.4-dev,libjsoncpp-dev,googletest"
+          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libjsoncpp-dev,googletest"
           exclude: "libraries/*"
           config_file: ".clang-tidy"
           build_dir: "build"
@@ -34,7 +34,6 @@ jobs:
               -DBUILD_LAUNCHER=1 \
               -DBUILD_TESTS=1 \
               -DBUILD_MASTER=1 \
-              -DUSE_INTERNAL_FLTK=0 \
               -DUSE_INTERNAL_GTEST=0 \
               -DUSE_INTERNAL_JSONCPP=0 \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -20,7 +20,7 @@ jobs:
           submodules: "recursive"
       - uses: ZedThree/clang-tidy-review@v0.23.1
         with:
-          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libfltk1.4-dev"
+          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libfltk1.4-dev,libjsoncpp-dev"
           exclude: "libraries/*"
           config_file: ".clang-tidy"
           build_dir: "build"
@@ -31,7 +31,11 @@ jobs:
               -DBUILD_CLIENT=1 \
               -DBUILD_SERVER=1 \
               -DBUILD_LAUNCHER=1 \
+              -DBUILD_TESTS=1 \
               -DBUILD_MASTER=1 \
+              -DUSE_INTERNAL_FLTK=0 \
+              -DUSE_INTERNAL_GTEST=0 \
+              -DUSE_INTERNAL_JSONCPP=0 \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,37 @@
+name: clang-tidy
+
+on:
+  pull_request:
+    paths:
+      # included some extras just in case
+      # we ever have some c files
+      # or decide to use hpp
+      - '**.cpp'
+      - '**.hpp'
+      - '**.c'
+      - '**.h'
+
+jobs:
+  clang-tidy-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: "recursive"
+      - uses: ZedThree/clang-tidy-review@v0.23.1
+        with:
+          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libfltk1.4-dev"
+          exclude: "libraries/*"
+          config_file: ".clang-tidy"
+          build_dir: "build"
+          cmake_command: |
+            cmake -B build . -GNinja \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DBUILD_OR_FAIL=1 \
+              -DBUILD_CLIENT=1 \
+              -DBUILD_SERVER=1 \
+              -DBUILD_LAUNCHER=1 \
+              -DBUILD_MASTER=1 \
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           submodules: "recursive"
       - uses: ZedThree/clang-tidy-review@v0.23.1
+        id: review
         with:
           apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libfltk1.4-dev,libjsoncpp-dev"
           exclude: "libraries/*"
@@ -37,5 +38,8 @@ jobs:
               -DUSE_INTERNAL_GTEST=0 \
               -DUSE_INTERNAL_JSONCPP=0 \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - if: steps.review.outputs.total_comments > 0
+        run: exit 1
 
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -39,7 +39,8 @@ jobs:
               -DUSE_INTERNAL_JSONCPP=0 \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-      - if: steps.review.outputs.total_comments > 0
+      - name: Fail on new warnings
+        if: steps.review.outputs.total_comments > 0
         run: exit 1
 
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
-          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libjsoncpp-dev,googletest"
+          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libjsoncpp-dev,libgtest-dev"
           exclude: "libraries/*"
           config_file: ".clang-tidy"
           build_dir: "build"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
-          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libfltk1.4-dev,libjsoncpp-dev"
+          apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libfltk1.4-dev,libjsoncpp-dev,googletest"
           exclude: "libraries/*"
           config_file: ".clang-tidy"
           build_dir: "build"

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -213,7 +213,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
       target_link_libraries(odamex fltk::fltk fltk::images)
     else()
       find_package(FLTK 1.4 CONFIG REQUIRED)
-      target_link_libraries(odamex fltk::fltk-shared fltk::images-shared)
+      target_link_libraries(odamex fltk::fltk fltk::images)
     endif()
   endif()
 

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -213,7 +213,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
       target_link_libraries(odamex fltk::fltk fltk::images)
     else()
       find_package(FLTK 1.4 CONFIG REQUIRED)
-      target_link_libraries(odamex fltk::fltk fltk::images)
+      target_link_libraries(odamex fltk::fltk-shared fltk::images-shared)
     endif()
   endif()
 


### PR DESCRIPTION
This adds a new workflow that will run clang-tidy on pull requests, comparing the output between the two branches. If there are any *new* warnings the workflow will fail, and comment on the pull request with suggestions.

Example PR: https://github.com/electricbrass/odamex/pull/16