### PR TITLE
Don't fail comment workflow when comments succeed

### DIFF
--- a/.github/workflows/clang-tidy-comment.yml
+++ b/.github/workflows/clang-tidy-comment.yml
@@ -11,3 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: ZedThree/clang-tidy-review/post@v0.23.1
+        with:
+          num_comments_as_exitcode: false


### PR DESCRIPTION
The review workflow will fail, this one instead is better for the exit to just be whether the actual comment succeeded

This should be the last little fix, mostly just to have it send only 1 email instead of 2