### PR TITLE
Remove STACK_ARGS

### DIFF
--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -675,7 +675,7 @@ bool I_InitInput()
 //
 // I_ShutdownInput
 //
-void STACK_ARGS I_ShutdownInput()
+void I_ShutdownInput()
 {
 	input_subsystem->disableTextEntry();
 

--- a/client/sdl/i_input.h
+++ b/client/sdl/i_input.h
@@ -34,7 +34,7 @@
 #define MOUSE_ZDOOM_DI 1
 
 bool I_InitInput (void);
-void STACK_ARGS I_ShutdownInput (void);
+void I_ShutdownInput (void);
 void I_ForceUpdateGrab();
 void I_FlushInput();
 

--- a/client/sdl/i_input.h
+++ b/client/sdl/i_input.h
@@ -34,7 +34,7 @@
 #define MOUSE_ZDOOM_DI 1
 
 bool I_InitInput (void);
-void I_ShutdownInput (void);
+void I_ShutdownInput ();
 void I_ForceUpdateGrab();
 void I_FlushInput();
 

--- a/client/sdl/i_main.cpp
+++ b/client/sdl/i_main.cpp
@@ -62,29 +62,29 @@
 EXTERN_CVAR (r_centerwindow)
 
 // functions to be called at shutdown are stored in this stack
-typedef void (STACK_ARGS *term_func_t)(void);
+using term_func_t = void (*)();
 std::stack< std::pair<term_func_t, std::string> > TermFuncs;
 
-void addterm (void (STACK_ARGS *func) (), const char *name)
+void addterm(term_func_t func, const char *name)
 {
-	TermFuncs.push(std::pair<term_func_t, std::string>(func, name));
+	TermFuncs.emplace(func, name);
 }
 
-void STACK_ARGS call_terms (void)
+void call_terms()
 {
 	while (!TermFuncs.empty())
 		TermFuncs.top().first(), TermFuncs.pop();
 }
 
 #ifdef __SWITCH__
-void STACK_ARGS nx_early_init (void)
+void nx_early_init (void)
 {
 	socketInitializeDefault();
 #ifdef ODAMEX_DEBUG
 	nxlinkStdio();
 #endif
 }
-void STACK_ARGS nx_early_deinit (void)
+void nx_early_deinit (void)
 {
 	socketExit();
 }

--- a/client/sdl/i_music.cpp
+++ b/client/sdl/i_music.cpp
@@ -219,7 +219,7 @@ void I_InitMusic(MusicSystemType musicsystem_type)
 	current_musicsystem_type = musicsystem_type;
 }
 
-void STACK_ARGS I_ShutdownMusic(void)
+void I_ShutdownMusic(void)
 {
 	if (musicsystem)
 	{

--- a/client/sdl/i_music.cpp
+++ b/client/sdl/i_music.cpp
@@ -219,7 +219,7 @@ void I_InitMusic(MusicSystemType musicsystem_type)
 	current_musicsystem_type = musicsystem_type;
 }
 
-void I_ShutdownMusic(void)
+void I_ShutdownMusic()
 {
 	if (musicsystem)
 	{

--- a/client/sdl/i_music.h
+++ b/client/sdl/i_music.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <string>
 #include <SDL_mixer.h>
 
 #include "m_memio.h"

--- a/client/sdl/i_music.h
+++ b/client/sdl/i_music.h
@@ -58,7 +58,7 @@ EXTERN_CVAR(snd_musicsystem)
 extern std::string currentmusic;
 
 void I_InitMusic(MusicSystemType musicsystem_type = (MusicSystemType)snd_musicsystem.asInt());
-void STACK_ARGS I_ShutdownMusic(void);
+void I_ShutdownMusic(void);
 // Volume.
 void I_SetMusicVolume (float volume);
 // PAUSE game handling.

--- a/client/sdl/i_music.h
+++ b/client/sdl/i_music.h
@@ -58,7 +58,7 @@ EXTERN_CVAR(snd_musicsystem)
 extern std::string currentmusic;
 
 void I_InitMusic(MusicSystemType musicsystem_type = (MusicSystemType)snd_musicsystem.asInt());
-void I_ShutdownMusic(void);
+void I_ShutdownMusic();
 // Volume.
 void I_SetMusicVolume (float volume);
 // PAUSE game handling.

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -562,7 +562,7 @@ void I_InitSound()
 		channel_in_use[i] = false;
 }
 
-void STACK_ARGS I_ShutdownSound (void)
+void I_ShutdownSound (void)
 {
 	if (!sound_initialized)
 		return;

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -562,7 +562,7 @@ void I_InitSound()
 		channel_in_use[i] = false;
 }
 
-void I_ShutdownSound (void)
+void I_ShutdownSound ()
 {
 	if (!sound_initialized)
 		return;

--- a/client/sdl/i_sound.h
+++ b/client/sdl/i_sound.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -32,9 +32,9 @@
 void I_InitSound();
 
 // ... shut down and relase at program termination.
-void STACK_ARGS I_ShutdownSound (void);
+void I_ShutdownSound();
 
-void I_SetSfxVolume (float volume);
+void I_SetSfxVolume(float volume);
 
 //
 //	SFX I/O

--- a/client/sdl/i_system.cpp
+++ b/client/sdl/i_system.cpp
@@ -307,7 +307,7 @@ void I_Endoom()
 //
 static int has_exited;
 
-void STACK_ARGS I_Quit (void)
+void I_Quit()
 {
 	has_exited = 1;		/* Prevent infinitely recursive exits -- killough */
 
@@ -332,7 +332,7 @@ bool gameisdead;
 
 #define MAX_ERRORTEXT	1024
 
-void STACK_ARGS call_terms (void);
+void call_terms();
 
 void I_BaseWarning(const std::string& warningtext)
 {

--- a/client/sdl/i_system.h
+++ b/client/sdl/i_system.h
@@ -76,7 +76,7 @@ ticcmd_t *I_BaseTiccmd (void);
 
 // Called by M_Responder when quit is selected.
 // Clean exit, displays sell blurb.
-void STACK_ARGS I_Quit (void);
+void I_Quit();
 
 void I_BaseWarning(const std::string& errortext);
 [[noreturn]] void I_BaseError(const std::string& errortext);
@@ -100,7 +100,7 @@ template <typename... ARGS>
 	I_BaseFatalError(fmt::format(format, std::forward<ARGS>(args)...));
 }
 
-void addterm (void (STACK_ARGS *func)(void), const char *name);
+void addterm (void (*func)(), const char *name);
 #define atterm(t) addterm (t, #t)
 
 // Repaint the pre-game console

--- a/client/sdl/i_video.cpp
+++ b/client/sdl/i_video.cpp
@@ -909,7 +909,7 @@ bool I_VideoInitialized()
 //
 // Destroys the application window and frees its memory.
 //
-void STACK_ARGS I_ShutdownHardware()
+void I_ShutdownHardware()
 {
 	I_FreeSurface(loading_icon_background_surface);
 

--- a/client/sdl/i_video.h
+++ b/client/sdl/i_video.h
@@ -52,7 +52,7 @@ class IWindowSurface;
 class DCanvas;
 
 void I_InitHardware();
-void STACK_ARGS I_ShutdownHardware();
+void I_ShutdownHardware();
 bool I_VideoInitialized();
 
 void I_SetVideoMode(const IVideoMode& video_mode);

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -993,7 +993,7 @@ void C_InitConCharsFont()
 //
 // C_ShutdownConCharsFont
 //
-void STACK_ARGS C_ShutdownConCharsFont()
+void C_ShutdownConCharsFont()
 {
 	delete [] ConChars;
 	ConChars = NULL;
@@ -1051,7 +1051,7 @@ void C_InitConsoleBackground()
 //
 // Frees the background_surface
 //
-void STACK_ARGS C_ShutdownConsoleBackground()
+void C_ShutdownConsoleBackground()
 {
 	I_FreeSurface(background_surface);
 }
@@ -1060,7 +1060,7 @@ void STACK_ARGS C_ShutdownConsoleBackground()
 //
 // C_ShutdownConsole
 //
-void STACK_ARGS C_ShutdownConsole()
+void C_ShutdownConsole()
 {
 	Lines.clear();
 	History.clear();

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -514,7 +514,7 @@ void CL_CheckDisplayPlayer(void)
 			MSG_WriteMarker(&net_buffer, clc_spy);
 			MSG_WriteByte(&net_buffer, newid);
 		}
-		
+
 		displayplayer_id = newid;
 
 		// Changing display player can sometimes affect status bar visibility
@@ -1093,7 +1093,7 @@ BEGIN_COMMAND (spy)
 }
 END_COMMAND (spy)
 
-void STACK_ARGS call_terms (void);
+void call_terms();
 
 void CL_QuitCommand()
 {

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -562,7 +562,7 @@ void D_DoAdvanceDemo (void)
 //
 // D_Close
 //
-void STACK_ARGS D_Close()
+void D_Close()
 {
 	I_FreeSurface(page_surface);
 
@@ -753,7 +753,7 @@ void D_Init()
 // Called to shutdown subsystems when unloading a set of WAD resource files.
 // Should be called prior to D_Init when loading a new set of WADs.
 //
-void STACK_ARGS D_Shutdown()
+void D_Shutdown()
 {
 	if (gamestate == GS_LEVEL)
 		G_ExitLevel(0, 0);

--- a/client/src/f_finale.cpp
+++ b/client/src/f_finale.cpp
@@ -226,7 +226,7 @@ void F_StartFinale(finale_options_t& options)
 //
 // Frees any memory allocated specifically for the finale
 //
-void STACK_ARGS F_ShutdownFinale()
+void F_ShutdownFinale()
 {
 	I_FreeSurface(cast_surface);
 	I_FreeSurface(finale_surface);

--- a/client/src/f_finale.h
+++ b/client/src/f_finale.h
@@ -47,4 +47,4 @@ struct finale_options_t
 };
 
 void F_StartFinale(finale_options_t& options);
-void STACK_ARGS F_ShutdownFinale();
+void F_ShutdownFinale();

--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -208,7 +208,7 @@ void HU_Init()
 //
 // Frees any memory allocated specifically for the HUD.
 //
-void STACK_ARGS HU_Shutdown()
+void HU_Shutdown()
 {
 	::sbline.clear();
 

--- a/client/src/hu_stuff.h
+++ b/client/src/hu_stuff.h
@@ -37,7 +37,7 @@
 #define HU_FONTSIZE 	(HU_FONTEND - HU_FONTSTART + 1)
 
 void HU_Init();
-void STACK_ARGS HU_Shutdown();
+void HU_Shutdown();
 
 void HU_Ticker();
 bool HU_Responder (event_t* ev);

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -1251,7 +1251,7 @@ void M_EndGame(int choice)
 // M_QuitDOOM
 //
 
-void STACK_ARGS call_terms();
+void call_terms();
 
 void M_QuitResponse(int ch)
 {

--- a/client/src/m_misc.cpp
+++ b/client/src/m_misc.cpp
@@ -72,7 +72,7 @@ bool DefaultsLoaded;
  * @author Randy Heit
  * @param Optional: The filename to save the current configuration to.
  */
-void STACK_ARGS M_SaveDefaults(std::string filename)
+void M_SaveDefaults(std::string filename)
 {
 	if (!DefaultsLoaded)
 		return;

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -712,7 +712,7 @@ void R_Init()
 //
 // R_Shutdown
 //
-void STACK_ARGS R_Shutdown()
+void R_Shutdown()
 {
     R_FreeTranslationTables();
 
@@ -871,7 +871,7 @@ void R_SetupFrame (player_t *player)
 	player_t &consolePlayer = consoleplayer();
 	const bool use_localview =
 	    (consolePlayer.id == displayplayer().id && consolePlayer.health > 0 &&
-	     !consolePlayer.mo->reactiontime && !netdemo.isPlaying() && !demoplayback) 
+	     !consolePlayer.mo->reactiontime && !netdemo.isPlaying() && !demoplayback)
 		||
 		displayplayer().isFreecam;
 

--- a/client/src/st_stuff.cpp
+++ b/client/src/st_stuff.cpp
@@ -1375,7 +1375,7 @@ void ST_Init()
 	}
 }
 
-void STACK_ARGS ST_Shutdown()
+void ST_Shutdown()
 {
 	ST_unloadData();
 

--- a/client/src/v_video.cpp
+++ b/client/src/v_video.cpp
@@ -460,7 +460,7 @@ static bool V_DoSetResolution()
 //
 // V_Close
 //
-void STACK_ARGS V_Close()
+void V_Close()
 {
 	R_ShutdownColormaps();
 }

--- a/client/switch/nx_system.h
+++ b/client/switch/nx_system.h
@@ -5,9 +5,9 @@
 #include "d_event.h"
 
 // This is added for compatibility with strptime.cpp and cmdlib.cpp
-char * strptime(const char *buf, const char *fmt, struct tm *timeptr);  
+char * strptime(const char *buf, const char *fmt, struct tm *timeptr);
 
-void STACK_ARGS nx_early_init (void);
-void STACK_ARGS nx_early_deinit (void);
+void nx_early_init();
+void nx_early_deinit();
 
 #endif

--- a/common/c_console.h
+++ b/common/c_console.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -40,13 +40,13 @@ extern constate_e	ConsoleState;
 
 // Initialize the console
 void C_InitConsole();
-void STACK_ARGS C_ShutdownConsole();
+void C_ShutdownConsole();
 
 void C_InitConsoleBackground();
-void STACK_ARGS C_ShutdownConsoleBackground();
+void C_ShutdownConsoleBackground();
 
 void C_InitConCharsFont();
-void STACK_ARGS C_ShutdownConCharsFont();
+void C_ShutdownConCharsFont();
 
 void C_ClearCommand();
 

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -1192,7 +1192,7 @@ static void D_InitTaskSchedulers(void (*sim_func)(), void(*display_func)())
 	}
 }
 
-void STACK_ARGS D_ClearTaskSchedulers()
+void D_ClearTaskSchedulers()
 {
 	simulation_scheduler.reset();
 	display_scheduler.reset();

--- a/common/d_main.h
+++ b/common/d_main.h
@@ -81,7 +81,7 @@ extern OWantFiles missingfiles;
 
 extern bool capfps;
 extern float maxfps;
-void STACK_ARGS D_ClearTaskSchedulers();
+void D_ClearTaskSchedulers();
 void D_RunTics(void (*sim_func)(), void(*display_func)());
 
 void D_AddWadCommandLineFiles(OWantFiles& out);
@@ -90,4 +90,4 @@ void D_AddDehCommandLineFiles(OWantFiles& out);
 std::string D_GetTitleString();
 
 void D_Init();
-void STACK_ARGS D_Shutdown();
+void D_Shutdown();

--- a/common/dobject.cpp
+++ b/common/dobject.cpp
@@ -115,7 +115,7 @@ void DObject::EndFrame ()
 	ToDestroy.clear();
 }
 
-void STACK_ARGS DObject::StaticShutdown ()
+void DObject::StaticShutdown ()
 {
 	Inactive = true;
 

--- a/common/dobject.h
+++ b/common/dobject.h
@@ -24,6 +24,8 @@
 #pragma once
 
 #include <stdlib.h>
+#include <vector>
+#include <stdint.h>
 
 class FArchive;
 

--- a/common/dobject.h
+++ b/common/dobject.h
@@ -192,7 +192,7 @@ public:
 
 	uint32_t ObjectFlags = 0;
 
-	static void STACK_ARGS StaticShutdown ();
+	static void StaticShutdown ();
 
 private:
 	static inline std::vector<DObject *> ToDestroy{};

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -47,12 +47,6 @@ using byte = uint8_t;
 
 using OByteSpan = nonstd::span<byte>;
 
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-	#define STACK_ARGS __cdecl
-#else
-	#define STACK_ARGS
-#endif
-
 // Predefined with some OS.
 #if !defined(UNIX) && !defined(_WIN32)
 	#include <limits.h>

--- a/common/m_misc.h
+++ b/common/m_misc.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -18,7 +18,7 @@
 //
 // DESCRIPTION:
 //		Default Config File.
-//    
+//
 //-----------------------------------------------------------------------------
 
 
@@ -26,7 +26,7 @@
 
 void M_LoadDefaults(void);
 
-void STACK_ARGS M_SaveDefaults(std::string filename = "");
+void M_SaveDefaults(std::string filename = "");
 
 std::string M_GetConfigPath(void);
 std::string M_ExpandTokens(const std::string &str);

--- a/common/m_misc.h
+++ b/common/m_misc.h
@@ -24,9 +24,11 @@
 
 #pragma once
 
-void M_LoadDefaults(void);
+#include <string>
+
+void M_LoadDefaults();
 
 void M_SaveDefaults(std::string filename = "");
 
-std::string M_GetConfigPath(void);
+std::string M_GetConfigPath();
 std::string M_ExpandTokens(const std::string &str);

--- a/common/p_acs.cpp
+++ b/common/p_acs.cpp
@@ -646,7 +646,7 @@ FBehavior::~FBehavior ()
 	}
 }
 
-int STACK_ARGS FBehavior::SortScripts (const void *a, const void *b)
+int FBehavior::SortScripts (const void *a, const void *b)
 {
 	ScriptPtr *ptr1 = (ScriptPtr *)a;
 	ScriptPtr *ptr2 = (ScriptPtr *)b;

--- a/common/p_acs.h
+++ b/common/p_acs.h
@@ -105,7 +105,7 @@ private:
 	uint32_t LanguageNeutral;
 	uint32_t Localized;
 
-	static int STACK_ARGS SortScripts (const void *a, const void *b);
+	static int SortScripts (const void *a, const void *b);
 	void AddLanguage (uint32_t lang);
 	uint32_t FindLanguage (uint32_t lang, bool ignoreregion) const;
 	uint32_t *CheckIfInList (uint32_t lang);

--- a/common/r_main.h
+++ b/common/r_main.h
@@ -199,7 +199,7 @@ void R_RenderPlayerView (player_t *player);
 void R_Init();
 
 // Called by exit code.
-void STACK_ARGS R_Shutdown();
+void R_Shutdown();
 
 void R_ExitLevel();
 

--- a/common/st_stuff.h
+++ b/common/st_stuff.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -68,7 +68,7 @@ void ST_Start();
 // Called by startup code.
 void ST_Init();
 
-void STACK_ARGS ST_Shutdown();
+void ST_Shutdown();
 
 namespace hud {
 

--- a/common/v_video.h
+++ b/common/v_video.h
@@ -447,7 +447,7 @@ extern argb_t Col2RGB8[65][256];
 extern palindex_t RGB32k[32][32][32];
 
 void V_Init();
-void STACK_ARGS V_Close();
+void V_Close();
 
 void V_ForceVideoModeAdjustment();
 void V_AdjustVideoMode();

--- a/common/z_zone.cpp
+++ b/common/z_zone.cpp
@@ -303,7 +303,7 @@ class OZone
 //
 // Z_Close
 //
-void STACK_ARGS Z_Close()
+void Z_Close()
 {
 	g_zone.clear();
 }

--- a/server/src/d_main.cpp
+++ b/server/src/d_main.cpp
@@ -237,7 +237,7 @@ void D_Init()
 // Called to shutdown subsystems when unloading a set of WAD resource files.
 // Should be called prior to D_Init when loading a new set of WADs.
 //
-void STACK_ARGS D_Shutdown()
+void D_Shutdown()
 {
 	if (gamestate == GS_LEVEL)
 		G_ExitLevel(0, 0);

--- a/server/src/i_main.cpp
+++ b/server/src/i_main.cpp
@@ -58,15 +58,15 @@ extern UINT TimerPeriod;
 #endif
 
 // functions to be called at shutdown are stored in this stack
-typedef void (STACK_ARGS *term_func_t)(void);
+using term_func_t = void (*)();
 std::stack< std::pair<term_func_t, std::string> > TermFuncs;
 
-void addterm (void (STACK_ARGS *func) (), const char *name)
+void addterm (void (*func) (), const char *name)
 {
-	TermFuncs.push(std::pair<term_func_t, std::string>(func, name));
+	TermFuncs.emplace(func, name);
 }
 
-void STACK_ARGS call_terms (void)
+void call_terms()
 {
 	while (!TermFuncs.empty())
 		TermFuncs.top().first(), TermFuncs.pop();

--- a/server/src/i_system.cpp
+++ b/server/src/i_system.cpp
@@ -158,7 +158,7 @@ void I_FinishClockCalibration ()
 //
 static int has_exited;
 
-void STACK_ARGS I_Quit (void)
+void I_Quit()
 {
     has_exited = 1;             /* Prevent infinitely recursive exits -- killough */
 
@@ -182,7 +182,7 @@ bool gameisdead;
 
 #define MAX_ERRORTEXT	1024
 
-void STACK_ARGS call_terms (void);
+void call_terms();
 
 [[noreturn]] void I_BaseError(const std::string& errortext)
 {

--- a/server/src/i_system.h
+++ b/server/src/i_system.h
@@ -87,7 +87,7 @@ template <typename... ARGS>
 	I_BaseFatalError(fmt::format(format, std::forward<ARGS>(args)...));
 }
 
-void addterm (void (*func)(void), const char *name);
+void addterm (void (*func)(), const char *name);
 #define atterm(t) addterm (t, #t)
 
 bool I_ConsoleUseColor();

--- a/server/src/i_system.h
+++ b/server/src/i_system.h
@@ -65,12 +65,12 @@ void *I_ZoneBase (size_t *size);
 // or calls a loadable driver to build it.
 // This ticcmd will then be modified by the gameloop
 // for normal input.
-ticcmd_t *I_BaseTiccmd (void);
+ticcmd_t *I_BaseTiccmd();
 
 
 // Called by M_Responder when quit is selected.
 // Clean exit, displays sell blurb.
-void STACK_ARGS I_Quit (void);
+void I_Quit();
 
 [[noreturn]] void I_BaseError(const std::string& errortext);
 [[noreturn]] void I_BaseFatalError(const std::string& errortext);
@@ -87,7 +87,7 @@ template <typename... ARGS>
 	I_BaseFatalError(fmt::format(format, std::forward<ARGS>(args)...));
 }
 
-void addterm (void (STACK_ARGS *func)(void), const char *name);
+void addterm (void (*func)(void), const char *name);
 #define atterm(t) addterm (t, #t)
 
 bool I_ConsoleUseColor();

--- a/server/src/m_misc.cpp
+++ b/server/src/m_misc.cpp
@@ -68,7 +68,7 @@ bool DefaultsLoaded;
  * @author Randy Heit
  * @param Optional: The filename to save the current configuration to.
  */
-void STACK_ARGS M_SaveDefaults(std::string filename)
+void M_SaveDefaults(std::string filename)
 {
 	if (!DefaultsLoaded)
 		return;

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -425,7 +425,7 @@ BEGIN_COMMAND (say)
 }
 END_COMMAND (say)
 
-void STACK_ARGS call_terms (void);
+void call_terms();
 
 void SV_QuitCommand()
 {

--- a/tests/unit-tests/src/i_system.cpp
+++ b/tests/unit-tests/src/i_system.cpp
@@ -125,7 +125,7 @@ void I_FinishClockCalibration ()
 //
 static int has_exited;
 
-void STACK_ARGS I_Quit (void) {}
+void I_Quit() {}
 
 
 //

--- a/tests/unit-tests/src/i_system.h
+++ b/tests/unit-tests/src/i_system.h
@@ -43,11 +43,11 @@ enum
 extern uint32_t LanguageIDs[4];
 extern void SetLanguageIDs ();
 
-void I_BeginRead (void);
-void I_EndRead (void);
+void I_BeginRead();
+void I_EndRead();
 
 // Called by DoomMain.
-void I_Init (void);
+void I_Init();
 
 // Asynchronous interrupt functions should maintain private queues
 // that are read by the synchronous functions
@@ -57,12 +57,12 @@ void I_Init (void);
 // or calls a loadable driver to build it.
 // This ticcmd will then be modified by the gameloop
 // for normal input.
-ticcmd_t *I_BaseTiccmd (void);
+ticcmd_t *I_BaseTiccmd();
 
 
 // Called by M_Responder when quit is selected.
 // Clean exit, displays sell blurb.
-void STACK_ARGS I_Quit (void);
+void I_Quit();
 
 void I_BaseError(const std::string& errortext);
 [[noreturn]] void I_BaseFatalError(const std::string& errortext);
@@ -79,7 +79,7 @@ void I_FatalError(const fmt::string_view format, const ARGS&... args)
 	I_BaseFatalError(fmt::format(format, args...));
 }
 
-void addterm (void (STACK_ARGS *func)(void), const char *name);
+void addterm (void (*func)(), const char *name);
 #define atterm(t) addterm (t, #t)
 
 std::string I_ConsoleInput (void);


### PR DESCRIPTION
This was a remnant from old ZDoom when builds were done with __fastcall instead of __cdecl. If Odamex builds ever used that, it has been a very long time. Because of this it, it ends up just being unecessary noise, and it doesn't do anything except on 32-bit targets anyway.