### PR TITLE
[BUGFIX] X11 WM_CLASS/Wayland app_id not set on BSD

### DIFF
--- a/client/gui/gui_boot.cpp
+++ b/client/gui/gui_boot.cpp
@@ -633,7 +633,7 @@ scannedWADs_t GUI_BootWindow()
 	// deforms the window.
 	Fl::keyboard_screen_scaling(0);
 
-	#ifdef __linux__
+	#if !defined(__APPLE__) && !defined(_WIN32)
 	Fl_Window::default_xclass("net.odamex.Odamex.Client");
 	#endif
 

--- a/client/sdl/i_main.cpp
+++ b/client/sdl/i_main.cpp
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
 			}
 		}
 
-#if defined(__linux__) && defined(SDL20)
+#if !defined(__APPLE__) && !defined(_WIN32) && defined(SDL20)
 		// despite the name, this also sets wayland app id
 		SDL_setenv("SDL_VIDEO_X11_WMCLASS", "net.odamex.Odamex.Client", false);
 #endif

--- a/odalaunch/src/main.cpp
+++ b/odalaunch/src/main.cpp
@@ -43,7 +43,7 @@ IMPLEMENT_APP(Application)
 
 bool Application::OnInit()
 {
-	#ifdef __linux__
+	#if !defined(__APPLE__) && !defined(_WIN32)
 	SetClassName("net.odamex.Odamex.Launcher");
 	#endif
 


### PR DESCRIPTION
Set them for everything but Windows and macOS instead of only for Linux