### PR TITLE
Consolidate Win32 SDK manipulations into header file

### DIFF
--- a/cmake/modules/OdamexTargetSettings.cmake
+++ b/cmake/modules/OdamexTargetSettings.cmake
@@ -32,14 +32,14 @@ function(odamex_target_settings _TARGET)
 
   target_compile_definitions("${_TARGET}" PRIVATE $<$<CONFIG:Debug>:ODAMEX_DEBUG>)
 
-  # The Win32 / Win SDK-related definitions and macros are controlled in a header file.
-  # Force that header file into our targets' compile options here.
   if (WIN32)
-      if (MSVC)
-        target_compile_options("${_TARGET}" PRIVATE /FI${CMAKE_SOURCE_DIR}/common/win32inc.h)
-      elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        target_compile_options("${_TARGET}" PRIVATE --include=${CMAKE_SOURCE_DIR}/common/win32inc.h)
-      endif()
+      target_compile_definitions("${_TARGET}"
+          PRIVATE
+            _CRT_SECURE_NO_WARNINGS
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            NODRAWTEXT
+            )
   endif()
 
   if(MSVC)

--- a/cmake/modules/OdamexTargetSettings.cmake
+++ b/cmake/modules/OdamexTargetSettings.cmake
@@ -30,18 +30,24 @@ function(odamex_target_settings _TARGET)
     target_compile_definitions("${_TARGET}" PRIVATE UNIX)
   endif()
 
+  target_compile_definitions("${_TARGET}" PRIVATE $<$<CONFIG:Debug>:ODAMEX_DEBUG>)
+
+  # The Win32 / Win SDK-related definitions and macros are controlled in a header file.
+  # Force that header file into our targets' compile options here.
+  if (WIN32)
+      if (MSVC)
+        target_compile_options("${_TARGET}" PRIVATE /FI${CMAKE_SOURCE_DIR}/common/win32inc.h)
+      elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        target_compile_options("${_TARGET}" PRIVATE --include=${CMAKE_SOURCE_DIR}/common/win32inc.h)
+      endif()
+  endif()
+
   if(MSVC)
-    # jsd: hide warnings about using insecure crt functions:
-    target_compile_definitions("${_TARGET}" PRIVATE
-      $<$<CONFIG:Debug>:ODAMEX_DEBUG> _CRT_SECURE_NO_WARNINGS
-      WIN32_LEAN_AND_MEAN NOMINMAX NODRAWTEXT)
     target_compile_options("${_TARGET}" PRIVATE /MP)
     if(USE_SANITIZE_ADDRESS)
       target_compile_options("${_TARGET}" PRIVATE /fsanitize=address)
     endif()
   else()
-    target_compile_definitions("${_TARGET}" PRIVATE
-      $<$<CONFIG:Debug>:ODAMEX_DEBUG>)
     target_compile_options("${_TARGET}" PRIVATE -Wall -Wextra)
 
     if(USE_GPROF)

--- a/common/CanarySocket.h
+++ b/common/CanarySocket.h
@@ -28,9 +28,9 @@
 #ifdef _WIN32
 #   include <winsock2.h>
 #   include <ws2ipdef.h>            // For the keep alive socket options under IPPROTO_TCP
+#   include "win32inc.h"
 #   define  CANARY_SOCKET_INT SOCKET
 #   define  CANARY_BAD_SOCKET INVALID_SOCKET
-
 #else
 #   include <netinet/in.h>
 #   include <sys/socket.h>

--- a/common/CanarySocket.h
+++ b/common/CanarySocket.h
@@ -26,49 +26,10 @@
 #include <vector>
 
 #ifdef _WIN32
-#   define  WIN32_LEAN_AND_MEAN
 #   include <winsock2.h>
 #   include <ws2ipdef.h>            // For the keep alive socket options under IPPROTO_TCP
 #   define  CANARY_SOCKET_INT SOCKET
 #   define  CANARY_BAD_SOCKET INVALID_SOCKET
-
-// Ugh.  Why, Microsoft, why?  Time to cleanup after the winsock inclusion...
-#   ifdef max
-#       undef max
-#   endif
-#   ifdef min
-#       undef min
-#   endif
-#   ifdef MAXCHAR
-#       undef MAXCHAR
-#   endif
-#   ifdef MAXSHORT
-#       undef MAXSHORT
-#   endif
-#   ifdef MAXINT
-#       undef MAXINT
-#   endif
-#   ifdef MAXUINT
-#       undef MAXUINT
-#   endif
-#   ifdef MAXLONG
-#       undef MAXLONG
-#   endif
-#   ifdef MINCHAR
-#       undef MINCHAR
-#   endif
-#   ifdef MINSHORT
-#       undef MINSHORT
-#   endif
-#   ifdef MININT
-#       undef MININT
-#   endif
-#   ifdef MINUINT
-#       undef MINUINT
-#   endif
-#   ifdef MINLONG
-#       undef MINLONG
-#   endif
 
 #else
 #   include <netinet/in.h>

--- a/common/win32inc.h
+++ b/common/win32inc.h
@@ -27,13 +27,20 @@
     // DrawText macros in winuser.h interfere with v_video.h
     #ifndef NODRAWTEXT
         #define NODRAWTEXT
-    #endif  // NODRAWTEXT
+    #endif
 
     #ifndef NOMINMAX
         #define NOMINMAX
-    #endif  // NOMINMAX;
+    #endif
 
-    #define WIN32_LEAN_AND_MEAN
+    #ifndef WIN32_LEAN_AND_MEAN
+    #   define WIN32_LEAN_AND_MEAN
+    #endif
+
+    #ifndef _CRT_SECURE_NO_WARNINGS
+    #   define _CRT_SECURE_NO_WARNINGS
+    #endif
+
     // need to make winxp compat for raw mouse input
     // need at least vista for SHGetKnownFolderPath
     #if (_WIN32_WINNT < _WIN32_WINNT_VISTA)

--- a/odalaunch/src/odalaunch.h
+++ b/odalaunch/src/odalaunch.h
@@ -24,6 +24,10 @@
 #pragma once
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
+#   ifndef WIN32_LEAN_AND_MEAN
+#       define WIN32_LEAN_AND_MEAN
+#   endif
+#   ifndef NOMINMAX
+#       define NOMINMAX
+#   endif
 #endif

--- a/odalpapi/net_utils.cpp
+++ b/odalpapi/net_utils.cpp
@@ -27,9 +27,16 @@
 #include <iostream>
 
 #ifdef _WIN32
-#   include <winsock2.h>
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <WinSock2.h>
+#include <Windows.h>
 #else
-#   include <sys/time.h>
+#include <sys/time.h>
+#endif
+
+#ifdef max
+	#undef max
 #endif
 
 #include <limits>

--- a/odalpapi/net_utils.cpp
+++ b/odalpapi/net_utils.cpp
@@ -27,16 +27,9 @@
 #include <iostream>
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <WinSock2.h>
-#include <Windows.h>
+#   include <winsock2.h>
 #else
-#include <sys/time.h>
-#endif
-
-#ifdef max
-	#undef max
+#   include <sys/time.h>
 #endif
 
 #include <limits>

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -26,7 +26,6 @@
 
 #include "win32inc.h"
 #ifdef _WIN32
-#   define WIN32_LEAN_AND_MEAN
 #   include <winsock2.h>
 #   include <time.h>
 #endif


### PR DESCRIPTION
This PR consolidates the WIN32 API and SDK macro manipulations into a "one true" **win32inc.h** header file, resolving a large number of duplicate macro definition warnings, e.g.:

```
[124/534] Building CXX object client\CMakeFiles\odamex.dir\__\common\i_crash_win32.cpp.obj
D:\Projects\odamex\common\win32inc.h(36): warning C4005: 'WIN32_LEAN_AND_MEAN': macro redefinition
D:\Projects\odamex\common\win32inc.h(36): note: 'WIN32_LEAN_AND_MEAN' previously declared on the command line
```

This involves:

- Removing the related macro definitions from the CMake files,
- adding a few more definitions/checks to **win32inc.h**,
- removing duplicated macros and checks from the source files, and
- forcing the inclusion of **win32inc.h** as a compiler command line option when building for Windows.

I'm flexible on the last bullet point, which was chosen for convenience and simplicity of implementation.  Arguably, adding explicit includes to each compilation unit is higher-quality because it would force inclusion traceability into every source file.  However of all the hidden side-effects buried in the codebase, this one felt like it carries enough of a value-add and low enough of a maintenance burden to come out in favor of taking the easy way out.  I could easily be pushed the other way though.