### PR TITLE
Fix double free in P_LoadThings2

### DIFF
--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -955,8 +955,6 @@ void P_LoadThings2 (int lump, int position)
 	});
 
 	P_SpawnAvatars();
-
-	Z_Free (data);
 }
 
 //


### PR DESCRIPTION
already handled here `const auto guard = nonstd::make_scope_exit([&]{ Z_Free(data); });`