### PR TITLE
Include flatpak debug bundles in artifacts and releases

### DIFF
--- a/.github/actions/odatests-notify/action.yml
+++ b/.github/actions/odatests-notify/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout odatests-results branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: odatests-results
         path: ./odatests-results

--- a/.github/actions/update-prerelease/action.yml
+++ b/.github/actions/update-prerelease/action.yml
@@ -46,7 +46,7 @@ runs:
         latest_tag=$(git tag -l --sort=version:refname "[0-9]*.[0-9]*.[0-9]*" | tail -n 1)
         echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
     - name: Create prerelease
-      uses: softprops/action-gh-release@v2.3.4
+      uses: softprops/action-gh-release@v3.0.2
       id: create_prerelease
       with:
         tag_name: prerelease

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   clang-tidy-review:
+    if: ${{ !startsWith(github.head_ref, 'release/') && github.head_ref != 'create-pull-request/patch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/linux-rc.yml
+++ b/.github/workflows/linux-rc.yml
@@ -172,7 +172,7 @@ jobs:
         curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-x64.tar.gz -o /tmp/powershell.tar.gz
         mkdir -p /opt/pwsh
         tar -xzf /tmp/powershell.tar.gz -C /opt/pwsh
-        ln -s /opt/pwsh/pwsh /usr/local/bin/pwsh
+        ln -sf /opt/pwsh/pwsh /usr/bin/pwsh
     - name:  Run Upversion
       id:    upversion
       shell: pwsh
@@ -219,7 +219,7 @@ jobs:
         curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-arm64.tar.gz -o /tmp/powershell.tar.gz
         mkdir -p /opt/pwsh
         tar -xzf /tmp/powershell.tar.gz -C /opt/pwsh
-        ln -s /opt/pwsh/pwsh /usr/local/bin/pwsh
+        ln -sf /opt/pwsh/pwsh /usr/bin/pwsh
     - name:  Run Upversion
       id:    upversion
       shell: pwsh

--- a/.github/workflows/linux-rc.yml
+++ b/.github/workflows/linux-rc.yml
@@ -19,7 +19,7 @@ jobs:
       minor: ${{ steps.gitversion.outputs.minor }}
       patch: ${{ steps.gitversion.outputs.patch }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
@@ -71,9 +71,10 @@ jobs:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
+        submodules: recursive
     - name:  Run Upversion
       id:    upversion
       shell: pwsh
@@ -82,8 +83,6 @@ jobs:
         MAJORVERSION: ${{ needs.pre_job.outputs.major }}
         MINORVERSION: ${{ needs.pre_job.outputs.minor }}
         PATCHVERSION: ${{ needs.pre_job.outputs.patch }}
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
     - name: Prepare build
       run: bash ci/ubuntu-buildgen.sh
     - name: Turn on problem matcher
@@ -106,9 +105,9 @@ jobs:
       CXX: /usr/bin/clang++
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Prepare build
       run: bash ci/ubuntu-buildgen.sh
     - name: Run build
@@ -119,9 +118,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Prepare build
       run: bash ci/ubuntu-buildgen.sh
     - name: Turn on problem matcher
@@ -134,9 +133,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Run build
       run: bash ci/fedora-buildgen.sh
   build-ubuntu-focal:
@@ -145,9 +144,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Run build
       run: bash ci/ubuntu-focal-buildgen.sh
   build-flatpak:
@@ -252,7 +251,7 @@ jobs:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-tags: true
     - name: Download x86_64 Flatpak
@@ -262,7 +261,7 @@ jobs:
     - name: Download Arm Flatpak
       uses: actions/download-artifact@v8
       with:
-        name: Odamex-Flatpak-ARM64
+        name: Odamex-Flatpak-arm64
     - name: Create or update prerelease
       uses: ./.github/actions/update-prerelease
       env:

--- a/.github/workflows/linux-rc.yml
+++ b/.github/workflows/linux-rc.yml
@@ -166,7 +166,7 @@ jobs:
     - name: Run build
       run: bash ci/ubuntu-focal-buildgen.sh
   build-flatpak:
-    name: Build Flatpak (Ubuntu Latest)
+    name: Build Flatpak (x86_64)
     needs: pre_job
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/linux-rc.yml
+++ b/.github/workflows/linux-rc.yml
@@ -168,6 +168,12 @@ jobs:
       with:
         fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
         submodules: recursive
+    - name: Install PowerShell
+      run: |
+        curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-x64.tar.gz -o /tmp/powershell.tar.gz
+        mkdir -p /opt/pwsh
+        tar -xzf /tmp/powershell.tar.gz -C /opt/pwsh
+        ln -s /opt/pwsh/pwsh /usr/local/bin/pwsh
     - name:  Run Upversion
       id:    upversion
       shell: pwsh
@@ -209,6 +215,12 @@ jobs:
       with:
         fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
         submodules: recursive
+    - name: Install PowerShell
+      run: |
+        curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-arm64.tar.gz -o /tmp/powershell.tar.gz
+        mkdir -p /opt/pwsh
+        tar -xzf /tmp/powershell.tar.gz -C /opt/pwsh
+        ln -s /opt/pwsh/pwsh /usr/local/bin/pwsh
     - name:  Run Upversion
       id:    upversion
       shell: pwsh

--- a/.github/workflows/linux-rc.yml
+++ b/.github/workflows/linux-rc.yml
@@ -239,6 +239,7 @@ jobs:
       uses: flatpak/flatpak-github-actions/flatpak-builder@8e357b1556f526e3642244bdf1a6d585be36de54
       with:
         manifest-path: packaging/flatpak/net.odamex.Odamex.yml
+        arch: aarch64
         bundle: odamex-linux-arm64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak
         branch: ${{ env.MODIFIED_BRANCH_NAME }}
         build-debug-bundle: true

--- a/.github/workflows/linux-rc.yml
+++ b/.github/workflows/linux-rc.yml
@@ -97,21 +97,6 @@ jobs:
       with:
         name: Odamex-Linux-x86_64
         path: 'build/artifact/*'
-  build-sdl12:
-    name: Build (SDL 1.2)
-    needs: pre_job
-    runs-on: ubuntu-latest
-    env:
-      USE_SDL12: 1
-    steps:
-    - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Prepare build
-      run: bash ci/ubuntu-buildgen.sh
-    - name: Run build
-      run: cmake --build ./build/
   build-clang:
     name: Build (Clang)
     needs: pre_job

--- a/.github/workflows/linux-rc.yml
+++ b/.github/workflows/linux-rc.yml
@@ -169,6 +169,9 @@ jobs:
     name: Build Flatpak (Ubuntu Latest)
     needs: pre_job
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
     env:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
@@ -176,9 +179,10 @@ jobs:
       MINORVERSION: ${{ needs.pre_job.outputs.minor }}
       PATCHVERSION: ${{ needs.pre_job.outputs.patch }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
+        submodules: recursive
     - name:  Run Upversion
       id:    upversion
       shell: pwsh
@@ -189,35 +193,26 @@ jobs:
         DATE=$(date +'%Y-%m-%d')
         sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.releases.xml
         sed -i "s/version=\"$MAJORVERSION\.$MINORVERSION\.$PATCHVERSION\"/version=\"$new_version-prerelease.$build_number\"/g" packaging/linux/net.odamex.Odamex.releases.xml
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Install flatpak
-      run: sudo apt update && sudo apt install flatpak flatpak-builder
     - name: Create escaped branch name
       env:
         name: "${{ github.ref_name }}"
       run: |
         echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
-    - name: Set flatpak repo
-      run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     - name: Run build
-      run: |
-        flatpak-builder --force-clean --user --install-deps-from=flathub \
-        --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-        --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
-    - name: Pack flatpak
-      run: |
-        flatpak build-bundle repo odamex-linux-x86_64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak \
-        net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-    - name: Upload artifact
-      uses: actions/upload-artifact@v7
+      uses: flatpak/flatpak-github-actions/flatpak-builder@8e357b1556f526e3642244bdf1a6d585be36de54
       with:
-        name: Odamex-Flatpak-x86_64
-        path: odamex-linux-x86_64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak
+        manifest-path: packaging/flatpak/net.odamex.Odamex.yml
+        bundle: odamex-linux-x86_64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak
+        branch: ${{ env.MODIFIED_BRANCH_NAME }}
+        build-debug-bundle: true
+        artifact-name: Odamex-Flatpak-x86_64
   build-flatpak-arm:
-    name: Build Flatpak (Ubuntu 24.04 ARM)
+    name: Build Flatpak (arm64)
     needs: pre_job
     runs-on: ubuntu-24.04-arm
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
     env:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
@@ -225,9 +220,10 @@ jobs:
       MINORVERSION: ${{ needs.pre_job.outputs.minor }}
       PATCHVERSION: ${{ needs.pre_job.outputs.patch }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
+        submodules: recursive
     - name:  Run Upversion
       id:    upversion
       shell: pwsh
@@ -238,31 +234,19 @@ jobs:
         DATE=$(date +'%Y-%m-%d')
         sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.releases.xml
         sed -i "s/version=\"$MAJORVERSION\.$MINORVERSION\.$PATCHVERSION\"/version=\"$new_version-prerelease.$build_number\"/g" packaging/linux/net.odamex.Odamex.releases.xml
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Install flatpak
-      run: sudo apt update && sudo apt install flatpak flatpak-builder
     - name: Create escaped branch name
       env:
         name: "${{ github.ref_name }}"
       run: |
         echo "MODIFIED_BRANCH_NAME=${name/\//-}" >> $GITHUB_ENV
-    - name: Set flatpak repo
-      run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     - name: Run build
-      run: |
-        flatpak-builder --force-clean --user --install-deps-from=flathub \
-        --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-        --default-branch=${{ env.MODIFIED_BRANCH_NAME }} -v
-    - name: Pack flatpak
-      run: |
-        flatpak build-bundle repo odamex-linux-arm64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak \
-        net.odamex.Odamex ${{ env.MODIFIED_BRANCH_NAME }} --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-    - name: Upload artifact
-      uses: actions/upload-artifact@v7
+      uses: flatpak/flatpak-github-actions/flatpak-builder@8e357b1556f526e3642244bdf1a6d585be36de54
       with:
-        name: Odamex-Flatpak-ARM64
-        path: odamex-linux-arm64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak
+        manifest-path: packaging/flatpak/net.odamex.Odamex.yml
+        bundle: odamex-linux-arm64-${{env.new_version}}-prerelease.${{ env.build_number }}.flatpak
+        branch: ${{ env.MODIFIED_BRANCH_NAME }}
+        build-debug-bundle: true
+        artifact-name: Odamex-Flatpak-arm64
   package-and-upload:
     name: Package and Upload Artifacts
     runs-on: windows-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
       should_skip: ${{ steps.check_skip.outputs.should_skip }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Check for build skip
         id: check_skip
         run: bash ci/check-skip.sh
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Prepare build
       run: bash ci/ubuntu-buildgen.sh
     - name: Turn on problem matcher
@@ -66,9 +66,9 @@ jobs:
       CXX: /usr/bin/clang++
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Prepare build
       run: bash ci/ubuntu-buildgen.sh
     - name: Run build
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Prepare build
       run: bash ci/ubuntu-buildgen.sh
     - name: Turn on problem matcher
@@ -100,9 +100,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Run build
       run: bash ci/fedora-buildgen.sh
   build-ubuntu-focal:
@@ -112,9 +112,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Run build
       run: bash ci/ubuntu-focal-buildgen.sh
   build-flatpak:
@@ -127,7 +127,7 @@ jobs:
       options: --privileged
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: Update metainfo dates
@@ -158,7 +158,7 @@ jobs:
       options: --privileged
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: Update metainfo dates

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -141,11 +141,13 @@ jobs:
       run: |
         echo "MODIFIED_BRANCH_NAME=${name//\//-}" >> $GITHUB_ENV
     - name: Build Flatpak
-      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      uses: flatpak/flatpak-github-actions/flatpak-builder@8e357b1556f526e3642244bdf1a6d585be36de54
       with:
         manifest-path: packaging/flatpak/net.odamex.Odamex.yml
-        bundle: odamex.flatpak
+        bundle: odamex-x86_64.flatpak
         branch: ${{ env.MODIFIED_BRANCH_NAME }}
+        build-debug-bundle: true
+        artifact-name: Odamex-Flatpak-x86_64
   build-flatpak-arm:
     name: Build Flatpak (Ubuntu 24.04 ARM)
     needs: pre_job
@@ -170,9 +172,11 @@ jobs:
       run: |
         echo "MODIFIED_BRANCH_NAME=${name//\//-}" >> $GITHUB_ENV
     - name: Build Flatpak
-      uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+      uses: flatpak/flatpak-github-actions/flatpak-builder@8e357b1556f526e3642244bdf1a6d585be36de54
       with:
         manifest-path: packaging/flatpak/net.odamex.Odamex.yml
         arch: aarch64
-        bundle: odamex.flatpak
+        bundle: odamex-arm64.flatpak
         branch: ${{ env.MODIFIED_BRANCH_NAME }}
+        build-debug-bundle: true
+        artifact-name: Odamex-Flatpak-arm64

--- a/.github/workflows/macos-rc.yml
+++ b/.github/workflows/macos-rc.yml
@@ -19,7 +19,7 @@ jobs:
       minor: ${{ steps.gitversion.outputs.minor }}
       patch: ${{ steps.gitversion.outputs.patch }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
@@ -80,9 +80,10 @@ jobs:
       zstd_version: "1.5.7"
       odamex_install_bindir: "/Applications/Odamex"
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
+        submodules: recursive
     - name: Run Upversion
       id:   upversion
       shell: pwsh
@@ -91,8 +92,6 @@ jobs:
         MAJORVERSION: ${{ needs.pre_job.outputs.major }}
         MINORVERSION: ${{ needs.pre_job.outputs.minor }}
         PATCHVERSION: ${{ needs.pre_job.outputs.patch }}
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
     - name: Cache macOS universal deps
       uses: actions/cache@v4
       with:
@@ -393,7 +392,7 @@ jobs:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-tags: true
     - name: Download universal artifact

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
       should_skip: ${{ steps.check_skip.outputs.should_skip }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Check for build skip
         id: check_skip
         run: bash ci/check-skip.sh
@@ -35,9 +35,9 @@ jobs:
     runs-on: macos-14
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Prepare build
       run: bash ci/macos-buildgen.sh
     - name: Run build

--- a/.github/workflows/release-upversion.yml
+++ b/.github/workflows/release-upversion.yml
@@ -26,7 +26,7 @@ jobs:
       minor: ${{ steps.gitversion.outputs.minor }}
       patch: ${{ steps.gitversion.outputs.patch }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
@@ -71,7 +71,7 @@ jobs:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Run Upversion
       id:   upversion
       shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,91 +158,81 @@ jobs:
           ./Output/zip/odamex-win32-${{env.new_version}}.zip
           ./Output/pdb/odamex-debug-pdb-${{env.new_version}}-x86.zip
   build-flatpak:
-    name: Build Flatpak (Ubuntu Latest)
+    name: Build Flatpak (x86_64)
     needs: pre_job
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
     env:
       new_version: ${{ needs.pre_job.outputs.new_version }}
       upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Update metainfo dates
       shell: bash
       run: |
         DATE=$(date +'%Y-%m-%d')
         sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.releases.xml
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Install flatpak
-      run: sudo apt update && sudo apt install flatpak flatpak-builder
     - name: Remove .git folders
       shell: bash
       run: rm -rf .git
-    - name: Set flatpak repo
-      run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     - name: Run build
-      run: |
-        flatpak-builder --force-clean --user --install-deps-from=flathub \
-        --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-        --default-branch=release -v
-    - name: Pack flatpak
-      run: |
-        flatpak build-bundle repo odamex-linux-x86_64-${{ env.new_version }}.flatpak net.odamex.Odamex release \
-        --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-    - name: Upload artifact
-      uses: actions/upload-artifact@v7
+      uses: flatpak/flatpak-github-actions/flatpak-builder@8e357b1556f526e3642244bdf1a6d585be36de54
       with:
-        name: Odamex-Flatpak-x86_64
-        path: odamex-linux-x86_64-${{ env.new_version }}.flatpak
+        manifest-path: packaging/flatpak/net.odamex.Odamex.yml
+        bundle: odamex-linux-x86_64-${{ env.new_version }}.flatpak
+        branch: release
+        build-debug-bundle: true
+        artifact-name: Odamex-Flatpak-x86_64
     - name: Upload release binary (x86_64)
       uses: softprops/action-gh-release@v2.3.4
       with:
-        files: odamex-linux-x86_64-${{ env.new_version }}.flatpak
+        files: |
+          odamex-linux-x86_64-${{ env.new_version }}.flatpak
+          odamex-linux-x86_64-${{ env.new_version }}-debug.flatpak
   build-flatpak-arm:
-    name: Build Flatpak (Ubuntu 24.04 ARM)
+    name: Build Flatpak (arm64)
     needs: pre_job
     runs-on: ubuntu-24.04-arm
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
     env:
       new_version: ${{ needs.pre_job.outputs.new_version }}
       upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Update metainfo dates
       shell: bash
       run: |
         DATE=$(date +'%Y-%m-%d')
         sed -i "s/YYYY-MM-DD/$DATE/g" packaging/linux/net.odamex.Odamex.releases.xml
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
-    - name: Install flatpak
-      run: sudo apt update && sudo apt install flatpak flatpak-builder
     - name: Remove .git folders
       shell: bash
       run: rm -rf .git
-    - name: Set flatpak repo
-      run: flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
     - name: Run build
-      run: |
-        flatpak-builder --force-clean --user --install-deps-from=flathub \
-        --repo=repo --install flatpak packaging/flatpak/net.odamex.Odamex.yml \
-        --default-branch=release -v
-    - name: Pack flatpak
-      run: |
-        flatpak build-bundle repo odamex-linux-arm64-${{ env.new_version }}.flatpak net.odamex.Odamex release \
-        --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
-    - name: Upload artifact
-      uses: actions/upload-artifact@v7
+      uses: flatpak/flatpak-github-actions/flatpak-builder@8e357b1556f526e3642244bdf1a6d585be36de54
       with:
-        name: Odamex-Flatpak-ARM64
-        path: odamex-linux-arm64-${{ env.new_version }}.flatpak
-    - name: Upload release binary (ARM64)
+        manifest-path: packaging/flatpak/net.odamex.Odamex.yml
+        bundle: odamex-linux-arm64-${{ env.new_version }}.flatpak
+        branch: release
+        build-debug-bundle: true
+        artifact-name: Odamex-Flatpak-arm64
+    - name: Upload release binary (arm64)
       uses: softprops/action-gh-release@v2.3.4
       env:
         GITHUB_TOKEN: ${{ github.token }}
       with:
-        files: odamex-linux-arm64-${{ env.new_version }}.flatpak
+        files: |
+          odamex-linux-arm64-${{ env.new_version }}.flatpak
+          odamex-linux-arm64-${{ env.new_version }}-debug.flatpak
   build-macos-universal:
     name: macOS Build (Universal DMG)
     needs: pre_job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         name: Odamex-Win-x64-pdb
         path: Output/pdb/*.zip
     - name: Upload release binary and debug pdb (x64)
-      uses: softprops/action-gh-release@v2.3.4
+      uses: softprops/action-gh-release@v3.0.2
       with:
         files: |
           ./Output/zip/odamex-win64-${{env.new_version}}.zip
@@ -152,7 +152,7 @@ jobs:
         name: Odamex-Win-x86-pdb
         path: Output/pdb/*.zip
     - name: Upload release binary and debug pdb (x86)
-      uses: softprops/action-gh-release@v2.3.4
+      uses: softprops/action-gh-release@v3.0.2
       with:
         files: |
           ./Output/zip/odamex-win32-${{env.new_version}}.zip
@@ -189,7 +189,7 @@ jobs:
         build-debug-bundle: true
         artifact-name: Odamex-Flatpak-x86_64
     - name: Upload release binary (x86_64)
-      uses: softprops/action-gh-release@v2.3.4
+      uses: softprops/action-gh-release@v3.0.2
       with:
         files: |
           odamex-linux-x86_64-${{ env.new_version }}.flatpak
@@ -226,7 +226,7 @@ jobs:
         build-debug-bundle: true
         artifact-name: Odamex-Flatpak-arm64
     - name: Upload release binary (arm64)
-      uses: softprops/action-gh-release@v2.3.4
+      uses: softprops/action-gh-release@v3.0.2
       env:
         GITHUB_TOKEN: ${{ github.token }}
       with:
@@ -546,7 +546,7 @@ jobs:
         name: Odamex-macOS-universal
         path: odamex-macos-${{ env.new_version }}.dmg
     - name: Upload release binary (Universal)
-      uses: softprops/action-gh-release@v2.3.4
+      uses: softprops/action-gh-release@v3.0.2
       with:
         files: odamex-macos-${{ env.new_version }}.dmg
   package-and-upload-windows:
@@ -601,7 +601,7 @@ jobs:
         name: Odamex-src-zip
         path: './odamex-src-${{ env.new_version }}.zip'
     - name: Upload zip and installer to Github Release Artifacts
-      uses: softprops/action-gh-release@v2.3.4
+      uses: softprops/action-gh-release@v3.0.2
       with:
         files: |
           ./odamex-src-${{env.new_version}}.zip
@@ -642,7 +642,7 @@ jobs:
         name: Odamex-tar-gz
         path: './*.tar.gz'
     - name: Upload tar.gz and tar.xz to Github Release Artifacts
-      uses: softprops/action-gh-release@v2.3.4
+      uses: softprops/action-gh-release@v3.0.2
       with:
         files: |
           ./odamex-src-${{env.new_version}}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       upload_url: ${{ steps.get_release.outputs.upload_url }}
       new_version: ${{ steps.gitversion.outputs.majorMinorPatch }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
       - name: Get release
@@ -70,9 +70,9 @@ jobs:
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Turn on problem matcher
       uses: ammaraskar/msvc-problem-matcher@master
     - name: Remove .git folders
@@ -118,9 +118,9 @@ jobs:
       upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Turn on problem matcher
       uses: ammaraskar/msvc-problem-matcher@master
     - name: Remove .git folders
@@ -250,9 +250,9 @@ jobs:
       odamex_install_bindir: "/Applications/Odamex"
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Cache macOS universal deps
       uses: actions/cache@v4
       with:
@@ -558,9 +558,9 @@ jobs:
       upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Remove .git folders
       shell: bash
       run: rm -rf .git
@@ -615,9 +615,9 @@ jobs:
       upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Remove .git folders
       shell: bash
       run: rm -rf .git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,11 @@ jobs:
     name: Build Preparation
     runs-on: ubuntu-latest
     outputs:
-      upload_url: ${{ steps.get_release.outputs.upload_url }}
       new_version: ${{ steps.gitversion.outputs.majorMinorPatch }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.3.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v4.5
         with:
@@ -66,7 +60,6 @@ jobs:
     needs: pre_job
     runs-on: windows-latest
     env:
-      upload_url: ${{ needs.pre_job.outputs.upload_url }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
     - name: Checkout source
@@ -115,7 +108,6 @@ jobs:
     runs-on: windows-latest
     env:
       new_version: ${{ needs.pre_job.outputs.new_version }}
-      upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
       uses: actions/checkout@v7
@@ -166,7 +158,6 @@ jobs:
       options: --privileged
     env:
       new_version: ${{ needs.pre_job.outputs.new_version }}
-      upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
       uses: actions/checkout@v7
@@ -203,7 +194,6 @@ jobs:
       options: --privileged
     env:
       new_version: ${{ needs.pre_job.outputs.new_version }}
-      upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
       uses: actions/checkout@v7
@@ -556,7 +546,6 @@ jobs:
     needs: [pre_job, build-windows, build-windows-x32]
     env:
       new_version: ${{ needs.pre_job.outputs.new_version }}
-      upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
       uses: actions/checkout@v7
@@ -613,7 +602,6 @@ jobs:
     needs: [pre_job]
     env:
       new_version: ${{ needs.pre_job.outputs.new_version }}
-      upload_url: ${{ needs.pre_job.outputs.upload_url }}
     steps:
     - name: Checkout source
       uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,7 @@ jobs:
       uses: flatpak/flatpak-github-actions/flatpak-builder@8e357b1556f526e3642244bdf1a6d585be36de54
       with:
         manifest-path: packaging/flatpak/net.odamex.Odamex.yml
+        arch: aarch64
         bundle: odamex-linux-arm64-${{ env.new_version }}.flatpak
         branch: release
         build-debug-bundle: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,12 +172,6 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: recursive
-    - name: Install PowerShell
-      run: |
-        curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-x64.tar.gz -o /tmp/powershell.tar.gz
-        mkdir -p /opt/pwsh
-        tar -xzf /tmp/powershell.tar.gz -C /opt/pwsh
-        ln -s /opt/pwsh/pwsh /usr/local/bin/pwsh
     - name: Update metainfo dates
       shell: bash
       run: |
@@ -215,12 +209,6 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: recursive
-    - name: Install PowerShell
-      run: |
-        curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-arm64.tar.gz -o /tmp/powershell.tar.gz
-        mkdir -p /opt/pwsh
-        tar -xzf /tmp/powershell.tar.gz -C /opt/pwsh
-        ln -s /opt/pwsh/pwsh /usr/local/bin/pwsh
     - name: Update metainfo dates
       shell: bash
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,12 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: recursive
+    - name: Install PowerShell
+      run: |
+        curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-x64.tar.gz -o /tmp/powershell.tar.gz
+        mkdir -p /opt/pwsh
+        tar -xzf /tmp/powershell.tar.gz -C /opt/pwsh
+        ln -s /opt/pwsh/pwsh /usr/local/bin/pwsh
     - name: Update metainfo dates
       shell: bash
       run: |
@@ -209,6 +215,12 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: recursive
+    - name: Install PowerShell
+      run: |
+        curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/powershell-7.6.4-linux-arm64.tar.gz -o /tmp/powershell.tar.gz
+        mkdir -p /opt/pwsh
+        tar -xzf /tmp/powershell.tar.gz -C /opt/pwsh
+        ln -s /opt/pwsh/pwsh /usr/local/bin/pwsh
     - name: Update metainfo dates
       shell: bash
       run: |

--- a/.github/workflows/windows-rc.yml
+++ b/.github/workflows/windows-rc.yml
@@ -19,7 +19,7 @@ jobs:
       minor: ${{ steps.gitversion.outputs.minor }}
       patch: ${{ steps.gitversion.outputs.patch }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
@@ -71,9 +71,10 @@ jobs:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
+        submodules: recursive
     - name: Run Upversion
       id:   upversion
       shell: pwsh
@@ -83,8 +84,6 @@ jobs:
         MAJORVERSION: ${{ needs.pre_job.outputs.major }}
         MINORVERSION: ${{ needs.pre_job.outputs.minor }}
         PATCHVERSION: ${{ needs.pre_job.outputs.patch }}
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
     - name: Turn on problem matcher
       uses: ammaraskar/msvc-problem-matcher@master
     - name: Run build powershell
@@ -120,9 +119,10 @@ jobs:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
+        submodules: recursive
     - name: Run Upversion
       id:   upversion
       shell: pwsh
@@ -132,8 +132,6 @@ jobs:
         MAJORVERSION: ${{ needs.pre_job.outputs.major }}
         MINORVERSION: ${{ needs.pre_job.outputs.minor }}
         PATCHVERSION: ${{ needs.pre_job.outputs.patch }}
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
     - name: Turn on problem matcher
       uses: ammaraskar/msvc-problem-matcher@master
     - name: Run build-x32 powershell
@@ -169,9 +167,10 @@ jobs:
       build_number: ${{ needs.pre_job.outputs.build_number }}
       new_version: ${{ needs.pre_job.outputs.new_version }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-tags: true
+        submodules: recursive
     - name: Run Upversion
       id:   upversion
       shell: pwsh
@@ -181,8 +180,6 @@ jobs:
         MAJORVERSION: ${{ needs.pre_job.outputs.major }}
         MINORVERSION: ${{ needs.pre_job.outputs.minor }}
         PATCHVERSION: ${{ needs.pre_job.outputs.patch }}
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
     - name: Download x86 artifacts
       uses: actions/download-artifact@v8
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
       should_skip: ${{ steps.check_skip.outputs.should_skip }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Check for build skip
         id: check_skip
         run: bash ci/check-skip.sh
@@ -36,9 +36,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Install Python packages
       uses: insightsengineering/pip-action@v2
       with:
@@ -123,9 +123,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v6
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Install Python packages
       uses: insightsengineering/pip-action@v2
       with:

--- a/installer/windows/odamex.iss
+++ b/installer/windows/odamex.iss
@@ -359,7 +359,7 @@ begin
   begin
     // Is the installed version new enough?
     Log('VC Redist Version check : found ' + Version);
-    Result := (CompareVersion(Version, {#VCRedistVersion})>0);
+    Result := (CompareVersion(Version, '{#VCRedistVersion}')>0);
   end
   else
   begin

--- a/packaging/flatpak/net.odamex.Odamex.yml
+++ b/packaging/flatpak/net.odamex.Odamex.yml
@@ -8,7 +8,9 @@ command: select-exe
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --device=all # change this to device=input + device=dri when available more widely
+  - --device-if=all:!has-input-device
+  - --device=input
+  - --device=dri
   - --socket=pulseaudio
   - --share=network
   - --socket=wayland

--- a/packaging/flatpak/net.odamex.Odamex.yml
+++ b/packaging/flatpak/net.odamex.Odamex.yml
@@ -97,7 +97,7 @@ modules:
       - -D BUILD_TESTS=0
       - -D USE_INTERNAL_LIBS=0
       - -D ODAMEX_INSTALL_BINDIR=/app/bin
-      - -D ODAMEX_INSTALL_DATADIR=/run/host/usr/share
+      - -D ODAMEX_INSTALL_DATADIR=/app/share
       - -D USE_EXTERNAL_LIBDWARF=1
       - -D ODAMEX_NO_GITVER=0
       - -D ODAMEX_UPDATE_CVARDOCS=0


### PR DESCRIPTION
Adds Flatpak bundles containing the net.odamex.Odamex.Debug package in all places where we publish Flatpak bundles. These can be installed to get debug symbols for the Flatpak.

I had been waiting for https://github.com/flatpak/flatpak-github-actions to do a new release but with the looming release of 12.3 I figured we should go ahead and do it.