### PR TITLE
Allow clang-tidy workflow to comment on PRs from forks

### DIFF
--- a/.github/workflows/clang-tidy-comment.yml
+++ b/.github/workflows/clang-tidy-comment.yml
@@ -1,0 +1,13 @@
+name: Post clang-tidy comments
+
+on:
+  workflow_run:
+    workflows: ["clang-tidy"]
+    types:
+      - completed
+
+jobs:
+  clang-tidy-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ZedThree/clang-tidy-review/post@v0.23.1

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
+          split_workflow: true
           apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libjsoncpp-dev,libgtest-dev"
           exclude: "libraries/*"
           config_file: ".clang-tidy"


### PR DESCRIPTION
Without this, the warnings can only be found by reading the logs, and there's a lot of other noise surrounding them.