### PR TITLE
Implement MBF's tmunstuck thing

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,8 @@ Checks: |
   -readability-named-parameter,
   # we mostly use lowercase
   -readability-uppercase-literal-suffix,
+  # simplified form can be less clear sometimes
+  -readability-simplify-boolean-expr
 CheckOptions:
   # Allow `if (pointer)`
   - key: readability-implicit-bool-conversion.AllowPointerConditions

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -65,3 +65,8 @@ CheckOptions:
     value: true
   - key: cppcoreguidelines-rvalue-reference-param-not-moved.AllowPartialMove
     value: true
+  - key: readability-magic-numbers.IgnorePowersOf2IntegerValues
+    value: true
+  # add 0.5 to list, 1/2 is rarely an actual magic number
+  - key: readability-magic-numbers.IgnoreFloatingPointValues
+    value: 1.0;100.0;0.5

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,8 @@ Checks: |
   # this is just a little silly
   -performance-enum-size
   misc-*,
+  # we intentionally use indirect includes, cleaning up is nice but its not configurably enough
+  -misc-include-cleaner,
   # again, so many of these that it's not worth it
   -misc-non-private-member-variables-in-classes,
   # some annoying warnings about reasonable uses of recursion

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,5 +68,5 @@ CheckOptions:
   - key: readability-magic-numbers.IgnorePowersOf2IntegerValues
     value: true
   # add 0.5 to list, 1/2 is rarely an actual magic number
-  - key: readability-magic-numbers.IgnoreFloatingPointValues
-    value: 1.0;100.0;0.5
+  - key: readability-magic-numbers.IgnoredFloatingPointValues
+    value: 1.0;100.0;0.25;0.5;0.75

--- a/.github/workflows/clang-tidy-comment.yml
+++ b/.github/workflows/clang-tidy-comment.yml
@@ -13,3 +13,4 @@ jobs:
       - uses: ZedThree/clang-tidy-review/post@v0.23.1
         with:
           num_comments_as_exitcode: false
+          lgtm_comment_body: ""

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -24,7 +24,7 @@ jobs:
           split_workflow: true
           apt_packages: "ninja-build,libsdl2-dev,libsdl2-mixer-dev,libcurl3-openssl-dev,libpng-dev,libwxgtk3.2-dev,zlib1g-dev,libzstd-dev,libjsoncpp-dev,libgtest-dev"
           exclude: "libraries/*"
-          config_file: ".clang-tidy"
+          config_file: "./ci/clang-tidy.yml"
           build_dir: "build"
           cmake_command: |
             cmake -B build . -GNinja \

--- a/ci/clang-tidy.yml
+++ b/ci/clang-tidy.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://www.schemastore.org/clang-tidy.json
+---
+InheritParentConfig: true
+# these are checks we want enabled while using clangd but produce too much noise
+# in the PR reviews for now
+# the goal should be to address these still, but they require greater changes to other
+# parts of the code to address well
+Checks: |
+  -readability-implicit-bool-conversion
+  -bugprone-narrowing-conversions

--- a/common/m_wdlstats.cpp
+++ b/common/m_wdlstats.cpp
@@ -851,7 +851,7 @@ void M_LogWDLEvent(WDLEvents event, const player_t* activator, const player_t* t
 /**
  * Log a WDL event when you have actor pointers.
  */
-void M_LogActorWDLEvent(WDLEvents event, AActor* activator, AActor* target, int arg0,
+void M_LogActorWDLEvent(WDLEvents event, const AActor* activator, const AActor* target, int arg0,
                         int arg1, int arg2, int arg3)
 {
 	if (!::wdlstate.recording)

--- a/common/m_wdlstats.h
+++ b/common/m_wdlstats.h
@@ -128,7 +128,7 @@ void M_LogWDLEvent(
 	int arg0, int arg1, int arg2, int arg3
 );
 void M_LogActorWDLEvent(
-	WDLEvents eventtype, AActor* activator, AActor* target,
+	WDLEvents eventtype, const AActor* activator, const AActor* target,
 	int arg0, int arg1, int arg2, int arg3
 );
 int M_GetPlayerId(const player_t& player, team_t team);

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2212,12 +2212,8 @@ void A_SkelFist (AActor *actor)
 // Detect a corpse that could be raised.
 //
 AActor* 		corpsehit;
-AActor* 		vileobj;
-fixed_t 		viletryx;
-fixed_t 		viletryy;
-int				viletryradius;
 
-bool PIT_VileCheck (AActor& thing)
+bool PIT_VileCheck (AActor& thing, AActor* /*vileobj*/, const fixed_t viletryx, const fixed_t viletryy, const int viletryradius)
 {
 	bool check;
 
@@ -2841,31 +2837,27 @@ bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 		return false;
 	}
 
-	int xl, xh;
-	int yl, yh;
-	int bx, by;
-
 	if (actor->movedir != DI_NODIR)
 	{
 		// check for corpses to raise
-		viletryx = actor->x + actor->info->speed * xspeed[actor->movedir];
-		viletryy = actor->y + actor->info->speed * yspeed[actor->movedir];
+		const fixed_t viletryx = actor->x + actor->info->speed * xspeed[actor->movedir];
+		const fixed_t viletryy = actor->y + actor->info->speed * yspeed[actor->movedir];
 
-		xl = (viletryx - bmaporgx - MAXRADIUS * 2) >> MAPBLOCKSHIFT;
-		xh = (viletryx - bmaporgx + MAXRADIUS * 2) >> MAPBLOCKSHIFT;
-		yl = (viletryy - bmaporgy - MAXRADIUS * 2) >> MAPBLOCKSHIFT;
-		yh = (viletryy - bmaporgy + MAXRADIUS * 2) >> MAPBLOCKSHIFT;
+		const int xl = (viletryx - bmaporgx - MAXRADIUS * 2) >> MAPBLOCKSHIFT;
+		const int xh = (viletryx - bmaporgx + MAXRADIUS * 2) >> MAPBLOCKSHIFT;
+		const int yl = (viletryy - bmaporgy - MAXRADIUS * 2) >> MAPBLOCKSHIFT;
+		const int yh = (viletryy - bmaporgy + MAXRADIUS * 2) >> MAPBLOCKSHIFT;
 
-		vileobj = actor;
-		viletryradius = radius;
-		for (bx = xl; bx <= xh; bx++)
+		auto* vileobj = actor;
+		const int viletryradius = radius;
+		for (int bx = xl; bx <= xh; bx++)
 		{
-			for (by = yl; by <= yh; by++)
+			for (int by = yl; by <= yh; by++)
 			{
 				// Call PIT_VileCheck to check
 				// whether object is a corpse
 				// that can be raised.
-				if (!P_BlockThingsIterator(bx, by, PIT_VileCheck, nullptr))
+				if (!P_BlockThingsIterator(bx, by, PIT_VileCheck, nullptr, vileobj, viletryx, viletryy, viletryradius))
 				{
 					mobjinfo_t* info;
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -640,7 +640,10 @@ bool P_HitFriend(AActor* self)
 
 extern fixed_t tmbbox[4];
 
-static bool PIT_AvoidDropoff(const line_t& line, const fixed_t floorz, fixed_t& dropoff_deltax, fixed_t& dropoff_deltay)
+namespace
+{
+
+bool PIT_AvoidDropoff(const line_t& line, const fixed_t floorz, fixed_t& dropoff_deltax, fixed_t& dropoff_deltay)
 {
 	if (line.backsector && // Ignore one-sided linedefs
 	    tmbbox[BOXRIGHT] > line.bbox[BOXLEFT] &&
@@ -648,8 +651,8 @@ static bool PIT_AvoidDropoff(const line_t& line, const fixed_t floorz, fixed_t& 
 	    tmbbox[BOXTOP] > line.bbox[BOXBOTTOM] && // Linedef must be contacted
 	    tmbbox[BOXBOTTOM] < line.bbox[BOXTOP] && P_BoxOnLineSide(tmbbox, &line) == -1)
 	{
-		fixed_t front = line.frontsector->floorheight;
-		fixed_t back = line.backsector->floorheight;
+		const fixed_t front = line.frontsector->floorheight;
+		const fixed_t back = line.backsector->floorheight;
 		angle_t angle;
 
 		// The monster must contact one of the two floors,
@@ -674,7 +677,7 @@ static bool PIT_AvoidDropoff(const line_t& line, const fixed_t floorz, fixed_t& 
 // Driver for above
 //
 
-static fixed_t P_AvoidDropoff(AActor* actor, fixed_t& dropoff_deltax, fixed_t& dropoff_deltay)
+fixed_t P_AvoidDropoff(AActor* actor, fixed_t& dropoff_deltax, fixed_t& dropoff_deltay)
 {
 	tmbbox[BOXTOP] = actor->y + actor->radius;
 	tmbbox[BOXBOTTOM] = actor->y - actor->radius;
@@ -711,7 +714,7 @@ static fixed_t P_AvoidDropoff(AActor* actor, fixed_t& dropoff_deltax, fixed_t& d
 // Uses the new ZDoom chase code
 //
 
-static void P_DoNewChaseDir(AActor* actor, fixed_t deltax, fixed_t deltay)
+void P_DoNewChaseDir(AActor* actor, fixed_t deltax, fixed_t deltay)
 {
 	dirtype_t d[3];
 
@@ -820,6 +823,8 @@ static void P_DoNewChaseDir(AActor* actor, fixed_t deltax, fixed_t deltay)
 
 	actor->movedir = DI_NODIR; // can not move
 }
+
+} // namespace
 
 void P_NewChaseDir (AActor *actor)
 {
@@ -2214,8 +2219,7 @@ int				viletryradius;
 
 bool PIT_VileCheck (AActor& thing)
 {
-	int 	maxdist;
-	bool 	check;
+	bool check;
 
 	if (thing.oflags & MFO_NORAISE)
 		return true;	// [AM] Can't raise
@@ -2229,7 +2233,7 @@ bool PIT_VileCheck (AActor& thing)
 	if (thing.info->raisestate == S_NULL)
 		return true;	// monster doesn't have a raise state
 
-	maxdist = thing.info->radius + viletryradius;
+	const int maxdist = thing.info->radius + viletryradius;
 
 	if ( abs(thing.x - viletryx) > maxdist
 		 || abs(thing.y - viletryy) > maxdist )
@@ -2243,11 +2247,9 @@ bool PIT_VileCheck (AActor& thing)
 
 	if (co_novileghosts)
 	{
-		int height, radius;
-
 		corpsehit->flags |= MF_SOLID;
-		height = corpsehit->height; // save temporarily
-		radius = corpsehit->radius; // save temporarily
+		const int height = corpsehit->height; // save temporarily
+		const int radius = corpsehit->radius; // save temporarily
 		corpsehit->height = P_ThingInfoHeight(corpsehit->info);
 		corpsehit->radius = corpsehit->info->radius;
 		check = P_CheckPosition(corpsehit, corpsehit->x, corpsehit->y);

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -638,10 +638,9 @@ bool P_HitFriend(AActor* self)
 	return false;
 }
 
-static fixed_t dropoff_deltax, dropoff_deltay, floorz;
 extern fixed_t tmbbox[4];
 
-static bool PIT_AvoidDropoff(const line_t& line)
+static bool PIT_AvoidDropoff(const line_t& line, const fixed_t floorz, fixed_t& dropoff_deltax, fixed_t& dropoff_deltay)
 {
 	if (line.backsector && // Ignore one-sided linedefs
 	    tmbbox[BOXRIGHT] > line.bbox[BOXLEFT] &&
@@ -675,7 +674,7 @@ static bool PIT_AvoidDropoff(const line_t& line)
 // Driver for above
 //
 
-static fixed_t P_AvoidDropoff(AActor* actor)
+static fixed_t P_AvoidDropoff(AActor* actor, fixed_t& dropoff_deltax, fixed_t& dropoff_deltay)
 {
 	tmbbox[BOXTOP] = actor->y + actor->radius;
 	tmbbox[BOXBOTTOM] = actor->y - actor->radius;
@@ -687,7 +686,7 @@ static fixed_t P_AvoidDropoff(AActor* actor)
 	const int xh = (tmbbox[BOXRIGHT] - bmaporgx) >> MAPBLOCKSHIFT;
 	const int xl = (tmbbox[BOXLEFT] - bmaporgx) >> MAPBLOCKSHIFT;
 
-	floorz = actor->z; // remember floor height
+	const fixed_t floorz = actor->z; // remember floor height
 
 	dropoff_deltax = dropoff_deltay = 0;
 
@@ -696,7 +695,7 @@ static fixed_t P_AvoidDropoff(AActor* actor)
 	validcount++;
 	for (int bx = xl; bx <= xh; bx++)
 		for (int by = yl; by <= yh; by++)
-			P_BlockLinesIterator(bx, by, PIT_AvoidDropoff); // all contacted lines
+			P_BlockLinesIterator(bx, by, PIT_AvoidDropoff, floorz, dropoff_deltax, dropoff_deltay); // all contacted lines
 
 	return dropoff_deltax | dropoff_deltay; // Non-zero if movement prescribed
 }
@@ -837,11 +836,14 @@ void P_NewChaseDir (AActor *actor)
 
 	actor->strafecount = 0;
 
+	fixed_t dropoff_deltax = 0;
+	fixed_t dropoff_deltay = 0;
+
 	if (P_IsMBFCompatMode())
 	{
 		if (actor->floorz - actor->dropoffz > FRACUNIT * 24 &&
 		    actor->z <= actor->floorz && !(actor->flags & (MF_DROPOFF | MF_FLOAT)) &&
-		    !P_AllowDropOff() && P_AvoidDropoff(actor)) /* Move away from dropoff */
+		    !P_AllowDropOff() && P_AvoidDropoff(actor, dropoff_deltax, dropoff_deltay)) /* Move away from dropoff */
 		{
 			P_DoNewChaseDir(actor, dropoff_deltax, dropoff_deltay);
 

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -2840,8 +2840,8 @@ bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 	if (actor->movedir != DI_NODIR)
 	{
 		// check for corpses to raise
-		const fixed_t viletryx = actor->x + actor->info->speed * xspeed[actor->movedir];
-		const fixed_t viletryy = actor->y + actor->info->speed * yspeed[actor->movedir];
+		const fixed_t viletryx = actor->x + (actor->info->speed * xspeed[actor->movedir]);
+		const fixed_t viletryy = actor->y + (actor->info->speed * yspeed[actor->movedir]);
 
 		const int xl = (viletryx - bmaporgx - MAXRADIUS * 2) >> MAPBLOCKSHIFT;
 		const int xh = (viletryx - bmaporgx + MAXRADIUS * 2) >> MAPBLOCKSHIFT;

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -641,25 +641,25 @@ bool P_HitFriend(AActor* self)
 static fixed_t dropoff_deltax, dropoff_deltay, floorz;
 extern fixed_t tmbbox[4];
 
-static bool PIT_AvoidDropoff(line_t* line)
+static bool PIT_AvoidDropoff(const line_t& line)
 {
-	if (line->backsector && // Ignore one-sided linedefs
-	    tmbbox[BOXRIGHT] > line->bbox[BOXLEFT] &&
-	    tmbbox[BOXLEFT] < line->bbox[BOXRIGHT] &&
-	    tmbbox[BOXTOP] > line->bbox[BOXBOTTOM] && // Linedef must be contacted
-	    tmbbox[BOXBOTTOM] < line->bbox[BOXTOP] && P_BoxOnLineSide(tmbbox, line) == -1)
+	if (line.backsector && // Ignore one-sided linedefs
+	    tmbbox[BOXRIGHT] > line.bbox[BOXLEFT] &&
+	    tmbbox[BOXLEFT] < line.bbox[BOXRIGHT] &&
+	    tmbbox[BOXTOP] > line.bbox[BOXBOTTOM] && // Linedef must be contacted
+	    tmbbox[BOXBOTTOM] < line.bbox[BOXTOP] && P_BoxOnLineSide(tmbbox, &line) == -1)
 	{
-		fixed_t front = line->frontsector->floorheight;
-		fixed_t back = line->backsector->floorheight;
+		fixed_t front = line.frontsector->floorheight;
+		fixed_t back = line.backsector->floorheight;
 		angle_t angle;
 
 		// The monster must contact one of the two floors,
 		// and the other must be a tall dropoff (more than 24).
 
 		if (back == floorz && front < floorz - FRACUNIT * 24)
-			angle = R_PointToAngle2(0, 0, line->dx, line->dy); // front side dropoff
+			angle = R_PointToAngle2(0, 0, line.dx, line.dy); // front side dropoff
 		else if (front == floorz && back < floorz - FRACUNIT * 24)
-			angle = R_PointToAngle2(line->dx, line->dy, 0, 0); // back side dropoff
+			angle = R_PointToAngle2(line.dx, line.dy, 0, 0); // back side dropoff
 		else
 			return true;
 
@@ -2210,30 +2210,30 @@ fixed_t 		viletryx;
 fixed_t 		viletryy;
 int				viletryradius;
 
-bool PIT_VileCheck (AActor *thing)
+bool PIT_VileCheck (AActor& thing)
 {
 	int 	maxdist;
 	bool 	check;
 
-	if (thing->oflags & MFO_NORAISE)
+	if (thing.oflags & MFO_NORAISE)
 		return true;	// [AM] Can't raise
 
-	if (!(thing->flags & MF_CORPSE) )
+	if (!(thing.flags & MF_CORPSE) )
 		return true;	// not a monster
 
-	if (thing->tics != -1)
+	if (thing.tics != -1)
 		return true;	// not lying still yet
 
-	if (thing->info->raisestate == S_NULL)
+	if (thing.info->raisestate == S_NULL)
 		return true;	// monster doesn't have a raise state
 
-	maxdist = thing->info->radius + viletryradius;
+	maxdist = thing.info->radius + viletryradius;
 
-	if ( abs(thing->x - viletryx) > maxdist
-		 || abs(thing->y - viletryy) > maxdist )
+	if ( abs(thing.x - viletryx) > maxdist
+		 || abs(thing.y - viletryy) > maxdist )
 		return true;			// not actually touching
 
-	corpsehit = thing;
+	corpsehit = &thing;
 	corpsehit->momx = corpsehit->momy = 0;
 
 	if (P_AllowPassover())
@@ -2861,7 +2861,7 @@ bool P_HealCorpse(AActor* actor, int radius, int healstate, int healsound)
 				// Call PIT_VileCheck to check
 				// whether object is a corpse
 				// that can be raised.
-				if (!P_BlockThingsIterator(bx, by, PIT_VileCheck))
+				if (!P_BlockThingsIterator(bx, by, PIT_VileCheck, nullptr))
 				{
 					mobjinfo_t* info;
 

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -558,13 +558,13 @@ bool P_BlockLinesIterator (int x, int y, F&& func, ARGS&&... args)
 		return true;
 
 	int offset = *(blockmap + (bmapwidth*y + x));
-	int *list = blockmaplump + offset;
+	const int *list = blockmaplump + offset;
 
 	/* [RH] Polyobj stuff from Hexen --> */
 	polyblock_t *polyLink;
 	extern polyblock_t **PolyBlockMap;
 
-	offset = y*bmapwidth + x;
+	offset = (y * bmapwidth) + x;
 	if (PolyBlockMap)
 	{
 		polyLink = PolyBlockMap[offset];
@@ -573,7 +573,7 @@ bool P_BlockLinesIterator (int x, int y, F&& func, ARGS&&... args)
 		{
 			if (polyLink->polyobj && polyLink->polyobj->validcount != validcount)
 			{
-				seg_t **tempSeg = polyLink->polyobj->segs;
+				seg_t*const* tempSeg = polyLink->polyobj->segs;
 				polyLink->polyobj->validcount = validcount;
 
 				for (int i = polyLink->polyobj->numsegs; i; i--, tempSeg++)
@@ -626,16 +626,14 @@ bool P_BlockThingsIterator (int x, int y, F&& func, AActor *actor, ARGS&&... arg
 {
 	if (x<0 || y<0 || x>=bmapwidth || y>=bmapheight)
 		return true;
-	else
- 	{
-		AActor *mobj = (actor != NULL ? actor : blocklinks[y*bmapwidth+x]);
-		while (mobj)
- 		{
-			if (!std::invoke(std::forward<F>(func), *mobj, std::forward<ARGS>(args)...))
- 				return false;
 
-			mobj = mobj->bmapnode.Next(x, y);
-		}
+	AActor *mobj = (actor != nullptr ? actor : blocklinks[(y*bmapwidth)+x]);
+	while (mobj)
+ 	{
+		if (!std::invoke(std::forward<F>(func), *mobj, std::forward<ARGS>(args)...))
+ 			return false;
+		mobj = mobj->bmapnode.Next(x, y);
 	}
+
 	return true;
 }

--- a/common/p_local.h
+++ b/common/p_local.h
@@ -44,13 +44,13 @@
 
 
 // player radius for movement checking
-#define PLAYERRADIUS	16*FRACUNIT
-#define PLAYERRADIUS64	16*FRACUNIT64
+#define PLAYERRADIUS	(16*FRACUNIT)
+#define PLAYERRADIUS64	(16*FRACUNIT64)
 
 // MAXRADIUS is for precalculated sector block boxes
 // the spider demon is larger,
 // but we do not have any moving sectors nearby
-#define MAXRADIUS		32*FRACUNIT
+#define MAXRADIUS		(32*FRACUNIT)
 
 //#define GRAVITY 		FRACUNIT
 #define MAXMOVE 		(30*FRACUNIT)
@@ -206,9 +206,6 @@ extern fixed_t			openrange;
 extern fixed_t			lowfloor;
 
 void P_LineOpening (const line_t *linedef, fixed_t x, fixed_t y, fixed_t refx=limits::MINFIXED, fixed_t refy=0);
-
-bool P_BlockLinesIterator (int x, int y, bool(*func)(line_t*) );
-bool P_BlockThingsIterator (int x, int y, bool(*func)(AActor*), AActor *start=NULL);
 
 #define PT_ADDLINES 	1
 #define PT_ADDTHINGS	2
@@ -530,3 +527,115 @@ void P_RunHelperTics();
 // P_SPEC
 //
 #include "p_spec.h"
+
+//
+// P_MAPUTL templates
+//
+
+//
+// BLOCK MAP ITERATORS
+// For each line/thing in the given mapblock,
+// call the passed PIT_* function.
+// If the function returns false,
+// exit with false without checking anything else.
+//
+
+
+//
+// P_BlockLinesIterator
+// The validcount flags are used to avoid checking lines
+// that are marked in multiple mapblocks,
+// so increment validcount before the first call
+// to P_BlockLinesIterator, then make one or more calls
+// to it.
+//
+template <typename F, typename... ARGS>
+// TODO: C++20, uncomment following line
+// requires std::predicate<F, line_t&, ARGS...>
+bool P_BlockLinesIterator (int x, int y, F&& func, ARGS&&... args)
+{
+	if (x<0 || y<0 || x>=bmapwidth || y>=bmapheight)
+		return true;
+
+	int offset = *(blockmap + (bmapwidth*y + x));
+	int *list = blockmaplump + offset;
+
+	/* [RH] Polyobj stuff from Hexen --> */
+	polyblock_t *polyLink;
+	extern polyblock_t **PolyBlockMap;
+
+	offset = y*bmapwidth + x;
+	if (PolyBlockMap)
+	{
+		polyLink = PolyBlockMap[offset];
+
+		while (polyLink)
+		{
+			if (polyLink->polyobj && polyLink->polyobj->validcount != validcount)
+			{
+				seg_t **tempSeg = polyLink->polyobj->segs;
+				polyLink->polyobj->validcount = validcount;
+
+				for (int i = polyLink->polyobj->numsegs; i; i--, tempSeg++)
+				{
+					if ((*tempSeg)->linedef->validcount != validcount)
+					{
+						(*tempSeg)->linedef->validcount = validcount;
+						if (!std::invoke(std::forward<F>(func), *(*tempSeg)->linedef, std::forward<ARGS>(args)...))
+							return false;
+					}
+				}
+			}
+			polyLink = polyLink->next;
+		}
+	}
+	/* <-- Polyobj stuff from Hexen */
+
+	// [RH] Get past starting 0 (from BOOM)
+	// denis - not so fast, this breaks doom1.wad 1.9 demo1
+	// [SL] The first entry in each block list appears to have been intended to
+	// be used for a special purpose but instead contains garbage (most often
+	// referencing linedef 0). Using this first entry (as vanilla Doom does) can
+	// cause hitscan weapons to erroneously hit the first linedef entry regardless
+	// of where that linedef is located in relation to the block.
+	if (!demoplayback && skipblstart)
+		++list;
+
+	for (; *list != -1; list++)
+	{
+		line_t& ld = lines[*list];
+
+		if (ld.validcount != validcount) {
+			ld.validcount = validcount;
+
+			if (!std::invoke(std::forward<F>(func), ld, std::forward<ARGS>(args)...))
+				return false;
+		}
+	}
+
+	return true;		// everything was checked
+}
+
+//
+// P_BlockThingsIterator
+//
+template <typename F, typename... ARGS>
+// TODO: C++20, uncomment following line
+// requires std::predicate<F, AActor&, ARGS...>
+bool P_BlockThingsIterator (int x, int y, F&& func, AActor *actor, ARGS&&... args)
+{
+	if (x<0 || y<0 || x>=bmapwidth || y>=bmapheight)
+		return true;
+	else
+ 	{
+		AActor *mobj = (actor != NULL ? actor : blocklinks[y*bmapwidth+x]);
+		while (mobj)
+ 		{
+			if (!std::invoke(std::forward<F>(func), *mobj, std::forward<ARGS>(args)...))
+ 				return false;
+
+			mobj = mobj->bmapnode.Next(x, y);
+		}
+	}
+	return true;
+}

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -169,12 +169,13 @@ bool PIT_StompThing (AActor& thing)
 	// monsters don't stomp things except on boss level
 	if (StompAlwaysFrags)
 	{
+		static constexpr int telefrag_damage = 10000;
 		// [AM] Surprise, avatars telefrag players who try to telefrag it!
 		//      Not your lucky day, I suppose.
 		if (thing.type == MT_AVATAR && tmthing->player)
-			P_DamageMobj(tmthing, &thing, &thing, 10000, MOD_TELEFRAG);
+			P_DamageMobj(tmthing, &thing, &thing, telefrag_damage, MOD_TELEFRAG);
 		else
-			P_DamageMobj(&thing, tmthing, tmthing, 10000, MOD_TELEFRAG);
+			P_DamageMobj(&thing, tmthing, tmthing, telefrag_damage, MOD_TELEFRAG);
 		return true;
 	}
 	return false;
@@ -370,10 +371,13 @@ int P_GetMoveFactor (const AActor *mo, int *frictionp)
 // longer and probably really isn't worth the effort.
 //
 
+namespace
+{
+
 //
 // CheckForPushSpecial
 //
-static void CheckForPushSpecial (line_t *line, int side, AActor *mobj)
+void CheckForPushSpecial (line_t *line, int side, AActor *mobj)
 {
 	if (line->special)
 	{
@@ -385,7 +389,8 @@ static void CheckForPushSpecial (line_t *line, int side, AActor *mobj)
 }
 
 
-static // killough 3/26/98: make static
+// killough 3/26/98: make static
+// now in anonymous namespace
 bool PIT_CrossLine (const line_t& ld)
 {
 	if (!(ld.flags & ML_TWOSIDED) ||
@@ -404,7 +409,8 @@ bool PIT_CrossLine (const line_t& ld)
 // Adjusts tmfloorz and tmceilingz as lines are contacted
 //
 
-static // killough 3/26/98: make static
+// killough 3/26/98: make static
+// now in anonymous namespace
 bool PIT_CheckLine(line_t& ld, bool tmunstuck)
 {
 	if (tmbbox[BOXRIGHT] <= ld.bbox[BOXLEFT]
@@ -556,6 +562,8 @@ bool PIT_CheckLine(line_t& ld, bool tmunstuck)
 
 	return true;
 }
+
+} // namespace
 
 /*
  * @brief Determines if a projectile should clip a friendly monster.

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -425,8 +425,8 @@ bool PIT_CheckLine(line_t& ld, bool tmunstuck)
 
 	const auto untouched = [](line_t& ld)
 	{
-		fixed_t x = tmthing->x;
-		fixed_t y = tmthing->y;
+		const fixed_t x = tmthing->x;
+		const fixed_t y = tmthing->y;
 		std::array<fixed_t, 4> tmbbox{};
 		tmbbox[BOXRIGHT] = x+tmthing->radius;
     	tmbbox[BOXLEFT] = x-tmthing->radius;
@@ -516,11 +516,11 @@ bool PIT_CheckLine(line_t& ld, bool tmunstuck)
 	{
 		// Find the point on the line closest to the actor's center, and use
 		// that to calculate openings
-		double dx = FIXED2DOUBLE(ld.dx);
-		double dy = FIXED2DOUBLE(ld.dy);
-		double r =	(FIXED2DOUBLE(tmx - ld.v1->x) * dx +
-					 FIXED2DOUBLE(tmy - ld.v1->y) * dy) /
-					(dx * dx + dy * dy);
+		const double dx = FIXED2DOUBLE(ld.dx);
+		const double dy = FIXED2DOUBLE(ld.dy);
+		const double r  = ((FIXED2DOUBLE(tmx - ld.v1->x) * dx) +
+		                   (FIXED2DOUBLE(tmy - ld.v1->y) * dy)) /
+		                   ((dx * dx) + (dy * dy));
 
 		if (r <= 0.0)
 		{
@@ -532,8 +532,8 @@ bool PIT_CheckLine(line_t& ld, bool tmunstuck)
 		}
 		else
 		{
-			fixed_t sx = ld.v1->x + r * ld.dx;
-			fixed_t sy = ld.v1->y + r * ld.dy;
+			const fixed_t sx = ld.v1->x + (r * ld.dx);
+			const fixed_t sy = ld.v1->y + (r * ld.dy);
 			P_LineOpening (&ld, sx, sy, tmx, tmy);
 		}
 	}
@@ -649,9 +649,12 @@ bool P_ProjectileImmune(AActor* target, AActor* source)
 	                mobjinfo[source->type].projectile_group));
 }
 
-static bool PIT_CheckThing (AActor& thing)
+namespace
 {
-	bool solid = thing.flags & MF_SOLID;
+
+bool PIT_CheckThing (AActor& thing)
+{
+	const bool solid = thing.flags & MF_SOLID;
 
 	// don't clip against self
 	if (&thing == tmthing)
@@ -672,7 +675,7 @@ static bool PIT_CheckThing (AActor& thing)
 	    P_IsFriendlyThing(&thing, tmthing) && sv_unblockfriendly)
 		return true;
 
-	fixed_t blockdist = thing.radius + tmthing->radius;
+	const fixed_t blockdist = thing.radius + tmthing->radius;
 	if (abs(thing.x - tmx) >= blockdist || abs(thing.y - tmy) >= blockdist)
 	{
 		// didn't hit thing
@@ -711,7 +714,7 @@ static bool PIT_CheckThing (AActor& thing)
 	    (thing.type ^ MT_SKULL) |        // (but Barons & Knights
 	        (tmthing->type ^ MT_PAIN))    // are intentionally not)
 	{
-		P_DamageMobj(&thing, NULL, NULL, thing.health); // kill object
+		P_DamageMobj(&thing, nullptr, nullptr, thing.health); // kill object
 		return true;
 	}
 
@@ -871,6 +874,9 @@ static bool PIT_CheckThing (AActor& thing)
 		         (tmthing->flags & MF_SOLID || (demoplayback || !co_boomphys)));
 }
 
+} // namespace
+
+
 // This routine checks for Lost Souls trying to be spawned		// phares
 // across 1-sided lines, impassible lines, or "monsters can't	//   |
 // cross" lines. Draw an imaginary line between the PE			//   V
@@ -947,14 +953,14 @@ bool PIT_CheckOnmobjZ (AActor& thing)
 	// over / under thing
 	if (tmthing->z > thing.z + thing.height)
 		return true;
-	else if (tmthing->z + tmthing->height <= thing.z)
+	if (tmthing->z + tmthing->height <= thing.z)
 		return true;
 
 	// Don't clip the projectile unless it's not a teammate.
 	if (tmthing->flags & MF_MISSILE && !P_ShouldClipPlayer(tmthing, &thing))
 		return true;
 
-	fixed_t blockdist = thing.radius+tmthing->radius;
+	const fixed_t blockdist = thing.radius+tmthing->radius;
 	if (abs(thing.x - tmx) >= blockdist || abs(thing.y - tmy) >= blockdist)
 		return true;		// Didn't hit thing
 
@@ -1499,7 +1505,10 @@ bool P_TryMove (AActor *thing, fixed_t x, fixed_t y,
 // so balancing is possible.
 //
 
-static bool PIT_ApplyTorque (const line_t& ld)
+namespace
+{
+
+bool PIT_ApplyTorque (const line_t& ld)
 {
 	if (ld.backsector &&		// If thing touches two-sided pivot linedef
 		tmbbox[BOXRIGHT]  > ld.bbox[BOXLEFT]  &&
@@ -1567,6 +1576,8 @@ static bool PIT_ApplyTorque (const line_t& ld)
 	}
 	return true;
 }
+
+} // namespace
 
 //
 // killough 9/12/98
@@ -3380,7 +3391,7 @@ bool PIT_ChangeSector (AActor& thing)
 	/* killough 11/98: kill touchy things immediately */
 	if (thing.flags & MF_TOUCHY && (thing.oflags & MFO_ARMED || sentient(&thing)))
 	{
-		P_DamageMobj(&thing, NULL, NULL, thing.health); // kill object
+		P_DamageMobj(&thing, nullptr, nullptr, thing.health); // kill object
 		return true;                                    // keep checking
 	}
 

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -1520,10 +1520,10 @@ bool PIT_ApplyTorque (const line_t& ld)
 		AActor *mo = tmthing;
 
 		fixed_t dist =								// lever arm
-	  + (ld.dx >> FRACBITS) * (mo->y >> FRACBITS)
-	  - (ld.dy >> FRACBITS) * (mo->x >> FRACBITS)
-	  - (ld.dx >> FRACBITS) * (ld.v1->y >> FRACBITS)
-	  + (ld.dy >> FRACBITS) * (ld.v1->x >> FRACBITS);
+			+ ((ld.dx >> FRACBITS) * (mo->y >> FRACBITS))
+			- ((ld.dy >> FRACBITS) * (mo->x >> FRACBITS))
+			- ((ld.dx >> FRACBITS) * (ld.v1->y >> FRACBITS))
+			+ ((ld.dy >> FRACBITS) * (ld.v1->x >> FRACBITS));
 
 		if (dist < 0 ?								// dropoff direction
 			P_FloorHeight(mo->x, mo->y, ld.frontsector) < mo->z &&
@@ -1534,7 +1534,8 @@ bool PIT_ApplyTorque (const line_t& ld)
 		// At this point, we know that the object straddles a two-sided
 		// linedef, and that the object's center of mass is above-ground.
 
-			fixed_t x = abs(ld.dx), y = abs(ld.dy);
+			fixed_t x = abs(ld.dx);
+			fixed_t y = abs(ld.dy);
 
 			if (y > x)
 			{
@@ -3091,6 +3092,8 @@ CVAR_FUNC_IMPL(sv_splashfactor)
 	selfthrustscale = 1.0f / var;
 }
 
+namespace
+{
 
 //
 // PIT_DoomRadiusAttack
@@ -3098,14 +3101,14 @@ CVAR_FUNC_IMPL(sv_splashfactor)
 // "bombsource" is the creature that caused the explosion at "bombspot".
 //
 
-static bool P_SplashImmune(const AActor& target, const AActor& spot)
+bool P_SplashImmune(const AActor& target, const AActor& spot)
 {
 	return // not default behaviour and same group
 	    mobjinfo[target.type].splash_group != SG_DEFAULT &&
 	    mobjinfo[target.type].splash_group == mobjinfo[spot.type].splash_group;
 }
 
-static bool PIT_DoomRadiusAttack(AActor& thing)
+bool PIT_DoomRadiusAttack(AActor& thing)
 {
 	if (!serverside || !(thing.flags & (MF_SHOOTABLE | MF_BOUNCES)))
 		return true;
@@ -3121,12 +3124,9 @@ static bool PIT_DoomRadiusAttack(AActor& thing)
 		!(bombspot->flags3 & MF3_FORCERADIUSDMG))
 		return true;
 
-	fixed_t dx = abs(thing.x - bombspot->x);
-	fixed_t dy = abs(thing.y - bombspot->y);
-	fixed_t dist = (MAX(dx, dy) - thing.radius) >> FRACBITS;
-
-	if (dist < 0)
-		dist = 0;
+	const fixed_t dx = abs(thing.x - bombspot->x);
+	const fixed_t dy = abs(thing.y - bombspot->y);
+	const fixed_t dist = std::max((std::max(dx, dy) - thing.radius) >> FRACBITS, 0);
 
 	if (dist >= bombdistance)
 	{
@@ -3162,7 +3162,7 @@ static bool PIT_DoomRadiusAttack(AActor& thing)
 // "bombsource" is the creature that caused the explosion at "bombspot".
 // [RH] Now it knows about vertical distances and can thrust things vertically, too.
 //
-static bool PIT_ZDoomRadiusAttack(AActor& thing)
+bool PIT_ZDoomRadiusAttack(AActor& thing)
 {
 	if (!serverside || !(thing.flags & (MF_SHOOTABLE | MF_BOUNCES)))
 		return true;
@@ -3190,10 +3190,10 @@ static bool PIT_ZDoomRadiusAttack(AActor& thing)
 
 	// [RH] New code. The bounding box only covers the
 	// height of the thing and not the height of the map.
-	fixed_t dx = abs(thing.x - bombspot->x);
-	fixed_t dy = abs(thing.y - bombspot->y);
-	float len = float(MAX(dx, dy));
-	float boxradius = float(thing.radius);
+	const fixed_t dx = abs(thing.x - bombspot->x);
+	const fixed_t dy = abs(thing.y - bombspot->y);
+	auto len = float(std::max(dx, dy));
+	const auto boxradius = float(thing.radius);
 
 	if (bombspot->z < thing.z || bombspot->z >= thing.z + thing.height)
 	{
@@ -3214,9 +3214,7 @@ static bool PIT_ZDoomRadiusAttack(AActor& thing)
 	}
 	else
 	{
-		len -= boxradius;
-		if (len < 0.0f)
-			len = 0.0f;
+		len -= std::max(boxradius, 0.0f);
 	}
 
 	float points;
@@ -3232,9 +3230,9 @@ static bool PIT_ZDoomRadiusAttack(AActor& thing)
 	{
 		// OK to damage; target is in direct path
 
-		fixed_t momx = thing.momx;
-		fixed_t momy = thing.momy;
-		int damage = (int)points;
+		const fixed_t momx = thing.momx;
+		const fixed_t momy = thing.momy;
+		const int damage = (int)points;
 
 		P_DamageMobj(&thing, bombspot, bombsource, damage, bombmod);
 
@@ -3264,6 +3262,8 @@ static bool PIT_ZDoomRadiusAttack(AActor& thing)
 
 	return true;
 }
+
+} // namespace
 
 //
 // P_RadiusAttack

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3410,9 +3410,9 @@ bool PIT_ChangeSector (AActor& thing)
 		// spray blood in a random direction
 		if (!(thing.flags&MF_NOBLOOD))
 		{
-			AActor *mo = new AActor (thing.x,
+			auto *mo = new AActor (thing.x,
 									 thing.y,
-									 thing.z + thing.height/2, MT_BLOOD);
+									 thing.z + (thing.height/2), MT_BLOOD);
 
 			mo->momx = P_RandomDiff (mo) << 12;
 			mo->momy = P_RandomDiff (mo) << 12;

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -122,36 +122,36 @@ CVAR_FUNC_IMPL (sv_gravity)
 //
 static bool StompAlwaysFrags;
 
-bool PIT_StompThing (AActor *thing)
+bool PIT_StompThing (AActor& thing)
 {
 	fixed_t blockdist;
 
-	if (!(thing->flags & MF_SHOOTABLE))
+	if (!(thing.flags & MF_SHOOTABLE))
 		return true;
 
 	// Spectators shouldn't stomp anybody, and cannot be stomped.
-	if (thing->player && thing->player->spectator)
+	if (thing.player && thing.player->spectator)
 		return true;
 
 	if (tmthing->player && tmthing->player->spectator)
 		return true;
 
 	// Unblocked players shouldn't telefrag other players.  Thanks Amateur Spammer!
-	if (tmthing->player && thing->player && sv_unblockplayers)
+	if (tmthing->player && thing.player && sv_unblockplayers)
 		return true;
 
 	// Unblocked friendlies shouldn't telefrag anyone.
-	if (tmthing && thing && thing->flags & MF_FRIEND && P_IsFriendlyThing(thing, tmthing) &&
+	if (tmthing && thing.flags & MF_FRIEND && P_IsFriendlyThing(&thing, tmthing) &&
 	    sv_unblockfriendly)
 		return true;
 
 	// don't clip against self
-	if (thing == tmthing)
+	if (&thing == tmthing)
 		return true;
 
-	blockdist = thing->radius + tmthing->radius;
+	blockdist = thing.radius + tmthing->radius;
 
-	if (abs(thing->x - tmx) >= blockdist || abs(thing->y - tmy) >= blockdist)
+	if (abs(thing.x - tmx) >= blockdist || abs(thing.y - tmy) >= blockdist)
 	{
 		// didn't hit it
 		return true;
@@ -160,9 +160,9 @@ bool PIT_StompThing (AActor *thing)
 	if (P_AllowPassover())
 	{
 		// [RH] Z-Check
-		if (tmz > thing->z + thing->height)
+		if (tmz > thing.z + thing.height)
 			return true;        // overhead
-		if (tmz + tmthing->height < thing->z)
+		if (tmz + tmthing->height < thing.z)
 			return true;        // underneath
 	}
 
@@ -171,10 +171,10 @@ bool PIT_StompThing (AActor *thing)
 	{
 		// [AM] Surprise, avatars telefrag players who try to telefrag it!
 		//      Not your lucky day, I suppose.
-		if (thing->type == MT_AVATAR && tmthing->player)
-			P_DamageMobj(tmthing, thing, thing, 10000, MOD_TELEFRAG);
+		if (thing.type == MT_AVATAR && tmthing->player)
+			P_DamageMobj(tmthing, &thing, &thing, 10000, MOD_TELEFRAG);
 		else
-			P_DamageMobj(thing, tmthing, tmthing, 10000, MOD_TELEFRAG);
+			P_DamageMobj(&thing, tmthing, tmthing, 10000, MOD_TELEFRAG);
 		return true;
 	}
 	return false;
@@ -254,7 +254,7 @@ bool P_TeleportMove (AActor *thing, fixed_t x, fixed_t y, fixed_t z, bool telefr
 
 	for (bx=xl ; bx<=xh ; bx++)
 		for (by=yl ; by<=yh ; by++)
-			if (!P_BlockThingsIterator(bx,by,PIT_StompThing))
+			if (!P_BlockThingsIterator(bx,by,PIT_StompThing, nullptr))
 				return false;
 
 	// the move is ok,
@@ -386,17 +386,17 @@ static void CheckForPushSpecial (line_t *line, int side, AActor *mobj)
 
 
 static // killough 3/26/98: make static
-bool PIT_CrossLine (line_t* ld)
+bool PIT_CrossLine (const line_t& ld)
 {
-	if (!(ld->flags & ML_TWOSIDED) ||
-		(ld->flags & (ML_BLOCKING|ML_BLOCKMONSTERS|ML_BLOCKEVERYTHING)))
-		if (!(tmbbox[BOXLEFT]   > ld->bbox[BOXRIGHT]  ||
-			  tmbbox[BOXRIGHT]  < ld->bbox[BOXLEFT]   ||
-			  tmbbox[BOXTOP]    < ld->bbox[BOXBOTTOM] ||
-			  tmbbox[BOXBOTTOM] > ld->bbox[BOXTOP]))
-			if (P_PointOnLineSide(pe_x,pe_y,ld) != P_PointOnLineSide(ls_x,ls_y,ld))
-				return(false);  // line blocks trajectory				//   ^
-	return(true); // line doesn't block trajectory					//   |
+	if (!(ld.flags & ML_TWOSIDED) ||
+		(ld.flags & (ML_BLOCKING|ML_BLOCKMONSTERS|ML_BLOCKEVERYTHING)))
+		if (!(tmbbox[BOXLEFT]   > ld.bbox[BOXRIGHT]  ||
+			  tmbbox[BOXRIGHT]  < ld.bbox[BOXLEFT]   ||
+			  tmbbox[BOXTOP]    < ld.bbox[BOXBOTTOM] ||
+			  tmbbox[BOXBOTTOM] > ld.bbox[BOXTOP]))
+			if (P_PointOnLineSide(pe_x,pe_y,&ld) != P_PointOnLineSide(ls_x,ls_y,&ld))
+				return false;  // line blocks trajectory				//   ^
+	return true; // line doesn't block trajectory					//   |
 }																	// phares
 
 //
@@ -405,17 +405,34 @@ bool PIT_CrossLine (line_t* ld)
 //
 
 static // killough 3/26/98: make static
-bool PIT_CheckLine (line_t *ld)
+bool PIT_CheckLine(line_t& ld, bool tmunstuck)
 {
-	if (tmbbox[BOXRIGHT] <= ld->bbox[BOXLEFT]
-		|| tmbbox[BOXLEFT] >= ld->bbox[BOXRIGHT]
-		|| tmbbox[BOXTOP] <= ld->bbox[BOXBOTTOM]
-		|| tmbbox[BOXBOTTOM] >= ld->bbox[BOXTOP] )
+	if (tmbbox[BOXRIGHT] <= ld.bbox[BOXLEFT]
+		|| tmbbox[BOXLEFT] >= ld.bbox[BOXRIGHT]
+		|| tmbbox[BOXTOP] <= ld.bbox[BOXBOTTOM]
+		|| tmbbox[BOXBOTTOM] >= ld.bbox[BOXTOP] )
 		return true;
 
-	if (P_BoxOnLineSide (tmbbox, ld) != -1)
+	if (P_BoxOnLineSide (tmbbox, &ld) != -1)
 		return true;
 
+
+	const auto untouched = [](line_t& ld)
+	{
+		fixed_t x = tmthing->x;
+		fixed_t y = tmthing->y;
+		std::array<fixed_t, 4> tmbbox{};
+		tmbbox[BOXRIGHT] = x+tmthing->radius;
+    	tmbbox[BOXLEFT] = x-tmthing->radius;
+    	tmbbox[BOXTOP] = y+tmthing->radius;
+    	tmbbox[BOXBOTTOM] = y-tmthing->radius;
+  		return
+    		tmbbox[BOXRIGHT] <= ld.bbox[BOXLEFT] ||
+    		tmbbox[BOXLEFT]>= ld.bbox[BOXRIGHT] ||
+    		tmbbox[BOXTOP] <= ld.bbox[BOXBOTTOM] ||
+    		tmbbox[BOXBOTTOM] >= ld.bbox[BOXTOP] ||
+    		P_BoxOnLineSide(tmbbox.data(), &ld) != -1;
+	};
 
     // A line has been hit
 
@@ -428,24 +445,29 @@ bool PIT_CheckLine (line_t *ld)
     // so two special lines that are only 8 pixels apart
     // could be crossed in either order.
 
-	if (!ld->backsector)
+	if (!ld.backsector)
 	{ // One sided line
-		BlockingLine = ld;
-		CheckForPushSpecial(ld, 0, tmthing);
-		return false;
+		BlockingLine = &ld;
+		CheckForPushSpecial(&ld, 0, tmthing);
+		return tmunstuck && !untouched(ld) && FixedMul(tmx-tmthing->x,ld.dy) > FixedMul(tmy-tmthing->y,ld.dx);
 	}
 
-    if (!(tmthing->flags & (MF_MISSILE | MF_BOUNCES)) || (ld->flags & ML_BLOCKEVERYTHING))
+    if (!(tmthing->flags & (MF_MISSILE | MF_BOUNCES)) || (ld.flags & ML_BLOCKEVERYTHING))
     {
-		if ((ld->flags &
+		if ((ld.flags &
 		     (ML_BLOCKING | ML_BLOCKEVERYTHING)) || // explicitly blocking everything
-		    (!P_IsPlayerOrAvatar(*tmthing) && !(tmthing->flags & MF_FRIEND) && (ld->flags & ML_BLOCKMONSTERS)) || // block monsters only
-		    (!P_IsPlayerOrAvatar(*tmthing) && !(tmthing->flags & MF_FRIEND) && (ld->flags & ML_BLOCKLANDMONSTERS) &&
-		     !(tmthing->flags & MF_FLOAT)) || // [Blair] Block land monsters.
 		    (P_IsPlayerOrAvatar(*tmthing) &&
-		     (ld->flags & ML_BLOCKPLAYERS))) // [Blair] Block players only
+		     (ld.flags & ML_BLOCKPLAYERS))) // [Blair] Block players only
 		{
-			CheckForPushSpecial(ld, 0, tmthing);
+			CheckForPushSpecial(&ld, 0, tmthing);
+			return tmunstuck && !untouched(ld);
+		}
+
+		if ((!P_IsPlayerOrAvatar(*tmthing) && !(tmthing->flags & MF_FRIEND) && (ld.flags & ML_BLOCKMONSTERS)) || // block monsters only
+		    (!P_IsPlayerOrAvatar(*tmthing) && !(tmthing->flags & MF_FRIEND) && (ld.flags & ML_BLOCKLANDMONSTERS) &&
+		     !(tmthing->flags & MF_FLOAT))) // [Blair] Block land monsters.
+		{
+			CheckForPushSpecial(&ld, 0, tmthing);
 			return false;
 		}
     }
@@ -454,8 +476,8 @@ bool PIT_CheckLine (line_t *ld)
 	if (!(tmthing->flags & MF_DROPOFF) &&
 		!(tmthing->flags & (MF_NOGRAVITY|MF_NOCLIP)))
 	{
-		if (ld->frontsector->floorplane.c < STEEPSLOPE ||
-			ld->backsector->floorplane.c < STEEPSLOPE)
+		if (ld.frontsector->floorplane.c < STEEPSLOPE ||
+			ld.backsector->floorplane.c < STEEPSLOPE)
 		{
 			const msecnode_t *node = tmthing->touching_sectorlist;
 			bool allow = false;
@@ -477,36 +499,36 @@ bool PIT_CheckLine (line_t *ld)
 	// set openrange, opentop, openbottom
 
 	// Are the sectors on both sides of the line non-sloped?
-	if (P_IsPlaneLevel(&ld->frontsector->floorplane) &&
-		P_IsPlaneLevel(&ld->backsector->floorplane) &&
-		P_IsPlaneLevel(&ld->frontsector->ceilingplane) &&
-		P_IsPlaneLevel(&ld->backsector->ceilingplane))
+	if (P_IsPlaneLevel(&ld.frontsector->floorplane) &&
+		P_IsPlaneLevel(&ld.backsector->floorplane) &&
+		P_IsPlaneLevel(&ld.frontsector->ceilingplane) &&
+		P_IsPlaneLevel(&ld.backsector->ceilingplane))
 	{
-		P_LineOpening(ld, tmx, tmy, tmx, tmy);
+		P_LineOpening(&ld, tmx, tmy, tmx, tmy);
 	}
 	else
 	{
 		// Find the point on the line closest to the actor's center, and use
 		// that to calculate openings
-		double dx = FIXED2DOUBLE(ld->dx);
-		double dy = FIXED2DOUBLE(ld->dy);
-		double r =	(FIXED2DOUBLE(tmx - ld->v1->x) * dx +
-					 FIXED2DOUBLE(tmy - ld->v1->y) * dy) /
+		double dx = FIXED2DOUBLE(ld.dx);
+		double dy = FIXED2DOUBLE(ld.dy);
+		double r =	(FIXED2DOUBLE(tmx - ld.v1->x) * dx +
+					 FIXED2DOUBLE(tmy - ld.v1->y) * dy) /
 					(dx * dx + dy * dy);
 
 		if (r <= 0.0)
 		{
-			P_LineOpening (ld, ld->v1->x, ld->v1->y, tmx, tmy);
+			P_LineOpening (&ld, ld.v1->x, ld.v1->y, tmx, tmy);
 		}
 		else if (r >= 1.0)
 		{
-			P_LineOpening (ld, ld->v2->x, ld->v2->y, tmthing->x, tmthing->y);
+			P_LineOpening (&ld, ld.v2->x, ld.v2->y, tmthing->x, tmthing->y);
 		}
 		else
 		{
-			fixed_t sx = ld->v1->x + r * ld->dx;
-			fixed_t sy = ld->v1->y + r * ld->dy;
-			P_LineOpening (ld, sx, sy, tmx, tmy);
+			fixed_t sx = ld.v1->x + r * ld.dx;
+			fixed_t sy = ld.v1->y + r * ld.dy;
+			P_LineOpening (&ld, sx, sy, tmx, tmy);
 		}
 	}
 
@@ -514,23 +536,23 @@ bool PIT_CheckLine (line_t *ld)
 	if (opentop < tmceilingz)
 	{
 		tmceilingz = opentop;
-		ceilingline = ld;
-		BlockingLine = ld;
+		ceilingline = &ld;
+		BlockingLine = &ld;
 	}
 
 	if (openbottom > tmfloorz)
 	{
 		tmfloorz = openbottom;
 		tmfloorsector = openbottomsec;
-		BlockingLine = ld;
+		BlockingLine = &ld;
 	}
 
 	if (lowfloor < tmdropoffz)
 		tmdropoffz = lowfloor;
 
 	// if contacted a special line, add it to the list
-	if (ld->special)
-		spechit.push_back(ld);
+	if (ld.special)
+		spechit.push_back(&ld);
 
 	return true;
 }
@@ -619,43 +641,43 @@ bool P_ProjectileImmune(AActor* target, AActor* source)
 	                mobjinfo[source->type].projectile_group));
 }
 
-static bool PIT_CheckThing (AActor *thing)
+static bool PIT_CheckThing (AActor& thing)
 {
-	bool solid = thing->flags & MF_SOLID;
+	bool solid = thing.flags & MF_SOLID;
 
 	// don't clip against self
-	if (thing == tmthing)
+	if (&thing == tmthing)
 		return true;
 
-	if (!(thing->flags & (MF_SOLID|MF_SPECIAL|MF_SHOOTABLE|MF_TOUCHY)) )
+	if (!(thing.flags & (MF_SOLID|MF_SPECIAL|MF_SHOOTABLE|MF_TOUCHY)) )
 		return true;	// can't hit thing
 
 	// GhostlyDeath -- Spectators go through everything!
-	if ((thing->player && thing->player->spectator) ||
+	if ((thing.player && thing.player->spectator) ||
 		(tmthing->player && tmthing->player->spectator))
 		return true;
 
-	if (tmthing->player && thing->player && sv_unblockplayers)
+	if (tmthing->player && thing.player && sv_unblockplayers)
 		return true;
 
-	if (tmthing && thing && thing->flags & MF_FRIEND &&
-	    P_IsFriendlyThing(thing, tmthing) && sv_unblockfriendly)
+	if (tmthing && thing.flags & MF_FRIEND &&
+	    P_IsFriendlyThing(&thing, tmthing) && sv_unblockfriendly)
 		return true;
 
-	fixed_t blockdist = thing->radius + tmthing->radius;
-	if (abs(thing->x - tmx) >= blockdist || abs(thing->y - tmy) >= blockdist)
+	fixed_t blockdist = thing.radius + tmthing->radius;
+	if (abs(thing.x - tmx) >= blockdist || abs(thing.y - tmy) >= blockdist)
 	{
 		// didn't hit thing
 		return true;
 	}
 
 	if (P_AllowPassover())
-		BlockingMobj = thing;
+		BlockingMobj = &thing;
 
 	if (P_AllowPassover() && (tmthing->flags2 & MF2_PASSMOBJ))
 	{
 		// check if a mobj passed over/under another object
-		if (tmthing->z >= thing->z + thing->height || tmthing->z + tmthing->height <= thing->z)
+		if (tmthing->z >= thing.z + thing.height || tmthing->z + tmthing->height <= thing.z)
 			return true;
 	}
 
@@ -667,21 +689,21 @@ static bool PIT_CheckThing (AActor *thing)
 	 * surroundings such as walls, then the touchy thing dies immediately.
 	 */
 
-	if (thing->flags & MF_TOUCHY &&               // touchy object
+	if (thing.flags & MF_TOUCHY &&               // touchy object
 	    tmthing->flags & MF_SOLID &&              // solid object touches it
-	    thing->health > 0 &&                      // touchy object is alive
-	    (thing->oflags & MFO_ARMED ||             // Thing is an armed mine
-	     sentient(thing)) &&                      // ... or a sentient thing
-	    (thing->type != tmthing->type ||          // only different species
-	     thing->type == MT_PLAYER) &&             // ... or different players
-	    thing->z + thing->height >= tmthing->z && // touches vertically
-	    tmthing->z + tmthing->height >= thing->z &&
-	    (thing->type ^ MT_PAIN) |         // PEs and lost souls
+	    thing.health > 0 &&                      // touchy object is alive
+	    (thing.oflags & MFO_ARMED ||             // Thing is an armed mine
+	     sentient(&thing)) &&                      // ... or a sentient thing
+	    (thing.type != tmthing->type ||          // only different species
+	     thing.type == MT_PLAYER) &&             // ... or different players
+	    thing.z + thing.height >= tmthing->z && // touches vertically
+	    tmthing->z + tmthing->height >= thing.z &&
+	    (thing.type ^ MT_PAIN) |         // PEs and lost souls
 	        (tmthing->type ^ MT_SKULL) && // are considered same
-	    (thing->type ^ MT_SKULL) |        // (but Barons & Knights
+	    (thing.type ^ MT_SKULL) |        // (but Barons & Knights
 	        (tmthing->type ^ MT_PAIN))    // are intentionally not)
 	{
-		P_DamageMobj(thing, NULL, NULL, thing->health); // kill object
+		P_DamageMobj(&thing, NULL, NULL, thing.health); // kill object
 		return true;
 	}
 
@@ -689,7 +711,7 @@ static bool PIT_CheckThing (AActor *thing)
 	if (tmthing->flags & MF_SKULLFLY)
 	{
 		int damage = ((P_Random(tmthing)%8)+1) * tmthing->info->damage;
-		P_DamageMobj (thing, tmthing, tmthing, damage, MOD_HIT);
+		P_DamageMobj (&thing, tmthing, tmthing, damage, MOD_HIT);
 		tmthing->flags &= ~MF_SKULLFLY;
 		tmthing->momx = tmthing->momy = tmthing->momz = 0;
 		P_SetMobjState (tmthing, tmthing->info->spawnstate);
@@ -706,61 +728,61 @@ static bool PIT_CheckThing (AActor *thing)
 		&& !(tmthing->flags & MF_SOLID)))
 	{
 		// see if it went over / under
-		if (tmthing->z > thing->z + thing->height)
+		if (tmthing->z > thing.z + thing.height)
 			return true;				// overhead
-		if (tmthing->z+tmthing->height < thing->z)
+		if (tmthing->z+tmthing->height < thing.z)
 			return true;				// underneath
 
     // Check with projectiles owner if we can explode
 		if (tmthing->target &&
-			(P_ProjectileImmune(thing, tmthing->target) &&
+			(P_ProjectileImmune(&thing, tmthing->target) &&
 		    !((level.flags2 & LEVEL2_INFIGHTINGMASK) ?
 			    level.flags2 & LEVEL2_TOTALINFIGHTING :
 			    G_GetCurrentSkill().flags & SKILL_TOTALINFIGHTING)))
 		{
 			// Don't hit same species as originator
-			if (thing == tmthing->target)
+			if (&thing == tmthing->target)
 				return true;
 
-			if (!thing->player)
+			if (!thing.player)
 			{
 				// Run friendly clip check early if same species
-				if ((thing->flags & tmthing->target->flags & MF_FRIEND) &&
-				    !P_ShouldClipFriendly(tmthing, thing))
+				if ((thing.flags & tmthing->target->flags & MF_FRIEND) &&
+				    !P_ShouldClipFriendly(tmthing, &thing))
 					return true;
 
 				// [RH] DeHackEd infighting is here.
 				if (!deh.Infight &&
-						(!((thing->flags ^ tmthing->target->flags) & MF_FRIEND) ||
-						(thing->flags & tmthing->target->flags & MF_FRIEND && P_IsFriendlyThing(thing, tmthing->target))))
+						(!((thing.flags ^ tmthing->target->flags) & MF_FRIEND) ||
+						(thing.flags & tmthing->target->flags & MF_FRIEND && P_IsFriendlyThing(&thing, tmthing->target))))
 					return false; // Hit same species as originator, explode, no damage
 			}
 		}
 
-		if (!(thing->flags & MF_SHOOTABLE))
+		if (!(thing.flags & MF_SHOOTABLE))
 			return !solid;		// didn't do any damage
 
 		// Don't clip the projectile unless it's not a teammate.
-		if (!P_ShouldClipPlayer(tmthing, thing))
+		if (!P_ShouldClipPlayer(tmthing, &thing))
 			return true;
 
 		// Don't clip the projectile unless it's not a friendly.
-		if (!P_ShouldClipFriendly(tmthing, thing))
+		if (!P_ShouldClipFriendly(tmthing, &thing))
 			return true;
 
 		if (tmthing->flags2 & MF2_RIP)
 		{
 			int damage = ((P_Random(tmthing) & 3) + 2) * tmthing->info->damage;
-			if (!(thing->flags & MF_NOBLOOD))
+			if (!(thing.flags & MF_NOBLOOD))
 				P_SpawnBlood(tmthing->x, tmthing->y, tmthing->z, damage);
 			if (tmthing->info->ripsound)
 				S_Sound(tmthing, CHAN_VOICE, tmthing->info->ripsound, 1, ATTN_NORM);
 
-			P_DamageMobj(thing, tmthing, tmthing->target, damage, MOD_UNKNOWN);
-			if (thing->flags2 & MF2_PUSHABLE && !(tmthing->flags2 & MF2_CANNOTPUSH))
+			P_DamageMobj(&thing, tmthing, tmthing->target, damage, MOD_UNKNOWN);
+			if (thing.flags2 & MF2_PUSHABLE && !(tmthing->flags2 & MF2_CANNOTPUSH))
 			{ // Push thing
-				thing->momx += tmthing->momx >> 2;
-				thing->momy += tmthing->momy >> 2;
+				thing.momx += tmthing->momx >> 2;
+				thing.momy += tmthing->momy >> 2;
 			}
 
 			return true;
@@ -797,7 +819,7 @@ static bool PIT_CheckThing (AActor *thing)
 							}
 						break;
 				}
-				P_DamageMobj (thing, tmthing, tmthing->target, damage, mod);
+				P_DamageMobj (&thing, tmthing, tmthing->target, damage, mod);
 			}
 		}
 
@@ -805,7 +827,7 @@ static bool PIT_CheckThing (AActor *thing)
 	}
 
 	// check for special pickup
-	if (thing->flags & MF_SPECIAL && tmthing->flags & MF_PICKUP)
+	if (thing.flags & MF_SPECIAL && tmthing->flags & MF_PICKUP)
 	{
 		// [SL] Work-around the additional height added to players
 		// in P_CheckPosition. Don't let players grab items above
@@ -816,8 +838,8 @@ static bool PIT_CheckThing (AActor *thing)
 		if (tmthing->player)
 			max_z -= 24 * FRACUNIT;
 
-		if (!P_AllowPassover() || thing->z < max_z)
-			P_TouchSpecialThing (*thing, *tmthing);	// can remove thing
+		if (!P_AllowPassover() || thing.z < max_z)
+			P_TouchSpecialThing (thing, *tmthing);	// can remove thing
 
 		return !solid;
 	}
@@ -835,9 +857,9 @@ static bool PIT_CheckThing (AActor *thing)
 	if (demoplayback || !co_boomphys
 	    //&& !prboom_comp[PC_TREAT_NO_CLIPPING_THINGS_AS_NOT_BLOCKING].state
 			)
-		return !(thing->flags & MF_SOLID);
+		return !(thing.flags & MF_SOLID);
 	else
-		return !((thing->flags & MF_SOLID && !(thing->flags & MF_NOCLIP)) &&
+		return !((thing.flags & MF_SOLID && !(thing.flags & MF_NOCLIP)) &&
 		         (tmthing->flags & MF_SOLID || (demoplayback || !co_boomphys)));
 }
 
@@ -892,43 +914,43 @@ bool Check_Sides(const AActor* actor, int x, int y)
 //
 //---------------------------------------------------------------------------
 
-bool PIT_CheckOnmobjZ (AActor *thing)
+bool PIT_CheckOnmobjZ (AActor& thing)
 {
-	if (!(thing->flags & MF_SOLID))
+	if (!(thing.flags & MF_SOLID))
 		return true;
 
 	// [RH] Corpses and specials don't block moves
-	if (thing->flags & (MF_CORPSE|MF_SPECIAL))
+	if (thing.flags & (MF_CORPSE|MF_SPECIAL))
 		return true;
 
 	// Don't clip against self
-	if (thing == tmthing)
+	if (&thing == tmthing)
 		return true;
 
 	// Don't clip against a player
-	if (tmthing->player && thing->player && sv_unblockplayers)
+	if (tmthing->player && thing.player && sv_unblockplayers)
 		return true;
 
 	// Don't clip against friendlies
-	if (tmthing && thing && thing->flags & MF_FRIEND &&
-	    P_IsFriendlyThing(thing, tmthing) && sv_unblockfriendly)
+	if (tmthing && thing.flags & MF_FRIEND &&
+	    P_IsFriendlyThing(&thing, tmthing) && sv_unblockfriendly)
 		return true;
 
 	// over / under thing
-	if (tmthing->z > thing->z + thing->height)
+	if (tmthing->z > thing.z + thing.height)
 		return true;
-	else if (tmthing->z + tmthing->height <= thing->z)
+	else if (tmthing->z + tmthing->height <= thing.z)
 		return true;
 
 	// Don't clip the projectile unless it's not a teammate.
-	if (tmthing->flags & MF_MISSILE && !P_ShouldClipPlayer(tmthing, thing))
+	if (tmthing->flags & MF_MISSILE && !P_ShouldClipPlayer(tmthing, &thing))
 		return true;
 
-	fixed_t blockdist = thing->radius+tmthing->radius;
-	if (abs(thing->x - tmx) >= blockdist || abs(thing->y - tmy) >= blockdist)
+	fixed_t blockdist = thing.radius+tmthing->radius;
+	if (abs(thing.x - tmx) >= blockdist || abs(thing.y - tmy) >= blockdist)
 		return true;		// Didn't hit thing
 
-	onmobj = thing;
+	onmobj = &thing;
 	return false;
 }
 
@@ -1100,7 +1122,7 @@ bool P_CheckPosition (AActor *thing, fixed_t x, fixed_t y)
 		// vanilla Doom's check for blocking things
 		for (int bx=xl ; bx<=xh ; bx++)
 			for (int by=yl ; by<=yh ; by++)
-				if (!P_BlockThingsIterator(bx,by,PIT_CheckThing))
+				if (!P_BlockThingsIterator(bx,by,PIT_CheckThing, nullptr))
 					return false;
 
 		if (tmflags & MF_NOCLIP)
@@ -1113,9 +1135,16 @@ bool P_CheckPosition (AActor *thing, fixed_t x, fixed_t y)
 	yl = (tmbbox[BOXBOTTOM] - bmaporgy)>>MAPBLOCKSHIFT;
 	yh = (tmbbox[BOXTOP] - bmaporgy)>>MAPBLOCKSHIFT;
 
+	// from mbf, allows players to get unstuck if they end up spawned
+	// partially inside a wall or blocking line
+	// i think this is safe to enable always (except for demo playback of course)
+	// but if it turns out to cause issues with vanilla or boom maps,
+	// we should change it to rely on co_mbfphys
+	const bool tmunstuck = (thing->player != nullptr) && !P_IsVoodooDoll(thing) && !demoplayback;
+
 	for (int bx=xl ; bx<=xh ; bx++)
 		for (int by=yl ; by<=yh ; by++)
-			if (!P_BlockLinesIterator (bx,by,PIT_CheckLine))
+			if (!P_BlockLinesIterator (bx,by,PIT_CheckLine, tmunstuck))
 				return false;
 
 	if (P_AllowPassover())
@@ -1174,7 +1203,7 @@ bool P_TestMobjZ (AActor *actor)
 
 	for (bx = xl; bx <= xh; bx++)
 		for (by = yl; by <= yh; by++)
-			if (!P_BlockThingsIterator (bx, by, PIT_CheckOnmobjZ))
+			if (!P_BlockThingsIterator (bx, by, PIT_CheckOnmobjZ, nullptr))
 				return false;
 
 	return true;
@@ -1462,33 +1491,33 @@ bool P_TryMove (AActor *thing, fixed_t x, fixed_t y,
 // so balancing is possible.
 //
 
-static bool PIT_ApplyTorque (line_t *ld)
+static bool PIT_ApplyTorque (const line_t& ld)
 {
-	if (ld->backsector &&		// If thing touches two-sided pivot linedef
-		tmbbox[BOXRIGHT]  > ld->bbox[BOXLEFT]  &&
-		tmbbox[BOXLEFT]   < ld->bbox[BOXRIGHT] &&
-		tmbbox[BOXTOP]    > ld->bbox[BOXBOTTOM] &&
-		tmbbox[BOXBOTTOM] < ld->bbox[BOXTOP] &&
-		P_BoxOnLineSide(tmbbox, ld) == -1)
+	if (ld.backsector &&		// If thing touches two-sided pivot linedef
+		tmbbox[BOXRIGHT]  > ld.bbox[BOXLEFT]  &&
+		tmbbox[BOXLEFT]   < ld.bbox[BOXRIGHT] &&
+		tmbbox[BOXTOP]    > ld.bbox[BOXBOTTOM] &&
+		tmbbox[BOXBOTTOM] < ld.bbox[BOXTOP] &&
+		P_BoxOnLineSide(tmbbox, &ld) == -1)
 	{
 		AActor *mo = tmthing;
 
 		fixed_t dist =								// lever arm
-	  + (ld->dx >> FRACBITS) * (mo->y >> FRACBITS)
-	  - (ld->dy >> FRACBITS) * (mo->x >> FRACBITS)
-	  - (ld->dx >> FRACBITS) * (ld->v1->y >> FRACBITS)
-	  + (ld->dy >> FRACBITS) * (ld->v1->x >> FRACBITS);
+	  + (ld.dx >> FRACBITS) * (mo->y >> FRACBITS)
+	  - (ld.dy >> FRACBITS) * (mo->x >> FRACBITS)
+	  - (ld.dx >> FRACBITS) * (ld.v1->y >> FRACBITS)
+	  + (ld.dy >> FRACBITS) * (ld.v1->x >> FRACBITS);
 
 		if (dist < 0 ?								// dropoff direction
-			P_FloorHeight(mo->x, mo->y, ld->frontsector) < mo->z &&
-			P_FloorHeight(mo->x, mo->y, ld->backsector) >= mo->z :
-				P_FloorHeight(mo->x, mo->y, ld->backsector) < mo->z &&
-				P_FloorHeight(mo->x, mo->y, ld->frontsector) >= mo->z)
+			P_FloorHeight(mo->x, mo->y, ld.frontsector) < mo->z &&
+			P_FloorHeight(mo->x, mo->y, ld.backsector) >= mo->z :
+				P_FloorHeight(mo->x, mo->y, ld.backsector) < mo->z &&
+				P_FloorHeight(mo->x, mo->y, ld.frontsector) >= mo->z)
 		{
 		// At this point, we know that the object straddles a two-sided
 		// linedef, and that the object's center of mass is above-ground.
 
-			fixed_t x = abs(ld->dx), y = abs(ld->dy);
+			fixed_t x = abs(ld.dx), y = abs(ld.dy);
 
 			if (y > x)
 			{
@@ -1514,8 +1543,8 @@ static bool PIT_ApplyTorque (line_t *ld)
 
 			// Apply momentum away from the pivot linedef.
 
-			x = FixedMul(ld->dy, dist);
-			y = FixedMul(ld->dx, dist);
+			x = FixedMul(ld.dy, dist);
+			y = FixedMul(ld.dx, dist);
 
 			// Avoid moving too fast all of a sudden (step into "overdrive")
 
@@ -3050,32 +3079,32 @@ CVAR_FUNC_IMPL(sv_splashfactor)
 // "bombsource" is the creature that caused the explosion at "bombspot".
 //
 
-static bool P_SplashImmune(AActor* target, AActor* spot)
+static bool P_SplashImmune(const AActor& target, const AActor& spot)
 {
 	return // not default behaviour and same group
-	    mobjinfo[target->type].splash_group != SG_DEFAULT &&
-	    mobjinfo[target->type].splash_group == mobjinfo[spot->type].splash_group;
+	    mobjinfo[target.type].splash_group != SG_DEFAULT &&
+	    mobjinfo[target.type].splash_group == mobjinfo[spot.type].splash_group;
 }
 
-static bool PIT_DoomRadiusAttack(AActor* thing)
+static bool PIT_DoomRadiusAttack(AActor& thing)
 {
-	if (!serverside || !(thing->flags & (MF_SHOOTABLE | MF_BOUNCES)))
+	if (!serverside || !(thing.flags & (MF_SHOOTABLE | MF_BOUNCES)))
 		return true;
 
 	// MBF21
-	if (P_SplashImmune(thing, bombspot))
+	if (P_SplashImmune(thing, *bombspot))
 		return true;
 
 	// Boss spider and cyborg
 	// take no damage from concussion.
-	if (((thing->type == MT_CYBORG && bombsource->type == MT_CYBORG) ||
-		(thing->flags3 & MF3_NORADIUSDMG || thing->flags2 & MF2_BOSS)) &&
+	if (((thing.type == MT_CYBORG && bombsource->type == MT_CYBORG) ||
+		(thing.flags3 & MF3_NORADIUSDMG || thing.flags2 & MF2_BOSS)) &&
 		!(bombspot->flags3 & MF3_FORCERADIUSDMG))
 		return true;
 
-	fixed_t dx = abs(thing->x - bombspot->x);
-	fixed_t dy = abs(thing->y - bombspot->y);
-	fixed_t dist = (MAX(dx, dy) - thing->radius) >> FRACBITS;
+	fixed_t dx = abs(thing.x - bombspot->x);
+	fixed_t dy = abs(thing.y - bombspot->y);
+	fixed_t dist = (MAX(dx, dy) - thing.radius) >> FRACBITS;
 
 	if (dist < 0)
 		dist = 0;
@@ -3091,7 +3120,7 @@ static bool PIT_DoomRadiusAttack(AActor* thing)
 		return true; // out of range
 	}
 
-	if (P_CheckSight(thing, bombspot))
+	if (P_CheckSight(&thing, bombspot))
 	{
 		int damage;
 
@@ -3101,7 +3130,7 @@ static bool PIT_DoomRadiusAttack(AActor* thing)
 			damage = (bombdamage * (bombdistance - dist) / bombdistance) + 1;
 
 		// must be in direct path
-		P_DamageMobj(thing, bombspot, bombsource, damage * sv_splashfactor, bombmod);
+		P_DamageMobj(&thing, bombspot, bombsource, damage * sv_splashfactor, bombmod);
 	}
 
 	return true;
@@ -3114,19 +3143,19 @@ static bool PIT_DoomRadiusAttack(AActor* thing)
 // "bombsource" is the creature that caused the explosion at "bombspot".
 // [RH] Now it knows about vertical distances and can thrust things vertically, too.
 //
-static bool PIT_ZDoomRadiusAttack(AActor* thing)
+static bool PIT_ZDoomRadiusAttack(AActor& thing)
 {
-	if (!serverside || !(thing->flags & (MF_SHOOTABLE | MF_BOUNCES)))
+	if (!serverside || !(thing.flags & (MF_SHOOTABLE | MF_BOUNCES)))
 		return true;
 
 	// MBF21
-	if (P_SplashImmune(thing, bombspot))
+	if (P_SplashImmune(thing, *bombspot))
 		return true;
 
 	// Boss spider and cyborg
 	// take no damage from concussion.
-	if (((thing->type == MT_CYBORG && bombsource->type == MT_CYBORG) ||
-	   (thing->flags3 & MF3_NORADIUSDMG || thing->flags2 & MF2_BOSS)) &&
+	if (((thing.type == MT_CYBORG && bombsource->type == MT_CYBORG) ||
+	   (thing.flags3 & MF3_NORADIUSDMG || thing.flags2 & MF2_BOSS)) &&
 	   !(bombspot->flags3 & MF3_FORCERADIUSDMG))
 		return true;
 
@@ -3134,27 +3163,27 @@ static bool PIT_ZDoomRadiusAttack(AActor* thing)
 	// them far too "active." BossBrains also use the old code
 	// because some user levels require they have a height of 16,
 	// which can make them near impossible to hit with the new code.
-	if (bombspot->type == MT_BARREL || thing->type == MT_BARREL ||
-		thing->type == MT_BOSSBRAIN)
+	if (bombspot->type == MT_BARREL || thing.type == MT_BARREL ||
+		thing.type == MT_BOSSBRAIN)
 	{
 		return PIT_DoomRadiusAttack(thing);
 	}
 
 	// [RH] New code. The bounding box only covers the
 	// height of the thing and not the height of the map.
-	fixed_t dx = abs(thing->x - bombspot->x);
-	fixed_t dy = abs(thing->y - bombspot->y);
+	fixed_t dx = abs(thing.x - bombspot->x);
+	fixed_t dy = abs(thing.y - bombspot->y);
 	float len = float(MAX(dx, dy));
-	float boxradius = float(thing->radius);
+	float boxradius = float(thing.radius);
 
-	if (bombspot->z < thing->z || bombspot->z >= thing->z + thing->height)
+	if (bombspot->z < thing.z || bombspot->z >= thing.z + thing.height)
 	{
 		float dz;
 
-		if (bombspot->z > thing->z)
-			dz = float(thing->z + thing->height - bombspot->z);
+		if (bombspot->z > thing.z)
+			dz = float(thing.z + thing.height - bombspot->z);
 		else
-			dz = float(thing->z - bombspot->z);
+			dz = float(thing.z - bombspot->z);
 
 		if (len <= boxradius)
 			len = dz;
@@ -3177,32 +3206,32 @@ static bool PIT_ZDoomRadiusAttack(AActor* thing)
 	else
 		points = (bombdamage * (bombdistance - (len / FRACUNIT)) / bombdistance) + 1.0f;
 
-	if (thing == bombsource)
+	if (&thing == bombsource)
 		points *= sv_splashfactor;
 
-	if (points > 0.0f && P_CheckSight(thing, bombspot))
+	if (points > 0.0f && P_CheckSight(&thing, bombspot))
 	{
 		// OK to damage; target is in direct path
 
-		fixed_t momx = thing->momx;
-		fixed_t momy = thing->momy;
+		fixed_t momx = thing.momx;
+		fixed_t momy = thing.momy;
 		int damage = (int)points;
 
-		P_DamageMobj(thing, bombspot, bombsource, damage, bombmod);
+		P_DamageMobj(&thing, bombspot, bombsource, damage, bombmod);
 
-		float thrust = points * 0.5f / thing->info->mass;
-		if (bombsource == thing)
+		float thrust = points * 0.5f / thing.info->mass;
+		if (bombsource == &thing)
 			thrust *= selfthrustscale;
 
-		float momz = (float)(thing->z + (thing->height>>1) - bombspot->z) * thrust;
-		if (bombsource != thing)
+		float momz = (float)(thing.z + (thing.height>>1) - bombspot->z) * thrust;
+		if (bombsource != &thing)
 			momz *= 0.5f;
 		else
 			momz *= 0.8f;
 
-		thing->momx = momx + (fixed_t)((thing->x - bombspot->x) * thrust);
-		thing->momy = momy + (fixed_t)((thing->y - bombspot->y) * thrust);
-		thing->momz += (fixed_t)momz;
+		thing.momx = momx + (fixed_t)((thing.x - bombspot->x) * thrust);
+		thing.momy = momy + (fixed_t)((thing.y - bombspot->y) * thrust);
+		thing.momz += (fixed_t)momz;
 	}
 	else
 	{
@@ -3245,7 +3274,7 @@ void P_RadiusAttack(AActor *spot, AActor *source, int damage, int distance,
 	}
 
 	// decide which radius attack function to use
-	bool (*pAttackFunc)(AActor*) = co_zdoomphys ?
+	bool (*pAttackFunc)(AActor&) = co_zdoomphys ?
 		PIT_ZDoomRadiusAttack : PIT_DoomRadiusAttack;
 
 	if (co_blockmapfix)
@@ -3271,14 +3300,14 @@ void P_RadiusAttack(AActor *spot, AActor *source, int damage, int distance,
 
 		for (const auto& actor : actorset)
 		{
-			pAttackFunc(actor);
+			pAttackFunc(*actor);
 		}
 	}
 	else
 	{
 		for (int y=yl ; y<=yh ; y++)
 			for (int x=xl ; x<=xh ; x++)
-				P_BlockThingsIterator (x, y, pAttackFunc);
+				P_BlockThingsIterator (x, y, pAttackFunc, nullptr);
 	}
 }
 
@@ -3303,28 +3332,28 @@ bool 	nofit;
 //
 // PIT_ChangeSector
 //
-bool PIT_ChangeSector (AActor *thing)
+bool PIT_ChangeSector (AActor& thing)
 {
-	if (P_ThingHeightClip (thing))
+	if (P_ThingHeightClip (&thing))
 	{
 		// keep checking
 		return true;
 	}
 
 	// GhostlyDeath -- if it's a spectator, keep checking
-	if (thing->player && thing->player->spectator)
+	if (thing.player && thing.player->spectator)
 		return true;
 
 	// crunch bodies to giblets
-	if (thing->health <= 0)
+	if (thing.health <= 0)
 	{
-		P_SetMobjState (thing, S_GIBS);
-		thing->effects = 0;
+		P_SetMobjState (&thing, S_GIBS);
+		thing.effects = 0;
 
 		// [Nes] - Classic demo compatability: Ghost monster bug.
 		if ((demoplayback)) {
-			thing->height = 0;
-			thing->radius = 0;
+			thing.height = 0;
+			thing.radius = 0;
 		}
 
 		// keep checking
@@ -3332,22 +3361,22 @@ bool PIT_ChangeSector (AActor *thing)
 	}
 
 	// crunch dropped items
-	if (thing->flags & MF_DROPPED)
+	if (thing.flags & MF_DROPPED)
 	{
-		thing->Destroy ();
+		thing.Destroy ();
 
 		// keep checking
 		return true;
 	}
 
 	/* killough 11/98: kill touchy things immediately */
-	if (thing->flags & MF_TOUCHY && (thing->oflags & MFO_ARMED || sentient(thing)))
+	if (thing.flags & MF_TOUCHY && (thing.oflags & MFO_ARMED || sentient(&thing)))
 	{
-		P_DamageMobj(thing, NULL, NULL, thing->health); // kill object
+		P_DamageMobj(&thing, NULL, NULL, thing.health); // kill object
 		return true;                                    // keep checking
 	}
 
-	if (! (thing->flags & MF_SHOOTABLE) )
+	if (! (thing.flags & MF_SHOOTABLE) )
 	{
 		// assume it is bloody gibs or something
 		return true;
@@ -3357,14 +3386,14 @@ bool PIT_ChangeSector (AActor *thing)
 
 	if (crushchange > 0 && !(level.time&3) )
 	{
-		P_DamageMobj(thing, NULL, NULL, crushchange, MOD_CRUSH);
+		P_DamageMobj(&thing, NULL, NULL, crushchange, MOD_CRUSH);
 
 		// spray blood in a random direction
-		if (!(thing->flags&MF_NOBLOOD))
+		if (!(thing.flags&MF_NOBLOOD))
 		{
-			AActor *mo = new AActor (thing->x,
-									 thing->y,
-									 thing->z + thing->height/2, MT_BLOOD);
+			AActor *mo = new AActor (thing.x,
+									 thing.y,
+									 thing.z + thing.height/2, MT_BLOOD);
 
 			mo->momx = P_RandomDiff (mo) << 12;
 			mo->momy = P_RandomDiff (mo) << 12;
@@ -3414,7 +3443,7 @@ bool P_ChangeSector (sector_t *sector, int crunch)
 				{
 					n->visited	= true; 						// mark thing as processed
 					if (n->m_thing && !(n->m_thing->flags & MF_NOBLOCKMAP))	// [Blair] Add nullcheck here
-						PIT_ChangeSector(n->m_thing); 						// for clients that aren't updated yet.
+						PIT_ChangeSector(*n->m_thing); 						// for clients that aren't updated yet.
 					break;										// exit and start over
 				}
 		while (n);	// repeat from scratch until all things left are marked valid
@@ -3426,7 +3455,7 @@ bool P_ChangeSector (sector_t *sector, int crunch)
 		// re-check heights for all things near the moving sector
 		for (x=sector->blockbox[BOXLEFT] ; x<= sector->blockbox[BOXRIGHT] ; x++)
 			for (y=sector->blockbox[BOXBOTTOM];y<= sector->blockbox[BOXTOP] ; y++)
-				P_BlockThingsIterator (x, y, PIT_ChangeSector);
+				P_BlockThingsIterator (x, y, PIT_ChangeSector, nullptr);
 
 	}
 
@@ -3577,15 +3606,15 @@ void P_DelSeclist (msecnode_t *node)
 // at this location, so don't bother with checking impassable or
 // blocking lines.
 
-bool PIT_GetSectors (line_t *ld)
+bool PIT_GetSectors (const line_t& ld)
 {
-	if (tmbbox[BOXRIGHT]	  <= ld->bbox[BOXLEFT]	 ||
-			tmbbox[BOXLEFT]   >= ld->bbox[BOXRIGHT]  ||
-			tmbbox[BOXTOP]	  <= ld->bbox[BOXBOTTOM] ||
-			tmbbox[BOXBOTTOM] >= ld->bbox[BOXTOP])
+	if (tmbbox[BOXRIGHT]	  <= ld.bbox[BOXLEFT]	 ||
+			tmbbox[BOXLEFT]   >= ld.bbox[BOXRIGHT]  ||
+			tmbbox[BOXTOP]	  <= ld.bbox[BOXBOTTOM] ||
+			tmbbox[BOXBOTTOM] >= ld.bbox[BOXTOP])
 		return true;
 
-	if (P_BoxOnLineSide (tmbbox, ld) != -1)
+	if (P_BoxOnLineSide (tmbbox, &ld) != -1)
 		return true;
 
 	// This line crosses through the object.
@@ -3595,7 +3624,7 @@ bool PIT_GetSectors (line_t *ld)
 	// allowed to move to this position, then the sector_list
 	// will be attached to the Thing's AActor at touching_sectorlist.
 
-	sector_list = P_AddSecnode (ld->frontsector,tmthing,sector_list);
+	sector_list = P_AddSecnode (ld.frontsector,tmthing,sector_list);
 
 	// Don't assume all lines are 2-sided, since some Things
 	// like MT_TFOG are allowed regardless of whether their radius takes
@@ -3604,8 +3633,8 @@ bool PIT_GetSectors (line_t *ld)
 	// killough 3/27/98, 4/4/98:
 	// Use sidedefs instead of 2s flag to determine two-sidedness.
 
-	if (ld->backsector)
-		sector_list = P_AddSecnode(ld->backsector, tmthing, sector_list);
+	if (ld.backsector)
+		sector_list = P_AddSecnode(ld.backsector, tmthing, sector_list);
 
 	return true;
 }

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -1173,15 +1173,12 @@ bool P_CheckPosition (AActor *thing, fixed_t x, fixed_t y)
 
 AActor *P_CheckOnmobj (AActor *thing)
 {
-	fixed_t oldz;
-	bool good;
-
-	oldz = thing->z;
+	const fixed_t oldz = thing->z;
 	P_FakeZMovement (thing);
-	good = P_TestMobjZ (thing);
+	const bool good = P_TestMobjZ (thing);
 	thing->z = oldz;
 
-	return good ? NULL : onmobj;
+	return good ? nullptr : onmobj;
 }
 
 bool P_TestMobjZ (AActor *actor)
@@ -3346,13 +3343,11 @@ void P_RadiusAttack(AActor *spot, AActor *source, int damage, int distance,
 //  the way it was and call P_ChangeSector again
 //  to undo the changes.
 //
-int		crushchange;
-bool 	nofit;
 
 //
 // PIT_ChangeSector
 //
-bool PIT_ChangeSector (AActor& thing)
+bool PIT_ChangeSector (AActor& thing, const int crushchange, bool& nofit)
 {
 	if (P_ThingHeightClip (&thing))
 	{
@@ -3436,8 +3431,7 @@ bool P_ChangeSector (sector_t *sector, int crunch)
 	if (!sector)
 		return true;
 
-	nofit = false;
-	crushchange = crunch;
+	bool nofit = false;
 
 	// [ML] co_boomsectortouch now part of co_boomphys
 	if (co_boomphys)
@@ -3463,19 +3457,17 @@ bool P_ChangeSector (sector_t *sector, int crunch)
 				{
 					n->visited	= true; 						// mark thing as processed
 					if (n->m_thing && !(n->m_thing->flags & MF_NOBLOCKMAP))	// [Blair] Add nullcheck here
-						PIT_ChangeSector(*n->m_thing); 						// for clients that aren't updated yet.
+						PIT_ChangeSector(*n->m_thing, crunch, nofit); 						// for clients that aren't updated yet.
 					break;										// exit and start over
 				}
 		while (n);	// repeat from scratch until all things left are marked valid
 	}
 	else
 	{
-		int x, y;
-
 		// re-check heights for all things near the moving sector
-		for (x=sector->blockbox[BOXLEFT] ; x<= sector->blockbox[BOXRIGHT] ; x++)
-			for (y=sector->blockbox[BOXBOTTOM];y<= sector->blockbox[BOXTOP] ; y++)
-				P_BlockThingsIterator (x, y, PIT_ChangeSector, nullptr);
+		for (int x=sector->blockbox[BOXLEFT] ; x<= sector->blockbox[BOXRIGHT] ; x++)
+			for (int y=sector->blockbox[BOXBOTTOM];y<= sector->blockbox[BOXTOP] ; y++)
+				P_BlockThingsIterator (x, y, PIT_ChangeSector, nullptr, crunch, nofit);
 
 	}
 

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3075,14 +3075,6 @@ void P_UseLines (player_t& player)
 //
 // RADIUS ATTACK
 //
-static AActor* 		bombsource;
-static AActor* 		bombspot;
-static int			bombdamage;
-static float		bombdamagefloat;
-static int			bombdistance;
-static float		bombdistancefloat;
-static bool			DamageSource;
-static int			bombmod;
 
 // [RH] Damage scale to apply to thing that shot the missile. (co_zdoomphys)
 static float selfthrustscale;
@@ -3108,7 +3100,15 @@ bool P_SplashImmune(const AActor& target, const AActor& spot)
 	    mobjinfo[target.type].splash_group == mobjinfo[spot.type].splash_group;
 }
 
-bool PIT_DoomRadiusAttack(AActor& thing)
+bool PIT_DoomRadiusAttack(AActor& thing,
+                          AActor* bombsource,
+                          const AActor* bombspot,
+                          const int bombdamage,
+                          const float bombdamagefloat,
+                          const int bombdistance,
+                          const float bombdistancefloat,
+                          const bool DamageSource,
+                          const int bombmod)
 {
 	if (!serverside || !(thing.flags & (MF_SHOOTABLE | MF_BOUNCES)))
 		return true;
@@ -3162,7 +3162,15 @@ bool PIT_DoomRadiusAttack(AActor& thing)
 // "bombsource" is the creature that caused the explosion at "bombspot".
 // [RH] Now it knows about vertical distances and can thrust things vertically, too.
 //
-bool PIT_ZDoomRadiusAttack(AActor& thing)
+bool PIT_ZDoomRadiusAttack(AActor& thing,
+                           AActor* bombsource,
+                           const AActor* bombspot,
+                           const int bombdamage,
+                           const float bombdamagefloat,
+                           const int bombdistance,
+                           const float bombdistancefloat,
+                           const bool DamageSource,
+                           const int bombmod)
 {
 	if (!serverside || !(thing.flags & (MF_SHOOTABLE | MF_BOUNCES)))
 		return true;
@@ -3185,7 +3193,7 @@ bool PIT_ZDoomRadiusAttack(AActor& thing)
 	if (bombspot->type == MT_BARREL || thing.type == MT_BARREL ||
 		thing.type == MT_BOSSBRAIN)
 	{
-		return PIT_DoomRadiusAttack(thing);
+		return PIT_DoomRadiusAttack(thing, bombsource, bombspot, bombdamage, bombdamagefloat, bombdistance, bombdistancefloat, DamageSource, bombmod);
 	}
 
 	// [RH] New code. The bounding box only covers the
@@ -3272,28 +3280,23 @@ bool PIT_ZDoomRadiusAttack(AActor& thing)
 void P_RadiusAttack(AActor *spot, AActor *source, int damage, int distance,
 	bool hurtSource, int mod)
 {
-	fixed_t dist = (distance+MAXRADIUS)<<FRACBITS;
-	int yh = MIN<int>((spot->y + dist - bmaporgy)>>MAPBLOCKSHIFT, bmapheight - 1);
-	int yl = MAX<int>((spot->y - dist - bmaporgy)>>MAPBLOCKSHIFT, 0);
-	int xh = MIN<int>((spot->x + dist - bmaporgx)>>MAPBLOCKSHIFT, bmapwidth - 1);
-	int xl = MAX<int>((spot->x - dist - bmaporgx)>>MAPBLOCKSHIFT, 0);
-	bombspot = spot;
-	bombsource = source;
-	bombdamage = damage;
-	bombdamagefloat = (float)damage;
-	bombdistance = distance;
-	bombdistancefloat = 1.f / (float)distance;
-	DamageSource = hurtSource;
-	bombmod = mod;
+	const fixed_t dist = (distance+MAXRADIUS)<<FRACBITS;
+	const int yh = std::min<int>((spot->y + dist - bmaporgy)>>MAPBLOCKSHIFT, bmapheight - 1);
+	const int yl = std::max<int>((spot->y - dist - bmaporgy)>>MAPBLOCKSHIFT, 0);
+	const int xh = std::min<int>((spot->x + dist - bmaporgx)>>MAPBLOCKSHIFT, bmapwidth - 1);
+	const int xl = std::max<int>((spot->x - dist - bmaporgx)>>MAPBLOCKSHIFT, 0);
+	AActor* bombsource = source;
+	const auto bombdamagefloat = (float)damage;
+	const float bombdistancefloat = 1.f / (float)distance;
 
 	// [Blair] Prevent crash from barrels hit by crushers
-	if (!demoplayback && bombsource == NULL && bombspot != NULL)
+	if (!demoplayback && bombsource == nullptr && spot != nullptr)
 	{
-		bombsource = bombspot;
+		bombsource = spot;
 	}
 
 	// decide which radius attack function to use
-	bool (*pAttackFunc)(AActor&) = co_zdoomphys ?
+	const auto pAttackFunc = co_zdoomphys ?
 		PIT_ZDoomRadiusAttack : PIT_DoomRadiusAttack;
 
 	if (co_blockmapfix)
@@ -3319,14 +3322,14 @@ void P_RadiusAttack(AActor *spot, AActor *source, int damage, int distance,
 
 		for (const auto& actor : actorset)
 		{
-			pAttackFunc(*actor);
+			pAttackFunc(*actor, spot, bombsource, damage, bombdamagefloat, distance, bombdistancefloat, hurtSource, mod);
 		}
 	}
 	else
 	{
 		for (int y=yl ; y<=yh ; y++)
 			for (int x=xl ; x<=xh ; x++)
-				P_BlockThingsIterator (x, y, pAttackFunc, nullptr);
+				P_BlockThingsIterator (x, y, pAttackFunc, nullptr, spot, bombsource, damage, bombdamagefloat, distance, bombdistancefloat, hurtSource, mod);
 	}
 }
 

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3102,10 +3102,10 @@ bool PIT_DoomRadiusAttack(AActor& thing,
                           AActor* bombsource,
                           const AActor* bombspot,
                           const int bombdamage,
-                          const float bombdamagefloat,
+                          const float /*bombdamagefloat*/,
                           const int bombdistance,
-                          const float bombdistancefloat,
-                          const bool DamageSource,
+                          const float /*bombdistancefloat*/,
+                          const bool /*DamageSource*/,
                           const int bombmod)
 {
 	if (!serverside || !(thing.flags & (MF_SHOOTABLE | MF_BOUNCES)))
@@ -3320,14 +3320,14 @@ void P_RadiusAttack(AActor *spot, AActor *source, int damage, int distance,
 
 		for (const auto& actor : actorset)
 		{
-			pAttackFunc(*actor, spot, bombsource, damage, bombdamagefloat, distance, bombdistancefloat, hurtSource, mod);
+			pAttackFunc(*actor, bombsource, spot, damage, bombdamagefloat, distance, bombdistancefloat, hurtSource, mod);
 		}
 	}
 	else
 	{
 		for (int y=yl ; y<=yh ; y++)
 			for (int x=xl ; x<=xh ; x++)
-				P_BlockThingsIterator (x, y, pAttackFunc, nullptr, spot, bombsource, damage, bombdamagefloat, distance, bombdistancefloat, hurtSource, mod);
+				P_BlockThingsIterator (x, y, pAttackFunc, nullptr, bombsource, spot, damage, bombdamagefloat, distance, bombdistancefloat, hurtSource, mod);
 	}
 }
 
@@ -3406,7 +3406,7 @@ bool PIT_ChangeSector (AActor& thing)
 
 	if (crushchange > 0 && !(level.time&3) )
 	{
-		P_DamageMobj(&thing, NULL, NULL, crushchange, MOD_CRUSH);
+		P_DamageMobj(&thing, nullptr, nullptr, crushchange, MOD_CRUSH);
 
 		// spray blood in a random direction
 		if (!(thing.flags&MF_NOBLOOD))

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -120,9 +120,7 @@ CVAR_FUNC_IMPL (sv_gravity)
 //
 // PIT_StompThing
 //
-static bool StompAlwaysFrags;
-
-bool PIT_StompThing (AActor& thing)
+bool PIT_StompThing (AActor& thing, const bool StompAlwaysFrags)
 {
 	fixed_t blockdist;
 
@@ -244,8 +242,8 @@ bool P_TeleportMove (AActor *thing, fixed_t x, fixed_t y, fixed_t z, bool telefr
 	validcount++;
 	spechit.clear();
 
-	StompAlwaysFrags = P_IsPlayerOrAvatar(*tmthing) ||
-	                   (level.flags & LEVEL_MONSTERSTELEFRAG) || telefrag;
+	const bool StompAlwaysFrags = P_IsPlayerOrAvatar(*tmthing) ||
+	                              (level.flags & LEVEL_MONSTERSTELEFRAG) || telefrag;
 
 	// stomp on any things contacted
 	xl = (tmbbox[BOXLEFT] - bmaporgx - MAXRADIUS)>>MAPBLOCKSHIFT;
@@ -255,7 +253,7 @@ bool P_TeleportMove (AActor *thing, fixed_t x, fixed_t y, fixed_t z, bool telefr
 
 	for (bx=xl ; bx<=xh ; bx++)
 		for (by=yl ; by<=yh ; by++)
-			if (!P_BlockThingsIterator(bx,by,PIT_StompThing, nullptr))
+			if (!P_BlockThingsIterator(bx,by,PIT_StompThing, nullptr, StompAlwaysFrags))
 				return false;
 
 	// the move is ok,

--- a/common/p_maputl.cpp
+++ b/common/p_maputl.cpp
@@ -632,114 +632,6 @@ void AActor::SetOrigin (fixed_t ix, fixed_t iy, fixed_t iz)
 	LinkToWorld ();
 }
 
-
-//
-// BLOCK MAP ITERATORS
-// For each line/thing in the given mapblock,
-// call the passed PIT_* function.
-// If the function returns false,
-// exit with false without checking anything else.
-//
-
-
-//
-// P_BlockLinesIterator
-// The validcount flags are used to avoid checking lines
-// that are marked in multiple mapblocks,
-// so increment validcount before the first call
-// to P_BlockLinesIterator, then make one or more calls
-// to it.
-//
-extern polyblock_t **PolyBlockMap;
-
-bool P_BlockLinesIterator (int x, int y, bool(*func)(line_t*))
-{
-	if (x<0 || y<0 || x>=bmapwidth || y>=bmapheight)
-		return true;
-
-	int offset = *(blockmap + (bmapwidth*y + x));
-	int *list = blockmaplump + offset;
-
-	/* [RH] Polyobj stuff from Hexen --> */
-	polyblock_t *polyLink;
-
-	offset = y*bmapwidth + x;
-	if (PolyBlockMap)
-	{
-		polyLink = PolyBlockMap[offset];
-
-		while (polyLink)
-		{
-			if (polyLink->polyobj && polyLink->polyobj->validcount != validcount)
-			{
-				int i;
-				seg_t **tempSeg = polyLink->polyobj->segs;
-				polyLink->polyobj->validcount = validcount;
-
-				for (i = polyLink->polyobj->numsegs; i; i--, tempSeg++)
-				{
-					if ((*tempSeg)->linedef->validcount != validcount)
-					{
-						(*tempSeg)->linedef->validcount = validcount;
-						if (!func ((*tempSeg)->linedef))
-							return false;
-					}
-				}
-			}
-			polyLink = polyLink->next;
-		}
-	}
-	/* <-- Polyobj stuff from Hexen */
-
-	// [RH] Get past starting 0 (from BOOM)
-	// denis - not so fast, this breaks doom1.wad 1.9 demo1
-	// [SL] The first entry in each block list appears to have been intended to
-	// be used for a special purpose but instead contains garbage (most often
-	// referencing linedef 0). Using this first entry (as vanilla Doom does) can
-	// cause hitscan weapons to erroneously hit the first linedef entry regardless
-	// of where that linedef is located in relation to the block.
-	if (!demoplayback && skipblstart)
-		++list;
-
-	for (; *list != -1; list++)
-	{
-		line_t *ld = &lines[*list];
-
-		if (ld->validcount != validcount) {
-			ld->validcount = validcount;
-
-			if ( !func(ld) )
-				return false;
-		}
-	}
-
-	return true;		// everything was checked
-}
-
-
-//
-// P_BlockThingsIterator
-//
-bool P_BlockThingsIterator (int x, int y, bool(*func)(AActor*), AActor *actor)
-{
-	if (x<0 || y<0 || x>=bmapwidth || y>=bmapheight)
-		return true;
-	else
- 	{
-		AActor *mobj = (actor != NULL ? actor : blocklinks[y*bmapwidth+x]);
-		while (mobj)
- 		{
- 			if (!func (mobj))
- 				return false;
-
-			mobj = mobj->bmapnode.Next(x, y);
-		}
-	}
-	return true;
-}
-
-
-
 //
 // INTERCEPT ROUTINES
 //
@@ -760,11 +652,10 @@ int 			ptflags;
 // are on opposite sides of the trace.
 // Returns true if earlyout and a solid line hit.
 //
-bool PIT_AddLineIntercepts (line_t *ld)
+bool PIT_AddLineIntercepts (line_t& ld)
 {
 	int 				s1;
 	int 				s2;
-	fixed_t 			frac;
 	divline_t			dl;
 
 	// avoid precision problems with two routines
@@ -773,21 +664,21 @@ bool PIT_AddLineIntercepts (line_t *ld)
 		 || trace.dx < -FRACUNIT*16
 		 || trace.dy < -FRACUNIT*16)
 	{
-		s1 = P_PointOnDivlineSide (ld->v1->x, ld->v1->y, &trace);
-		s2 = P_PointOnDivlineSide (ld->v2->x, ld->v2->y, &trace);
+		s1 = P_PointOnDivlineSide (ld.v1->x, ld.v1->y, &trace);
+		s2 = P_PointOnDivlineSide (ld.v2->x, ld.v2->y, &trace);
 	}
 	else
 	{
-		s1 = P_PointOnLineSide (trace.x, trace.y, ld);
-		s2 = P_PointOnLineSide (trace.x+trace.dx, trace.y+trace.dy, ld);
+		s1 = P_PointOnLineSide (trace.x, trace.y, &ld);
+		s2 = P_PointOnLineSide (trace.x+trace.dx, trace.y+trace.dy, &ld);
 	}
 
 	if (s1 == s2)
 		return true;	// line isn't crossed
 
 	// hit the line
-	P_MakeDivline (ld, &dl);
-	frac = P_InterceptVector (&trace, &dl);
+	P_MakeDivline (&ld, &dl);
+	const fixed_t frac = P_InterceptVector (&trace, &dl);
 
 	if (frac < 0)
 		return true;	// behind source
@@ -795,7 +686,7 @@ bool PIT_AddLineIntercepts (line_t *ld)
 	// try to early out the check
 	if (earlyout
 		&& frac < FRACUNIT
-		&& !ld->backsector)
+		&& !ld.backsector)
 	{
 		return false;	// stop checking
 	}
@@ -804,7 +695,7 @@ bool PIT_AddLineIntercepts (line_t *ld)
 	intercept_t intercept;
 	intercept.frac = frac;
 	intercept.isaline = true;
-	intercept.d.line = ld;
+	intercept.d.line = &ld;
 	intercepts.push_back(intercept);
 
 	return true;		// continue
@@ -815,7 +706,7 @@ bool PIT_AddLineIntercepts (line_t *ld)
 //
 // PIT_AddThingIntercepts
 //
-bool PIT_AddThingIntercepts (AActor* thing)
+bool PIT_AddThingIntercepts (AActor& thing)
 {
 	fixed_t 		x1;
 	fixed_t 		y1;
@@ -836,19 +727,19 @@ bool PIT_AddThingIntercepts (AActor* thing)
 	// check a corner to corner crossection for hit
 	if (tracepositive)
 	{
-		x1 = thing->x - thing->radius;
-		y1 = thing->y + thing->radius;
+		x1 = thing.x - thing.radius;
+		y1 = thing.y + thing.radius;
 
-		x2 = thing->x + thing->radius;
-		y2 = thing->y - thing->radius;
+		x2 = thing.x + thing.radius;
+		y2 = thing.y - thing.radius;
 	}
 	else
 	{
-		x1 = thing->x - thing->radius;
-		y1 = thing->y - thing->radius;
+		x1 = thing.x - thing.radius;
+		y1 = thing.y - thing.radius;
 
-		x2 = thing->x + thing->radius;
-		y2 = thing->y + thing->radius;
+		x2 = thing.x + thing.radius;
+		y2 = thing.y + thing.radius;
 	}
 
 	s1 = P_PointOnDivlineSide (x1, y1, &trace);
@@ -870,7 +761,7 @@ bool PIT_AddThingIntercepts (AActor* thing)
 	intercept_t intercept;
 	intercept.frac = frac;
 	intercept.isaline = false;
-	intercept.d.thing = thing;
+	intercept.d.thing = &thing;
 	intercepts.push_back(intercept);
 
 	return true;				// keep going
@@ -1031,7 +922,7 @@ bool P_PathTraverse (fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2, int flags, 
 
 		if (flags & PT_ADDTHINGS)
 		{
-			if (!P_BlockThingsIterator (mapx, mapy,PIT_AddThingIntercepts))
+			if (!P_BlockThingsIterator (mapx, mapy,PIT_AddThingIntercepts, nullptr))
 				return false;	// early out
 		}
 

--- a/common/p_maputl.cpp
+++ b/common/p_maputl.cpp
@@ -639,8 +639,6 @@ void AActor::SetOrigin (fixed_t ix, fixed_t iy, fixed_t iz)
 std::vector<intercept_t> intercepts;
 
 divline_t		trace;
-bool 			earlyout;
-int 			ptflags;
 
 //
 // PIT_AddLineIntercepts.
@@ -652,7 +650,7 @@ int 			ptflags;
 // are on opposite sides of the trace.
 // Returns true if earlyout and a solid line hit.
 //
-bool PIT_AddLineIntercepts (line_t& ld)
+bool PIT_AddLineIntercepts (line_t& ld, bool earlyout)
 {
 	int 				s1;
 	int 				s2;
@@ -713,16 +711,9 @@ bool PIT_AddThingIntercepts (AActor& thing)
 	fixed_t 		x2;
 	fixed_t 		y2;
 
-	int 			s1;
-	int 			s2;
-
-	bool 			tracepositive;
-
 	divline_t		dl;
 
-	fixed_t 		frac;
-
-	tracepositive = (trace.dx ^ trace.dy)>0;
+	const bool tracepositive = (trace.dx ^ trace.dy)>0;
 
 	// check a corner to corner crossection for hit
 	if (tracepositive)
@@ -742,8 +733,8 @@ bool PIT_AddThingIntercepts (AActor& thing)
 		y2 = thing.y + thing.radius;
 	}
 
-	s1 = P_PointOnDivlineSide (x1, y1, &trace);
-	s2 = P_PointOnDivlineSide (x2, y2, &trace);
+	const int s1 = P_PointOnDivlineSide (x1, y1, &trace);
+	const int s2 = P_PointOnDivlineSide (x2, y2, &trace);
 
 	if (s1 == s2)
 		return true;			// line isn't crossed
@@ -753,7 +744,7 @@ bool PIT_AddThingIntercepts (AActor& thing)
 	dl.dx = x2-x1;
 	dl.dy = y2-y1;
 
-	frac = P_InterceptVector (&trace, &dl);
+	const fixed_t frac = P_InterceptVector (&trace, &dl);
 
 	if (frac < 0)
 		return true;			// behind source
@@ -837,7 +828,7 @@ bool P_PathTraverse (fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2, int flags, 
 
 	int 		count;
 
-	earlyout = flags & PT_EARLYOUT;
+	const bool earlyout = flags & PT_EARLYOUT;
 
 	validcount++;
 
@@ -916,7 +907,7 @@ bool P_PathTraverse (fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2, int flags, 
 	{
 		if (flags & PT_ADDLINES)
 		{
-			if (!P_BlockLinesIterator (mapx, mapy,PIT_AddLineIntercepts))
+			if (!P_BlockLinesIterator (mapx, mapy,PIT_AddLineIntercepts, earlyout))
 				return false;	// early out
 		}
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2905,7 +2905,7 @@ bool PIT_PushThing (AActor& thing)
 	{
 		int sx = tmpusher->m_X;
 		int sy = tmpusher->m_Y;
-		int dist = P_AproxDistance (thing.x - sx,thing.y - sy);
+		const int dist = P_AproxDistance (thing.x - sx,thing.y - sy);
 		int speed = (tmpusher->m_Magnitude -
 					((dist>>FRACBITS)>>1))<<(FRACBITS-PUSH_FACTOR-1);
 
@@ -2919,8 +2919,8 @@ bool PIT_PushThing (AActor& thing)
 
 		if (speed > 0 && P_IsMBFCompatMode())
 		{
-			int x = (thing.x - sx) >> FRACBITS;
-			int y = (thing.y - sy) >> FRACBITS;
+			const int x = (thing.x - sx) >> FRACBITS;
+			const int y = (thing.y - sy) >> FRACBITS;
 			speed = (int)(((uint64_t)tmpusher->m_Magnitude << 23) / (x * x + y * y + 1));
 		}
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2894,9 +2894,7 @@ DPusher::DPusher (DPusher::EPusher type, line_t *l, int magnitude, int angle,
 // tmpusher belongs to the point source (MT_PUSH/MT_PULL).
 //
 
-DPusher *tmpusher; // pusher structure for blockmap searches
-
-bool PIT_PushThing (AActor& thing)
+bool PIT_PushThing (AActor& thing, DPusher* tmpusher)
 {
 	if (!P_IsMBFCompatMode() ?
 			thing.player && !(thing.flags & (MF_NOGRAVITY | MF_NOCLIP)) :
@@ -2988,7 +2986,6 @@ void DPusher::RunThink ()
 		// Seek out all pushable things within the force radius of this
 		// point pusher. Crosses sectors, so use blockmap.
 
-		tmpusher = this; // MT_PUSH/MT_PULL point source
 		radius = m_Radius; // where force goes to zero
 		tmbbox[BOXTOP]    = m_Y + radius;
 		tmbbox[BOXBOTTOM] = m_Y - radius;
@@ -3001,7 +2998,7 @@ void DPusher::RunThink ()
 		yh = (tmbbox[BOXTOP] - bmaporgy + MAXRADIUS)>>MAPBLOCKSHIFT;
 		for (bx=xl ; bx<=xh ; bx++)
 			for (by=yl ; by<=yh ; by++)
-				P_BlockThingsIterator (bx, by, PIT_PushThing, nullptr);
+				P_BlockThingsIterator (bx, by, PIT_PushThing, nullptr, this /*MT_PUSH/MT_PULL point source*/);
 		return;
 	}
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2896,16 +2896,16 @@ DPusher::DPusher (DPusher::EPusher type, line_t *l, int magnitude, int angle,
 
 DPusher *tmpusher; // pusher structure for blockmap searches
 
-bool PIT_PushThing (AActor *thing)
+bool PIT_PushThing (AActor& thing)
 {
 	if (!P_IsMBFCompatMode() ?
-			thing->player && !(thing->flags & (MF_NOGRAVITY | MF_NOCLIP)) :
-			(sentient(thing) || thing->flags & MF_SHOOTABLE) &&
-			!(thing->flags & MF_NOCLIP))
+			thing.player && !(thing.flags & (MF_NOGRAVITY | MF_NOCLIP)) :
+			(sentient(&thing) || thing.flags & MF_SHOOTABLE) &&
+			!(thing.flags & MF_NOCLIP))
 	{
 		int sx = tmpusher->m_X;
 		int sy = tmpusher->m_Y;
-		int dist = P_AproxDistance (thing->x - sx,thing->y - sy);
+		int dist = P_AproxDistance (thing.x - sx,thing.y - sy);
 		int speed = (tmpusher->m_Magnitude -
 					((dist>>FRACBITS)>>1))<<(FRACBITS-PUSH_FACTOR-1);
 
@@ -2919,22 +2919,22 @@ bool PIT_PushThing (AActor *thing)
 
 		if (speed > 0 && P_IsMBFCompatMode())
 		{
-			int x = (thing->x - sx) >> FRACBITS;
-			int y = (thing->y - sy) >> FRACBITS;
+			int x = (thing.x - sx) >> FRACBITS;
+			int y = (thing.y - sy) >> FRACBITS;
 			speed = (int)(((uint64_t)tmpusher->m_Magnitude << 23) / (x * x + y * y + 1));
 		}
 
 		// If speed <= 0, you're outside the effective radius. You also have
 		// to be able to see the push/pull source point.
 
-		if (speed > 0 && P_CheckSight(thing, tmpusher->m_Source))
+		if (speed > 0 && P_CheckSight(&thing, tmpusher->m_Source))
 		{
-			angle_t pushangle = P_PointToAngle (thing->x, thing->y, sx, sy);
+			angle_t pushangle = P_PointToAngle (thing.x, thing.y, sx, sy);
 			if (tmpusher->m_Source->type == MT_PUSH)
 				pushangle += ANG180;    // away
 			pushangle >>= ANGLETOFINESHIFT;
-			thing->momx += FixedMul (speed, finecosine[pushangle]);
-			thing->momy += FixedMul (speed, finesine[pushangle]);
+			thing.momx += FixedMul (speed, finecosine[pushangle]);
+			thing.momy += FixedMul (speed, finesine[pushangle]);
 		}
 	}
 	return true;
@@ -3001,7 +3001,7 @@ void DPusher::RunThink ()
 		yh = (tmbbox[BOXTOP] - bmaporgy + MAXRADIUS)>>MAPBLOCKSHIFT;
 		for (bx=xl ; bx<=xh ; bx++)
 			for (by=yl ; by<=yh ; by++)
-				P_BlockThingsIterator (bx, by, PIT_PushThing);
+				P_BlockThingsIterator (bx, by, PIT_PushThing, nullptr);
 		return;
 	}
 

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -340,7 +340,7 @@ protected:
 	int m_Y         = 0;          // Y of point source if point pusher
 	int m_Affectee  = 0;          // Number of affected sector
 
-	friend bool PIT_PushThing (AActor *thing);
+	friend bool PIT_PushThing (AActor& thing);
 };
 
 inline FArchive &operator<< (FArchive &arc, DPusher::EPusher type)

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -340,7 +340,7 @@ protected:
 	int m_Y         = 0;          // Y of point source if point pusher
 	int m_Affectee  = 0;          // Number of affected sector
 
-	friend bool PIT_PushThing (AActor& thing);
+	friend bool PIT_PushThing (AActor& thing, DPusher* tmpusher);
 };
 
 inline FArchive &operator<< (FArchive &arc, DPusher::EPusher type)


### PR DESCRIPTION
This allows players to escape from being stuck inside of blocking/one-sided lines in certain cases.

MBF implements this using a global variable for passing extra information into PIT_CheckLine. To avoid that, I made the blockmap iterators into variadic templates that allow passing in additional arguments to the PIT_* functions. Because of this, I also took the opportunity to clean up many of the existing globals in the same way.

This is a partial fix to #1825, but more investigation is required to figure out the complete solution for it. See comments on #1832

I also am using this PR somewhat to test how the clang-tidy bot behaves on real PRs, so there's some changes and code cleanup related to that too.