### PR TITLE
[BUGFIX] SDL text input mode enabled all the time

### DIFF
--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -735,12 +735,14 @@ void I_StartTic()
 
 void I_EnableTextEntry()
 {
-	input_subsystem->enableTextEntry();
+	if (input_subsystem)
+		input_subsystem->enableTextEntry();
 }
 
 void I_DisableTextEntry()
 {
-	input_subsystem->disableTextEntry();
+	if (input_subsystem)
+		input_subsystem->disableTextEntry();
 }
 
 // ============================================================================

--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -57,9 +57,12 @@ bool tab_keydown = false;	// [ML] Actual status of tab key
 
 EXTERN_CVAR(ui_mouse)
 
-static IInputSubsystem* input_subsystem = NULL;
+namespace
+{
 
-static bool nomouse = false;
+std::unique_ptr<IInputSubsystem> input_subsystem;
+
+bool nomouse = false;
 
 enum EInputMode
 {
@@ -68,7 +71,9 @@ enum EInputMode
 	INPUT_MODE_GAME
 };
 
-static EInputMode current_input_mode = INPUT_MODE_RELEASED;
+EInputMode current_input_mode = INPUT_MODE_RELEASED;
+
+} // namespace
 
 KeyNameTable key_names;
 
@@ -653,7 +658,7 @@ bool I_InitInput()
 	atterm(I_ShutdownInput);
 
 	#ifdef SDL20
-	input_subsystem = new ISDL20InputSubsystem();
+	input_subsystem = std::make_unique<ISDL20InputSubsystem>();
 	#endif
 
 	input_subsystem->initKeyboard(0);
@@ -666,8 +671,6 @@ bool I_InitInput()
 
 	I_ForceUpdateGrab();
 
-	input_subsystem->enableTextEntry();
-
 	return true;
 }
 
@@ -677,12 +680,9 @@ bool I_InitInput()
 //
 void I_ShutdownInput()
 {
-	input_subsystem->disableTextEntry();
-
 	I_ApplyInputMode(INPUT_MODE_RELEASED);
 
-	delete input_subsystem;
-	input_subsystem = NULL;
+	input_subsystem.reset();
 }
 
 
@@ -728,12 +728,20 @@ void I_GetEvents(bool mouseOnly)
 //
 // I_StartTic
 //
-void I_StartTic (void)
+void I_StartTic()
 {
 	I_GetEvents(false);
 }
 
+void I_EnableTextEntry()
+{
+	input_subsystem->enableTextEntry();
+}
 
+void I_DisableTextEntry()
+{
+	input_subsystem->disableTextEntry();
+}
 
 // ============================================================================
 //
@@ -814,7 +822,7 @@ void IInputSubsystem::disableKeyRepeat()
 //
 void IInputSubsystem::enableTextEntry()
 {
-	IKeyboardInputDevice* device = static_cast<IKeyboardInputDevice*>(getKeyboardInputDevice());
+	auto* device = static_cast<IKeyboardInputDevice*>(getKeyboardInputDevice());
 	if (device)
 		device->enableTextEntry();
 }
@@ -825,7 +833,7 @@ void IInputSubsystem::enableTextEntry()
 //
 void IInputSubsystem::disableTextEntry()
 {
-	IKeyboardInputDevice* device = static_cast<IKeyboardInputDevice*>(getKeyboardInputDevice());
+	auto* device = static_cast<IKeyboardInputDevice*>(getKeyboardInputDevice());
 	if (device)
 		device->disableTextEntry();
 }

--- a/client/sdl/i_input.h
+++ b/client/sdl/i_input.h
@@ -33,8 +33,8 @@
 #define MOUSE_DOOM 0
 #define MOUSE_ZDOOM_DI 1
 
-bool I_InitInput (void);
-void I_ShutdownInput ();
+bool I_InitInput();
+void I_ShutdownInput();
 void I_ForceUpdateGrab();
 void I_FlushInput();
 
@@ -47,6 +47,8 @@ int I_GetKeyFromName(const std::string& name);
 
 void I_GetEvents(bool mouseOnly);
 
+void I_EnableTextEntry();
+void I_DisableTextEntry();
 
 bool I_GetUIMousePosition(int& x, int& y);
 bool I_IsUIMouseButtonDown(int button);
@@ -62,7 +64,7 @@ class IInputDevice
 public:
 	virtual ~IInputDevice() { }
 
-	virtual bool active() const = 0;
+	[[nodiscard]] virtual bool active() const = 0;
 	virtual void pause() = 0;
 	virtual void resume() = 0;
 	virtual void reset() = 0;
@@ -71,7 +73,7 @@ public:
 	{	resume();	}
 
 	virtual void gatherEvents() = 0;
-	virtual bool hasEvent() const = 0;
+	[[nodiscard]] virtual bool hasEvent() const = 0;
 	virtual void getEvent(event_t* ev) = 0;
 
 	virtual void flushEvents()
@@ -123,7 +125,7 @@ public:
 	virtual void grabInputForUI()
 	{	releaseInput();	}
 
-	virtual bool isInputGrabbed() const
+	[[nodiscard]] virtual bool isInputGrabbed() const
 	{	return false;	}
 
 	virtual void enableKeyRepeat();
@@ -139,22 +141,22 @@ public:
 			getEvent(&dummy_event);
 	}
 
-	virtual bool hasEvent() const
+	[[nodiscard]] virtual bool hasEvent() const
 	{	return mEvents.empty() == false;	}
 
 	virtual void gatherEvents();
 	virtual void gatherMouseEvents();
 	virtual void getEvent(event_t* ev);
 
-	virtual std::vector<IInputDeviceInfo> getKeyboardDevices() const = 0;
+	[[nodiscard]] virtual std::vector<IInputDeviceInfo> getKeyboardDevices() const = 0;
 	virtual void initKeyboard(int id) = 0;
 	virtual void shutdownKeyboard(int id) = 0;
 
-	virtual std::vector<IInputDeviceInfo> getMouseDevices() const = 0;
+	[[nodiscard]] virtual std::vector<IInputDeviceInfo> getMouseDevices() const = 0;
 	virtual void initMouse(int id) = 0;
 	virtual void shutdownMouse(int id) = 0;
 
-	virtual std::vector<IInputDeviceInfo> getJoystickDevices() const = 0;
+	[[nodiscard]] virtual std::vector<IInputDeviceInfo> getJoystickDevices() const = 0;
 	virtual void initJoystick(int id) = 0;
 	virtual void shutdownJoystick(int id) = 0;
 
@@ -210,22 +212,23 @@ private:
 	// the EventRepeaterTable hashtable typedef uses
 	// event_t::data1 as its key as there should only be
 	// a single instance with that value in the table.
-	typedef OHashTable<int, EventRepeater> EventRepeaterTable;
+	using EventRepeaterTable = OHashTable<int, EventRepeater>;
 	EventRepeaterTable	mEventRepeaters;
 
 	bool				mRepeating;
 
-	typedef std::queue<event_t> EventQueue;
+	using EventQueue = std::queue<event_t>;
 	EventQueue			mEvents;
 
 	// Input device management
-	typedef std::list<IInputDevice*> InputDeviceList;
+	using InputDeviceList = std::list<IInputDevice*>;
 	InputDeviceList		mInputDevices;
 
+	// TODO: do the types here need to be the base class?
 	IInputDevice*		mKeyboardInputDevice;
 	IInputDevice*		mMouseInputDevice;
 	IInputDevice*		mJoystickInputDevice;
 };
 
-typedef OHashTable<int, std::string> KeyNameTable;
+using KeyNameTable = OHashTable<int, std::string>;
 extern KeyNameTable key_names;

--- a/client/sdl/i_input_sdl20.h
+++ b/client/sdl/i_input_sdl20.h
@@ -16,7 +16,7 @@
 // GNU General Public License for more details.
 //
 // DESCRIPTION:
-//	
+//
 //
 //-----------------------------------------------------------------------------
 
@@ -27,10 +27,9 @@
 
 #include "d_event.h"
 #include <queue>
-#include <list>
 #include "hashtable.h"
 
-typedef OHashTable<int, int> KeyTranslationTable;
+using KeyTranslationTable = OHashTable<int, int>;
 
 #ifdef SDL20
 
@@ -44,25 +43,25 @@ class ISDL20KeyboardInputDevice : public IKeyboardInputDevice
 {
 public:
 	ISDL20KeyboardInputDevice(int id);
-	virtual ~ISDL20KeyboardInputDevice();
+	~ISDL20KeyboardInputDevice() override;
 
-	virtual bool active() const;
+	[[nodiscard]] bool active() const override;
 
-	virtual void pause();
-	virtual void resume();
-	virtual void reset();
+	void pause() override;
+	void resume() override;
+	void reset() override;
 
-	virtual void gatherEvents();
+	void gatherEvents() override;
 
-	virtual bool hasEvent() const
+	[[nodiscard]] bool hasEvent() const override
 	{	return !mEvents.empty();	}
 
-	virtual void getEvent(event_t* ev);
+	void getEvent(event_t* ev) override;
 
-	virtual void flushEvents();
+	void flushEvents() override;
 
-	virtual void enableTextEntry();
-	virtual void disableTextEntry();
+	void enableTextEntry() override;
+	void disableTextEntry() override;
 
 private:
 	int translateKey(SDL_Keysym keysym);
@@ -71,7 +70,7 @@ private:
 	bool					mActive;
 	bool					mTextEntry;
 
-	typedef std::queue<event_t> EventQueue;
+	using EventQueue = std::queue<event_t>;
 	EventQueue				mEvents;
 };
 
@@ -86,23 +85,23 @@ class ISDL20MouseInputDevice : public IInputDevice
 {
 public:
 	ISDL20MouseInputDevice(int id);
-	virtual ~ISDL20MouseInputDevice();
+	~ISDL20MouseInputDevice() override;
 
-	virtual bool active() const;
+	[[nodiscard]] bool active() const override;
 
-	virtual void pause();
-	virtual void resume();
-	virtual void resumeUI();
-	virtual void reset();
+	void pause() override;
+	void resume() override;
+	void resumeUI() override;
+	void reset() override;
 
-	virtual void gatherEvents();
+	void gatherEvents() override;
 
-	virtual bool hasEvent() const
+	[[nodiscard]] bool hasEvent() const override
 	{	return !mEvents.empty();	}
 
-	virtual void getEvent(event_t* ev);
+	void getEvent(event_t* ev) override;
 
-	virtual void flushEvents();
+	void flushEvents() override;
 
 private:
 	void enableEvents(bool relative);
@@ -111,7 +110,7 @@ private:
 
 	bool			mUIMode;
 
-	typedef std::queue<event_t> EventQueue;
+	using EventQueue = std::queue<event_t>;
 	EventQueue		mEvents;
 };
 
@@ -126,22 +125,22 @@ class ISDL20JoystickInputDevice : public IInputDevice
 {
 public:
 	ISDL20JoystickInputDevice(int id);
-	virtual ~ISDL20JoystickInputDevice();
+	~ISDL20JoystickInputDevice() override;
 
-	virtual bool active() const;
+	[[nodiscard]] bool active() const override;
 
-	virtual void pause();
-	virtual void resume();
-	virtual void reset();
+	void pause() override;
+	void resume() override;
+	void reset() override;
 
-	virtual void gatherEvents();
+	void gatherEvents() override;
 
-	virtual bool hasEvent() const
+	[[nodiscard]] bool hasEvent() const override
 	{	return !mEvents.empty();	}
 
-	virtual void getEvent(event_t* ev);
+	void getEvent(event_t* ev) override;
 
-	virtual void flushEvents();
+	void flushEvents() override;
 
 private:
 	int calcAxisValue(int raw_value);
@@ -150,7 +149,7 @@ private:
 
 	bool			mActive;
 
-	typedef std::queue<event_t> EventQueue;
+	using EventQueue = std::queue<event_t>;
 	EventQueue		mEvents;
 
 	int				mJoystickId;
@@ -168,26 +167,26 @@ class ISDL20InputSubsystem : public IInputSubsystem
 {
 public:
 	ISDL20InputSubsystem();
-	virtual ~ISDL20InputSubsystem();
+	~ISDL20InputSubsystem() override;
 
-	virtual void grabInput();
-	virtual void releaseInput();
-	virtual void grabInputForUI();
+	void grabInput() override;
+	void releaseInput() override;
+	void grabInputForUI() override;
 
-	virtual bool isInputGrabbed() const
+	[[nodiscard]] bool isInputGrabbed() const override
 	{	return mInputGrabbed;	}
 
-	virtual std::vector<IInputDeviceInfo> getKeyboardDevices() const;
-	virtual void initKeyboard(int id);
-	virtual void shutdownKeyboard(int id);
+	[[nodiscard]] std::vector<IInputDeviceInfo> getKeyboardDevices() const override;
+	void initKeyboard(int id) override;
+	void shutdownKeyboard(int id) override;
 
-	virtual std::vector<IInputDeviceInfo> getMouseDevices() const;
-	virtual void initMouse(int id);
-	virtual void shutdownMouse(int id);
+	[[nodiscard]] std::vector<IInputDeviceInfo> getMouseDevices() const override;
+	void initMouse(int id) override;
+	void shutdownMouse(int id) override;
 
-	virtual std::vector<IInputDeviceInfo> getJoystickDevices() const;
-	virtual void initJoystick(int id);
-	virtual void shutdownJoystick(int id);
+	[[nodiscard]] std::vector<IInputDeviceInfo> getJoystickDevices() const override;
+	void initJoystick(int id) override;
+	void shutdownJoystick(int id) override;
 
 private:
 	bool				mInputGrabbed;

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -33,6 +33,7 @@
 #include "c_console.h"
 #include "c_dispatch.h"
 #include "c_bind.h"
+#include "i_input.h"
 #include "i_system.h"
 #include "i_video.h"
 #include "v_palette.h"
@@ -1569,6 +1570,8 @@ void C_FullConsole()
 	TabCycleClear();
 
 	C_AdjustBottom();
+
+	I_EnableTextEntry();
 }
 
 
@@ -1584,6 +1587,7 @@ void C_HideConsole()
 	CmdLine.clear();
 	CmdCompletions.clear();
 	History.resetPosition();
+	I_DisableTextEntry();
 }
 
 
@@ -1626,6 +1630,7 @@ void C_ToggleConsole()
 			ConsoleState = c_falling;
 
 		TabCycleClear();
+		I_EnableTextEntry();
 	}
 	else
 	{
@@ -1635,6 +1640,7 @@ void C_ToggleConsole()
 			ConsoleState = c_rising;
 
 		C_FlushDisplay();
+		I_DisableTextEntry();
 	}
 
 	CmdLine.clear();

--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -41,6 +41,7 @@
 
 #include "cl_main.h"
 #include "p_ctf.h"
+#include "i_input.h"
 #include "i_video.h"
 #include "cl_netgraph.h"
 #include "hu_mousegraph.h"
@@ -140,16 +141,19 @@ chatmode_t HU_ChatMode()
 void HU_SetChatMode()
 {
 	chatmode = CHAT_NORMAL;
+	I_EnableTextEntry();
 }
 
 void HU_SetTeamChatMode()
 {
 	chatmode = CHAT_TEAM;
+	I_EnableTextEntry();
 }
 
 void HU_UnsetChatMode()
 {
 	chatmode = CHAT_INACTIVE;
+	I_DisableTextEntry();
 }
 
 

--- a/client/src/m_menu.cpp
+++ b/client/src/m_menu.cpp
@@ -31,6 +31,7 @@
 #include "c_console.h"
 #include "c_dispatch.h"
 #include "d_main.h"
+#include "i_input.h"
 #include "i_music.h"
 #include "i_time.h"
 #include "i_video.h"
@@ -787,6 +788,8 @@ void M_SaveSelect (int choice)
 	}
 
 	saveCharIndex = strlen(savegamestrings[choice]);
+
+	I_EnableTextEntry();
 }
 
 //
@@ -1759,6 +1762,8 @@ static void M_EditPlayerName (int choice)
 	if (!strcmp(savegamestrings[0], GStrings(EMPTYSTRING)))
 		savegamestrings[0][0] = 0;
 	saveCharIndex = strlen(savegamestrings[0]);
+
+	I_EnableTextEntry();
 }
 
 static void M_PlayerNameChanged (int choice)
@@ -2290,6 +2295,7 @@ bool M_Responder(const event_t& ev)
 				M_ClearMenus();
 			genStringEnter = oldmenustring_t::NONE;
 			M_StringCopy(&savegamestrings[saveSlot][0], saveOldString, SAVESTRINGSIZE);
+			I_DisableTextEntry();
 		}
 		else if (Key_IsAcceptKey(ch) ||
 		         (ch == OKEY_MOUSE1 && M_MouseOverEditField()))
@@ -2300,6 +2306,7 @@ bool M_Responder(const event_t& ev)
 			genStringEnter = oldmenustring_t::NONE;
 			if (savegamestrings[saveSlot][0])
 				genStringEnd(saveSlot);	// [RH] Function to call when enter is pressed
+			I_DisableTextEntry();
 		}
 		else
 		{

--- a/common/win32inc.h
+++ b/common/win32inc.h
@@ -53,6 +53,37 @@
         #undef PlaySound
     #endif
 
+    #ifdef MAXCHAR
+        #undef MAXCHAR
+    #endif
+    #ifdef MAXSHORT
+        #undef MAXSHORT
+    #endif
+    #ifdef MAXINT
+        #undef MAXINT
+    #endif
+    #ifdef MAXUINT
+        #undef MAXUINT
+    #endif
+    #ifdef MAXLONG
+        #undef MAXLONG
+    #endif
+    #ifdef MINCHAR
+        #undef MINCHAR
+    #endif
+    #ifdef MINSHORT
+        #undef MINSHORT
+    #endif
+    #ifdef MININT
+        #undef MININT
+    #endif
+    #ifdef MINUINT
+        #undef MINUINT
+    #endif
+    #ifdef MINLONG
+        #undef MINLONG
+    #endif
+
     // POSIX functions
 	#include <ctime>
     char * strptime(const char *buf, const char *fmt, struct tm *timeptr);


### PR DESCRIPTION
Fixes #1884

Now text input mode is enable when opening the chat, team chat, console, or full console, when editing a save name, and when editing the player name, and is disabled when leaving/finishing any of those.