### PR TITLE
[FEATURE] Allow redefining menu and intermission sounds in SNDINFO

### DIFF
--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -154,7 +154,7 @@ void WriteWAV(char* filename, byte* data, uint32_t length, int samplerate)
 
 // Generic sound expansion function for any sample rate
 
-void ExpandSoundData(byte* data, int samplerate, int bits, int length,
+void ExpandSoundData(const byte* data, int samplerate, int bits, int length,
                      Mix_Chunk* destination)
 {
 	Sint16* expanded = reinterpret_cast<Sint16*>(destination->abuf);

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -60,6 +60,9 @@ CVAR_FUNC_IMPL(snd_samplerate)
 	S_Init(snd_sfxvolume, snd_musicvolume);
 }
 
+namespace
+{
+
 #if 0
 
 /**
@@ -73,7 +76,7 @@ CVAR_FUNC_IMPL(snd_samplerate)
  * @param length Total length of data to write.
  * @param samplerate Samplerate to put in the header.
  */
-static void WriteWAV(char* filename, byte* data, uint32_t length, int samplerate)
+void WriteWAV(char* filename, byte* data, uint32_t length, int samplerate)
 {
 	FILE* wav;
 	unsigned int i;
@@ -120,7 +123,7 @@ static void WriteWAV(char* filename, byte* data, uint32_t length, int samplerate
 
 //// [Russell] - Chocolate Doom's sound converter code, how awesome!
 //// unused for now
-//static bool ConvertibleRatio(int freq1, int freq2)
+//bool ConvertibleRatio(int freq1, int freq2)
 //{
 //    int ratio;
 //
@@ -151,8 +154,8 @@ static void WriteWAV(char* filename, byte* data, uint32_t length, int samplerate
 
 // Generic sound expansion function for any sample rate
 
-static void ExpandSoundData(byte* data, int samplerate, int bits, int length,
-                            Mix_Chunk* destination)
+void ExpandSoundData(byte* data, int samplerate, int bits, int length,
+                     Mix_Chunk* destination)
 {
 	Sint16* expanded = reinterpret_cast<Sint16*>(destination->abuf);
 	size_t samplecount = length / (bits / 8);
@@ -215,7 +218,7 @@ static void ExpandSoundData(byte* data, int samplerate, int bits, int length,
 	}
 }
 
-static Uint8 *perform_sdlmix_conv(Uint8 *data, Uint32 size, Uint32 *newsize)
+Uint8 *perform_sdlmix_conv(Uint8 *data, Uint32 size, Uint32 *newsize)
 {
     Mix_Chunk *chunk;
     SDL_RWops *mem_op;
@@ -258,7 +261,7 @@ static Uint8 *perform_sdlmix_conv(Uint8 *data, Uint32 size, Uint32 *newsize)
     return ret_data;
 }
 
-static void getsfx(sfxinfo_t *sfx)
+void getsfx(sfxinfo_t *sfx)
 {
 	Uint32 new_size = 0;
 	Mix_Chunk *chunk;
@@ -323,6 +326,8 @@ static void getsfx(sfxinfo_t *sfx)
     ExpandSoundData(static_cast<byte*>(data) + 8, samplerate, 8, length, chunk);
     sfx->data = chunk;
 }
+
+} // namespace
 
 //
 // SFX API

--- a/client/sdl/i_sound.cpp
+++ b/client/sdl/i_sound.cpp
@@ -258,7 +258,7 @@ static Uint8 *perform_sdlmix_conv(Uint8 *data, Uint32 size, Uint32 *newsize)
     return ret_data;
 }
 
-static void getsfx(sfxinfo_struct *sfx)
+static void getsfx(sfxinfo_t *sfx)
 {
 	Uint32 new_size = 0;
 	Mix_Chunk *chunk;
@@ -462,7 +462,7 @@ void I_UpdateSoundParams (int handle, float vol, int sep, int pitch)
 	Mix_SetPanning(handle, sep, 255-sep);
 }
 
-void I_LoadSound (sfxinfo_struct *sfx)
+void I_LoadSound (sfxinfo_t *sfx)
 {
 	if (!sound_initialized)
 		return;

--- a/client/sdl/i_sound.h
+++ b/client/sdl/i_sound.h
@@ -44,7 +44,7 @@ void I_SetSfxVolume(float volume);
 void I_SetChannels (int);
 
 // load a sound from disk
-void I_LoadSound (struct sfxinfo_struct *sfx);
+void I_LoadSound (sfxinfo_t *sfx);
 
 // Starts a sound in a particular sound channel.
 int

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -831,7 +831,7 @@ void M_QuickSaveResponse(int ch)
 	if (ch == 'y' || Key_IsYesKey(ch))
 	{
 		M_DoSave (quickSaveSlot);
-		S_Sound (CHAN_INTERFACE, "switches/exitbutn", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "menu/dismiss", 1, ATTN_NONE);
 	}
 }
 
@@ -839,14 +839,14 @@ void M_QuickSave()
 {
 	if (multiplayer)
 	{
-		S_Sound (CHAN_INTERFACE, "player/male/grunt1", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "menu/invalid", 1, ATTN_NONE);
 		M_ClearMenus ();
 		return;
 	}
 
 	if (!usergame)
 	{
-		S_Sound (CHAN_INTERFACE, "player/male/grunt1", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "menu/invalid", 1, ATTN_NONE);
 		M_ClearMenus ();
 		return;
 	}
@@ -878,7 +878,7 @@ void M_QuickLoadResponse(int ch)
 	if (ch == 'y' || Key_IsYesKey(ch))
 	{
 		M_LoadSelect(quickSaveSlot);
-		S_Sound (CHAN_INTERFACE, "switches/exitbutn", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "menu/dismiss", 1, ATTN_NONE);
 	}
 }
 
@@ -1234,7 +1234,7 @@ void M_EndGame(int)
 {
 	if (!usergame)
 	{
-		S_Sound (CHAN_INTERFACE, "player/male/grunt1", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "menu/invalid", 1, ATTN_NONE);
 		return;
 	}
 
@@ -2055,7 +2055,7 @@ static void M_UpdateMessageSelection()
 	if (button != MSGBUTTON_NONE && button != messageSelection)
 	{
 		messageSelection = button;
-		S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 	}
 }
 
@@ -2145,7 +2145,7 @@ static void M_UpdateMouseItem()
 	if (item != -1 && item != itemOn)
 	{
 		itemOn = item;
-		S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 	}
 }
 
@@ -2194,12 +2194,12 @@ static void M_ActivateItem(int item)
 	if (currentMenu->menuitems[item].status == 2)
 	{
 		currentMenu->menuitems[item].routine(1);		// right arrow
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 	}
 	else
 	{
 		currentMenu->menuitems[item].routine(item);
-		S_Sound(CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/choose", 1, ATTN_NONE);
 	}
 }
 
@@ -2282,7 +2282,7 @@ bool M_Responder(const event_t& ev)
 			}
 		}
 		else if (Key_IsCancelKey(ch) ||
-		         (ui_mouse.asInt() != 0 && ch == OKEY_MOUSE2))
+		         (ui_mouse.asBool() && ch == OKEY_MOUSE2))
 		{
 			// Escape, or a right click, cancels the entry and restores the
 			// previous text.
@@ -2322,17 +2322,17 @@ bool M_Responder(const event_t& ev)
 	{
 		int answer = 0;
 
-		const bool buttons_shown = ui_mouse.asInt() != 0 && messageNeedsInput;
+		const bool buttons_shown = ui_mouse.asBool() && messageNeedsInput;
 
 		if (buttons_shown && (Key_IsUpKey(ch, numlock) || Key_IsDownKey(ch, numlock) ||
 		                      Key_IsLeftKey(ch, numlock) || Key_IsRightKey(ch, numlock)))
 		{
 			messageSelection = (messageSelection == MSGBUTTON_YES) ? MSGBUTTON_NO : MSGBUTTON_YES;
-			S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+			S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 			return true;
 		}
 
-		if (ui_mouse.asInt() != 0 && (ch == OKEY_MOUSE1 || ch == OKEY_MOUSE2))
+		if (ui_mouse.asBool() && (ch == OKEY_MOUSE1 || ch == OKEY_MOUSE2))
 		{
 			if (!messageNeedsInput)
 			{
@@ -2375,7 +2375,7 @@ bool M_Responder(const event_t& ev)
 
 		menuactive = false;
 		M_ResumeSound();
-		S_Sound (CHAN_INTERFACE, "switches/exitbutn", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "menu/dismiss", 1, ATTN_NONE);
 		return true;
 	}
 
@@ -2399,7 +2399,7 @@ bool M_Responder(const event_t& ev)
 		                     ((gamestate == GS_LEVEL || gamestate == GS_INTERMISSION) &&
 		                      demoplayback);
 
-		if (ui_mouse.asInt() != 0 && attract && (ch == OKEY_MOUSE1 || ch == OKEY_MOUSE2))
+		if (ui_mouse.asBool() && attract && (ch == OKEY_MOUSE1 || ch == OKEY_MOUSE2))
 		{
 			AddCommandString("menu_main");
 			return true;
@@ -2418,7 +2418,7 @@ bool M_Responder(const event_t& ev)
 		}
 	}
 
-	if (ui_mouse.asInt() != 0)
+	if (ui_mouse.asBool())
 	{
 		if (ch == OKEY_MOUSE1)
 		{
@@ -2437,7 +2437,7 @@ bool M_Responder(const event_t& ev)
 				if (colorslider && I_GetUIMousePosition(mouse_x, mouse_y))
 				{
 					M_SetPlayerColorFromMouse(item, mouse_x);
-					S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+					S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 
 					// Keep following the pointer until the button is released
 					PSetupDragItem = item;
@@ -2466,7 +2466,7 @@ bool M_Responder(const event_t& ev)
 					itemOn = 0;
 				else
 					itemOn++;
-				S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 			} while (currentMenu->menuitems[itemOn].status == -1);
 			return true;
 		}
@@ -2477,7 +2477,7 @@ bool M_Responder(const event_t& ev)
 					itemOn = currentMenu->numitems - 1;
 				else
 					itemOn--;
-				S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 			} while (currentMenu->menuitems[itemOn].status == -1);
 			return true;
 		}
@@ -2486,7 +2486,7 @@ bool M_Responder(const event_t& ev)
 			if (currentMenu->menuitems[itemOn].routine &&
 				currentMenu->menuitems[itemOn].status == 2)
 			{
-				S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 				currentMenu->menuitems[itemOn].routine(0);
 			}
 			return true;
@@ -2496,7 +2496,7 @@ bool M_Responder(const event_t& ev)
 			if (currentMenu->menuitems[itemOn].routine &&
 				currentMenu->menuitems[itemOn].status == 2)
 			{
-				S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 				currentMenu->menuitems[itemOn].routine(1);
 			}
 			return true;
@@ -2523,14 +2523,14 @@ bool M_Responder(const event_t& ev)
 					if (tolower(currentMenu->menuitems[i].alphaKey) == ch2)
 					{
 						itemOn = i;
-						S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+						S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 						return true;
 					}
 				for (int i = 0; i <= itemOn; i++)
 					if (tolower(currentMenu->menuitems[i].alphaKey) == ch2)
 					{
 						itemOn = i;
-						S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+						S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 						return true;
 					}
 			}
@@ -2561,7 +2561,7 @@ void M_StartControlPanel()
 	itemOn = currentMenu->lastOn;
 	OptionsActive = false;			// [RH] Make sure none of the options menus appear.
 	M_PauseSound();
-	S_Sound(CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
+	S_Sound(CHAN_INTERFACE, "menu/activate", 1, ATTN_NONE);
 }
 
 
@@ -2591,7 +2591,7 @@ void M_Drawer()
 
 		V_FreeBrokenLines (lines);
 
-		if (messageNeedsInput && ui_mouse.asInt() != 0)
+		if (messageNeedsInput && ui_mouse.asBool())
 			M_DrawMessageButtons(y + ch->height());
 	}
 	else if (menuactive)
@@ -2688,7 +2688,7 @@ void M_PopMenuStack()
 		}
 		drawSkull = MenuStack[MenuStackDepth].drawSkull;
 		MenuStackDepth++;
-		S_Sound (CHAN_INTERFACE, "switches/normbutn", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "menu/backup", 1, ATTN_NONE);
 	} else {
 		M_ClearMenus ();
 		if (currentMenu == &PSetupDef && PSetupDepth > 0)			// hack for PlayerSetup
@@ -2699,7 +2699,7 @@ void M_PopMenuStack()
 			M_Options(0);
 		}
 		else
-			S_Sound (CHAN_INTERFACE, "switches/exitbutn", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "menu/clear", 1, ATTN_NONE);
 	}
 }
 
@@ -2715,7 +2715,7 @@ void M_Ticker()
 		skullAnimCounter = 8;
 	}
 
-	if (messageToPrint && messageNeedsInput && ui_mouse.asInt() != 0)
+	if (messageToPrint && messageNeedsInput && ui_mouse.asBool())
 		M_UpdateMessageSelection();
 	else if (menuactive)
 	{

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -29,6 +29,7 @@
 
 #include "odamex.h"
 
+#include <algorithm>
 #include <cmath>
 
 #include "gstrings.h"
@@ -1588,14 +1589,14 @@ void M_SizeDisplay (float diff)
 BEGIN_COMMAND (sizedown)
 {
 	M_SizeDisplay (-1.0);
-	S_Sound (CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+	S_Sound (CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 }
 END_COMMAND (sizedown)
 
 BEGIN_COMMAND (sizeup)
 {
 	M_SizeDisplay(1.0);
-	S_Sound (CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+	S_Sound (CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 }
 END_COMMAND (sizeup)
 
@@ -1616,9 +1617,6 @@ void M_BuildKeyList (menuitem_t *item, int numitems)
 
 void M_SwitchMenu(menu_t* menu)
 {
-	int i, widest = 0, thiswidth;
-	menuitem_t *item;
-
 	MenuStack[MenuStackDepth].menu.newmenu = menu;
 	MenuStack[MenuStackDepth].isNewStyle = true;
 	MenuStack[MenuStackDepth].drawSkull = false;
@@ -1631,14 +1629,14 @@ void M_SwitchMenu(menu_t* menu)
 
 	if (!menu->indent)
 	{
-		for (i = 0; i < menu->numitems; i++)
+		int widest = 0;
+		for (int i = 0; i < menu->numitems; i++)
 		{
-			item = menu->items + i;
+			const menuitem_t* item = menu->items + i;
 			if (item->type != whitetext && item->type != redtext && item->type != orangetext)
 			{
-				thiswidth = V_StringWidth (item->label);
-				if (thiswidth > widest)
-					widest = thiswidth;
+				const int thiswidth = V_StringWidth (item->label);
+				widest = std::max(thiswidth, widest);
 			}
 		}
 		menu->indent = widest + 6;
@@ -1715,20 +1713,19 @@ int M_FindCurVal (float cur, value_t *values, int numvals)
 	return v;
 }
 
-void M_OptDrawer (void)
+void M_OptDrawer()
 {
 	int color;
 	int y, width, i, x, ytop;
-	int x1,y1,x2,y2;
 	int theight = 0;
 	menuitem_t *item;
 	patch_t *title;
 
-	x1 = (I_GetSurfaceWidth() / 2)-(160*CleanXfac);
-	y1 = (I_GetSurfaceHeight() / 2)-(100*CleanYfac);
+	const int x1 = (I_GetSurfaceWidth() / 2)-(160*CleanXfac);
+	const int y1 = (I_GetSurfaceHeight() / 2)-(100*CleanYfac);
 
-    x2 = (I_GetSurfaceWidth() / 2)+(160*CleanXfac);
-	y2 = (I_GetSurfaceHeight() / 2)+(100*CleanYfac);
+    const int x2 = (I_GetSurfaceWidth() / 2)+(160*CleanXfac);
+	const int y2 = (I_GetSurfaceHeight() / 2)+(100*CleanYfac);
 
 	// Background effect
 	OdamexEffect(x1,y1,x2,y2);
@@ -2161,7 +2158,7 @@ static void M_OptMouseClick(int mouse_x, int mouse_y)
 	if (M_OptItemIsSlider(item))
 	{
 		M_OptSetSliderFromMouse(item, mouse_x);
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 
 		// Keep following the pointer until the button is released
 		OptDragItem = index;
@@ -2242,7 +2239,7 @@ void M_OptUpdateMouseItem()
 	if (CurrentMenu->items[CurrentItem].type == screenres)
 		CurrentMenu->items[CurrentItem].a.selmode = M_OptScreenResColumn(mouse_x);
 
-	S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+	S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 }
 
 void M_OptResponder(const event_t& ev)
@@ -2409,7 +2406,7 @@ void M_OptResponder(const event_t& ev)
 			if (CurrentMenu->items[CurrentItem].type == screenres)
 				CurrentMenu->items[CurrentItem].a.selmode = modecol;
 
-			S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+			S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 		}
 		else if (Key_IsUpKey(ch, numlock))
 		{
@@ -2432,12 +2429,11 @@ void M_OptResponder(const event_t& ev)
 					CurrentItem == CurrentMenu->scrolltop + CurrentMenu->scrollpos)
 				{
 					CurrentMenu->scrollpos--;
-					if (CurrentMenu->scrollpos < 0)
-						CurrentMenu->scrollpos = 0;
+					CurrentMenu->scrollpos = std::max(CurrentMenu->scrollpos, 0);
 				}
 				if (CurrentItem < 0)
 				{
-					CurrentMenu->scrollpos = MAX(0, CurrentMenu->numitems - 22 + CurrentMenu->scrolltop);
+					CurrentMenu->scrollpos = std::max(0, CurrentMenu->numitems - 22 + CurrentMenu->scrolltop);
 					CurrentItem = CurrentMenu->numitems - 1;
 				}
 			} while (CurrentMenu->items[CurrentItem].type == redtext ||
@@ -2450,17 +2446,14 @@ void M_OptResponder(const event_t& ev)
 			if (CurrentMenu->items[CurrentItem].type == screenres)
 				CurrentMenu->items[CurrentItem].a.selmode = modecol;
 
-			S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+			S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 		}
 		else if (Key_IsPageUpKey(ch, numlock))
 		{
 			if (CanScrollUp)
 			{
 				CurrentMenu->scrollpos -= VisBottom - CurrentMenu->scrollpos - CurrentMenu->scrolltop;
-				if (CurrentMenu->scrollpos < 0)
-				{
-					CurrentMenu->scrollpos = 0;
-				}
+				CurrentMenu->scrollpos = std::max(CurrentMenu->scrollpos, 0);
 				CurrentItem = CurrentMenu->scrolltop + CurrentMenu->scrollpos + 1;
 				while (CurrentMenu->items[CurrentItem].type == redtext ||
 					CurrentMenu->items[CurrentItem].type == whitetext ||
@@ -2471,7 +2464,7 @@ void M_OptResponder(const event_t& ev)
 				{
 					++CurrentItem;
 				}
-				S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 			}
 		}
 		else if (Key_IsPageDownKey(ch, numlock))
@@ -2494,7 +2487,7 @@ void M_OptResponder(const event_t& ev)
 				{
 					++CurrentItem;
 				}
-				S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/cursor", 1, ATTN_NONE);
 			}
 		}
 		else if (Key_IsLeftKey(ch, numlock))
@@ -2515,7 +2508,7 @@ void M_OptResponder(const event_t& ev)
 			else
 				item->a.cvar->Set(newval);
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 		break;
 		case redslider:
 		case greenslider:
@@ -2541,8 +2534,7 @@ void M_OptResponder(const event_t& ev)
 
 			if (part > 0x00)
 				part -= 0x11;
-			if (part < 0x00)
-				part = 0x00;
+			part = std::max(part, 0x00);
 
 			char singlecolor[3];
 			snprintf(singlecolor, 3, "%02x", part);
@@ -2556,7 +2548,7 @@ void M_OptResponder(const event_t& ev)
 
 			item->a.cvar->Set(newcolor);
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 		break;
 		case discrete:
 		case cdiscrete:
@@ -2580,7 +2572,7 @@ void M_OptResponder(const event_t& ev)
 			if (item->e.values == Depths)
 				BuildModesList(I_GetVideoWidth(), I_GetVideoHeight());
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 		break;
 
 		case screenres:
@@ -2604,7 +2596,7 @@ void M_OptResponder(const event_t& ev)
 				item->a.selmode = col;
 			}
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/choose", 1, ATTN_NONE);
 		break;
 
 		case joyactive:
@@ -2616,7 +2608,7 @@ void M_OptResponder(const event_t& ev)
 			else if (static_cast<size_t>(item->a.cvar->value()) > 0)
 				item->a.cvar->Set(item->a.cvar->value() - 1);
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 		break;
 
 		default:
@@ -2641,7 +2633,7 @@ void M_OptResponder(const event_t& ev)
 			else
 				item->a.cvar->Set(newval);
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 		break;
 		case redslider:
 		case greenslider:
@@ -2667,8 +2659,7 @@ void M_OptResponder(const event_t& ev)
 
 			if (part < 0xff)
 				part += 0x11;
-			if (part > 0xff)
-				part = 0xff;
+			part = std::min(part, 0xff);
 
 			char singlecolor[3];
 			snprintf(singlecolor, 3, "%02x", part);
@@ -2682,7 +2673,7 @@ void M_OptResponder(const event_t& ev)
 
 			item->a.cvar->Set(newcolor);
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 		break;
 		case discrete:
 		case cdiscrete:
@@ -2706,7 +2697,7 @@ void M_OptResponder(const event_t& ev)
 			if (item->e.values == Depths)
 				BuildModesList(I_GetVideoWidth(), I_GetVideoHeight());
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 		break;
 
 		case screenres:
@@ -2733,7 +2724,7 @@ void M_OptResponder(const event_t& ev)
 				item->a.selmode = col;
 			}
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_stop", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/choose", 1, ATTN_NONE);
 		break;
 
 		case joyactive:
@@ -2746,7 +2737,7 @@ void M_OptResponder(const event_t& ev)
 				item->a.cvar->Set(item->a.cvar->value() + 1);
 
 		}
-		S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 		break;
 
 		default:
@@ -2785,12 +2776,12 @@ void M_OptResponder(const event_t& ev)
 				}
 
 				M_SetVideoMode(width, height);
-				S_Sound(CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/choose", 1, ATTN_NONE);
 			}
 			else if (item->type == more && item->e.mfunc)
 			{
 				CurrentMenu->lastOn = CurrentItem;
-				S_Sound(CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/advance", 1, ATTN_NONE);
 				item->e.mfunc();
 			}
 			else if (item->type == discrete || item->type == cdiscrete ||
@@ -2813,7 +2804,7 @@ void M_OptResponder(const event_t& ev)
 				// Hack hack. Rebuild list of resolutions
 				if (item->e.values == Depths)
 					BuildModesList(I_GetVideoWidth(), I_GetVideoHeight());
-				S_Sound(CHAN_INTERFACE, "plats/pt1_mid", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 			}
 			else if (item->type == control || item->type == mapcontrol || item->type == netdemocontrol)
 			{
@@ -2828,7 +2819,7 @@ void M_OptResponder(const event_t& ev)
 			else if (item->type == listelement)
 			{
 				CurrentMenu->lastOn = CurrentItem;
-				S_Sound(CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/choose", 1, ATTN_NONE);
 				item->e.lfunc(CurrentItem);
 			}
 			else if (item->type == joyaxis)
@@ -2872,7 +2863,7 @@ void M_OptResponder(const event_t& ev)
 				testingmode = I_MSTime() * TICRATE / 1000 + 5 * TICRATE;
 				M_SetVideoMode(width, height);
 
-				S_Sound(CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+				S_Sound(CHAN_INTERFACE, "menu/choose", 1, ATTN_NONE);
 			}
 		}
 		}

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1277,20 +1277,23 @@ void M_RestoreVideoMode()
 	M_SetVideoMode(old_width, old_height);
 }
 
+namespace
+{
 
-static value_t Depths[22];
+constexpr int MAX_LINES_ONSCREEN = 22;
+value_t Depths[MAX_LINES_ONSCREEN];
 
 #ifdef GCONSOLE
-static const char VMEnterText[] = "Press A to set mode";
-static const char VMTestText[] = "Press X to test mode for 5 seconds";
+constexpr const char VMEnterText[] = "Press A to set mode";
+constexpr const char VMTestText[] = "Press X to test mode for 5 seconds";
 #else
-static const char VMEnterText[] = "Press ENTER to set mode";
-static const char VMTestText[] = "Press T to test mode for 5 seconds";
+constexpr const char VMEnterText[] = "Press ENTER to set mode";
+constexpr const char VMTestText[] = "Press T to test mode for 5 seconds";
 #endif
 
-static const char VMTestWaitText[] = "Please wait 5 seconds...";
+constexpr const char VMTestWaitText[] = "Please wait 5 seconds...";
 
-static value_t VidFPSCaps[] = {
+value_t VidFPSCaps[] = {
 	{ 35.0,		"35fps" },
 	{ 60.0,		"60fps" },
 	{ 70.0,		"70fps" },
@@ -1303,13 +1306,13 @@ static value_t VidFPSCaps[] = {
 	{ 0.0,		"Unlimited" }
 };
 
-static value_t FullScreenOptions[] = {
+value_t FullScreenOptions[] = {
 	{ WINDOW_Windowed,			"Window" },
 	{ WINDOW_Fullscreen,		"Full Screen Exclusive" },
 	{ WINDOW_DesktopFullscreen,	"Full Screen Window" }
 };
 
-static value_t WidescreenMode[] = {
+value_t WidescreenMode[] = {
 	{ 0.0,			"Off" },
 	{ 1.0,			"Auto" },
 	{ 2.0,			"16:10" },
@@ -1318,7 +1321,7 @@ static value_t WidescreenMode[] = {
 	{ 5.0,			"32:9" }
 };
 
-static menuitem_t ModesItems[] = {
+menuitem_t ModesItems[] = {
 #ifdef GCONSOLE
 	{ slider, "Overscan",				{&vid_overscan},		{0.84375}, {1.0}, {0.03125}, {NULL} },
 #else
@@ -1342,6 +1345,8 @@ static menuitem_t ModesItems[] = {
 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
 	{ yellowtext, " ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
 };
+
+}
 
 #define VM_DEPTHITEM	0
 #define VM_RESSTART		6
@@ -1533,7 +1538,7 @@ static void M_SlideUIBlue (int val)
 
 void M_OptInit (void)
 {
-	for (int i = 0; i < 22; i++)
+	for (size_t i = 0; i < ARRAY_LENGTH(Depths); i++)
 	{
 		Depths[i].value = i;
 		Depths[i].name = NULL;
@@ -2433,7 +2438,7 @@ void M_OptResponder(const event_t& ev)
 				}
 				if (CurrentItem < 0)
 				{
-					CurrentMenu->scrollpos = std::max(0, CurrentMenu->numitems - 22 + CurrentMenu->scrolltop);
+					CurrentMenu->scrollpos = std::max(0, CurrentMenu->numitems - MAX_LINES_ONSCREEN + CurrentMenu->scrolltop);
 					CurrentItem = CurrentMenu->numitems - 1;
 				}
 			} while (CurrentMenu->items[CurrentItem].type == redtext ||

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -2325,7 +2325,7 @@ void M_OptResponder(const event_t& ev)
 		return;
 	}
 
-	if (ui_mouse.asInt() != 0 && ev.type == ev_keydown &&
+	if (ui_mouse.asBool() && ev.type == ev_keydown &&
 	    ch >= OKEY_MOUSE1 && ch <= OKEY_MWHEELRIGHT)
 	{
 		int mouse_x, mouse_y;

--- a/client/src/s_sound.cpp
+++ b/client/src/s_sound.cpp
@@ -683,7 +683,7 @@ static void S_StartSound(sound_origin_t origin, int channel,
 
 	while (sfxinfo->link != static_cast<size_t>(sfxinfo_t::NO_LINK))
 	{
-		sfx_id = ResolveSound(sfxinfo->link);
+		sfx_id = ResolveSound(sfx_id);
 		sfxinfo = &S_sfx[sfx_id];
 	}
 
@@ -692,7 +692,7 @@ static void S_StartSound(sound_origin_t origin, int channel,
 		I_LoadSound(sfxinfo);
 		while (sfxinfo->link != static_cast<size_t>(sfxinfo_t::NO_LINK))
 		{
-			sfx_id = ResolveSound(sfxinfo->link);
+			sfx_id = ResolveSound(sfx_id);
 			sfxinfo = &S_sfx[sfx_id];
 		}
 	}

--- a/client/src/wi_stuff.cpp
+++ b/client/src/wi_stuff.cpp
@@ -852,7 +852,7 @@ void WI_updateNetgameStats()
 		acceleratestage = 0;
 
 		i = 0;
-		for (Players::iterator it = players.begin();it != players.end();++it,++i)
+		for (auto it = players.begin();it != players.end();++it,++i)
 		{
 			if (!(it->ingame()))
 				continue;
@@ -864,18 +864,18 @@ void WI_updateNetgameStats()
 			if (dofrags)
 				cnt_frags_c[i] = WI_fragSum(*it);
 		}
-		S_Sound (CHAN_INTERFACE, "weapons/rocklx", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 		ng_state = 10;
 	}
 	if (ng_state == 2)
 	{
 		if (!(bcnt&3))
-			S_Sound (CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/tick", 1, ATTN_NONE);
 
 		stillticking = false;
 
 		i = 0;
-		for (Players::iterator it = players.begin();it != players.end();++it,++i)
+		for (auto it = players.begin();it != players.end();++it,++i)
 		{
 			if (!(it->ingame()))
 				continue;
@@ -890,14 +890,14 @@ void WI_updateNetgameStats()
 
 		if (!stillticking)
 		{
-			S_Sound (CHAN_INTERFACE, "weapons/rocklx", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 			ng_state++;
 		}
 	}
 	else if (ng_state == 4)
 	{
 		if (!(bcnt&3))
-			S_Sound (CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/tick", 1, ATTN_NONE);
 
 		stillticking = false;
 
@@ -915,14 +915,14 @@ void WI_updateNetgameStats()
 		}
 		if (!stillticking)
 		{
-			S_Sound (CHAN_INTERFACE, "weapons/rocklx", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 			ng_state++;
 		}
 	}
 	else if (ng_state == 6)
 	{
 		if (!(bcnt&3))
-			S_Sound (CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/tick", 1, ATTN_NONE);
 
 		stillticking = false;
 
@@ -942,7 +942,7 @@ void WI_updateNetgameStats()
 
 		if (!stillticking)
 		{
-			S_Sound (CHAN_INTERFACE, "weapons/rocklx", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 			ng_state += 1 + 2*!dofrags;
 		}
 	}
@@ -950,7 +950,7 @@ void WI_updateNetgameStats()
 	{
 		int fsum;
 		if (!(bcnt&3))
-			S_Sound (CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/tick", 1, ATTN_NONE);
 
 		stillticking = false;
 
@@ -970,7 +970,7 @@ void WI_updateNetgameStats()
 
 		if (!stillticking)
 		{
-			S_Sound (CHAN_INTERFACE, "player/male/death1", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/cooptotal", 1, ATTN_NONE);
 			ng_state++;
 		}
 	}
@@ -978,7 +978,10 @@ void WI_updateNetgameStats()
 	{
 		if (acceleratestage)
 		{
-			S_Sound (CHAN_INTERFACE, "weapons/shotgr", 1, ATTN_NONE);
+			if (dofrags)
+				S_Sound (CHAN_INTERFACE, "intermission/pastdmstats", 1, ATTN_NONE);
+			else
+				S_Sound (CHAN_INTERFACE, "intermission/pastcoopstats", 1, ATTN_NONE);
 			if ((gameinfo.flags & GI_MAPxx) && (enteranim == nullptr || demoplayback))
 				WI_initNoState();
 			else
@@ -1117,7 +1120,7 @@ void WI_updateStats()
 		cnt_time   = (plrs[me].stime) ? plrs[me].stime / TICRATE : level.time / TICRATE;
 		cnt_par    = wminfo.partime / TICRATE;
 
-		S_Sound (CHAN_INTERFACE, "world/barrelx", 1, ATTN_NONE);
+		S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 		sp_state = 10;
 	}
 	if (sp_state == 2)
@@ -1125,12 +1128,12 @@ void WI_updateStats()
 		cnt_kills += 2;
 
 		if (!(bcnt&3))
-			S_Sound (CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/tick", 1, ATTN_NONE);
 
 		if (!gameinfo.intermissionCounter || cnt_kills >= finalKillPercent)
 		{
 			cnt_kills = finalKillPercent;
-			S_Sound (CHAN_INTERFACE, "world/barrelx", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 			sp_state++;
 		}
 	}
@@ -1139,12 +1142,12 @@ void WI_updateStats()
 		cnt_items += 2;
 
 		if (!(bcnt&3))
-			S_Sound (CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/tick", 1, ATTN_NONE);
 
 		if (!gameinfo.intermissionCounter || cnt_items >= finalItemPercent)
 		{
 			cnt_items = finalItemPercent;
-			S_Sound (CHAN_INTERFACE, "world/barrelx", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 			sp_state++;
 		}
 	}
@@ -1153,19 +1156,19 @@ void WI_updateStats()
 		cnt_secret += 2;
 
 		if (!(bcnt&3))
-			S_Sound (CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/tick", 1, ATTN_NONE);
 
 		if (!gameinfo.intermissionCounter || cnt_secret >= finalSecretPercent)
 		{
 			cnt_secret = finalSecretPercent;
-			S_Sound (CHAN_INTERFACE, "world/barrelx", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 			sp_state++;
 		}
 	}
 	else if (sp_state == 8)
 	{
 		if (!(bcnt&3))
-			S_Sound (CHAN_INTERFACE, "weapons/pistol", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/tick", 1, ATTN_NONE);
 
 		cnt_time += 3;
 
@@ -1180,7 +1183,7 @@ void WI_updateStats()
 
 			if (cnt_time >= plrs[me].stime / TICRATE)
 			{
-			S_Sound (CHAN_INTERFACE, "world/barrelx", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/nextstage", 1, ATTN_NONE);
 			sp_state++;
 			}
 		}
@@ -1218,7 +1221,7 @@ void WI_updateStats()
 				background_surface->unlock();
 			}
 
-			S_Sound (CHAN_INTERFACE, "weapons/shotgr", 1, ATTN_NONE);
+			S_Sound (CHAN_INTERFACE, "intermission/paststats", 1, ATTN_NONE);
 
 			if (gameinfo.flags & GI_MAPxx && (enteranim == nullptr || demoplayback))
 				WI_initNoState();

--- a/common/s_sound.cpp
+++ b/common/s_sound.cpp
@@ -156,9 +156,9 @@ void S_ParseSndInfo()
 		char* buffer = W_CacheLumpNum<char>(lump, PU_CACHE);
 
 		const OScannerConfig config = {
-		    "SNDINFO", // lumpName
-		    true,      // semiComments
-		    true,      // cComments
+		    .lumpName     = "SNDINFO",
+		    .semiComments = true,
+		    .cComments    = true,
 		};
 		OScanner os = OScanner::openBuffer(config, buffer, buffer + W_LumpLength(lump));
 
@@ -278,7 +278,7 @@ void S_ParseSndInfo()
 				else if (os.compareTokenNoCase("alias"))
 				{
 					os.mustScan();
-					const int sfxfrom = S_AddSound(os.getToken().c_str(), NULL);
+					const int sfxfrom = S_AddSound(os.getToken().c_str(), nullptr);
 					os.mustScan();
 					S_sfx[sfxfrom].link = FindSoundTentative(os.getToken().c_str());
 				}

--- a/common/s_sound.h
+++ b/common/s_sound.h
@@ -33,9 +33,7 @@ class player_t;
 //
 // SoundFX struct.
 //
-typedef struct sfxinfo_struct sfxinfo_t;
-
-struct sfxinfo_struct
+struct sfxinfo_t
 {
 	char name[MAX_SNDNAME + 1]; // [RH] Sound name defined in SNDINFO
 	unsigned normal;            // Normal sample handle

--- a/wad/lumps/sndinfo.lmp
+++ b/wad/lumps/sndinfo.lmp
@@ -602,3 +602,25 @@ vox/red/flag/return		dvrfr
 
 $random menu/quit1 { player/male/death1 demon/pain grunt/pain misc/gibbed misc/teleport grunt/sight1 grunt/sight3 demon/melee }
 $random menu/quit2 { vile/active misc/p_pkup brain/cube misc/gibbed skeleton/swing knight/death baby/active demon/melee  }
+
+//---------------------------------------------------------------------------
+// MENU & INTERMISSION
+//---------------------------------------------------------------------------
+
+menu/activate dsswtchn // Activate a new menu
+menu/backup   dsswtchn // Backup to previous menu
+menu/prompt   dsswtchn // Activate a prompt "menu"
+menu/cursor   dspstop  // Move cursor up/down
+menu/change   dsstnmov // Select new value for option
+menu/invalid  dsoof    // Menu not available
+menu/dismiss  dsswtchx // Dismiss a prompt message
+menu/choose   dspistol // Choose a menu item
+menu/clear    dsswtchx // Close top menu
+$alias menu/advance menu/choose // Open a submenu
+
+$alias intermission/tick          weapons/pistol
+$alias intermission/cooptotal     *death
+$alias intermission/nextstage     weapons/rocklx
+$alias intermission/paststats     weapons/shotgr
+$alias intermission/pastcoopstats weapons/shotgr
+$alias intermission/pastdmstats   *gibbed

--- a/wad/lumps/sndinfo.lmp
+++ b/wad/lumps/sndinfo.lmp
@@ -618,9 +618,12 @@ menu/choose   dspistol // Choose a menu item
 menu/clear    dsswtchx // Close top menu
 $alias menu/advance menu/choose // Open a submenu
 
+// TODO: implement $playersound and $playercompat
+// and resolve gendered sounds in aliases
+// and change the 2 player sounds here to *death and *gibbed
 $alias intermission/tick          weapons/pistol
-$alias intermission/cooptotal     *death
+$alias intermission/cooptotal     player/male/death1
 $alias intermission/nextstage     weapons/rocklx
 $alias intermission/paststats     weapons/shotgr
 $alias intermission/pastcoopstats weapons/shotgr
-$alias intermission/pastdmstats   *gibbed
+$alias intermission/pastdmstats   player/male/gibbed


### PR DESCRIPTION
Resolves #1259

Also contains a bugfix for $alias, which since 10.1 has crashed when an alias sound is played.