### PR TITLE
Write out build end-item artifacts to a single directory;  remove odamex.wad copying

### DIFF
--- a/.github/workflows/macos-rc.yml
+++ b/.github/workflows/macos-rc.yml
@@ -318,14 +318,14 @@ jobs:
           done
         }
         for app_bin in \
-          "build/client/odamex.app/Contents/MacOS/odamex" \
-          "build/odalaunch/odalaunch.app/Contents/MacOS/odalaunch"
+          "build/odamex/odamex.app/Contents/MacOS/odamex" \
+          "build/odamex/odalaunch.app/Contents/MacOS/odalaunch"
         do
           if [ ! -f "${app_bin}" ]; then
             continue
           fi
           is_odamex=0
-          if [[ "${app_bin}" == *"/client/odamex.app/"* ]]; then
+          if [[ "${app_bin}" == *"/odamex/odamex.app/"* ]]; then
             is_odamex=1
           fi
           bundle_dir="$(dirname "${app_bin}")/../Frameworks"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -470,14 +470,14 @@ jobs:
           done
         }
         for app_bin in \
-          "build/client/odamex.app/Contents/MacOS/odamex" \
-          "build/odalaunch/odalaunch.app/Contents/MacOS/odalaunch"
+          "build/odamex/odamex.app/Contents/MacOS/odamex" \
+          "build/odamex/odalaunch.app/Contents/MacOS/odalaunch"
         do
           if [ ! -f "${app_bin}" ]; then
             continue
           fi
           is_odamex=0
-          if [[ "${app_bin}" == *"/client/odamex.app/"* ]]; then
+          if [[ "${app_bin}" == *"/odamex/odamex.app/"* ]]; then
             is_odamex=1
           fi
           bundle_dir="$(dirname "${app_bin}")/../Frameworks"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # CMake >= 3.13 needed for -S and -B params in library compilation.
 # CMake >= 3.19 needed for policy CMP0112: target-dependent generator expressions
 #               do not implicitly add target-level dependencies.
+# CMake >= 3.20 needed for restricted set of generator expressions allowed in custom command OUTPUT args.
 #
 # Note that if you are running Linux, there are many ways to get newer
 # versions of CMake.
@@ -14,7 +15,7 @@
 # - If you have Python installed, you can install CMake through pip.
 #
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.20)
 
 project(Odamex VERSION 13.0.0)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ cmake_dependent_option( USE_INTERNAL_LIBADLMIDI "Use internal libADLMIDI" 1 BUIL
 set(ODAMEX_INSTALL_BINDIR "/usr/local/bin" CACHE PATH "Smart default for bin dir location")
 set(ODAMEX_INSTALL_DATADIR "/usr/local/share" CACHE PATH "Smart default for data dir location")
 
+set(ODAMEX_ARTIFACT_DIR "${CMAKE_BINARY_DIR}/odamex" CACHE PATH "The build directory in which to place deployable end items such as executables, dynamic libraries, and data resources.")
+
 if(NOT APPLE AND NOT WIN32)
   add_definitions(-DODAMEX_INSTALL_BINDIR="${ODAMEX_INSTALL_BINDIR}")
   add_definitions(-DODAMEX_INSTALL_DATADIR="${ODAMEX_INSTALL_DATADIR}")

--- a/ci/macos-dmg.sh
+++ b/ci/macos-dmg.sh
@@ -21,14 +21,14 @@ trap cleanup EXIT
 odamex_dir="Odamex"
 mkdir -p "${staging_dir}/${odamex_dir}"
 
-if [ -d "build/client/odamex.app" ]; then
-  cp -R "build/client/odamex.app" "${staging_dir}/${odamex_dir}/Odamex.app"
+if [ -d "build/odamex/odamex.app" ]; then
+  cp -R "build/odamex/odamex.app" "${staging_dir}/${odamex_dir}/Odamex.app"
 fi
-if [ -d "build/odalaunch/odalaunch.app" ]; then
-  cp -R "build/odalaunch/odalaunch.app" "${staging_dir}/${odamex_dir}/odalaunch.app"
+if [ -d "build/odamex/odalaunch.app" ]; then
+  cp -R "build/odamex/odalaunch.app" "${staging_dir}/${odamex_dir}/odalaunch.app"
 fi
-if [ -f "build/server/odasrv" ]; then
-  cp "build/server/odasrv" "${staging_dir}/${odamex_dir}/odasrv"
+if [ -f "build/odamex/odasrv" ]; then
+  cp "build/odamex/odasrv" "${staging_dir}/${odamex_dir}/odasrv"
 fi
 if [ -f "${staging_dir}/${odamex_dir}/Odamex.app/Contents/MacOS/odamex.wad" ]; then
   ln -s "Odamex.app/Contents/MacOS/odamex.wad" "${staging_dir}/${odamex_dir}/odamex.wad"
@@ -93,8 +93,8 @@ set_custom_icon() {
 }
 
 folder_icon="media/odamex.icns"
-if [ -f "build/client/odamex.app/Contents/Resources/odamex.icns" ]; then
-  folder_icon="build/client/odamex.app/Contents/Resources/odamex.icns"
+if [ -f "build/odamex/odamex.app/Contents/Resources/odamex.icns" ]; then
+  folder_icon="build/odamex/odamex.app/Contents/Resources/odamex.icns"
 fi
 set_custom_icon "${staging_dir}/${odamex_dir}" "${folder_icon}"
 set_custom_icon "${staging_dir}/${odamex_dir}/odasrv" "media/odasrv.icns"

--- a/ci/ubuntu-artifact.sh
+++ b/ci/ubuntu-artifact.sh
@@ -10,5 +10,8 @@ set -x
 mkdir -p build/artifact && cd build
 
 cp -aR \
-    "client/odamex" "server/odasrv" "odalaunch/odalaunch" \
-    "wad/odamex.wad" artifact/
+    "odamex/odamex" \
+    "odamex/odasrv" \
+    "odamex/odalaunch" \
+    "odamex/odamex.wad" \
+    artifact/

--- a/ci/win-artifact.ps1
+++ b/ci/win-artifact.ps1
@@ -13,15 +13,15 @@ New-Item -Name "archive" -ItemType "directory" | Out-Null
 
 # Copy all built files into artifact directory
 Copy-Item -Path `
-    ".\client\RelWithDebInfo\odamex.exe", `
-    ".\client\RelWithDebInfo\odamex.pdb", `
-    ".\client\RelWithDebInfo\*.dll", `
-    ".\server\RelWithDebInfo\odasrv.exe", `
-    ".\server\RelWithDebInfo\odasrv.pdb", `
-    ".\odalaunch\RelWithDebInfo\odalaunch.exe", `
-    ".\odalaunch\RelWithDebInfo\odalaunch.pdb", `
-    ".\odalaunch\RelWithDebInfo\*.dll", `
-    ".\wad\odamex.wad", `
+    ".\odamex\RelWithDebInfo\odamex.exe", `
+    ".\odamex\RelWithDebInfo\odamex.pdb", `
+    ".\odamex\RelWithDebInfo\*.dll", `
+    ".\odamex\RelWithDebInfo\odasrv.exe", `
+    ".\odamex\RelWithDebInfo\odasrv.pdb", `
+    ".\odamex\RelWithDebInfo\odalaunch.exe", `
+    ".\odamex\RelWithDebInfo\odalaunch.pdb", `
+    ".\odamex\RelWithDebInfo\*.dll", `
+    ".\odamex\odamex.wad", `
     "C:\Windows\System32\msvcp140.dll", `
     "C:\Windows\System32\vcruntime140.dll", `
     "C:\Windows\System32\vcruntime140_1.dll" `

--- a/ci/win-artifact.ps1
+++ b/ci/win-artifact.ps1
@@ -21,7 +21,7 @@ Copy-Item -Path `
     ".\odamex\RelWithDebInfo\odalaunch.exe", `
     ".\odamex\RelWithDebInfo\odalaunch.pdb", `
     ".\odamex\RelWithDebInfo\*.dll", `
-    ".\odamex\odamex.wad", `
+    ".\odamex\RelWithDebInfo\odamex.wad", `
     "C:\Windows\System32\msvcp140.dll", `
     "C:\Windows\System32\vcruntime140.dll", `
     "C:\Windows\System32\vcruntime140_1.dll" `

--- a/ci/win-prepare-demotest.ps1
+++ b/ci/win-prepare-demotest.ps1
@@ -5,15 +5,15 @@ New-Item -Name "demotest" -ItemType "directory" | Out-Null
 
 # Copy all built files into artifact directory
 Copy-Item -Path `
-    ".\client\RelWithDebInfo\odamex.exe", `
-    ".\client\RelWithDebInfo\odamex.pdb", `
-    ".\client\RelWithDebInfo\*.dll", `
-    ".\server\RelWithDebInfo\odasrv.exe", `
-    ".\server\RelWithDebInfo\odasrv.pdb", `
-    ".\odalaunch\RelWithDebInfo\odalaunch.exe", `
-    ".\odalaunch\RelWithDebInfo\odalaunch.pdb", `
-    ".\odalaunch\RelWithDebInfo\*.dll", `
-    ".\wad\odamex.wad", `
+    ".\odamex\RelWithDebInfo\odamex.exe", `
+    ".\odamex\RelWithDebInfo\odamex.pdb", `
+    ".\odamex\RelWithDebInfo\*.dll", `
+    ".\odamex\RelWithDebInfo\odasrv.exe", `
+    ".\odamex\RelWithDebInfo\odasrv.pdb", `
+    ".\odamex\RelWithDebInfo\odalaunch.exe", `
+    ".\odamex\RelWithDebInfo\odalaunch.pdb", `
+    ".\odamex\RelWithDebInfo\*.dll", `
+    ".\odamex\odamex.wad", `
     "C:\Windows\System32\msvcp140.dll", `
     "C:\Windows\System32\vcruntime140.dll", `
     "C:\Windows\System32\vcruntime140_1.dll" `

--- a/ci/win-prepare-demotest.ps1
+++ b/ci/win-prepare-demotest.ps1
@@ -13,7 +13,7 @@ Copy-Item -Path `
     ".\odamex\RelWithDebInfo\odalaunch.exe", `
     ".\odamex\RelWithDebInfo\odalaunch.pdb", `
     ".\odamex\RelWithDebInfo\*.dll", `
-    ".\odamex\odamex.wad", `
+    ".\odamex\RelWithDebInfo\odamex.wad", `
     "C:\Windows\System32\msvcp140.dll", `
     "C:\Windows\System32\vcruntime140.dll", `
     "C:\Windows\System32\vcruntime140_1.dll" `

--- a/ci/win-release-x64.ps1
+++ b/ci/win-release-x64.ps1
@@ -94,7 +94,7 @@ function CopyFilesX64 {
         -Destination "${CommonDir}\MAINTAINERS.txt"
     Copy-Item -Force -Path "${CurrentDir}\README" `
         -Destination "${CommonDir}\README.txt"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\wad\odamex.wad" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\odamex\odamex.wad" `
         -Destination "${CommonDir}"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\COPYING.SDL2_mixer.txt"
@@ -121,23 +121,23 @@ function CopyFilesX64 {
     New-Item -Force -ItemType "directory" -Path "${X64Dir}\redist"
 
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libgme.dll", `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libwavpack-1.dll", `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libxmp.dll", `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libogg-0.dll", `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libopus-0.dll", `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\libopusfile-0.dll", `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\odamex.exe", `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\SDL2_mixer.dll", `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\SDL2.dll", `
-        "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\odalaunch.exe", `
-        "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\wxbase332u_net_vc14x_x64.dll", `
-        "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\wxbase332u_vc14x_x64.dll", `
-        "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\wxbase332u_xml_vc14x_x64.dll", `
-        "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\wxmsw332u_core_vc14x_x64.dll", `
-        "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\wxmsw332u_html_vc14x_x64.dll", `
-        "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\wxmsw332u_xrc_vc14x_x64.dll", `
-        "${CurrentDir}\BuildX64\server\RelWithDebInfo\odasrv.exe" `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\libgme.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\libwavpack-1.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\libxmp.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\libogg-0.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\libopus-0.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\libopusfile-0.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\odamex.exe", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\SDL2_mixer.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\SDL2.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\odalaunch.exe", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\wxbase332u_net_vc14x_x64.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\wxbase332u_vc14x_x64.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\wxbase332u_xml_vc14x_x64.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\wxmsw332u_core_vc14x_x64.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\wxmsw332u_html_vc14x_x64.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\wxmsw332u_xrc_vc14x_x64.dll", `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\odasrv.exe" `
         -Destination "${X64Dir}\"
 
     # Get VC++ Redist
@@ -170,13 +170,13 @@ function ZipDebugX64 {
 
     # Copy pdb files into zip.  DO NOT THROW THESE AWAY!
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX64\client\RelWithDebInfo\odamex.pdb" `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\odamex.pdb" `
         -Destination "${OutputDir}\odamex-x64-${OdamexVersion}${OdamexTestSuffix}.pdb"
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX64\server\RelWithDebInfo\odasrv.pdb" `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\odasrv.pdb" `
         -Destination "${OutputDir}\odasrv-x64-${OdamexVersion}${OdamexTestSuffix}.pdb"
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX64\odalaunch\RelWithDebInfo\odalaunch.pdb" `
+        "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\odalaunch.pdb" `
         -Destination "${OutputDir}\odalaunch-x64-${OdamexVersion}${OdamexTestSuffix}.pdb"
 
     7z.exe a `

--- a/ci/win-release-x64.ps1
+++ b/ci/win-release-x64.ps1
@@ -94,7 +94,7 @@ function CopyFilesX64 {
         -Destination "${CommonDir}\MAINTAINERS.txt"
     Copy-Item -Force -Path "${CurrentDir}\README" `
         -Destination "${CommonDir}\README.txt"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX64\odamex\odamex.wad" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX64\odamex\RelWithDebInfo\odamex.wad" `
         -Destination "${CommonDir}"
     Copy-Item -Force -Path "${CurrentDir}\BuildX64\libraries\SDL2_mixer-2.8.1\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\COPYING.SDL2_mixer.txt"

--- a/ci/win-release-x86.ps1
+++ b/ci/win-release-x86.ps1
@@ -94,7 +94,7 @@ function CopyFilesX86 {
         -Destination "${CommonDir}\MAINTAINERS.txt"
     Copy-Item -Force -Path "${CurrentDir}\README" `
         -Destination "${CommonDir}\README.txt"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\odamex\odamex.wad" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\odamex.wad" `
         -Destination "${CommonDir}"
     Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\COPYING.SDL2_mixer.txt"

--- a/ci/win-release-x86.ps1
+++ b/ci/win-release-x86.ps1
@@ -94,7 +94,7 @@ function CopyFilesX86 {
         -Destination "${CommonDir}\MAINTAINERS.txt"
     Copy-Item -Force -Path "${CurrentDir}\README" `
         -Destination "${CommonDir}\README.txt"
-    Copy-Item -Force -Path "${CurrentDir}\BuildX86\wad\odamex.wad" `
+    Copy-Item -Force -Path "${CurrentDir}\BuildX86\odamex\odamex.wad" `
         -Destination "${CommonDir}"
     Copy-Item -Force -Path "${CurrentDir}\BuildX86\libraries\SDL2_mixer-2.8.1\LICENSE.txt" `
         -Destination "${CommonDir}\licenses\COPYING.SDL2_mixer.txt"
@@ -121,23 +121,23 @@ function CopyFilesX86 {
     New-Item -Force -ItemType "directory" -Path "${X86Dir}\redist"
 
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libgme.dll", `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libwavpack-1.dll", `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libxmp.dll", `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libogg-0.dll", `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libopus-0.dll", `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\libopusfile-0.dll", `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\odamex.exe", `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\SDL2_mixer.dll", `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\SDL2.dll", `
-        "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\odalaunch.exe", `
-        "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\wxbase32u_net_vc14x.dll", `
-        "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\wxbase32u_vc14x.dll", `
-        "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\wxbase32u_xml_vc14x.dll", `
-        "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\wxmsw32u_core_vc14x.dll", `
-        "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\wxmsw32u_html_vc14x.dll", `
-        "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\wxmsw32u_xrc_vc14x.dll", `
-        "${CurrentDir}\BuildX86\server\RelWithDebInfo\odasrv.exe" `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\libgme.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\libwavpack-1.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\libxmp.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\libogg-0.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\libopus-0.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\libopusfile-0.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\odamex.exe", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\SDL2_mixer.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\SDL2.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\odalaunch.exe", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\wxbase32u_net_vc14x.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\wxbase32u_vc14x.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\wxbase32u_xml_vc14x.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\wxmsw32u_core_vc14x.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\wxmsw32u_html_vc14x.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\wxmsw32u_xrc_vc14x.dll", `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\odasrv.exe" `
         -Destination "${X86Dir}\"
 
     # Get VC++ Redist
@@ -168,13 +168,13 @@ function ZipDebugX86 {
     New-Item  -Force -ItemType "directory" -Path "${PdbDir}"
     # Copy pdb files into zip.  DO NOT THROW THESE AWAY!
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX86\client\RelWithDebInfo\odamex.pdb" `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\odamex.pdb" `
         -Destination "${OutputDir}\odamex-x86-${OdamexVersion}${OdamexTestSuffix}.pdb"
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX86\server\RelWithDebInfo\odasrv.pdb" `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\odasrv.pdb" `
         -Destination "${OutputDir}\odasrv-x86-${OdamexVersion}${OdamexTestSuffix}.pdb"
     Copy-Item -Force -Path `
-        "${CurrentDir}\BuildX86\odalaunch\RelWithDebInfo\odalaunch.pdb" `
+        "${CurrentDir}\BuildX86\odamex\RelWithDebInfo\odalaunch.pdb" `
         -Destination "${OutputDir}\odalaunch-x86-${OdamexVersion}${OdamexTestSuffix}.pdb"
 
     7z.exe a `

--- a/ci/win-x32-artifact.ps1
+++ b/ci/win-x32-artifact.ps1
@@ -17,7 +17,7 @@ Copy-Item `
         ".\odamex\RelWithDebInfo\odamex.pdb", `
         ".\odamex\RelWithDebInfo\odasrv.exe", `
         ".\odamex\RelWithDebInfo\odasrv.pdb", `
-        ".\odamex\odamex.wad", `
+        ".\odamex\RelWithDebInfo\odamex.wad", `
         ".\libraries\SDL2-2.32.8\lib\x86\*.dll", `
         ".\libraries\SDL2_mixer-2.8.1\lib\x86\*.dll", `
         ".\libraries\SDL2_mixer-2.8.1\lib\x86\optional\*.dll", `

--- a/ci/win-x32-artifact.ps1
+++ b/ci/win-x32-artifact.ps1
@@ -12,12 +12,18 @@ mkdir artifact | Out-Null
 
 # Copy all built files into artifact directory
 Copy-Item `
-    -Path ".\client\RelWithDebInfo\odamex.exe", ".\client\RelWithDebInfo\odamex.pdb", `
-    ".\server\RelWithDebInfo\odasrv.exe", ".\server\RelWithDebInfo\odasrv.pdb", `
-    ".\wad\odamex.wad", `
-    ".\libraries\SDL2-2.32.8\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.8.1\lib\x86\*.dll", ".\libraries\SDL2_mixer-2.8.1\lib\x86\optional\*.dll", `
-    "C:\Windows\System32\msvcp140.dll", "C:\Windows\System32\vcruntime140.dll", `
-    "C:\Windows\System32\vcruntime140_1.dll" `
+    -Path `
+        ".\odamex\RelWithDebInfo\odamex.exe", `
+        ".\odamex\RelWithDebInfo\odamex.pdb", `
+        ".\odamex\RelWithDebInfo\odasrv.exe", `
+        ".\odamex\RelWithDebInfo\odasrv.pdb", `
+        ".\odamex\odamex.wad", `
+        ".\libraries\SDL2-2.32.8\lib\x86\*.dll", `
+        ".\libraries\SDL2_mixer-2.8.1\lib\x86\*.dll", `
+        ".\libraries\SDL2_mixer-2.8.1\lib\x86\optional\*.dll", `
+        "C:\Windows\System32\msvcp140.dll", `
+        "C:\Windows\System32\vcruntime140.dll", `
+        "C:\Windows\System32\vcruntime140_1.dll" `
     -Destination "artifact"
 
 # Archive files into a zip

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -158,7 +158,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
 
   add_executable(odamex MACOSX_BUNDLE WIN32
     ${CLIENT_SOURCES} ${CLIENT_SDL_SOURCES} ${COMMON_SOURCES} ${CLIENT_GUI_SOURCES})
-  odamex_target_settings(odamex)
+  odamex_target_settings(TARGET odamex)
   odamex_target_errors(odamex)
 
   if(USE_DEFAULT_SIMD)

--- a/cmake/modules/OdamexTargetSettings.cmake
+++ b/cmake/modules/OdamexTargetSettings.cmake
@@ -12,7 +12,7 @@ endfunction()
 function(odamex_target_settings)
   set(options NO_DEPLOYMENT_ARTIFACT)
   set(oneValueArgs TARGET)
-  set(multiValueArgs TARGETS)
+  set(multiValueArgs )
 
   cmake_parse_arguments(PARSE_ARGV 0 arg "${options}" "${oneValueArgs}" "${multiValueArgs}")
 

--- a/cmake/modules/OdamexTargetSettings.cmake
+++ b/cmake/modules/OdamexTargetSettings.cmake
@@ -9,81 +9,91 @@ function(checked_add_compile_flag _LIST _FLAG _VAR)
   endif()
 endfunction()
 
-function(odamex_target_settings _TARGET)
+function(odamex_target_settings)
+  set(options NO_DEPLOYMENT_ARTIFACT)
+  set(oneValueArgs TARGET)
+  set(multiValueArgs TARGETS)
+
+  cmake_parse_arguments(PARSE_ARGV 0 arg "${options}" "${oneValueArgs}" "${multiValueArgs}")
+
   set(ODAMEX_DLLS "")
 
-  set_property(TARGET "${_TARGET}" PROPERTY CXX_STANDARD 20)
+  set_target_properties("${arg_TARGET}" PROPERTIES CXX_STANDARD 20)
+
+  if (NOT arg_NO_DEPLOYMENT_ARTIFACT)
+    set_target_properties("${arg_TARGET}" PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${ODAMEX_ARTIFACT_DIR}")
+  endif()
 
   if(HAS_LTO)
-    set_property(TARGET "${_TARGET}"
+    set_property(TARGET "${arg_TARGET}"
       PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
   endif()
 
   if(APPLE)
-    target_compile_definitions("${_TARGET}" PRIVATE OSX UNIX)
-    set_target_properties("${_TARGET}" PROPERTIES
+    target_compile_definitions("${arg_TARGET}" PRIVATE OSX UNIX)
+    set_target_properties("${arg_TARGET}" PROPERTIES
       XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "")
   elseif(SOLARIS)
-    target_compile_definitions("${_TARGET}" PRIVATE SOLARIS UNIX BSD_COMP)
-    target_compile_options("${_TARGET}" PRIVATE -gstabs+)
+    target_compile_definitions("${arg_TARGET}" PRIVATE SOLARIS UNIX BSD_COMP)
+    target_compile_options("${arg_TARGET}" PRIVATE -gstabs+)
   elseif(UNIX)
-    target_compile_definitions("${_TARGET}" PRIVATE UNIX)
+    target_compile_definitions("${arg_TARGET}" PRIVATE UNIX)
   endif()
 
-  target_compile_definitions("${_TARGET}" PRIVATE $<$<CONFIG:Debug>:ODAMEX_DEBUG>)
+  target_compile_definitions("${arg_TARGET}" PRIVATE $<$<CONFIG:Debug>:ODAMEX_DEBUG>)
 
   # The Win32 / Win SDK-related definitions and macros are controlled in a header file.
   # Force that header file into our targets' compile options here.
   if (WIN32)
       if (MSVC)
-        target_compile_options("${_TARGET}" PRIVATE /FI${CMAKE_SOURCE_DIR}/common/win32inc.h)
+        target_compile_options("${arg_TARGET}" PRIVATE /FI${CMAKE_SOURCE_DIR}/common/win32inc.h)
       elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        target_compile_options("${_TARGET}" PRIVATE --include=${CMAKE_SOURCE_DIR}/common/win32inc.h)
+        target_compile_options("${arg_TARGET}" PRIVATE --include=${CMAKE_SOURCE_DIR}/common/win32inc.h)
       endif()
   endif()
 
   if(MSVC)
-    target_compile_options("${_TARGET}" PRIVATE /MP)
+    target_compile_options("${arg_TARGET}" PRIVATE /MP)
     if(USE_SANITIZE_ADDRESS)
-      target_compile_options("${_TARGET}" PRIVATE /fsanitize=address)
+      target_compile_options("${arg_TARGET}" PRIVATE /fsanitize=address)
     endif()
   else()
-    target_compile_options("${_TARGET}" PRIVATE -Wall -Wextra)
+    target_compile_options("${arg_TARGET}" PRIVATE -Wall -Wextra)
 
     if(USE_GPROF)
-      target_compile_options("${_TARGET}" PRIVATE -p)
+      target_compile_options("${arg_TARGET}" PRIVATE -p)
     endif()
 
     if(USE_COLOR_DIAGNOSTICS)
       if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        target_compile_options("${_TARGET}" PRIVATE -fcolor-diagnostics)
+        target_compile_options("${arg_TARGET}" PRIVATE -fcolor-diagnostics)
       else()
-        target_compile_options("${_TARGET}" PRIVATE -fdiagnostics-color=always)
+        target_compile_options("${arg_TARGET}" PRIVATE -fdiagnostics-color=always)
       endif()
     endif()
 
     if(USE_STATIC_STDLIB)
-      target_link_options("${_TARGET}" PRIVATE -static-libgcc -static-libstdc++)
+      target_link_options("${arg_TARGET}" PRIVATE -static-libgcc -static-libstdc++)
     endif()
 
     if(USE_SANITIZE_ADDRESS)
-      target_compile_options("${_TARGET}" PRIVATE
+      target_compile_options("${arg_TARGET}" PRIVATE
         -fsanitize=address -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls)
-      target_link_options("${_TARGET}" PRIVATE -fsanitize=address)
+      target_link_options("${arg_TARGET}" PRIVATE -fsanitize=address)
     endif()
 
     if(USE_SANITIZE_THREAD)
-      target_compile_options("${_TARGET}" PRIVATE
+      target_compile_options("${arg_TARGET}" PRIVATE
         -fsanitize=thread -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls)
-      target_link_options("${_TARGET}" PRIVATE -fsanitize=thread)
+      target_link_options("${arg_TARGET}" PRIVATE -fsanitize=thread)
     endif()
 
     if(USE_SANITIZE_UNDEFINED)
       # doom is full of left shifts of negative values, which is UB
       # but since there's so many, it drowns out the rest of the UB warnings
-      target_compile_options("${_TARGET}" PRIVATE
+      target_compile_options("${arg_TARGET}" PRIVATE
         -fsanitize=undefined -fno-sanitize=shift -O1)
-      target_link_options("${_TARGET}" PRIVATE -fsanitize=undefined -fno-sanitize=shift)
+      target_link_options("${arg_TARGET}" PRIVATE -fsanitize=undefined -fno-sanitize=shift)
     endif()
   endif()
 
@@ -105,22 +115,22 @@ function(odamex_target_settings _TARGET)
     checked_add_compile_flag(CHECKED_OPTIONS -Wno-unused-parameter W_NO_UNUSED_PARAMETER)
     checked_add_compile_flag(CHECKED_OPTIONS -Wstrict-aliasing W_STRICT_ALIASING)
   endif()
-  target_compile_options("${_TARGET}" PRIVATE ${CHECKED_OPTIONS})
-  target_compile_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:${CHECKED_RELEASE_OPTIONS}>)
+  target_compile_options("${arg_TARGET}" PRIVATE ${CHECKED_OPTIONS})
+  target_compile_options("${arg_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:${CHECKED_RELEASE_OPTIONS}>)
 
   # Add link options - checked link options need at least 3.18.
   if(MSVC)
     if(USE_SANITIZE_ADDRESS)
-      target_link_options("${_TARGET}" PRIVATE /INCREMENTAL:NO)
+      target_link_options("${arg_TARGET}" PRIVATE /INCREMENTAL:NO)
     else()
-      target_link_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
+      target_link_options("${arg_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>)
     endif()
-    target_link_options("${_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/LTCG>)
+    target_link_options("${arg_TARGET}" PRIVATE $<$<NOT:$<CONFIG:Debug>>:/LTCG>)
   endif()
 
   # Ensure we get a useful stack trace on Linux.
   if(UNIX AND NOT APPLE)
-    target_link_options("${_TARGET}" PRIVATE -rdynamic)
+    target_link_options("${arg_TARGET}" PRIVATE -rdynamic)
   endif()
 
   if(MINGW)
@@ -145,9 +155,9 @@ function(odamex_target_settings _TARGET)
 
   # Copy library files to target directory.
   foreach(ODAMEX_DLL ${ODAMEX_DLLS})
-    add_custom_command(TARGET "${_TARGET}" POST_BUILD
+    add_custom_command(TARGET "${arg_TARGET}" POST_BUILD
       COMMAND "${CMAKE_COMMAND}" -E copy_if_different
-      "${ODAMEX_DLL}" $<TARGET_FILE_DIR:${_TARGET}> VERBATIM)
+      "${ODAMEX_DLL}" $<TARGET_FILE_DIR:${arg_TARGET}> VERBATIM)
   endforeach()
 endfunction()
 

--- a/master/CMakeLists.txt
+++ b/master/CMakeLists.txt
@@ -5,7 +5,7 @@ file(GLOB MASTER_SOURCES *.cpp *.h)
 
 # Master target
 add_executable(odamast ${MASTER_SOURCES})
-odamex_target_settings(odamast)
+odamex_target_settings(TARGET odamast)
 set_property(TARGET odamast PROPERTY CXX_STANDARD 98)
 
 if(WIN32)

--- a/odalaunch/CMakeLists.txt
+++ b/odalaunch/CMakeLists.txt
@@ -62,7 +62,7 @@ if(wxWidgets_FOUND)
     ${LAUNCH_SOURCES} ${LAUNCH_HEADERS}
     ${CVARDOC_SOURCE}
     ${XRCRES_HEADER} ${LAUNCH_WIN32_RESOURCES})
-  odamex_target_settings(odalaunch)
+  odamex_target_settings(TARGET odalaunch)
 
   target_link_libraries(odalaunch ${wxWidgets_LIBRARIES})
 

--- a/odalpapi/net_utils.cpp
+++ b/odalpapi/net_utils.cpp
@@ -27,16 +27,20 @@
 #include <iostream>
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <WinSock2.h>
-#include <Windows.h>
+#   ifndef WIN32_LEAN_AND_MEAN
+#       define WIN32_LEAN_AND_MEAN
+#   endif
+#   ifndef NOMINMAX
+#       define NOMINMAX
+#   endif
+#   include <WinSock2.h>
+#   include <Windows.h>
 #else
-#include <sys/time.h>
+#   include <sys/time.h>
 #endif
 
 #ifdef max
-	#undef max
+#   undef max
 #endif
 
 #include <limits>

--- a/odaproto/CMakeLists.txt
+++ b/odaproto/CMakeLists.txt
@@ -20,7 +20,7 @@ source_group("Definitions" FILES ${ODAPROTO_PROTOS})
 source_group("Generated" FILES ${ODAPROTO_SOURCES})
 
 add_library(odaproto STATIC ${ODAPROTO_SOURCES} ${ODAPROTO_PROTOS})
-odamex_target_settings(odaproto)
+odamex_target_settings(TARGET odaproto)
 target_include_directories(odaproto PUBLIC "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(odaproto protobuf::libprotobuf)
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 add_executable(odasrv
   ${COMMON_SOURCES} ${SERVER_SOURCES} ${SERVER_WIN32_SOURCES})
-odamex_target_settings(odasrv)
+odamex_target_settings(TARGET odasrv)
 odamex_target_errors(odasrv)
 
 target_include_directories(odasrv PRIVATE src)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -43,5 +43,5 @@ elseif(UNIX AND NOT APPLE)
   target_link_libraries(odagtest rt)
 endif()
 
-odamex_target_settings(odagtest)
+odamex_target_settings(TARGET odagtest NO_DEPLOYMENT_ARTIFACT)
 odamex_target_errors(odagtest)

--- a/wad/CMakeLists.txt
+++ b/wad/CMakeLists.txt
@@ -14,23 +14,31 @@ file(GLOB_RECURSE ODAWAD_SOURCES
 if(Python_FOUND)
   message(STATUS "Found Python: ${Python_EXECUTABLE}")
 
+  get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if (IS_MULTI_CONFIG)
+      set (WAD_OUTPUT_DIR "${ODAMEX_ARTIFACT_DIR}/$<CONFIG>")
+  else()
+      set (WAD_OUTPUT_DIR "${ODAMEX_ARTIFACT_DIR}")
+  endif()
+
+  # CMake >= 3.20 needed so that a potential embedded $<CONFIG> can work in OUTPUT below.
   add_custom_command(
-    OUTPUT "${ODAMEX_ARTIFACT_DIR}/odamex.wad"
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${ODAMEX_ARTIFACT_DIR}"
-    COMMAND "${Python_EXECUTABLE}" odawad.py -o "${ODAMEX_ARTIFACT_DIR}/odamex.wad" wadinfo.txt
+    OUTPUT "${WAD_OUTPUT_DIR}/odamex.wad"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${WAD_OUTPUT_DIR}"
+    COMMAND "${Python_EXECUTABLE}" odawad.py -o "${WAD_OUTPUT_DIR}/odamex.wad" wadinfo.txt
     DEPENDS ${ODAWAD_SOURCES}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     VERBATIM)
 
   add_custom_target(odawad ALL
-    DEPENDS "${ODAMEX_ARTIFACT_DIR}/odamex.wad")
+    DEPENDS "${WAD_OUTPUT_DIR}/odamex.wad")
 
   if(WIN32)
-    install(FILES "${ODAMEX_ARTIFACT_DIR}/odamex.wad"
+    install(FILES "${WAD_OUTPUT_DIR}/odamex.wad"
       DESTINATION .
       COMPONENT common)
   else()
-    install(FILES "${ODAMEX_ARTIFACT_DIR}/odamex.wad"
+    install(FILES "${WAD_OUTPUT_DIR}/odamex.wad"
       DESTINATION "${CMAKE_INSTALL_DATADIR}/odamex"
       COMPONENT common)
   endif()

--- a/wad/CMakeLists.txt
+++ b/wad/CMakeLists.txt
@@ -10,53 +10,27 @@ file(GLOB_RECURSE ODAWAD_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/lumps/*.wav
   ${CMAKE_CURRENT_SOURCE_DIR}/sprites/*.png)
 
-# Please note that we add the copier commands in the same directory as the custom target
-# because CMake requires it for proper dependency creation - please see add_custom_command
-# documentation.
-
-macro(odamex_copy_wad _target)
-
-  add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/odawad_${_target}.stamp"
-      COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${_target}>
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad" $<TARGET_FILE_DIR:${_target}>
-      COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/odawad_${_target}.stamp"
-      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad" ${_target}
-      VERBATIM
-      COMMENT "Copying $<TARGET_NAME:${_target}> odamex.wad if necessary..."
-      )
-  add_custom_target(odawad_${_target} ALL
-      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odawad_${_target}.stamp")
-
-endmacro()
-
 # If Python is available, use it to build the WAD.
 if(Python_FOUND)
   message(STATUS "Found Python: ${Python_EXECUTABLE}")
 
   add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad"
-    COMMAND "${Python_EXECUTABLE}" odawad.py -o "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad" wadinfo.txt
+    OUTPUT "${ODAMEX_ARTIFACT_DIR}/odamex.wad"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${ODAMEX_ARTIFACT_DIR}"
+    COMMAND "${Python_EXECUTABLE}" odawad.py -o "${ODAMEX_ARTIFACT_DIR}/odamex.wad" wadinfo.txt
     DEPENDS ${ODAWAD_SOURCES}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     VERBATIM)
 
   add_custom_target(odawad ALL
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad")
-
-  if (TARGET odamex)
-    odamex_copy_wad(odamex)
-  endif()
-  if (TARGET odasrv)
-    odamex_copy_wad(odasrv)
-  endif()
+    DEPENDS "${ODAMEX_ARTIFACT_DIR}/odamex.wad")
 
   if(WIN32)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad"
+    install(FILES "${ODAMEX_ARTIFACT_DIR}/odamex.wad"
       DESTINATION .
       COMPONENT common)
   else()
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/odamex.wad"
+    install(FILES "${ODAMEX_ARTIFACT_DIR}/odamex.wad"
       DESTINATION "${CMAKE_INSTALL_DATADIR}/odamex"
       COMPONENT common)
   endif()


### PR DESCRIPTION
### Overview

This PR consolidates the runtime end-item artifacts to a single "deployment artifacts only" directory.

***NOTE***:  This PR has a commit-level (but not technical) dependency on https://github.com/odamex/odamex/pull/1897

Instead of the executables, dlls, and wads being dropped into separate build subdirectories for `client/`, `server/`, `odalaunch/`, and `wad/` (with file-copying glue custom commands), the build process directly writes the deployable end-item artifacts into a single directory (`odamex/` by default).

```
$ ls -l build_protobreak/odamex/
total 230012
-rwxr-xr-x 1 xxx yyy  1576448 Aug 11 08:40 SDL2.dll*
-rwxr-xr-x 1 xxx yyy   421376 Aug 11 08:40 SDL2_mixer.dll*
-rwxr-xr-x 1 xxx yyy   409088 Aug 11 08:40 libgme.dll*
-rwxr-xr-x 1 xxx yyy    35328 Aug 11 08:40 libogg-0.dll*
-rwxr-xr-x 1 xxx yyy   370176 Aug 11 08:40 libopus-0.dll*
-rwxr-xr-x 1 xxx yyy    51200 Aug 11 08:40 libopusfile-0.dll*
-rwxr-xr-x 1 xxx yyy   175616 Aug 11 08:40 libwavpack-1.dll*
-rwxr-xr-x 1 xxx yyy   411648 Aug 11 08:40 libxmp.dll*
-rwxr-xr-x 1 xxx yyy  2264576 Aug 11 08:39 odalaunch.exe*
-rw-r--r-- 1 xxx yyy 14422016 Aug 11 08:39 odalaunch.pdb
-rwxr-xr-x 1 xxx yyy 11267072 Aug 11 10:47 odamex.exe*
-rw-r--r-- 1 xxx yyy 96497664 Aug 11 10:47 odamex.pdb
-rw-r--r-- 1 xxx yyy  6217128 Aug 11 08:56 odamex.wad
-rw-r--r-- 1 xxx yyy    99767 Aug 11 10:47 odamex_cvardoc.json
-rwxr-xr-x 1 xxx yyy  7630336 Aug 11 10:46 odasrv.exe*
-rw-r--r-- 1 xxx yyy 78548992 Aug 11 10:46 odasrv.pdb
-rwxr-xr-x 1 xxx yyy   347136 Aug 11 08:39 wxbase332u_net_vc14x_x64.dll*
-rwxr-xr-x 1 xxx yyy  3122176 Aug 11 08:39 wxbase332u_vc14x_x64.dll*
-rwxr-xr-x 1 xxx yyy   204800 Aug 11 08:39 wxbase332u_xml_vc14x_x64.dll*
-rwxr-xr-x 1 xxx yyy  9545728 Aug 11 08:39 wxmsw332u_core_vc14x_x64.dll*
-rwxr-xr-x 1 xxx yyy   832000 Aug 11 08:39 wxmsw332u_html_vc14x_x64.dll*
-rwxr-xr-x 1 xxx yyy  1053696 Aug 11 08:39 wxmsw332u_xrc_vc14x_x64.dll*
```

This also removes the need for copying the odamex.wad in the build process.

### Details

The changes are:

- Add the `ODAMEX_ARTIFACT_DIR` path variable to the CMake cache, which allows for the above directory to be configurable.
- `odamex_target_settings`:
  - Set the `RUNTIME_OUTPUT_DIRECTORY` target property to `${ODAMEX_ARTIFACT_DIR}`
  - Allow targets to specify `NO_DEPLOYMENT_ARTIFACT` in the call to `odamex_target_settings` to prevent the artifact from being placed into the output directory.  This is essentially for the unit testing executable target's use.
- Write the generated **odamex.wad** to `${ODAMEX_ARTIFACT_DIR}`, or, for multi-config build systems such as msbuild, `${ODAMEX_ARTIFACT_DIR}/$<CONFIG>`.
- Remove the copy commands for **odamex.wad**
- Corresponding updates to the CI and github workflow artifact-collection scripts.