### PR TITLE
Fix for interpolation of camera when using freecam

### DIFF
--- a/client/src/cl_pred.cpp
+++ b/client/src/cl_pred.cpp
@@ -314,7 +314,10 @@ void CL_PredictWorld(void)
 	// tenatively tell the netgraph that our prediction was successful
 	netgraph.setMisprediction(false);
 
-	if (consoleplayer_id != displayplayer_id)
+	if (consoleplayer_id != displayplayer_id && displayplayer().isFreecam)
+		CL_PredictFreecam();
+
+	if (consoleplayer_id != displayplayer_id && not displayplayer().isFreecam)
 		CL_PredictSpying();
 
 	CL_PredictRemotePlayers();

--- a/client/src/r_interp.cpp
+++ b/client/src/r_interp.cpp
@@ -501,7 +501,7 @@ void OInterpolation::interpolateCamera(fixed_t amount, bool use_localview,
 			}
 			else
 			{
-				// Only interpolate if we are spectating
+				// Only interpolate if we are spectating/freecam
 				// interpolate amount/FRACUNIT percent between previous value and
 				// current value
 				viewangle = camera->prevangle +
@@ -550,11 +550,10 @@ void OInterpolation::interpolateView(player_t* player, fixed_t amount)
 		return;
 
 	player_t& consolePlayer = consoleplayer();
-	const bool use_localview =
-	    (consolePlayer.id == displayplayer().id && consolePlayer.health > 0 &&
-	     !consolePlayer.mo->reactiontime && !netdemo.isPlaying() && !demoplayback)
-		||
-		displayplayer().isFreecam;
+	const bool use_localview = consolePlayer.id == displayplayer().id &&
+	                           consolePlayer.health > 0 &&
+	                           not consolePlayer.mo->reactiontime &&
+	                           not netdemo.isInPlayback() && not demoplayback;
 
 	interpolateCamera(amount, use_localview, player->cheats & CF_CHASECAM);
 }

--- a/client/src/r_main.cpp
+++ b/client/src/r_main.cpp
@@ -869,11 +869,10 @@ void R_SetupFrame (player_t *player)
 		return;
 
 	player_t &consolePlayer = consoleplayer();
-	const bool use_localview =
-	    (consolePlayer.id == displayplayer().id && consolePlayer.health > 0 &&
-	     !consolePlayer.mo->reactiontime && !netdemo.isPlaying() && !demoplayback)
-		||
-		displayplayer().isFreecam;
+	const bool use_localview = consolePlayer.id == displayplayer().id &&
+	                           consolePlayer.health > 0 &&
+	                           not consolePlayer.mo->reactiontime &&
+	                           not netdemo.isInPlayback() && not demoplayback;
 
 	if (camera->player && camera->player->xviewshift && !paused)
 	{
@@ -943,13 +942,13 @@ void R_SetupFrame (player_t *player)
 		memset (scalelightfixed, 0, MAXLIGHTSCALE*sizeof(*scalelightfixed));
 	}
 
-	if ((use_localview && !::localview.skippitch) || netdemo.isPaused() || displayplayer().isFreecam)
+	if ((use_localview && !::localview.skippitch) || netdemo.isPaused())
 	{
 		R_ViewShear(std::clamp(camera->pitch - ::localview.pitch, -ANG(32), ANG(56)));
 	}
 	else
 	{
-		// Only interpolate if we are spectating
+		// Only interpolate if we are spectating/freecam
 		fixed_t pitch = camera->prevpitch + FixedMul(render_lerp_amount, camera->pitch - camera->prevpitch);
 		R_ViewShear(pitch);
 	}


### PR DESCRIPTION
Previously the freecam was going through CL_PredictSpying which resets prevangle/prevpitch-- because of that I couldnt get camera interp to work, so I incorrectly forced the freecam through with use_localview. This fix stops that and interpolates the freecam camera similar to spectator, fixes #1885