### PR TITLE
Resolve all clang-tidy errors in M_Options.cpp

### DIFF
--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -100,7 +100,7 @@ void D_DoAdvanceDemo();
 
 void D_DoomLoop();
 
-extern int testingmode;
+extern dtime_t testingmode;
 extern bool gameisdead;
 extern bool M_DemoNoPlay;	// [RH] if true, then skip any demos in the loop
 extern DThinker ThinkerCap;
@@ -190,7 +190,7 @@ void D_ProcessEvents (void)
 	// [RH] If testing mode, do not accept input until test is over
 	if (testingmode)
 	{
-		if (static_cast <dtime_t>(testingmode) <= I_MSTime() * TICRATE / 1000)
+		if (testingmode <= I_MSTime() * TICRATE / MSECS_PER_SEC)
 			M_RestoreVideoMode();
 		else
 			M_ModeFlashTestText();

--- a/client/src/m_menu.h
+++ b/client/src/m_menu.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <array>
+
 #include "d_event.h"
 
 // Some defines...
@@ -204,11 +206,11 @@ typedef struct
 	bool drawSkull;
 } menustack_t;
 
-extern value_t YesNo[2];
-extern value_t NoYes[2];
-extern value_t OnOff[2];
-extern value_t OffOn[2];
-extern value_t OnOffAuto[3];
+extern std::array<value_t, 2> YesNo;
+extern std::array<value_t, 2> NoYes;
+extern std::array<value_t, 2> OnOff;
+extern std::array<value_t, 2> OffOn;
+extern std::array<value_t, 3> OnOffAuto;
 
 extern menustack_t MenuStack[16];
 extern int MenuStackDepth;

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -260,6 +260,10 @@ constexpr int RESCOLUMN_WIDTH = 104;
 constexpr int RESCOLUMN_TEXT_X = 20;
 constexpr int RESCOLUMN_CURSOR_X = 8;
 
+// Menu item text indents.
+constexpr int MENU_HALFPASTINDENT = 177;
+constexpr int MENU_LONGTEXTINDENT = 240;
+
 struct optmouserow_t
 {
 	int		item;		// index into CurrentMenu->items
@@ -394,7 +398,7 @@ menu_t OptionMenu = {
 	"M_OPTTTL",
 	0,
 	OptionItems.size(),
-	177,
+	MENU_HALFPASTINDENT,
 	OptionItems.data(),
 	0,
 	0,
@@ -578,7 +582,7 @@ menu_t MouseMenu = {
 	"M_MOUSET",
 	0,
 	MouseItems.size(),
-	177,
+	MENU_HALFPASTINDENT,
 	MouseItems.data(),
 	0,
 	0,
@@ -617,7 +621,7 @@ menu_t JoystickMenu = {
 	"M_JOYSTK",
 	0,
 	JoystickItems.size(),
-	177,
+	MENU_HALFPASTINDENT,
 	JoystickItems.data(),
 	0,
 	0,
@@ -759,7 +763,7 @@ menu_t AdvMidiMenu = {
 	"M_SOUND",
 	3,
 	ARRAY_LENGTH(AdvMidiItems),
-	177,
+	MENU_HALFPASTINDENT,
 	AdvMidiItems,
 	0,
 	0,
@@ -770,7 +774,7 @@ menu_t LibAdlMidiMenu = {
 	"M_SOUND",
 	3,
 	LibAdlMidiItems.size(),
-	177,
+	MENU_HALFPASTINDENT,
 	LibAdlMidiItems.data(),
 	0,
 	0,
@@ -781,7 +785,7 @@ menu_t SoundMenu = {
 	"M_SOUND",
 	2,
 	SoundItems.size(),
-	177,
+	MENU_HALFPASTINDENT,
 	SoundItems.data(),
 	0,
 	0,
@@ -839,7 +843,7 @@ menu_t CompatMenu = {
 	"M_COMPAT",
 	1,
 	CompatItems.size(),
-	240,
+	MENU_LONGTEXTINDENT,
 	CompatItems.data(),
 	0,
 	0,
@@ -884,7 +888,7 @@ menu_t NetworkMenu = {
 	"M_NETWRK",
 	2,
 	NetworkItems.size(),
-	177,
+	MENU_HALFPASTINDENT,
 	NetworkItems.data(),
 	1,
 	0,
@@ -948,7 +952,7 @@ menu_t WeaponMenu = {
 	"M_WEAPON",
 	1,
 	WeaponItems.size(),
-	177,
+	MENU_HALFPASTINDENT,
 	WeaponItems.data(),
 	0,
 	0,

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -29,6 +29,8 @@
 
 #include "odamex.h"
 
+#include <array>
+
 #include <algorithm>
 #include <cmath>
 
@@ -157,7 +159,7 @@ EXTERN_CVAR (co_novileghosts)
 EXTERN_CVAR (co_zdoomfriendtargeting)
 
 // [Toke - Menu] New Menu Stuff.
-void MouseSetup (void);
+void MouseSetup();
 EXTERN_CVAR (mouse_sensitivity)
 EXTERN_CVAR (m_pitch)
 EXTERN_CVAR (novert)
@@ -186,7 +188,7 @@ EXTERN_CVAR (cl_disconnectalert)
 EXTERN_CVAR (snd_votesfx)
 
 // Joystick menu -- Hyper_Eye
-void JoystickSetup (void);
+void JoystickSetup();
 EXTERN_CVAR (use_joystick)
 EXTERN_CVAR (joy_active)
 EXTERN_CVAR (joy_forwardaxis)
@@ -230,86 +232,113 @@ EXTERN_CVAR (cl_weaponpref_rl)
 EXTERN_CVAR (cl_weaponpref_pls)
 EXTERN_CVAR (cl_weaponpref_bfg)
 
-void M_ChangeMessages(void);
+void M_ChangeMessages();
 void M_SizeDisplay(float diff);
-void M_StartControlPanel(void);
 
 int  M_StringHeight(char *string);
-void M_ClearMenus (void);
+void M_ClearMenus();
+namespace
+{
 
-static bool CanScrollUp;
-static bool CanScrollDown;
-static int VisBottom;
+
+bool CanScrollUp;
+bool CanScrollDown;
+int VisBottom;
+} // namespace
+
 
 EXTERN_CVAR(ui_mouse)
 
-#define MAX_OPT_MOUSE_ROWS	32
+constexpr int MAX_OPT_MOUSE_ROWS = 32;
+
+// The menu lays itself out in the 320x200 "clean" coordinate space.
+constexpr int MENU_CENTER_X = 160;
+constexpr int MENU_TITLE_Y = 10;
+
+// Video modes are listed in three columns of resolution strings.
+constexpr int RESCOLUMN_WIDTH = 104;
+constexpr int RESCOLUMN_TEXT_X = 20;
+constexpr int RESCOLUMN_CURSOR_X = 8;
 
 struct optmouserow_t
 {
 	int		item;		// index into CurrentMenu->items
 	int		y1, y2;		// surface pixel bounds of the row
 };
-
-static optmouserow_t	OptMouseRows[MAX_OPT_MOUSE_ROWS];
-static int				OptMouseRowCount = 0;
-
-static const int		OPT_WHEEL_LINES = 3;
-
-static int				OptDragItem = -1;
-static menu_t*			OptDragMenu = NULL;
-
-value_t YesNo[2] = {
-	{ 0.0, "No" },
-	{ 1.0, "Yes" }
-};
-
-value_t NoYes[2] = {
-	{ 0.0, "Yes" },
-	{ 1.0, "No" }
-};
-
-value_t OnOff[2] = {
-	{ 0.0, "Off" },
-	{ 1.0, "On" }
-};
-
-value_t HideShow[2] = {
-	{ 0.0, "Hide" },
-	{ 1.0, "Show" }
-};
-
-value_t OffOn[2] = {
-	{ 0.0, "On" },
-	{ 1.0, "Off" }
-};
-
-value_t OnOffAuto[3] = {
-	{ 0.0, "Off" },
-	{ 1.0, "On" },
-	{ 2.0, "Auto" }
-};
-
-value_t DemoRestrictions[2] = {
-	{ 0.0, "Restrict" },
-	{ 1.0, "Allow" }
-};
-
-static value_t DoomOrOdamex[2] =
+namespace
 {
-	{ 0.0, "Odamex" },
-	{ 1.0, "Doom" }
-};
+
+
+std::array<optmouserow_t, MAX_OPT_MOUSE_ROWS>	OptMouseRows;
+int				OptMouseRowCount = 0;
+
+const int		OPT_WHEEL_LINES = 3;
+
+int				OptDragItem = -1;
+menu_t*			OptDragMenu = nullptr;
+} // namespace
+
+
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<value_t, 2> YesNo = {{
+	{ .value = 0.0, .name = "No"},
+	{ .value = 1.0, .name = "Yes"}
+}};
+
+std::array<value_t, 2> NoYes = {{
+	{ .value = 0.0, .name = "Yes"},
+	{ .value = 1.0, .name = "No"}
+}};
+
+std::array<value_t, 2> OnOff = {{
+	{ .value = 0.0, .name = "Off"},
+	{ .value = 1.0, .name = "On"}
+}};
+
+std::array<value_t, 2> HideShow = {{
+	{ .value = 0.0, .name = "Hide"},
+	{ .value = 1.0, .name = "Show"}
+}};
+
+std::array<value_t, 2> OffOn = {{
+	{ .value = 0.0, .name = "On"},
+	{ .value = 1.0, .name = "Off"}
+}};
+
+std::array<value_t, 3> OnOffAuto = {{
+	{ .value = 0.0, .name = "Off"},
+	{ .value = 1.0, .name = "On"},
+	{ .value = 2.0, .name = "Auto"}
+}};
+
+std::array<value_t, 2> DemoRestrictions = {{
+	{ .value = 0.0, .name = "Restrict"},
+	{ .value = 1.0, .name = "Allow"}
+}};
+namespace
+{
+
+
+std::array<value_t, 2> DoomOrOdamex = {{
+	{ .value = 0.0, .name = "Odamex"},
+	{ .value = 1.0, .name = "Doom"}
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t  *CurrentMenu;
 int		CurrentItem;
 bool configuring_controls = false;
-static bool	WaitingForKey;
-static bool	WaitingForAxis;
-static const char	   *OldContMessage;
-static itemtype OldContType;
-static const char	   *OldAxisMessage;
-static itemtype OldAxisType;
+namespace
+{
+
+bool	WaitingForKey;
+bool	WaitingForAxis;
+const char	   *OldContMessage;
+itemtype OldContType;
+const char	   *OldAxisMessage;
+itemtype OldAxisType;
 
 /*=======================================
  *
@@ -317,52 +346,63 @@ static itemtype OldAxisType;
  *
  *=======================================*/
 
-static void PlayerSetup();
-static void CustomizeControls();
-static void VideoOptions();
-static void SoundOptions();
-static void CompatOptions();
-static void NetworkOptions();
-static void WeaponOptions();
-static void GoToConsole();
+void PlayerSetup();
+void CustomizeControls();
+void VideoOptions();
+void SoundOptions();
+void CompatOptions();
+void NetworkOptions();
+void WeaponOptions();
+void GoToConsole();
+} // namespace
+
 void Reset2Defaults();
 void Reset2Saved();
-
-static void SetVidMode();
-
-static menuitem_t OptionItems[] =
+namespace
 {
-    { more, 	"Player Setup",     	{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = PlayerSetup} },
-	{ more,		"Weapon Preferences",	{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = WeaponOptions} },
- 	{ more,		"Customize Controls",	{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = CustomizeControls} },
-	{ more,		"Mouse Options" ,	    {NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = MouseSetup} },
-	{ more,		"Joystick Setup" ,	    {NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = JoystickSetup} },
- 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
- 	{ more,		"Compatibility Options",{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = CompatOptions} },
-	{ more,		"Network Options",		{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = NetworkOptions} },
-	{ more,		"Sound Options",		{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = SoundOptions} },
- 	{ more,		"Display Options",		{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = VideoOptions} },
-	{ more,		"Set Video Mode",		{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = SetVidMode} },
-    { redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ more,		"Go To Console",		{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = GoToConsole} },
-    { redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ discrete,	"Always Run",			{&cl_run},				{2.0}, {0.0},	{0.0}, {OnOff} },
- 	{ discrete, "Skip Boot Window",		{&i_skipbootwin},		{2.0}, {0.0},	{0.0}, {OnOff} },
- 	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
- 	{ more,		"Reset to defaults",	{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = Reset2Defaults} },
- 	{ more,		"Reset to last saved",	{NULL},					{0.0}, {0.0},	{0.0}, {.mfunc = Reset2Saved} }
-};
+
+
+void SetVidMode();
+
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<menuitem_t, 19> OptionItems = {{
+	{ .type = more, 	.label = "Player Setup",     	.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = PlayerSetup}},
+	{ .type = more,		.label = "Weapon Preferences",	.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = WeaponOptions}},
+	{ .type = more,		.label = "Customize Controls",	.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = CustomizeControls}},
+	{ .type = more,		.label = "Mouse Options",	    .a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = MouseSetup}},
+	{ .type = more,		.label = "Joystick Setup",	    .a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = JoystickSetup}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = more,		.label = "Compatibility Options",.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = CompatOptions}},
+	{ .type = more,		.label = "Network Options",		.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = NetworkOptions}},
+	{ .type = more,		.label = "Sound Options",		.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = SoundOptions}},
+	{ .type = more,		.label = "Display Options",		.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = VideoOptions}},
+	{ .type = more,		.label = "Set Video Mode",		.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = SetVidMode}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = more,		.label = "Go To Console",		.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = GoToConsole}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete,	.label = "Always Run",			.a = {.cvar = &cl_run},				.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Skip Boot Window",		.a = {.cvar = &i_skipbootwin},		.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = more,		.label = "Reset to defaults",	.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = Reset2Defaults}},
+	{ .type = more,		.label = "Reset to last saved",	.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.mfunc = Reset2Saved}}
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t OptionMenu = {
 	"M_OPTTTL",
 	0,
-	ARRAY_LENGTH(OptionItems),
+	OptionItems.size(),
 	177,
-	OptionItems,
+	OptionItems.data(),
 	0,
 	0,
-	NULL
+	nullptr
 };
+namespace
+{
+
 
 /*=======================================
  *
@@ -370,106 +410,113 @@ menu_t OptionMenu = {
  *
  *=======================================*/
 
-static menuitem_t ControlsItems[] = {
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+// Sized by the initializer: entries here are conditionally compiled,
+// so a fixed std::array size would be wrong on some builds.
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+menuitem_t ControlsItems[] = {
 #ifdef GCONSOLE
-	{ whitetext,"A to change, START to clear", {NULL}, {0.0}, {0.0}, {0.0}, {NULL} },
+	{ .type = whitetext,.label = "A to change, START to clear", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
 #else
-	{ whitetext,"ENTER to change, BACKSPACE to clear", {NULL}, {0.0}, {0.0}, {0.0}, {NULL} },
+	{ .type = whitetext,.label = "ENTER to change, BACKSPACE to clear", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
 #endif
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,"Basic Movement",		{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ control,	"Move forward",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+forward"} },
-	{ control,	"Move backward",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+back"} },
-	{ control,	"Strafe left",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+moveleft"} },
-	{ control,	"Strafe right",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+moveright"} },
-	{ control,	"Turn left",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+left"} },
-	{ control,	"Turn right",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+right"} },
-	{ control,	"Run",					{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+speed"} },
-	{ control,	"Always Run",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "togglerun"} },
-	{ control,	"Strafe",				{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+strafe"} },
-	{ control,	"Jump",					{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+jump"} },
-	{ control,	"Turn 180",				{NULL}, {0.0}, {0.0}, {0.0}, {.command = "turn180"} },
-	{ control,	"Alternate Turn",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+fastturn"} },
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,"Actions",		        {NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ control,	"Fire",					{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+attack"} },
-	{ control,	"Use / Open",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+use"} },
-	{ control,	"Next weapon",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "weapnext"} },
-	{ control,	"Previous weapon",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "weapprev"} },
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,"Weapons",		        {NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ control,	"Fist/Chainsaw",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "impulse 1"} },
-	{ control,	"Pistol",       		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "impulse 2"} },
-	{ control,	"Shotgun/SSG",  		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "impulse 3"} },
-	{ control,	"Chaingun",     		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "impulse 4"} },
-	{ control,	"Rocket Launcher",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "impulse 5"} },
-	{ control,	"Plasma Rifle",   		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "impulse 6"} },
-	{ control,	"BFG",          		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "impulse 7"} },
-	{ control,	"Chainsaw",     		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "impulse 8"} },
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,	"Automap Controls",	{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ control,		"Toggle Automap",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "togglemap"} },
-	{ mapcontrol,	"Follow Player",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "am_togglefollow"} },
-	{ mapcontrol,	"Toggle Grid",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "am_grid"} },
-	{ mapcontrol,	"Add Marker",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "am_setmark"} },
-	{ mapcontrol,	"Clear Markers",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "am_clearmarks"} },
-	{ mapcontrol,	"Big Automap",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "am_big"} },
-	{ mapcontrol,	"Zoom In",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+am_zoomin"} },
-	{ mapcontrol,	"Zoom Out",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+am_zoomout"} },
-	{ mapcontrol,	"Pan Up",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+am_panup"} },
-	{ mapcontrol,	"Pan Down",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+am_pandown"} },
-	{ mapcontrol,	"Pan Left",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+am_panleft"} },
-	{ mapcontrol,	"Pan Right",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+am_panright"} },
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,"Advanced Movement",    {NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ control,	"Fly / Swim up",		{NULL},	{0.0}, {0.0}, {0.0}, {.command = "+moveup"} },
-	{ control,	"Fly / Swim down",		{NULL},	{0.0}, {0.0}, {0.0}, {.command = "+movedown"} },
-	{ control,	"Toggle flying",		{NULL},	{0.0}, {0.0}, {0.0}, {.command = "fly"} },
-	{ control,	"Look up",				{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+lookup"} },
-	{ control,	"Look down",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+lookdown"} },
-	{ control,	"Center view",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "centerview"} },
-	{ control,	"Mouse look",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+mlook"} },
-	{ control,	"Keyboard look",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+klook"} },
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,"Multiplayer",		    {NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ control,	"Say",					{NULL}, {0.0}, {0.0}, {0.0}, {.command = "messagemode"} },
-	{ control,	"Team say",				{NULL}, {0.0}, {0.0}, {0.0}, {.command = "messagemode2"} },
-	{ control,	"Ready",				{NULL}, {0.0}, {0.0}, {0.0}, {.command = "ready"} },
-	{ control,	"Change teams",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "changeteams"} },
-	{ control,	"Spectate",				{NULL}, {0.0}, {0.0}, {0.0}, {.command = "spectate"} },
-	{ control,	"Coop Spy",				{NULL}, {0.0}, {0.0}, {0.0}, {.command = "spynext"} },
-	{ control,	"Show Scoreboard",		{NULL}, {0.0}, {0.0}, {0.0}, {.command = "+showscores"} },
-	{ control,	"Vote Yes", {NULL}, {0.0}, {0.0}, {0.0}, {.command = "vote_yes"} },
-	{ control,	"Vote No", {NULL}, {0.0}, {0.0}, {0.0}, {.command = "vote_no"} },
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,"Menus",				{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ control,  "Main menu",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_main"} },
-	{ control,	"Help menu",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_help"} },
-	{ control,	"Save menu",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_save"} },
-	{ control,	"Load menu",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_load"} },
-	{ control,	"Options menu",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_options"} },
-	{ control,	"Display options",	    {NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_display"} },
-	{ control,	"Player setup menu",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_player"} },
-	{ control,	"Configure controls",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_keys"} },
-	{ control,	"Change resolution",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_video"} },
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,	"Netdemo Controls",	{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ netdemocontrol,"Pause Netdemo",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "netpause"} },
-    { netdemocontrol, "Fast Forward", {NULL}, {0.0}, {0.0}, {0.0}, {.command = "netff"}},
-    { netdemocontrol, "Rewind", {NULL}, {0.0}, {0.0}, {0.0}, {.command = "netrew"}},
-    { netdemocontrol, "Next map", {NULL}, {0.0}, {0.0}, {0.0}, {.command = "netnextmap"}},
-	{ netdemocontrol,	"Previous map",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "netprevmap"} },
-	{ redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,"Other",				{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-    { control,	"Increase screen size",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "sizeup"} },
-	{ control,	"Reduce screen size",	{NULL}, {0.0}, {0.0}, {0.0}, {.command = "sizedown"} },
-	{ control,	"Chasecam",				{NULL}, {0.0}, {0.0}, {0.0}, {.command = "chase"} },
-	{ control,	"Screenshot",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "screenshot"} },
-	{ control,  "Open console",			{NULL}, {0.0}, {0.0}, {0.0}, {.command = "toggleconsole"} },
-	{ control,  "End current game",     {NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_endgame"} },
-	{ control,  "Quit Odamex",	        {NULL}, {0.0}, {0.0}, {0.0}, {.command = "menu_quit"} }
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,.label = "Basic Movement",		.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = control,	.label = "Move forward",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+forward"}},
+	{ .type = control,	.label = "Move backward",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+back"}},
+	{ .type = control,	.label = "Strafe left",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+moveleft"}},
+	{ .type = control,	.label = "Strafe right",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+moveright"}},
+	{ .type = control,	.label = "Turn left",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+left"}},
+	{ .type = control,	.label = "Turn right",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+right"}},
+	{ .type = control,	.label = "Run",					.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+speed"}},
+	{ .type = control,	.label = "Always Run",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "togglerun"}},
+	{ .type = control,	.label = "Strafe",				.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+strafe"}},
+	{ .type = control,	.label = "Jump",					.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+jump"}},
+	{ .type = control,	.label = "Turn 180",				.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "turn180"}},
+	{ .type = control,	.label = "Alternate Turn",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+fastturn"}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,.label = "Actions",		        .a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = control,	.label = "Fire",					.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+attack"}},
+	{ .type = control,	.label = "Use / Open",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+use"}},
+	{ .type = control,	.label = "Next weapon",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "weapnext"}},
+	{ .type = control,	.label = "Previous weapon",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "weapprev"}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,.label = "Weapons",		        .a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = control,	.label = "Fist/Chainsaw",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "impulse 1"}},
+	{ .type = control,	.label = "Pistol",       		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "impulse 2"}},
+	{ .type = control,	.label = "Shotgun/SSG",  		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "impulse 3"}},
+	{ .type = control,	.label = "Chaingun",     		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "impulse 4"}},
+	{ .type = control,	.label = "Rocket Launcher",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "impulse 5"}},
+	{ .type = control,	.label = "Plasma Rifle",   		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "impulse 6"}},
+	{ .type = control,	.label = "BFG",          		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "impulse 7"}},
+	{ .type = control,	.label = "Chainsaw",     		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "impulse 8"}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,	.label = "Automap Controls",	.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = control,		.label = "Toggle Automap",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "togglemap"}},
+	{ .type = mapcontrol,	.label = "Follow Player",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "am_togglefollow"}},
+	{ .type = mapcontrol,	.label = "Toggle Grid",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "am_grid"}},
+	{ .type = mapcontrol,	.label = "Add Marker",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "am_setmark"}},
+	{ .type = mapcontrol,	.label = "Clear Markers",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "am_clearmarks"}},
+	{ .type = mapcontrol,	.label = "Big Automap",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "am_big"}},
+	{ .type = mapcontrol,	.label = "Zoom In",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+am_zoomin"}},
+	{ .type = mapcontrol,	.label = "Zoom Out",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+am_zoomout"}},
+	{ .type = mapcontrol,	.label = "Pan Up",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+am_panup"}},
+	{ .type = mapcontrol,	.label = "Pan Down",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+am_pandown"}},
+	{ .type = mapcontrol,	.label = "Pan Left",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+am_panleft"}},
+	{ .type = mapcontrol,	.label = "Pan Right",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+am_panright"}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,.label = "Advanced Movement",    .a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = control,	.label = "Fly / Swim up",		.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+moveup"}},
+	{ .type = control,	.label = "Fly / Swim down",		.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+movedown"}},
+	{ .type = control,	.label = "Toggle flying",		.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "fly"}},
+	{ .type = control,	.label = "Look up",				.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+lookup"}},
+	{ .type = control,	.label = "Look down",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+lookdown"}},
+	{ .type = control,	.label = "Center view",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "centerview"}},
+	{ .type = control,	.label = "Mouse look",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+mlook"}},
+	{ .type = control,	.label = "Keyboard look",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+klook"}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,.label = "Multiplayer",		    .a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = control,	.label = "Say",					.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "messagemode"}},
+	{ .type = control,	.label = "Team say",				.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "messagemode2"}},
+	{ .type = control,	.label = "Ready",				.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "ready"}},
+	{ .type = control,	.label = "Change teams",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "changeteams"}},
+	{ .type = control,	.label = "Spectate",				.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "spectate"}},
+	{ .type = control,	.label = "Coop Spy",				.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "spynext"}},
+	{ .type = control,	.label = "Show Scoreboard",		.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "+showscores"}},
+	{ .type = control,	.label = "Vote Yes", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "vote_yes"}},
+	{ .type = control,	.label = "Vote No", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "vote_no"}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,.label = "Menus",				.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = control,  .label = "Main menu",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_main"}},
+	{ .type = control,	.label = "Help menu",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_help"}},
+	{ .type = control,	.label = "Save menu",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_save"}},
+	{ .type = control,	.label = "Load menu",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_load"}},
+	{ .type = control,	.label = "Options menu",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_options"}},
+	{ .type = control,	.label = "Display options",	    .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_display"}},
+	{ .type = control,	.label = "Player setup menu",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_player"}},
+	{ .type = control,	.label = "Configure controls",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_keys"}},
+	{ .type = control,	.label = "Change resolution",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_video"}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,	.label = "Netdemo Controls",	.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = netdemocontrol,.label = "Pause Netdemo",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "netpause"}},
+	{ .type = netdemocontrol, .label = "Fast Forward", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "netff"}},
+	{ .type = netdemocontrol, .label = "Rewind", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "netrew"}},
+	{ .type = netdemocontrol, .label = "Next map", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "netnextmap"}},
+	{ .type = netdemocontrol,	.label = "Previous map",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "netprevmap"}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,.label = "Other",				.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = control,	.label = "Increase screen size",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "sizeup"}},
+	{ .type = control,	.label = "Reduce screen size",	.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "sizedown"}},
+	{ .type = control,	.label = "Chasecam",				.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "chase"}},
+	{ .type = control,	.label = "Screenshot",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "screenshot"}},
+	{ .type = control,  .label = "Open console",			.a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "toggleconsole"}},
+	{ .type = control,  .label = "End current game",     .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_endgame"}},
+	{ .type = control,  .label = "Quit Odamex",	        .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.command = "menu_quit"}}
 
 };
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t ControlsMenu = {
 	"M_CONTRO",
@@ -479,7 +526,7 @@ menu_t ControlsMenu = {
 	ControlsItems,
 	2,
 	0,
-	NULL
+	nullptr
 };
 
 // -------------------------------------------------------
@@ -499,38 +546,47 @@ void M_ResetMouseValues()
 	m_side.RestoreDefault();
 	m_forward.RestoreDefault();
 }
-
-
-static menuitem_t MouseItems[] =
+namespace
 {
-	{ slider,	"Overall Sensitivity"			, {&mouse_sensitivity},	{0.05},	{2.5},		{0.05},		{NULL}},
-	{ slider,	"Freelook Sensitivity"			, {&m_pitch},			{0.05},	{2.5},		{0.05},		{NULL}},
 
-	{ redtext,	" "								, {NULL},				{0.0},	{0.0},		{0.0},		{NULL}},
-	{ discrete,	"Always FreeLook"				, {&cl_mouselook},		{2.0},	{0.0},		{0.0},		{OnOff}},
-	{ discrete,	"Invert Mouse"					, {&invertmouse},		{2.0},	{0.0},		{0.0},		{OnOff}},
-	{ discrete, "Auto SR50 on Strafe"			, {&in_autosr50},		{2.0},	{0.0},		{0.0},		{OnOff}}, // [AM] Does not belong here
-	{ discrete, "Lookspring"					, {&lookspring},		{2.0},	{0.0},		{0.0},		{OnOff}},
-	{ redtext,	" "								, {NULL},				{0.0},	{0.0},		{0.0},		{NULL}},
-	{ discrete,	"Horizontal Movement"			, {&lookstrafe},		{2.0},	{0.0},		{0.0},		{OnOff}},
-	{ discrete,	"Vertical Movement"				, {&novert},			{2.0},	{0.0},		{0.0},		{OffOn}},
-	{ slider,	"Horizontal Movement Speed"		, {&m_side},			{0.0},	{15},		{0.5},		{NULL}},
-	{ slider,	"Vertical Movement Speed"		, {&m_forward},			{0.0},	{15},		{0.5},		{NULL}},
-	{ redtext,	" "								, {NULL},				{0.0},	{0.0},		{0.0},		{NULL}},
-	{ more,		"Reset mouse to defaults"		, {NULL},				{0.0},	{0.0},		{0.0},		{.mfunc = M_ResetMouseValues}},
-};
+
+
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<menuitem_t, 14> MouseItems = {{
+	{ .type = slider,	.label = "Overall Sensitivity", .a = {.cvar = &mouse_sensitivity},	.b = {.leftval = 0.05},	.c = {.rightval = 2.5},		.d = {.step = 0.05},		.e = {.values = nullptr}},
+	{ .type = slider,	.label = "Freelook Sensitivity", .a = {.cvar = &m_pitch},			.b = {.leftval = 0.05},	.c = {.rightval = 2.5},		.d = {.step = 0.05},		.e = {.values = nullptr}},
+
+	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = discrete,	.label = "Always FreeLook", .a = {.cvar = &cl_mouselook},		.b = {.leftval = ARRAY_LENGTH(OnOff)},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = discrete,	.label = "Invert Mouse", .a = {.cvar = &invertmouse},		.b = {.leftval = ARRAY_LENGTH(OnOff)},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Auto SR50 on Strafe", .a = {.cvar = &in_autosr50},		.b = {.leftval = ARRAY_LENGTH(OnOff)},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}}, // [AM] Does not belong here
+	{ .type = discrete, .label = "Lookspring", .a = {.cvar = &lookspring},		.b = {.leftval = ARRAY_LENGTH(OnOff)},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = discrete,	.label = "Horizontal Movement", .a = {.cvar = &lookstrafe},		.b = {.leftval = ARRAY_LENGTH(OnOff)},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = discrete,	.label = "Vertical Movement", .a = {.cvar = &novert},			.b = {.leftval = ARRAY_LENGTH(OffOn)},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OffOn.data()}},
+	{ .type = slider,	.label = "Horizontal Movement Speed", .a = {.cvar = &m_side},			.b = {.leftval = 0.0},	.c = {.rightval = 15},		.d = {.step = 0.5},		.e = {.values = nullptr}},
+	{ .type = slider,	.label = "Vertical Movement Speed", .a = {.cvar = &m_forward},			.b = {.leftval = 0.0},	.c = {.rightval = 15},		.d = {.step = 0.5},		.e = {.values = nullptr}},
+	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = more,		.label = "Reset mouse to defaults", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},	.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.mfunc = M_ResetMouseValues}},
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 
 menu_t MouseMenu = {
-    "M_MOUSET",
-    0,
-    ARRAY_LENGTH(MouseItems),
-    177,
-    MouseItems,
+	"M_MOUSET",
+	0,
+	MouseItems.size(),
+	177,
+	MouseItems.data(),
 	0,
 	0,
-	NULL
+	nullptr
 };
+namespace
+{
+
 
 
 /*=======================================
@@ -539,31 +595,37 @@ menu_t MouseMenu = {
  *
  *=======================================*/
 
-static menuitem_t JoystickItems[] =
-{
-	{ discrete	,	"Use Joystick"							, {&use_joystick},		{2.0},		{0.0},		{0.0},		{OnOff}						},
-	{ redtext	,	" "										, {NULL},				{0.0},		{0.0},		{0.0},		{NULL}						},
-	{ joyactive	,	"Active Joystick"						, {&joy_active},		{0.0},		{0.0},		{0.0},		{NULL}						},
-	{ redtext	,	" "										, {NULL},				{0.0},		{0.0},		{0.0},		{NULL}						},
-	{ discrete	,	"Always FreeLook"						, {&joy_freelook},		{2.0},		{0.0},		{0.0},		{OnOff}						},
-	{ discrete	,	"Invert Look Axis"						, {&joy_invert},		{2.0},		{0.0},		{0.0},		{OnOff}						},
-	{ redtext	,	" "										, {NULL},				{0.0},		{0.0},		{0.0},		{NULL}						},
-	{ whitetext	,	"Sensitivity Settings"					, {NULL}, 				{0.0}, 		{0.0}, 		{0.0}, 		{NULL} 						},
-	{ slider	,	"Turn Sensitivity"						, {&joy_sensitivity},	{1.0},		{30.0},		{1.0},		{NULL}						},
-	{ slider	,	"Alt. Turn Sensitivity"					, {&joy_fastsensitivity},	{1.0},		{30.0},		{1.0},		{NULL}						},
-	{ slider	,	"Joystick Deadzone"						, {&joy_deadzone},		{0.0},		{0.75},		{0.05},		{NULL}						},
-};
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<menuitem_t, 11> JoystickItems = {{
+	{ .type = discrete,	.label = "Use Joystick", .a = {.cvar = &use_joystick},		.b = {.leftval = ARRAY_LENGTH(OnOff)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = joyactive,	.label = "Active Joystick", .a = {.cvar = &joy_active},		.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = discrete,	.label = "Always FreeLook", .a = {.cvar = &joy_freelook},		.b = {.leftval = ARRAY_LENGTH(OnOff)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = discrete,	.label = "Invert Look Axis", .a = {.cvar = &joy_invert},		.b = {.leftval = ARRAY_LENGTH(OnOff)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = whitetext,	.label = "Sensitivity Settings", .a = {.cvar = nullptr}, 				.b = {.leftval = 0.0}, 		.c = {.rightval = 0.0}, 		.d = {.step = 0.0}, 		.e = {.values = nullptr}},
+	{ .type = slider,	.label = "Turn Sensitivity", .a = {.cvar = &joy_sensitivity},	.b = {.leftval = 1.0},		.c = {.rightval = 30.0},		.d = {.step = 1.0},		.e = {.values = nullptr}},
+	{ .type = slider,	.label = "Alt. Turn Sensitivity", .a = {.cvar = &joy_fastsensitivity},	.b = {.leftval = 1.0},		.c = {.rightval = 30.0},		.d = {.step = 1.0},		.e = {.values = nullptr}},
+	{ .type = slider,	.label = "Joystick Deadzone", .a = {.cvar = &joy_deadzone},		.b = {.leftval = 0.0},		.c = {.rightval = 0.75},		.d = {.step = 0.05},		.e = {.values = nullptr}},
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t JoystickMenu = {
-    "M_JOYSTK",
-    0,
-    ARRAY_LENGTH(JoystickItems),
-    177,
-    JoystickItems,
+	"M_JOYSTK",
+	0,
+	JoystickItems.size(),
+	177,
+	JoystickItems.data(),
 	0,
 	0,
-	NULL
+	nullptr
 };
+namespace
+{
+
 
  /*=======================================
   *
@@ -571,112 +633,127 @@ menu_t JoystickMenu = {
   *
   *=======================================*/
 
-static value_t MusSys[] = {
-	{ MS_AUTO,		"Auto"},
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+// Sized by the initializer: entries here are conditionally compiled,
+// so a fixed std::array size would be wrong on some builds.
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+value_t MusSys[] = {
+	{ .value = MS_AUTO,		.name = "Auto"},
 	#ifndef _WIN32
-	{ MS_SDLMIXER,	"SDL Mixer"},
+	{ .value = MS_SDLMIXER,	.name = "SDL Mixer"},
 	#endif
-	{ MS_LIBADLMIDI,"libADLMIDI (OPL3 FM)"},
+	{ .value = MS_LIBADLMIDI,.name = "libADLMIDI (OPL3 FM)"},
 	#ifdef OSX
-	{ MS_AUDIOUNIT,	"AudioUnit"},
+	{ .value = MS_AUDIOUNIT,	.name = "AudioUnit"},
 	#endif	// OSX
 	#ifdef PORTMIDI
-	{ MS_PORTMIDI,	"PortMidi"},
+	{ .value = MS_PORTMIDI,	.name = "PortMidi"},
 	#endif	// PORTMIDI
 };
 
-static value_t MidiReset[] = {
-	{ 0.0,			"None" },
-	{ 1.0,			"GM" },
-	{ 2.0,			"GS" },
-	{ 3.0,			"XG" }
-};
+std::array<value_t, 4> MidiReset = {{
+	{ .value = 0.0,			.name = "None"},
+	{ .value = 1.0,			.name = "GM"},
+	{ .value = 2.0,			.name = "GS"},
+	{ .value = 3.0,			.name = "XG"}
+}};
 
-static value_t OplCore[] = {
-	{ 0.0,			"Fast (Dosbox)"},
-	{ 1.0,			"Balanced (Nuked-Fast 1.8)"},
-	{ 2.0,			"Accurate (Nuked 1.8)"}
-};
+std::array<value_t, 3> OplCore = {{
+	{ .value = 0.0,			.name = "Fast (Dosbox)"},
+	{ .value = 1.0,			.name = "Balanced (Nuked-Fast 1.8)"},
+	{ .value = 2.0,			.name = "Accurate (Nuked 1.8)"}
+}};
 
-static value_t OplBank[] = {
-	{ 0.0,			"Doom"},
-	{ 1.0,			"Doom II"},
-	{ 2.0,			"DMXOPL3"}
-};
+std::array<value_t, 3> OplBank = {{
+	{ .value = 0.0,			.name = "Doom"},
+	{ .value = 1.0,			.name = "Doom II"},
+	{ .value = 2.0,			.name = "DMXOPL3"}
+}};
 
-static value_t VoxType[] = {
-	{ 0.0,			"Off" },
-	{ 1.0,			"Team Colors" },
-	{ 2.0,			"Possessive" }
-};
+std::array<value_t, 3> VoxType = {{
+	{ .value = 0.0,			.name = "Off"},
+	{ .value = 1.0,			.name = "Team Colors"},
+	{ .value = 2.0,			.name = "Possessive"}
+}};
 
-static value_t ChatSndType[] = {
-	{ 0.0,			"Disabled" },
-	{ 1.0,			"Enabled" },
-	{ 2.0,			"Teamchat only" }
-};
+std::array<value_t, 3> ChatSndType = {{
+	{ .value = 0.0,			.name = "Disabled"},
+	{ .value = 1.0,			.name = "Enabled"},
+	{ .value = 2.0,			.name = "Teamchat only"}
+}};
+// NOLINTEND(readability-magic-numbers)
 
-static void AdvMidiOptions (void);
-static void LibAdlMidiOptions (void);
+void AdvMidiOptions();
+void LibAdlMidiOptions();
+} // namespace
 
-static constexpr float num_mussys = static_cast<float>(ARRAY_LENGTH(MusSys));
 
 EXTERN_CVAR(cl_chatsounds)
 
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+// Sized by the initializer: entries here are conditionally compiled,
+// so a fixed std::array size would be wrong on some builds.
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
 static menuitem_t AdvMidiItems[] = {
-	{ redtext   , " "               , {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext, "Advanced MIDI Options" , {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ redtext   , " "               , {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ discrete  , "MIDI Instrument Fallback", {&snd_midifallback}, {4.0}, {0.0}, {0.0}, {OnOff} },
-	{ slider    , "MIDI Reset Delay (ms)", {&snd_mididelay}, {0.0}, {2000.0}, {50.0}, {NULL} },
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = "Advanced MIDI Options", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "MIDI Instrument Fallback", .a = {.cvar = &snd_midifallback}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = slider, .label = "MIDI Reset Delay (ms)", .a = {.cvar = &snd_mididelay}, .b = {.leftval = 0.0}, .c = {.rightval = 2000.0}, .d = {.step = 50.0}, .e = {.values = nullptr}},
 	#ifdef PORTMIDI
-	{ redtext   , " "               , {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext, "PortMidi Options", {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ redtext   , " "               , {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ discrete  , "MIDI Reset"      , {&snd_midireset}, {4.0}, {0.0}, {0.0}, {MidiReset} },
-	{ discrete  , "Read MIDI SysEx" , {&snd_midisysex}, {4.0}, {0.0}, {0.0}, {OnOff} },
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = "PortMidi Options", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "MIDI Reset", .a = {.cvar = &snd_midireset}, .b = {.leftval = ARRAY_LENGTH(MidiReset)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = MidiReset.data()}},
+	{ .type = discrete, .label = "Read MIDI SysEx", .a = {.cvar = &snd_midisysex}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
 	#endif
-	{ redtext   , " "               , {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ redtext   , " "               , {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ redtext   , " "               , {NULL}          , {0.0}, {0.0}, {0.0}, {NULL} },
-	{yellowtext, "! ! ! NOTICE ! ! !", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {orangetext, "Modifying these settings may cause", {NULL},{0.0}, {0.0}, {0.0}, {NULL}},
-    {orangetext, "unwanted behavior during MIDI playback!", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = "! ! ! NOTICE ! ! !", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = orangetext, .label = "Modifying these settings may cause", .a = {.cvar = nullptr},.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = orangetext, .label = "unwanted behavior during MIDI playback!", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
 };
+namespace
+{
 
- static menuitem_t LibAdlMidiItems[] = {
-	{ redtext   , " "                   , {NULL}         , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext, "OPL FM Synth Options", {NULL}         , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ redtext   , " "                   , {NULL}         , {0.0}, {0.0}, {0.0}, {NULL} },
-	{ discrete  , "OPL quality"         , {&snd_oplcore} , {3.0}, {0.0}, {0.0}, {OplCore} },
-	{ discrete  , "Full OPL panning"    , {&snd_oplpan}  , {2.0}, {0.0}, {0.0}, {OnOff} },
-	{ slider    , "# of OPL chips"      , {&snd_oplchips}, {1.0}, {8.0}, {1.0}, {NULL} },
-	{ discrete  , "OPL instruments"     , {&snd_oplbank} , {3.0}, {0.0}, {0.0}, {OplBank} },
-};
 
-static menuitem_t SoundItems[] = {
-	{ redtext   ,   " "                        , {NULL},                {0.0},        {0.0}, {0.0},      {NULL} },
-	{ yellowtext,   "Sound Levels"             , {NULL},                {0.0},        {0.0}, {0.0},      {NULL} },
-	{ slider    ,	"Music Volume"             , {&snd_musicvolume},    {0.0},        {1.0}, {0.015625}, {NULL} },
-	{ slider    ,	"Sound Volume"             , {&snd_sfxvolume},      {0.0},        {1.0}, {0.015625}, {NULL} },
-	{ slider    ,	"Announcer Volume"         , {&snd_announcervolume},{0.0},        {1.0}, {0.015625}, {NULL} },
-	{ discrete  ,   "Stereo Switch"            , {&snd_crossover},      {2.0},        {0.0}, {0.0},      {OnOff} },
-	{ redtext   ,	" "                        , {NULL},                {0.0},        {0.0}, {0.0},      {NULL} },
-	{ yellowtext,   "Music Options"            , {NULL},                {0.0},        {0.0}, {0.0},      {NULL} },
-	{ discrete  ,   "Midi Synth"               , {&snd_musicsystem},    {num_mussys}, {0.0}, {0.0},      {MusSys} },
-	{ discrete  ,   "Disable Music"            , {&snd_nomusic},        {2.0},        {0.0}, {0.0},      {YesNo} },
-	{ redtext   ,	" "                        , {NULL},                {0.0},        {0.0}, {0.0},      {NULL} },
-	{ more      ,   "OPL FM Synth Options"     , {NULL},                {0.0},        {0.0}, {0.0},      {.mfunc = LibAdlMidiOptions}},
-	{ more      ,   "Advanced MIDI Options"    , {NULL},                {0.0},        {0.0}, {0.0},      {.mfunc = AdvMidiOptions}},
-	{ redtext   ,   " "                        , {NULL},                {0.0},        {0.0}, {0.0},      {NULL} },
-	{ yellowtext,   "Sound Options"            , {NULL},                {0.0},        {0.0}, {0.0},      {NULL} },
-	{ discrete  ,   "Game SFX"                 , {&snd_gamesfx},        {2.0},        {0.0}, {0.0},      {OnOff} },
-	{ discrete  ,   "Announcer Type"           , {&snd_voxtype},        {3.0},        {0.0}, {0.0},      {VoxType} },
-	{ discrete  ,   "Player Connect Alert"     , {&cl_connectalert},    {2.0},        {0.0}, {0.0},      {OnOff} },
-	{ discrete  ,   "Player Disconnect Alert"  , {&cl_disconnectalert}, {2.0},        {0.0}, {0.0},      {OnOff} },
-	{ discrete  ,   "Chat sounds"              , {&cl_chatsounds},      {3.0},        {0.0}, {0.0},      {ChatSndType}},
-     {discrete	,   "Voting Sounds"            , {&snd_votesfx},		{2.0},        {0.0}, {0.0},	     {OnOff}},
- };
+ std::array<menuitem_t, 7> LibAdlMidiItems = {{
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = "OPL FM Synth Options", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "OPL quality", .a = {.cvar = &snd_oplcore}, .b = {.leftval = ARRAY_LENGTH(OplCore)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OplCore.data()}},
+	{ .type = discrete, .label = "Full OPL panning", .a = {.cvar = &snd_oplpan}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = slider, .label = "# of OPL chips", .a = {.cvar = &snd_oplchips}, .b = {.leftval = 1.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "OPL instruments", .a = {.cvar = &snd_oplbank}, .b = {.leftval = ARRAY_LENGTH(OplBank)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OplBank.data()}},
+}};
+
+std::array<menuitem_t, 21> SoundItems = {{
+	{ .type = redtext,   .label = " ", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = nullptr}},
+	{ .type = yellowtext,   .label = "Sound Levels", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Music Volume", .a = {.cvar = &snd_musicvolume},    .b = {.leftval = 0.0},        .c = {.rightval = 1.0}, .d = {.step = 0.015625}, .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Sound Volume", .a = {.cvar = &snd_sfxvolume},      .b = {.leftval = 0.0},        .c = {.rightval = 1.0}, .d = {.step = 0.015625}, .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Announcer Volume", .a = {.cvar = &snd_announcervolume},.b = {.leftval = 0.0},        .c = {.rightval = 1.0}, .d = {.step = 0.015625}, .e = {.values = nullptr}},
+	{ .type = discrete,   .label = "Stereo Switch", .a = {.cvar = &snd_crossover},      .b = {.leftval = ARRAY_LENGTH(OnOff)},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = OnOff.data()}},
+	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = nullptr}},
+	{ .type = yellowtext,   .label = "Music Options", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = nullptr}},
+	{ .type = discrete,   .label = "Midi Synth", .a = {.cvar = &snd_musicsystem},    .b = {.leftval = ARRAY_LENGTH(MusSys)}, .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = MusSys}},
+	{ .type = discrete,   .label = "Disable Music", .a = {.cvar = &snd_nomusic},        .b = {.leftval = ARRAY_LENGTH(YesNo)},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = YesNo.data()}},
+	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = nullptr}},
+	{ .type = more,   .label = "OPL FM Synth Options", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.mfunc = LibAdlMidiOptions}},
+	{ .type = more,   .label = "Advanced MIDI Options", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.mfunc = AdvMidiOptions}},
+	{ .type = redtext,   .label = " ", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = nullptr}},
+	{ .type = yellowtext,   .label = "Sound Options", .a = {.cvar = nullptr},                .b = {.leftval = 0.0},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = nullptr}},
+	{ .type = discrete,   .label = "Game SFX", .a = {.cvar = &snd_gamesfx},        .b = {.leftval = ARRAY_LENGTH(OnOff)},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = OnOff.data()}},
+	{ .type = discrete,   .label = "Announcer Type", .a = {.cvar = &snd_voxtype},        .b = {.leftval = ARRAY_LENGTH(VoxType)},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = VoxType.data()}},
+	{ .type = discrete,   .label = "Player Connect Alert", .a = {.cvar = &cl_connectalert},    .b = {.leftval = ARRAY_LENGTH(OnOff)},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = OnOff.data()}},
+	{ .type = discrete,   .label = "Player Disconnect Alert", .a = {.cvar = &cl_disconnectalert}, .b = {.leftval = ARRAY_LENGTH(OnOff)},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = OnOff.data()}},
+	{ .type = discrete,   .label = "Chat sounds", .a = {.cvar = &cl_chatsounds},      .b = {.leftval = ARRAY_LENGTH(ChatSndType)},        .c = {.rightval = 0.0}, .d = {.step = 0.0},      .e = {.values = ChatSndType.data()}},
+	{ .type = discrete,   .label = "Voting Sounds", .a = {.cvar = &snd_votesfx},		.b = {.leftval = ARRAY_LENGTH(OnOff)},        .c = {.rightval = 0.0}, .d = {.step = 0.0},	     .e = {.values = OnOff.data()}},
+ }};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t AdvMidiMenu = {
 	"M_SOUND",
@@ -686,30 +763,33 @@ menu_t AdvMidiMenu = {
 	AdvMidiItems,
 	0,
 	0,
-	NULL
+	nullptr
 };
 
 menu_t LibAdlMidiMenu = {
 	"M_SOUND",
 	3,
-	ARRAY_LENGTH(LibAdlMidiItems),
+	LibAdlMidiItems.size(),
 	177,
-	LibAdlMidiItems,
+	LibAdlMidiItems.data(),
 	0,
 	0,
-	NULL
+	nullptr
 };
 
 menu_t SoundMenu = {
 	"M_SOUND",
 	2,
-	ARRAY_LENGTH(SoundItems),
+	SoundItems.size(),
 	177,
-	SoundItems,
+	SoundItems.data(),
 	0,
 	0,
-	NULL
+	nullptr
 };
+namespace
+{
+
 
 
 /*=======================================
@@ -717,50 +797,57 @@ menu_t SoundMenu = {
  * Compatibility Options Menu
  *
  *=======================================*/
-static menuitem_t CompatItems[] ={
-	{yellowtext, "Gameplay",							{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{svdiscrete, "Finer-precision Autoaim",        {&co_fineautoaim},       {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Fix hit detection at grid edges",{&co_blockmapfix},       {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Remove pain elemental spawn limit",{&co_removesoullimit}, {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Fix arch-vile ghost bug",			{&co_novileghosts}, {2.0}, {0.0}, {0.0}, {OnOff}},
-	{redtext,   " ",								{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{yellowtext, "Items and Decoration",				{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{svdiscrete, "Fix invisible puffs under skies",{&co_fixweaponimpacts},  {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Items can be walked over/under", {&co_realactorheight},   {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Items can drop off ledges",      {&co_allowdropoff},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{redtext,   " ",								{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{yellowtext, "Engine Compatibility",				{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{svdiscrete, "BOOM actor/sector/line checks",  {&co_boomphys},			 {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "MBF movement and collision",  {&co_mbfphys},			 {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "ZDOOM 1.23 physics",             {&co_zdoomphys},         {2.0}, {0.0}, {0.0}, {OnOff}},
-  {svdiscrete, "ZDOOM 1.23 ammo checks",         {&co_zdoomammo},         {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "ZDOOM Friendly Targeting",       {&co_zdoomfriendtargeting},   {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "MBF Monster target selection",{&co_pursuit},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Monsters help friends (MBF)",{&co_helpfriends},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Monsters strafe (MBF)",{&co_monsterbacking},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Monster wind/friction (MBF)",{&co_monsterfriction},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Monsters avoid crushers (MBF)",{&co_avoidhazards},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Monsters climb (MBF)",{&co_monstersclimbsteep},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Monsters stay on lifts (MBF)",{&co_staylift},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "Friends can drop off (MBF)",{&co_friend_ledgejumping},      {2.0}, {0.0}, {0.0}, {OnOff}},
-	{slider,		 "Friend distance (MBF)", {&co_friend_distance}, {0.0}, {2048.0}, {64.0}, {NULL}},
-	{redtext,   " ",								{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{yellowtext, "Sound",							{NULL},                  {0.0}, {0.0}, {0.0}, {NULL}},
-	{svdiscrete, "Fix silent west spawns",         {&co_nosilentspawns},    {2.0}, {0.0}, {0.0}, {OnOff}},
-	{svdiscrete, "ZDoom Sound Response",			{&co_zdoomsound},		 {2.0}, {0.0}, {0.0}, {OnOff}},
-    {svdiscrete, "Global Pickup Sounds",			{&co_globalsound},		 {2.0}, {0.0}, {0.0}, {OnOff}},
-};
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<menuitem_t, 31> CompatItems = {{
+	{.type = yellowtext, .label = "Gameplay",							.a = {.cvar = nullptr},                  .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = svdiscrete, .label = "Finer-precision Autoaim",        .a = {.cvar = &co_fineautoaim},       .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Fix hit detection at grid edges",.a = {.cvar = &co_blockmapfix},       .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Remove pain elemental spawn limit",.a = {.cvar = &co_removesoullimit}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Fix arch-vile ghost bug",			.a = {.cvar = &co_novileghosts}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = redtext,   .label = " ",								.a = {.cvar = nullptr},                  .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = yellowtext, .label = "Items and Decoration",				.a = {.cvar = nullptr},                  .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = svdiscrete, .label = "Fix invisible puffs under skies",.a = {.cvar = &co_fixweaponimpacts},  .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Items can be walked over/under", .a = {.cvar = &co_realactorheight},   .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Items can drop off ledges",      .a = {.cvar = &co_allowdropoff},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = redtext,   .label = " ",								.a = {.cvar = nullptr},                  .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = yellowtext, .label = "Engine Compatibility",				.a = {.cvar = nullptr},                  .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = svdiscrete, .label = "BOOM actor/sector/line checks",  .a = {.cvar = &co_boomphys},			 .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "MBF movement and collision",  .a = {.cvar = &co_mbfphys},			 .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "ZDOOM 1.23 physics",             .a = {.cvar = &co_zdoomphys},         .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "ZDOOM 1.23 ammo checks",         .a = {.cvar = &co_zdoomammo},         .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "ZDOOM Friendly Targeting",       .a = {.cvar = &co_zdoomfriendtargeting},   .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "MBF Monster target selection",.a = {.cvar = &co_pursuit},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Monsters help friends (MBF)",.a = {.cvar = &co_helpfriends},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Monsters strafe (MBF)",.a = {.cvar = &co_monsterbacking},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Monster wind/friction (MBF)",.a = {.cvar = &co_monsterfriction},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Monsters avoid crushers (MBF)",.a = {.cvar = &co_avoidhazards},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Monsters climb (MBF)",.a = {.cvar = &co_monstersclimbsteep},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Monsters stay on lifts (MBF)",.a = {.cvar = &co_staylift},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Friends can drop off (MBF)",.a = {.cvar = &co_friend_ledgejumping},      .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = slider,		 .label = "Friend distance (MBF)", .a = {.cvar = &co_friend_distance}, .b = {.leftval = 0.0}, .c = {.rightval = 2048.0}, .d = {.step = 64.0}, .e = {.values = nullptr}},
+	{.type = redtext,   .label = " ",								.a = {.cvar = nullptr},                  .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = yellowtext, .label = "Sound",							.a = {.cvar = nullptr},                  .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = svdiscrete, .label = "Fix silent west spawns",         .a = {.cvar = &co_nosilentspawns},    .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "ZDoom Sound Response",			.a = {.cvar = &co_zdoomsound},		 .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{.type = svdiscrete, .label = "Global Pickup Sounds",			.a = {.cvar = &co_globalsound},		 .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t CompatMenu = {
 	"M_COMPAT",
 	1,
-	ARRAY_LENGTH(CompatItems),
+	CompatItems.size(),
 	240,
-	CompatItems,
+	CompatItems.data(),
 	0,
 	0,
-	NULL,
+	nullptr,
 };
+namespace
+{
+
 
 
 /*=======================================
@@ -769,36 +856,43 @@ menu_t CompatMenu = {
  *
  *=======================================*/
 
-static menuitem_t NetworkItems[] = {
-    { redtext,	" ",					{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,	"Wad Download Settings",		{NULL},				{0.0},		{0.0},		{0.0},		{NULL} },
-	{ discrete, 	"Download From Internet", 		{&cl_serverdownload}, {2.0}, 		{0.0}, 		{0.0}, 		{OnOff} },
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<menuitem_t, 15> NetworkItems = {{
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,	.label = "Wad Download Settings",		.a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = discrete, 	.label = "Download From Internet", 		.a = {.cvar = &cl_serverdownload}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, 		.c = {.rightval = 0.0}, 		.d = {.step = 0.0}, 		.e = {.values = OnOff.data()}},
 
-	{ redtext,		" ",							{NULL},				{0.0},		{0.0},		{0.0},		{NULL} },
-	{ yellowtext,	"Netdemo Settings",				{NULL},				{0.0},		{0.0},		{0.0},		{NULL} },
-	{ discrete,		"Autorecord demos",				{&cl_autorecord},	{2.0},		{0.0},		{0.0},		{OnOff} },
-	{ discrete,		"Split every map",				{&cl_splitnetdemos},	{2.0},		{0.0},		{0.0},		{OnOff} },
+	{ .type = redtext,		.label = " ",							.a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = yellowtext,	.label = "Netdemo Settings",				.a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = discrete,		.label = "Autorecord demos",				.a = {.cvar = &cl_autorecord},	.b = {.leftval = ARRAY_LENGTH(OnOff)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = discrete,		.label = "Split every map",				.a = {.cvar = &cl_splitnetdemos},	.b = {.leftval = ARRAY_LENGTH(OnOff)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
 
-	{ redtext,		" ",							{NULL},	{0.0}, {0.0}, {0.0}, {NULL} },
-	{ yellowtext,	"Autorecord filters",			{NULL},				{0.0},		{0.0},		{0.0},		{NULL} },
-	{ discrete,		"Cooperation",					{&cl_autorecord_coop},{2.0},		{0.0},		{0.0},		{DemoRestrictions} },
-	{ discrete,		"Deathmatch",					{&cl_autorecord_deathmatch},{2.0},		{0.0},		{0.0},		{DemoRestrictions} },
-	{ discrete,		"Duel",							{&cl_autorecord_duel},{2.0},		{0.0},		{0.0},		{DemoRestrictions} },
-	{ discrete,		"Team Deathmatch",				{&cl_autorecord_teamdm},{2.0},		{0.0},		{0.0},		{DemoRestrictions} },
-	{ discrete,		"Capture the Flag",				{&cl_autorecord_ctf},{2.0},		{0.0},		{0.0},		{DemoRestrictions} },
-	{ discrete,		"Horde",						{&cl_autorecord_horde},{2.0},		{0.0},		{0.0},		{DemoRestrictions} },
-};
+	{ .type = redtext,		.label = " ",							.a = {.cvar = nullptr},	.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,	.label = "Autorecord filters",			.a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
+	{ .type = discrete,		.label = "Cooperation",					.a = {.cvar = &cl_autorecord_coop},.b = {.leftval = ARRAY_LENGTH(DemoRestrictions)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = DemoRestrictions.data()}},
+	{ .type = discrete,		.label = "Deathmatch",					.a = {.cvar = &cl_autorecord_deathmatch},.b = {.leftval = ARRAY_LENGTH(DemoRestrictions)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = DemoRestrictions.data()}},
+	{ .type = discrete,		.label = "Duel",							.a = {.cvar = &cl_autorecord_duel},.b = {.leftval = ARRAY_LENGTH(DemoRestrictions)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = DemoRestrictions.data()}},
+	{ .type = discrete,		.label = "Team Deathmatch",				.a = {.cvar = &cl_autorecord_teamdm},.b = {.leftval = ARRAY_LENGTH(DemoRestrictions)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = DemoRestrictions.data()}},
+	{ .type = discrete,		.label = "Capture the Flag",				.a = {.cvar = &cl_autorecord_ctf},.b = {.leftval = ARRAY_LENGTH(DemoRestrictions)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = DemoRestrictions.data()}},
+	{ .type = discrete,		.label = "Horde",						.a = {.cvar = &cl_autorecord_horde},.b = {.leftval = ARRAY_LENGTH(DemoRestrictions)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = DemoRestrictions.data()}},
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t NetworkMenu = {
 	"M_NETWRK",
 	2,
-	ARRAY_LENGTH(NetworkItems),
+	NetworkItems.size(),
 	177,
-	NetworkItems,
+	NetworkItems.data(),
 	1,
 	0,
-	NULL
+	nullptr
 };
+namespace
+{
+
 
 
 /*=======================================
@@ -807,48 +901,62 @@ menu_t NetworkMenu = {
  *
  *=======================================*/
 
-static value_t WeapSwitch[] = {
-	{ 0.0,			"Never" },
-	{ 1.0,			"Always" },
-	{ 2.0,			"By Preference" },
-    { 3.0,			"Attack Cancels PWO"}
-};
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<value_t, 4> WeapSwitch = {{
+	{ .value = 0.0,			.name = "Never"},
+	{ .value = 1.0,			.name = "Always"},
+	{ .value = 2.0,			.name = "By Preference"},
+	{ .value = 3.0,			.name = "Attack Cancels PWO"}
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 extern const char *weaponnames[];
+namespace
+{
 
-static menuitem_t WeaponItems[] = {
-	{yellowtext, "Weapon Preferences",  {NULL},               {0.0}, {0.0}, {0.0}, {NULL}},
-	{discrete,  "Switch on pickup",    {&cl_switchweapon},   {4.0}, {0.0}, {0.0}, {WeapSwitch}},
-	{redtext,   " ",                   {NULL},               {0.0}, {0.0}, {0.0}, {NULL}},
-	{yellowtext, "Weapon Switch Order", {NULL},               {0.0}, {0.0}, {0.0}, {NULL}},
-	{slider,    weaponnames[0],        {&cl_weaponpref_fst}, {0.0}, {8.0}, {1.0}, {NULL}},
-	{slider,    weaponnames[7],        {&cl_weaponpref_csw}, {0.0}, {8.0}, {1.0}, {NULL}},
-	{slider,    weaponnames[1],        {&cl_weaponpref_pis}, {0.0}, {8.0}, {1.0}, {NULL}},
-	{slider,    weaponnames[2],        {&cl_weaponpref_sg},  {0.0}, {8.0}, {1.0}, {NULL}},
-	{slider,    weaponnames[8],        {&cl_weaponpref_ssg}, {0.0}, {8.0}, {1.0}, {NULL}},
-	{slider,    weaponnames[3],        {&cl_weaponpref_cg},  {0.0}, {8.0}, {1.0}, {NULL}},
-	{slider,    weaponnames[4],        {&cl_weaponpref_rl},  {0.0}, {8.0}, {1.0}, {NULL}},
-	{slider,    weaponnames[5],        {&cl_weaponpref_pls}, {0.0}, {8.0}, {1.0}, {NULL}},
-	{slider,    weaponnames[6],        {&cl_weaponpref_bfg}, {0.0}, {8.0}, {1.0}, {NULL}},
-	{redtext,   " ",                   {NULL},               {0.0}, {0.0}, {0.0}, {NULL}},
-	{whitetext, "Weapons with higher", {NULL},               {0.0}, {0.0}, {0.0}, {NULL}},
-	{whitetext, "preference are selected first", {NULL},     {0.0}, {0.0}, {0.0}, {NULL}},
-    {redtext,	" ",				   {NULL},				 {0.0}, {0.0}, {0.0}, {NULL}},
-    {yellowtext, "! ! ! NOTICE ! ! !", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {orangetext, "While playing online, this feature", {NULL},{0.0}, {0.0}, {0.0}, {NULL}},
-    {orangetext, "only works when the server allows it!", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-};
+
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<menuitem_t, 20> WeaponItems = {{
+	{.type = yellowtext, .label = "Weapon Preferences",  .a = {.cvar = nullptr},               .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = discrete,  .label = "Switch on pickup",    .a = {.cvar = &cl_switchweapon},   .b = {.leftval = ARRAY_LENGTH(WeapSwitch)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = WeapSwitch.data()}},
+	{.type = redtext,   .label = " ",                   .a = {.cvar = nullptr},               .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = yellowtext, .label = "Weapon Switch Order", .a = {.cvar = nullptr},               .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[0],        .a = {.cvar = &cl_weaponpref_fst}, .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[7],        .a = {.cvar = &cl_weaponpref_csw}, .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[1],        .a = {.cvar = &cl_weaponpref_pis}, .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[2],        .a = {.cvar = &cl_weaponpref_sg},  .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[8],        .a = {.cvar = &cl_weaponpref_ssg}, .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[3],        .a = {.cvar = &cl_weaponpref_cg},  .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[4],        .a = {.cvar = &cl_weaponpref_rl},  .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[5],        .a = {.cvar = &cl_weaponpref_pls}, .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = slider,    .label = weaponnames[6],        .a = {.cvar = &cl_weaponpref_bfg}, .b = {.leftval = 0.0}, .c = {.rightval = 8.0}, .d = {.step = 1.0}, .e = {.values = nullptr}},
+	{.type = redtext,   .label = " ",                   .a = {.cvar = nullptr},               .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = whitetext, .label = "Weapons with higher", .a = {.cvar = nullptr},               .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = whitetext, .label = "preference are selected first", .a = {.cvar = nullptr},     .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = redtext,	.label = " ",				   .a = {.cvar = nullptr},				 .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = yellowtext, .label = "! ! ! NOTICE ! ! !", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = orangetext, .label = "While playing online, this feature", .a = {.cvar = nullptr},.b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{.type = orangetext, .label = "only works when the server allows it!", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t WeaponMenu = {
 	"M_WEAPON",
 	1,
-	ARRAY_LENGTH(WeaponItems),
+	WeaponItems.size(),
 	177,
-	WeaponItems,
+	WeaponItems.data(),
 	0,
 	0,
-	NULL
+	nullptr
 };
+namespace
+{
+
 
 
 /*=======================================
@@ -856,10 +964,12 @@ menu_t WeaponMenu = {
  * Display Options Menu
  *
  *=======================================*/
-static void StartHUDMenu();
-static void StartMessagesMenu (void);
-static void StartAutomapMenu (void);
-void ResetCustomColors (void);
+void StartHUDMenu();
+void StartMessagesMenu();
+void StartAutomapMenu();
+} // namespace
+
+void ResetCustomColors();
 
 EXTERN_CVAR (am_rotate)
 EXTERN_CVAR (am_overlay)
@@ -894,111 +1004,129 @@ EXTERN_CVAR(am_ovlocation)
 EXTERN_CVAR(am_ovscalewidth)
 EXTERN_CVAR(am_ovscaleheight)
 
-static value_t Wipes[] = {
-	{ 0.0, "None" },
-	{ 1.0, "Melt" },
-	{ 2.0, "Burn" },
-	{ 3.0, "Crossfade" }
-};
+namespace
+{
 
-static value_t Overlays[] = {
-    { 0.0, "Off" },
-    { 1.0, "Standard" },
-    { 2.0, "Full" },
-    { 3.0, "Full Only" }
-};
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<value_t, 4> Wipes = {{
+	{ .value = 0.0, .name = "None"},
+	{ .value = 1.0, .name = "Melt"},
+	{ .value = 2.0, .name = "Burn"},
+	{ .value = 3.0, .name = "Crossfade"}
+}};
 
-static void M_SendUINewColor (int red, int green, int blue);
-static void M_SlideUIRed (int);
-static void M_SlideUIGreen (int);
-static void M_SlideUIBlue (int);
+
+std::array<value_t, 4> Overlays = {{
+	{ .value = 0.0, .name = "Off"},
+	{ .value = 1.0, .name = "Standard"},
+	{ .value = 2.0, .name = "Full"},
+	{ .value = 3.0, .name = "Full Only"}
+}};
+// NOLINTEND(readability-magic-numbers)
+
+void M_SendUINewColor (int red, int green, int blue);
+void M_SlideUIRed (int);
+void M_SlideUIGreen (int);
+void M_SlideUIBlue (int);
+} // namespace
+
 
 int dummy = 0;
 
 CVAR_FUNC_IMPL (ui_transred)
 {
-    M_SlideUIRed(var.asInt());
+	M_SlideUIRed(var.asInt());
 }
 
 CVAR_FUNC_IMPL (ui_transgreen)
 {
-    M_SlideUIGreen(var.asInt());
+	M_SlideUIGreen(var.asInt());
 }
 
 CVAR_FUNC_IMPL (ui_transblue)
 {
-    M_SlideUIBlue(var.asInt());
+	M_SlideUIBlue(var.asInt());
 }
-
-static value_t Endoom[] = {{0.0, "Off"}, {1.0, "On"}, {2.0, "PWAD Only"}};
-
-static menuitem_t VideoItems[] = {
-	{ more, "Heads-up display", {NULL}, {0.0}, {0.0}, {0.0}, {.mfunc = StartHUDMenu}},
-	{ more,		"Messages",				    {NULL},					{0.0}, {0.0},	{0.0},  {.mfunc = StartMessagesMenu} },
-	{ more,		"Automap",				    {NULL},					{0.0}, {0.0},	{0.0},  {.mfunc = StartAutomapMenu} },
-	{ redtext,	" ",					    {NULL},					{0.0}, {0.0},	{0.0},  {NULL} },
-	{ slider,	"Screen size",			    {&screenblocks},	   	{3.0}, {12.0},	{1.0},  {NULL} },
-	{ slider,	"Brightness",			    {&gammalevel},			{1.0}, {8.0},	{1.0},  {NULL} },
-	{ slider,	"Red Pain Intensity",		{&r_painintensity},		{0.0}, {1.0},	{0.1},  {NULL} },
-	{ slider,	"Movement bobbing",			{&cl_movebob},			{0.0}, {1.0},	{0.1},	{NULL} },
-	{ slider,   "Weapon Visibility",        {&r_drawplayersprites}, {0.0}, {1.0},   {0.1},  {NULL} },
-	{ discrete,	"Visible Spawn Points",		{&cl_showspawns},		{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Center weapon when firing",{&cl_centerbobonfire},	{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Show Killing Sprees",		{&cl_showsprees},	{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Show Multi Kills",		{&cl_showmultikills},	{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Show Sprees Offline",	{&cl_showofflinesprees},{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Show Multi Kills Offline",	{&cl_showofflinemultikills},{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ redtext,	" ",					    {NULL},				    {0.0}, {0.0},	{0.0},  {NULL} },
-	{ discrete, "Force Team Color",			{&r_forceteamcolor},	{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ redslider,   "Team Color Red",        {&r_teamcolor},  {0.0}, {0.0},   {0.0},  {NULL} },
-	{ greenslider, "Team Color Green",      {&r_teamcolor},  {0.0}, {0.0},   {0.0},  {NULL} },
-	{ blueslider,  "Team Color Blue",       {&r_teamcolor},  {0.0}, {0.0},   {0.0},  {NULL} },
-	{ redtext,	" ",					    {NULL},				    {0.0}, {0.0},	{0.0},  {NULL} },
-	{ discrete, "Force Enemy Color",        {&r_forceenemycolor},	{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ redslider,   "Enemy Color Red",       {&r_enemycolor},  {0.0}, {0.0},   {0.0},  {NULL} },
-	{ greenslider, "Enemy Color Green",     {&r_enemycolor},  {0.0}, {0.0},   {0.0},  {NULL} },
-	{ blueslider,  "Enemy Color Blue",      {&r_enemycolor},  {0.0}, {0.0},   {0.0},  {NULL} },
-	{ redtext,	" ",					    {NULL},				    {0.0}, {0.0},	{0.0},  {NULL} },
-	{ slider,   "UI Background Red",        {&ui_transred},         {0.0}, {255.0}, {16.0}, {NULL} },
-	{ slider,   "UI Background Green",      {&ui_transgreen},       {0.0}, {255.0}, {16.0}, {NULL} },
-	{ slider,   "UI Background Blue",       {&ui_transblue},        {0.0}, {255.0}, {16.0}, {NULL} },
-	{ slider,   "UI Background Visibility", {&ui_dimamount},        {0.0}, {1.0},   {0.1},  {NULL} },
-	{ redtext,	" ",					    {NULL},					{0.0}, {0.0},	{0.0},  {NULL} },
-	{ discrete, "See killer on Death",			{&cl_deathcam},   {2.0}, {0.0}, {0.0}, {OnOff}},
-	{ discrete, "Stretch short skies",	    {&r_stretchsky},	   	{3.0}, {0.0},	{0.0},  {OnOffAuto} },
-	{ discrete, "Linear Skies",			    {&r_linearsky},	   		{2.0}, {0.0},	{0.0},  {OnOff} },
-	{ discrete, "Invuln changes skies",		{&r_skypalette},		{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Use softer invuln effect", {&r_softinvulneffect},	{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Heart effect on friendlies", {&cl_showfriends},	{2.0}, {0.0},	{0.0},	{OnOff} },
-	{ discrete, "Screen wipe style",	    {&r_wipetype},			{4.0}, {0.0},	{0.0},  {Wipes} },
-	{ discrete, "Multiplayer Intermissions",{&wi_oldintermission},	{2.0}, {0.0},	{0.0},  {DoomOrOdamex} },
-	{ discrete, "Show loading disk icon",	{&r_loadicon},			{2.0}, {0.0},	{0.0},	{OnOff} },
-    { discrete,	"Show DOS ending screen" ,  {&r_showendoom},		{3.0}, {0.0},	{0.0},  {Endoom} },
-
-
-};
-
-static void M_UpdateDisplayOptions()
+namespace
 {
-	const static size_t menu_length = ARRAY_LENGTH(VideoItems);
-	const static size_t gamma_index = M_FindCvarInMenu(gammalevel, VideoItems, menu_length);
+
+
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<value_t, 3> Endoom = {{{.value = 0.0, .name = "Off"}, {.value = 1.0, .name = "On"}, {.value = 2.0, .name = "PWAD Only"}}};
+
+std::array<menuitem_t, 41> VideoItems = {{
+	{ .type = more, .label = "Heads-up display", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.mfunc = StartHUDMenu}},
+	{ .type = more,		.label = "Messages",				    .a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.mfunc = StartMessagesMenu}},
+	{ .type = more,		.label = "Automap",				    .a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.mfunc = StartAutomapMenu}},
+	{ .type = redtext,	.label = " ",					    .a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Screen size",			    .a = {.cvar = &screenblocks},	   	.b = {.leftval = 3.0}, .c = {.rightval = 12.0},	.d = {.step = 1.0},  .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Brightness",			    .a = {.cvar = &gammalevel},			.b = {.leftval = 1.0}, .c = {.rightval = 8.0},	.d = {.step = 1.0},  .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Red Pain Intensity",		.a = {.cvar = &r_painintensity},		.b = {.leftval = 0.0}, .c = {.rightval = 1.0},	.d = {.step = 0.1},  .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Movement bobbing",			.a = {.cvar = &cl_movebob},			.b = {.leftval = 0.0}, .c = {.rightval = 1.0},	.d = {.step = 0.1},	.e = {.values = nullptr}},
+	{ .type = slider,   .label = "Weapon Visibility",        .a = {.cvar = &r_drawplayersprites}, .b = {.leftval = 0.0}, .c = {.rightval = 1.0},   .d = {.step = 0.1},  .e = {.values = nullptr}},
+	{ .type = discrete,	.label = "Visible Spawn Points",		.a = {.cvar = &cl_showspawns},		.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Center weapon when firing",.a = {.cvar = &cl_centerbobonfire},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Show Killing Sprees",		.a = {.cvar = &cl_showsprees},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Show Multi Kills",		.a = {.cvar = &cl_showmultikills},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Show Sprees Offline",	.a = {.cvar = &cl_showofflinesprees},.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Show Multi Kills Offline",	.a = {.cvar = &cl_showofflinemultikills},.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = redtext,	.label = " ",					    .a = {.cvar = nullptr},				    .b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Force Team Color",			.a = {.cvar = &r_forceteamcolor},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = redslider,   .label = "Team Color Red",        .a = {.cvar = &r_teamcolor},  .b = {.leftval = 0.0}, .c = {.rightval = 0.0},   .d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = greenslider, .label = "Team Color Green",      .a = {.cvar = &r_teamcolor},  .b = {.leftval = 0.0}, .c = {.rightval = 0.0},   .d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = blueslider,  .label = "Team Color Blue",       .a = {.cvar = &r_teamcolor},  .b = {.leftval = 0.0}, .c = {.rightval = 0.0},   .d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = redtext,	.label = " ",					    .a = {.cvar = nullptr},				    .b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Force Enemy Color",        .a = {.cvar = &r_forceenemycolor},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = redslider,   .label = "Enemy Color Red",       .a = {.cvar = &r_enemycolor},  .b = {.leftval = 0.0}, .c = {.rightval = 0.0},   .d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = greenslider, .label = "Enemy Color Green",     .a = {.cvar = &r_enemycolor},  .b = {.leftval = 0.0}, .c = {.rightval = 0.0},   .d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = blueslider,  .label = "Enemy Color Blue",      .a = {.cvar = &r_enemycolor},  .b = {.leftval = 0.0}, .c = {.rightval = 0.0},   .d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = redtext,	.label = " ",					    .a = {.cvar = nullptr},				    .b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = slider,   .label = "UI Background Red",        .a = {.cvar = &ui_transred},         .b = {.leftval = 0.0}, .c = {.rightval = 255.0}, .d = {.step = 16.0}, .e = {.values = nullptr}},
+	{ .type = slider,   .label = "UI Background Green",      .a = {.cvar = &ui_transgreen},       .b = {.leftval = 0.0}, .c = {.rightval = 255.0}, .d = {.step = 16.0}, .e = {.values = nullptr}},
+	{ .type = slider,   .label = "UI Background Blue",       .a = {.cvar = &ui_transblue},        .b = {.leftval = 0.0}, .c = {.rightval = 255.0}, .d = {.step = 16.0}, .e = {.values = nullptr}},
+	{ .type = slider,   .label = "UI Background Visibility", .a = {.cvar = &ui_dimamount},        .b = {.leftval = 0.0}, .c = {.rightval = 1.0},   .d = {.step = 0.1},  .e = {.values = nullptr}},
+	{ .type = redtext,	.label = " ",					    .a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = discrete, .label = "See killer on Death",			.a = {.cvar = &cl_deathcam},   .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Stretch short skies",	    .a = {.cvar = &r_stretchsky},	   	.b = {.leftval = ARRAY_LENGTH(OnOffAuto)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOffAuto.data()}},
+	{ .type = discrete, .label = "Linear Skies",			    .a = {.cvar = &r_linearsky},	   		.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Invuln changes skies",		.a = {.cvar = &r_skypalette},		.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Use softer invuln effect", .a = {.cvar = &r_softinvulneffect},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Heart effect on friendlies", .a = {.cvar = &cl_showfriends},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Screen wipe style",	    .a = {.cvar = &r_wipetype},			.b = {.leftval = ARRAY_LENGTH(Wipes)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = Wipes.data()}},
+	{ .type = discrete, .label = "Multiplayer Intermissions",.a = {.cvar = &wi_oldintermission},	.b = {.leftval = ARRAY_LENGTH(DoomOrOdamex)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = DoomOrOdamex.data()}},
+	{ .type = discrete, .label = "Show loading disk icon",	.a = {.cvar = &r_loadicon},			.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete,	.label = "Show DOS ending screen",  .a = {.cvar = &r_showendoom},		.b = {.leftval = ARRAY_LENGTH(Endoom)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = Endoom.data()}},
+
+
+}};
+// NOLINTEND(readability-magic-numbers)
+
+void M_UpdateDisplayOptions()
+{
+	const static size_t menu_length = VideoItems.size();
+	const static size_t gamma_index = M_FindCvarInMenu(gammalevel, VideoItems.data(), menu_length);
 
 	// update the parameters for gammalevel based on vid_gammatype (doom or zdoom gamma)
 	VideoItems[gamma_index].b.leftval = V_GetMinimumGammaLevel();
 	VideoItems[gamma_index].c.rightval = V_GetMaximumGammaLevel();
 	VideoItems[gamma_index].d.step = 0.1f;
 }
+} // namespace
+
 
 menu_t VideoMenu = {
 	"M_VIDEO",
 	0,
-	ARRAY_LENGTH(VideoItems),
+	VideoItems.size(),
 	0,
-	VideoItems,
+	VideoItems.data(),
 	4,
 	0,
 	&M_UpdateDisplayOptions
 };
+namespace
+{
+
 
 /*=======================================
  *
@@ -1006,78 +1134,88 @@ menu_t VideoMenu = {
  *
  *=======================================*/
 
-static value_t SecretOptions[] = {
-    {0.0, "Off"},
-    {1.0, "On (with sounds)"},
-    {2.0, "On (w/o sounds)"},
-    {3.0, "Own only"},
-};
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<value_t, 4> SecretOptions = {{
+	{ .value = 0.0, .name = "Off"},
+	{ .value = 1.0, .name = "On (with sounds)"},
+	{ .value = 2.0, .name = "On (w/o sounds)"},
+	{ .value = 3.0, .name = "Own only"},
+}};
 
-static value_t TimerStyles[] = {
-    {0.0, "No Timer"}, {1.0, "Count Down"}, {2.0, "Count Up"}};
+std::array<value_t, 3> TimerStyles = {{
+	{ .value = 0.0, .name = "No Timer" }, { .value = 1.0, .name = "Count Down" }, { .value = 2.0, .name = "Count Up" }
+}};
 
-static value_t FlagHelds[] = {{0.0, "Off"}, {1.0, "Complete"}, {2.0, "Simple"}};
+std::array<value_t, 3> FlagHelds = {{
+	{ .value = 0.0, .name = "Off" }, { .value = 1.0, .name = "Complete" }, { .value = 2.0, .name = "Simple" }
+}};
 
-static value_t Crosshairs[] = {{0.0, "None"}, {1.0, "Cross 1"}, {2.0, "Cross 2"},
-                               {3.0, "X"},    {4.0, "Diamond"}, {5.0, "Dot"},
-                               {6.0, "Box"},  {7.0, "Angle"},   {8.0, "Big Thing"}};
+std::array<value_t, 9> Crosshairs = {{
+	{ .value = 0.0, .name = "None" }, { .value = 1.0, .name = "Cross 1" }, { .value = 2.0, .name = "Cross 2" },
+	{ .value = 3.0, .name = "X" },    { .value = 4.0, .name = "Diamond" }, { .value = 5.0, .name = "Dot" },
+	{ .value = 6.0, .name = "Box"},  {.value = 7.0, .name = "Angle"},   {.value = 8.0, .name = "Big Thing"}}};
 
-static value_t ExtendedHudStyles[] = {{0.0, "Off"}, {1.0, "Horizontal 1"}, {2.0, "Horizontal 2"},
-								 {3.0, "Vertical 1"}, {4.0, "Vertical 2"},};
+std::array<value_t, 5> ExtendedHudStyles = {{
+	{ .value = 0.0, .name = "Off" }, { .value = 1.0, .name = "Horizontal 1" }, { .value = 2.0, .name = "Horizontal 2" },
+	{ .value = 3.0, .name = "Vertical 1" }, { .value = 4.0, .name = "Vertical 2" }
+}};
 
-static menuitem_t HUDItems[] = {
-    {yellowtext, "Status Bar", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {discrete, "Scale status bar", {&st_scale}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {redtext, " ", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {yellowtext, "Floating HUD elements", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {discrete, "Scale HUD elements", {&hud_scale}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {slider, "HUD Transparency", {&hud_transparency}, {0.0}, {1.0}, {0.1}, {NULL}},
-    {slider, "HUD Anchoring", {&hud_anchoring}, {0.0}, {1.0}, {0.1}, {NULL}},
-    {discrete, "Bigger font in HUD", {&hud_bigfont}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    // clang-format off
-    {discrete, "Show Secret Messages", {&hud_revealsecrets}, {4.0}, {0.0}, {0.0}, {SecretOptions}},
-    {discrete, "Player target names", {&hud_targetnames}, {2.0}, {0.0}, {0.0}, {HideShow}},
-    // clang-format on
-    {discrete, "Timer Type", {&hud_timer}, {3.0}, {0.0}, {0.0}, {TimerStyles}},
-    {discrete, "Speedometer", {&hud_speedometer}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {slider, "Feed Timeout", {&hud_feedtime}, {1.0}, {10.0}, {0.25}, {NULL}},
-    {discrete, "Show Kills in Feed", {&hud_feedobits}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {discrete, "Netdemo infos", {&hud_demobar}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {discrete, "Extended hud", {&hud_extendedinfo}, {5.0}, {0.0}, {0.0}, {ExtendedHudStyles}},
-    {redtext, " ", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
+std::array<menuitem_t, 34> HUDItems = {{
+	{ .type = yellowtext, .label = "Status Bar", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Scale status bar", .a = {.cvar = &st_scale}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = "Floating HUD elements", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Scale HUD elements", .a = {.cvar = &hud_scale}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = slider, .label = "HUD Transparency", .a = {.cvar = &hud_transparency}, .b = {.leftval = 0.0}, .c = {.rightval = 1.0}, .d = {.step = 0.1}, .e = {.values = nullptr}},
+	{ .type = slider, .label = "HUD Anchoring", .a = {.cvar = &hud_anchoring}, .b = {.leftval = 0.0}, .c = {.rightval = 1.0}, .d = {.step = 0.1}, .e = {.values = nullptr}},
+	{.type = discrete, .label = "Bigger font in HUD", .a = {.cvar = &hud_bigfont}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	// clang-format off
+	{ .type = discrete, .label = "Show Secret Messages", .a = {.cvar = &hud_revealsecrets}, .b = {.leftval = ARRAY_LENGTH(SecretOptions)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = SecretOptions.data()}},
+	{ .type = discrete, .label = "Player target names", .a = {.cvar = &hud_targetnames}, .b = {.leftval = ARRAY_LENGTH(HideShow)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = HideShow.data()}},
+	// clang-format on
+	{ .type = discrete, .label = "Timer Type", .a = {.cvar = &hud_timer}, .b = {.leftval = ARRAY_LENGTH(TimerStyles)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = TimerStyles.data()}},
+	{ .type = discrete, .label = "Speedometer", .a = {.cvar = &hud_speedometer}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = slider, .label = "Feed Timeout", .a = {.cvar = &hud_feedtime}, .b = {.leftval = 1.0}, .c = {.rightval = 10.0}, .d = {.step = 0.25}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Show Kills in Feed", .a = {.cvar = &hud_feedobits}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Netdemo infos", .a = {.cvar = &hud_demobar}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Extended hud", .a = {.cvar = &hud_extendedinfo}, .b = {.leftval = ARRAY_LENGTH(ExtendedHudStyles)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = ExtendedHudStyles.data()}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
 
-    {yellowtext, "Scoreboard", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {slider, "Scale scoreboard", {&hud_scalescoreboard}, {0.0}, {1.0}, {0.125}, {NULL}},
-    // clang-format off
-	{discrete, "Scores on Death", {&hud_show_scoreboard_ondeath}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    // clang-format on
-    {redtext, " ", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
+	{ .type = yellowtext, .label = "Scoreboard", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = slider, .label = "Scale scoreboard", .a = {.cvar = &hud_scalescoreboard}, .b = {.leftval = 0.0}, .c = {.rightval = 1.0}, .d = {.step = 0.125}, .e = {.values = nullptr}},
+	// clang-format off
+	{ .type = discrete, .label = "Scores on Death", .a = {.cvar = &hud_show_scoreboard_ondeath}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	// clang-format on
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
 
-    {yellowtext, "Capture the Flag", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {discrete, "Event Message Type", {&hud_gamemsgtype}, {3.0}, {0.0}, {0.0}, {VoxType}},
-    {discrete, "Held Flag Border", {&hud_heldflag}, {3.0}, {0.0}, {0.0}, {FlagHelds}},
-    {discrete, "Held Flag Flashes", {&hud_heldflag_flash}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {redtext, " ", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
+	{ .type = yellowtext, .label = "Capture the Flag", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Event Message Type", .a = {.cvar = &hud_gamemsgtype}, .b = {.leftval = ARRAY_LENGTH(VoxType)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = VoxType.data()}},
+	{ .type = discrete, .label = "Held Flag Border", .a = {.cvar = &hud_heldflag}, .b = {.leftval = ARRAY_LENGTH(FlagHelds)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = FlagHelds.data()}},
+	{ .type = discrete, .label = "Held Flag Flashes", .a = {.cvar = &hud_heldflag_flash}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
 
-    {yellowtext, "Crosshair", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {discrete, "Crosshair type", {&hud_crosshair}, {9.0}, {0.0}, {0.0}, {Crosshairs}},
-    {discrete, "Scale crosshair", {&hud_crosshairscale}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {discrete, "Crosshair health", {&hud_crosshairhealth}, {2.0}, {0.0}, {0.0}, {OnOff}},
-    {redslider, "Crosshair Red", {&hud_crosshaircolor}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {greenslider, "Crosshair Green", {&hud_crosshaircolor}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {blueslider, "Crosshair Blue", {&hud_crosshaircolor}, {0.0}, {0.0}, {0.0}, {NULL}},
-    {redtext, " ", {NULL}, {0.0}, {0.0}, {0.0}, {NULL}},
-};
+	{ .type = yellowtext, .label = "Crosshair", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Crosshair type", .a = {.cvar = &hud_crosshair}, .b = {.leftval = ARRAY_LENGTH(Crosshairs)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = Crosshairs.data()}},
+	{ .type = discrete, .label = "Scale crosshair", .a = {.cvar = &hud_crosshairscale}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Crosshair health", .a = {.cvar = &hud_crosshairhealth}, .b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = OnOff.data()}},
+	{ .type = redslider, .label = "Crosshair Red", .a = {.cvar = &hud_crosshaircolor}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = greenslider, .label = "Crosshair Green", .a = {.cvar = &hud_crosshaircolor}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = blueslider, .label = "Crosshair Blue", .a = {.cvar = &hud_crosshaircolor}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = redtext, .label = " ", .a = {.cvar = nullptr}, .b = {.leftval = 0.0}, .c = {.rightval = 0.0}, .d = {.step = 0.0}, .e = {.values = nullptr}},
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t HUDMenu = {
-    "M_HUD",                // title
-    1,                      // lastOn
-    ARRAY_LENGTH(HUDItems), // numitems
-    0,                      // indent
-    HUDItems,               // items
-    0,                      // scrolltop
-    0,                      // scrollpos
-    NULL,                   // refreshfunc
+	"M_HUD",                // title
+	1,                      // lastOn
+	HUDItems.size(),        // numitems
+	0,                      // indent
+	HUDItems.data(),        // items
+	0,                      // scrolltop
+	0,                      // scrollpos
+	nullptr,                // refreshfunc
 };
 
 /*=======================================
@@ -1097,67 +1235,84 @@ EXTERN_CVAR (msg3color)
 EXTERN_CVAR (msg4color)
 EXTERN_CVAR (msgmidcolor)
 
-static value_t TextColors[] =
+namespace
 {
-	{ CR_BRICK,		"brick" },
-	{ CR_TAN,		"tan" },
-	{ CR_GRAY,		"gray" },
-	{ CR_GREEN,		"green" },
-	{ CR_BROWN,		"brown" },
-	{ CR_GOLD, 		"gold" },
-	{ CR_RED,		"red" },
-	{ CR_BLUE,		"blue" },
-	{ CR_ORANGE,	"orange" },
-	{ CR_WHITE,		"white" },
-	{ CR_YELLOW,	"yellow" },
-	{ CR_BLACK,		"black" },
-	{ CR_LIGHTBLUE,	"light blue" },
-	{ CR_CREAM,		"cream" },
-	{ CR_OLIVE,		"olive" },
-	{ CR_DARKGREEN,	"dark green" },
-	{ CR_DARKRED,	"dark red" },
-	{ CR_DARKBROWN,	"dark brown" },
-	{ CR_PURPLE,	"purple" },
-	{ CR_DARKGRAY,	"dark gray" },
-	{ CR_CYAN,		"cyan" }
-};
+
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<value_t, 21> TextColors =
+{{
+	{ .value = CR_BRICK,		.name = "brick"},
+	{ .value = CR_TAN,		.name = "tan"},
+	{ .value = CR_GRAY,		.name = "gray"},
+	{ .value = CR_GREEN,		.name = "green"},
+	{ .value = CR_BROWN,		.name = "brown"},
+	{ .value = CR_GOLD, 		.name = "gold"},
+	{ .value = CR_RED,		.name = "red"},
+	{ .value = CR_BLUE,		.name = "blue"},
+	{ .value = CR_ORANGE,	.name = "orange"},
+	{ .value = CR_WHITE,		.name = "white"},
+	{ .value = CR_YELLOW,	.name = "yellow"},
+	{ .value = CR_BLACK,		.name = "black"},
+	{ .value = CR_LIGHTBLUE,	.name = "light blue"},
+	{ .value = CR_CREAM,		.name = "cream"},
+	{ .value = CR_OLIVE,		.name = "olive"},
+	{ .value = CR_DARKGREEN,	.name = "dark green"},
+	{ .value = CR_DARKRED,	.name = "dark red"},
+	{ .value = CR_DARKBROWN,	.name = "dark brown"},
+	{ .value = CR_PURPLE,	.name = "purple"},
+	{ .value = CR_DARKGRAY,	.name = "dark gray"},
+	{ .value = CR_CYAN,		.name = "cyan"}
+}};
+
 
 // TODO: Put all language info in one array, auto detect what's in the lump?
 //static value_t Languages[] = { // unused
-//	{ 0.0, "Auto" },
-//	{ 1.0, "English" },
-//	{ 2.0, "French" },
-//	{ 3.0, "Italian" }
+//	{ .value = 0.0, .name = "Auto"},
+//	{ .value = 1.0, .name = "English"},
+//	{ .value = 2.0, .name = "French"},
+//	{ .value = 3.0, .name = "Italian"}
 //};
 
-static value_t ScaleFactors[] = {{0.0, "Auto"}, {1.0, "1X"}, {2.0, "2X"},
-                                 {3.0, "3X"},   {4.0, "4X"}, {5.0, "5X"}};
+// Stops at 4X: hud_scaletext and con_scaletext are both ranged 0 to 4.
+std::array<value_t, 5> ScaleFactors = {{
+	{ .value = 0.0, .name = "Auto"},
+	{ .value = 1.0, .name = "1X"},
+	{ .value = 2.0, .name = "2X"},
+	{ .value = 3.0, .name = "3X"},
+	{ .value = 4.0, .name = "4X"}
+}};
 
-static menuitem_t MessagesItems[] = {
+// Sized by the initializer: entries here are conditionally compiled,
+// so a fixed std::array size would be wrong on some builds.
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+menuitem_t MessagesItems[] = {
 #if 0
-	{ discrete, "Language", 			 {&language},		   	{4.0}, {0.0},   {0.0}, {Languages} },
+	{ .type = discrete, .label = "Language", 			 .a = {.cvar = &language},		   	.b = {.leftval = ARRAY_LENGTH(Languages)}, .c = {.rightval = 0.0},   .d = {.step = 0.0}, .e = {.values = Languages}},
 #endif
-	{ slider,	"Message Timeout",		 {&con_notifytime},		{1.0}, {10.0},	{0.25}, {NULL} },
-	{ slider,	"Center Message Timeout",{&con_midtime},		{1.0}, {10.0},	{0.25}, {NULL} },
-	{ discrete,	"Scale message text",    {&hud_scaletext},		{5.0}, {0.0}, 	{0.0}, {ScaleFactors} },
-	{ discrete,	"Colorize messages",	{&con_coloredmessages},	{2.0}, {0.0},   {0.0},	{OnOff} },
-	{ discrete,	"Scale console text",   {&con_scaletext},		{5.0}, {0.0}, 	{0.0}, {ScaleFactors} },
-	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ yellowtext,"Display settings",	{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ discrete,	"Pickup messages",		{&message_showpickups},	{2.0}, {0.0},   {0.0},	{OnOff} },
-	{ discrete,	"Death messages",		{&message_showobituaries},	{2.0}, {0.0},   {0.0},	{OnOff} },
-	{ discrete,	"Spectator messages",	{&mute_spectators},	{2.0}, {0.0},   {0.0},	{OffOn} },
-	{ discrete,	"Enemy messages",		{&mute_enemies},	{2.0}, {0.0},   {0.0},	{OffOn} },
+	{ .type = slider,	.label = "Message Timeout",		 .a = {.cvar = &con_notifytime},		.b = {.leftval = 1.0}, .c = {.rightval = 10.0},	.d = {.step = 0.25}, .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Center Message Timeout",.a = {.cvar = &con_midtime},		.b = {.leftval = 1.0}, .c = {.rightval = 10.0},	.d = {.step = 0.25}, .e = {.values = nullptr}},
+	{ .type = discrete,	.label = "Scale message text",    .a = {.cvar = &hud_scaletext},		.b = {.leftval = ARRAY_LENGTH(ScaleFactors)}, .c = {.rightval = 0.0}, 	.d = {.step = 0.0}, .e = {.values = ScaleFactors.data()}},
+	{ .type = discrete,	.label = "Colorize messages",	.a = {.cvar = &con_coloredmessages},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete,	.label = "Scale console text",   .a = {.cvar = &con_scaletext},		.b = {.leftval = ARRAY_LENGTH(ScaleFactors)}, .c = {.rightval = 0.0}, 	.d = {.step = 0.0}, .e = {.values = ScaleFactors.data()}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext,.label = "Display settings",	.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete,	.label = "Pickup messages",		.a = {.cvar = &message_showpickups},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete,	.label = "Death messages",		.a = {.cvar = &message_showobituaries},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete,	.label = "Spectator messages",	.a = {.cvar = &mute_spectators},	.b = {.leftval = ARRAY_LENGTH(OffOn)}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OffOn.data()}},
+	{ .type = discrete,	.label = "Enemy messages",		.a = {.cvar = &mute_enemies},	.b = {.leftval = ARRAY_LENGTH(OffOn)}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OffOn.data()}},
 
-	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ yellowtext, "Message Colors",		{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ cdiscrete, "Item Pickup",			{&msg0color},		   	{21.0}, {0.0},	{0.0}, {TextColors} },
-	{ cdiscrete, "Obituaries",			{&msg1color},		   	{21.0}, {0.0},	{0.0}, {TextColors} },
-	{ cdiscrete, "Critical Messages",	{&msg2color},		   	{21.0}, {0.0},	{0.0}, {TextColors} },
-	{ cdiscrete, "Chat Messages",		{&msg3color},		   	{21.0}, {0.0},	{0.0}, {TextColors} },
-	{ cdiscrete, "Team Messages",		{&msg4color},		   	{21.0}, {0.0},	{0.0}, {TextColors} },
-	{ cdiscrete, "Centered Messages",	{&msgmidcolor},			{21.0}, {0.0},	{0.0}, {TextColors} }
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = "Message Colors",		.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = cdiscrete, .label = "Item Pickup",			.a = {.cvar = &msg0color},		   	.b = {.leftval = ARRAY_LENGTH(TextColors)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = TextColors.data()}},
+	{ .type = cdiscrete, .label = "Obituaries",			.a = {.cvar = &msg1color},		   	.b = {.leftval = ARRAY_LENGTH(TextColors)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = TextColors.data()}},
+	{ .type = cdiscrete, .label = "Critical Messages",	.a = {.cvar = &msg2color},		   	.b = {.leftval = ARRAY_LENGTH(TextColors)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = TextColors.data()}},
+	{ .type = cdiscrete, .label = "Chat Messages",		.a = {.cvar = &msg3color},		   	.b = {.leftval = ARRAY_LENGTH(TextColors)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = TextColors.data()}},
+	{ .type = cdiscrete, .label = "Team Messages",		.a = {.cvar = &msg4color},		   	.b = {.leftval = ARRAY_LENGTH(TextColors)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = TextColors.data()}},
+	{ .type = cdiscrete, .label = "Centered Messages",	.a = {.cvar = &msgmidcolor},			.b = {.leftval = ARRAY_LENGTH(TextColors)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = TextColors.data()}}
 };
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t MessagesMenu = {
 	"M_MESS",
@@ -1167,8 +1322,11 @@ menu_t MessagesMenu = {
 	MessagesItems,
 	0,
 	0,
-	NULL
+	nullptr
 };
+namespace
+{
+
 
 /*=======================================
  *
@@ -1176,65 +1334,69 @@ menu_t MessagesMenu = {
  *
  *=======================================*/
 
-static value_t ClassicMapStringTypes[] = {
-	{ 0.0, "Odamex" },
-	{ 1.0, "Classic" }
-};
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<value_t, 2> ClassicMapStringTypes = {{
+	{ .value = 0.0, .name = "Odamex"},
+	{ .value = 1.0, .name = "Classic"}
+}};
 
-static value_t AutomapScales[] = {
-	{ 0.0, "Auto" },
-	{ 1.0, "1X" },
-	{ 2.0, "2X" },
-	{ 3.0, "3X" },
-	{ 4.0, "4X" },
-	{ 5.0, "5X" },
-	{ 6.0, "6X" },
-};
+std::array<value_t, 7> AutomapScales = {{
+	{ .value = 0.0, .name = "Auto"},
+	{ .value = 1.0, .name = "1X"},
+	{ .value = 2.0, .name = "2X"},
+	{ .value = 3.0, .name = "3X"},
+	{ .value = 4.0, .name = "4X"},
+	{ .value = 5.0, .name = "5X"},
+	{ .value = 6.0, .name = "6X"},
+}};
 
-static value_t MinimapLocations[] = {
-	{ 0.0, "Left Top" },
-	{ 1.0, "Left Middle" },
-	{ 2.0, "Left Bottom" },
-	{ 3.0, "Right Top" },
-	{ 4.0, "Right Middle" },
-	{ 5.0, "Right Bottom" },
-};
+std::array<value_t, 6> MinimapLocations = {{
+	{ .value = 0.0, .name = "Left Top"},
+	{ .value = 1.0, .name = "Left Middle"},
+	{ .value = 2.0, .name = "Left Bottom"},
+	{ .value = 3.0, .name = "Right Top"},
+	{ .value = 4.0, .name = "Right Middle"},
+	{ .value = 5.0, .name = "Right Bottom"},
+}};
 
-static menuitem_t AutomapItems[] = {
-	{ discrete, "Rotate automap",		{&am_rotate},		   	{2.0}, {0.0},	{0.0},  {OnOff} },
-	{ discrete, "Overlay automap",		{&am_overlay},			{4.0}, {0.0},	{0.0},  {Overlays} },
-	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ discrete, "Line Thickeness",		{&am_thickness},		{7.0}, {0.0},	{0.0},  {AutomapScales} },
-	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-    { discrete, "Show item count",		{&am_showitems},		{2.0}, {0.0},	{0.0},  {OnOff} },
-    { discrete, "Show monster count",	{&am_showmonsters},		{2.0}, {0.0},	{0.0},	{OnOff} },
-    { discrete, "Show secrets count",	{&am_showsecrets},	   	{2.0}, {0.0},	{0.0},  {OnOff} },
-    { discrete, "Show map timer", 	    {&am_showtime}, 	   	{2.0}, {0.0},	{0.0},  {OnOff} },
-    { discrete, "Map name style",       {&am_classicmapstring},	{2.0}, {0.0},	{0.0},  {ClassicMapStringTypes} },
+std::array<menuitem_t, 21> AutomapItems = {{
+	{ .type = discrete, .label = "Rotate automap",		.a = {.cvar = &am_rotate},		   	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Overlay automap",		.a = {.cvar = &am_overlay},			.b = {.leftval = ARRAY_LENGTH(Overlays)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = Overlays.data()}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Line Thickeness",		.a = {.cvar = &am_thickness},		.b = {.leftval = ARRAY_LENGTH(AutomapScales)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = AutomapScales.data()}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Show item count",		.a = {.cvar = &am_showitems},		.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Show monster count",	.a = {.cvar = &am_showmonsters},		.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},	.e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Show secrets count",	.a = {.cvar = &am_showsecrets},	   	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Show map timer", 	    .a = {.cvar = &am_showtime}, 	   	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Map name style",       .a = {.cvar = &am_classicmapstring},	.b = {.leftval = ARRAY_LENGTH(ClassicMapStringTypes)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = ClassicMapStringTypes.data()}},
 
-	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ yellowtext, "Automap Colors",		{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ discrete, "Highlight locked doors",{&am_showlocked},		{2.0}, {0.0},	{0.0},  {OnOff} },
-	{ discrete, "Custom map colors",	{&am_usecustomcolors},	{2.0}, {0.0},	{0.0},  {OnOff} },
-	{ more,     "Reset custom map colors",  {NULL},    {0.0}, {0.0},   {0.0},  {.mfunc = ResetCustomColors} },
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = "Automap Colors",		.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Highlight locked doors",.a = {.cvar = &am_showlocked},		.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Custom map colors",	.a = {.cvar = &am_usecustomcolors},	.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
+	{ .type = more,     .label = "Reset custom map colors",  .a = {.cvar = nullptr},    .b = {.leftval = 0.0}, .c = {.rightval = 0.0},   .d = {.step = 0.0},  .e = {.mfunc = ResetCustomColors}},
 
-	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0},  {NULL} },
-	{ yellowtext, "Overlay Minimap Options", {NULL},			{0.0}, {0.0},	{0.0},  {NULL} },
-	{ discrete, "Enable Minimap",		{&am_ovminimap},		{2.0}, {0.0},	{0.0},  {OnOff} },
-	{ discrete, "Location",				{&am_ovlocation},		{6.0}, {0.0},	{0.0},  {MinimapLocations} },
-	{ slider,	"Scale Width",			{&am_ovscalewidth},		{0.0}, {1.0},	{0.05}, {NULL} },
-	{ slider,	"Scale Height",			{&am_ovscaleheight},	{0.0}, {1.0},	{0.05}, {NULL} },
-};
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = "Overlay Minimap Options", .a = {.cvar = nullptr},			.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = nullptr}},
+	{ .type = discrete, .label = "Enable Minimap",		.a = {.cvar = &am_ovminimap},		.b = {.leftval = ARRAY_LENGTH(OnOff)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
+	{ .type = discrete, .label = "Location",				.a = {.cvar = &am_ovlocation},		.b = {.leftval = ARRAY_LENGTH(MinimapLocations)}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = MinimapLocations.data()}},
+	{ .type = slider,	.label = "Scale Width",			.a = {.cvar = &am_ovscalewidth},		.b = {.leftval = 0.0}, .c = {.rightval = 1.0},	.d = {.step = 0.05}, .e = {.values = nullptr}},
+	{ .type = slider,	.label = "Scale Height",			.a = {.cvar = &am_ovscaleheight},	.b = {.leftval = 0.0}, .c = {.rightval = 1.0},	.d = {.step = 0.05}, .e = {.values = nullptr}},
+}};
+// NOLINTEND(readability-magic-numbers)
+} // namespace
+
 
 menu_t AutomapMenu = {
 	"M_AUTOMP",
 	0,
-	ARRAY_LENGTH(AutomapItems),
+	AutomapItems.size(),
 	0,
-	AutomapItems,
+	AutomapItems.data(),
 	0,
 	0,
-	NULL
+	nullptr
 };
 
 
@@ -1244,9 +1406,15 @@ menu_t AutomapMenu = {
  *
  *=======================================*/
 
-int testingmode;		// Holds time to revert to old mode
+// Tick at which the mode test expires, on the same clock as I_MSTime.
+dtime_t testingmode;
+namespace
+{
+		// Holds time to revert to old mode
 
-static bool GetSelectedSize(int line, int *width, int *height);
+bool GetSelectedSize(int line, int *width, int *height);
+} // namespace
+
 
 EXTERN_CVAR (vid_widescreen)
 EXTERN_CVAR (vid_maxfps)
@@ -1257,10 +1425,13 @@ EXTERN_CVAR (vid_32bpp)
 EXTERN_CVAR(vid_vsync)
 
 static uint16_t old_width, old_height;
+namespace
+{
 
-static void SetModesMenu(int w, int h);
 
-static void M_SetVideoMode(uint16_t width, uint16_t height)
+void SetModesMenu(int w, int h);
+
+void M_SetVideoMode(uint16_t width, uint16_t height)
 {
 	old_width = I_GetVideoWidth();
 	old_height = I_GetVideoHeight();
@@ -1269,6 +1440,8 @@ static void M_SetVideoMode(uint16_t width, uint16_t height)
 
 	SetModesMenu(width, height);
 }
+} // namespace
+
 
 
 void M_RestoreVideoMode()
@@ -1281,7 +1454,7 @@ namespace
 {
 
 constexpr int MAX_LINES_ONSCREEN = 22;
-value_t Depths[MAX_LINES_ONSCREEN];
+std::array<value_t, MAX_LINES_ONSCREEN> Depths;
 
 #ifdef GCONSOLE
 constexpr const char VMEnterText[] = "Press A to set mode";
@@ -1293,58 +1466,63 @@ constexpr const char VMTestText[] = "Press T to test mode for 5 seconds";
 
 constexpr const char VMTestWaitText[] = "Please wait 5 seconds...";
 
-value_t VidFPSCaps[] = {
-	{ 35.0,		"35fps" },
-	{ 60.0,		"60fps" },
-	{ 70.0,		"70fps" },
-	{ 90.0,		"90fps" },
-	{ 105.0,	"105fps"},
-	{ 120.0,	"120fps" },
-	{ 140.0,	"140fps"},
-	{ 144.0,	"144fps"},
-	{ 240.0,	"240fps"},
-	{ 0.0,		"Unlimited" }
-};
+// NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
+std::array<value_t, 10> VidFPSCaps = {{
+	{ .value = 35.0,	.name = "35fps"},
+	{ .value = 60.0,	.name = "60fps"},
+	{ .value = 70.0,	.name = "70fps"},
+	{ .value = 90.0,	.name = "90fps"},
+	{ .value = 105.0,	.name = "105fps"},
+	{ .value = 120.0,	.name = "120fps"},
+	{ .value = 140.0,	.name = "140fps"},
+	{ .value = 144.0,	.name = "144fps"},
+	{ .value = 240.0,	.name = "240fps"},
+	{ .value = 0.0,		.name = "Unlimited"}
+}};
 
-value_t FullScreenOptions[] = {
-	{ WINDOW_Windowed,			"Window" },
-	{ WINDOW_Fullscreen,		"Full Screen Exclusive" },
-	{ WINDOW_DesktopFullscreen,	"Full Screen Window" }
-};
+std::array<value_t, 3> FullScreenOptions = {{
+	{ .value = WINDOW_Windowed,			.name = "Window"},
+	{ .value = WINDOW_Fullscreen,		.name = "Full Screen Exclusive"},
+	{ .value = WINDOW_DesktopFullscreen,	.name = "Full Screen Window"}
+}};
 
-value_t WidescreenMode[] = {
-	{ 0.0,			"Off" },
-	{ 1.0,			"Auto" },
-	{ 2.0,			"16:10" },
-	{ 3.0,			"16:9" },
-	{ 4.0,			"21:9" },
-	{ 5.0,			"32:9" }
-};
+std::array<value_t, 6> WidescreenMode = {{
+	{ .value = 0.0,			.name = "Off"},
+	{ .value = 1.0,			.name = "Auto"},
+	{ .value = 2.0,			.name = "16:10"},
+	{ .value = 3.0,			.name = "16:9"},
+	{ .value = 4.0,			.name = "21:9"},
+	{ .value = 5.0,			.name = "32:9"}
+}};
 
+// Sized by the initializer: entries here are conditionally compiled,
+// so a fixed std::array size would be wrong on some builds.
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
 menuitem_t ModesItems[] = {
 #ifdef GCONSOLE
-	{ slider, "Overscan",				{&vid_overscan},		{0.84375}, {1.0}, {0.03125}, {NULL} },
+	{ .type = slider, .label = "Overscan",				.a = {.cvar = &vid_overscan},		.b = {.leftval = 0.84375}, .c = {.rightval = 1.0}, .d = {.step = 0.03125}, .e = {.values = nullptr}},
 #else
-	{ discrete, "Fullscreen",			{&vid_fullscreen},		{3.0}, {0.0},	{0.0}, {FullScreenOptions} },
+	{ .type = discrete, .label = "Fullscreen",			.a = {.cvar = &vid_fullscreen},		.b = {.leftval = ARRAY_LENGTH(FullScreenOptions)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = FullScreenOptions.data()}},
 #endif
-	{ discrete,	"Widescreen",			{&vid_widescreen},		{6.0}, {0.0},	{0.0}, {WidescreenMode} } ,
-	{ discrete,	"VSync",				{&vid_vsync},			{2.0}, {0.0},	{0.0}, {YesNo} },
-	{ discrete, "Framerate",			{&vid_maxfps},			{9.0}, {0.0},	{0.0}, {VidFPSCaps} },
-	{ discrete, "32-bit color",			{&vid_32bpp},			{2.0}, {0.0},	{0.0}, {YesNo} },
-	{ redtext,	"",						{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ screenres, NULL,					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ whitetext, " ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ redtext,	" ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
-	{ yellowtext, " ",					{NULL},					{0.0}, {0.0},	{0.0}, {NULL} },
+	{ .type = discrete,	.label = "Widescreen",			.a = {.cvar = &vid_widescreen},		.b = {.leftval = ARRAY_LENGTH(WidescreenMode)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = WidescreenMode.data()}} ,
+	{ .type = discrete,	.label = "VSync",				.a = {.cvar = &vid_vsync},			.b = {.leftval = ARRAY_LENGTH(YesNo)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = YesNo.data()}},
+	{ .type = discrete, .label = "Framerate",			.a = {.cvar = &vid_maxfps},			.b = {.leftval = ARRAY_LENGTH(VidFPSCaps)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = VidFPSCaps.data()}},
+	{ .type = discrete, .label = "32-bit color",			.a = {.cvar = &vid_32bpp},			.b = {.leftval = ARRAY_LENGTH(YesNo)}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = YesNo.data()}},
+	{ .type = redtext,	.label = "",						.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = screenres, .label = nullptr,					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = screenres, .label = nullptr,					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = screenres, .label = nullptr,					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = screenres, .label = nullptr,					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = screenres, .label = nullptr,					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = screenres, .label = nullptr,					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = screenres, .label = nullptr,					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = screenres, .label = nullptr,					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = whitetext, .label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
+	{ .type = yellowtext, .label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
 };
+// NOLINTEND(readability-magic-numbers)
 
 }
 
@@ -1361,14 +1539,17 @@ menu_t ModesMenu = {
 	ModesItems,
 	0,
 	0,
-	NULL
+	nullptr
 };
+namespace
+{
 
-static void BuildModesList(int hiwidth, int hiheight)
+
+void BuildModesList(int hiwidth, int hiheight)
 {
 	// gathers a list of unique resolutions availible for the current
 	// screen mode (windowed or fullscreen)
-	bool fullscreen = I_GetWindow()->getVideoMode().isFullScreen();
+	const bool fullscreen = I_GetWindow()->getVideoMode().isFullScreen();
 
 	typedef std::vector< std::pair<uint16_t, uint16_t> > MenuModeList;
 	MenuModeList menumodelist;
@@ -1381,7 +1562,7 @@ static void BuildModesList(int hiwidth, int hiheight)
 
 	MenuModeList::const_iterator mode_it = menumodelist.begin();
 
-	char** str = NULL;
+	char** str = nullptr;
 
 	for (int i = VM_RESSTART; ModesItems[i].type == screenres; i++)
 	{
@@ -1409,25 +1590,30 @@ static void BuildModesList(int hiwidth, int hiheight)
 			}
 			else
 			{
-				str = NULL;
+				str = nullptr;
 			}
 		}
 	}
 }
+} // namespace
+
 
 void M_RefreshModesList()
 {
 	BuildModesList(I_GetVideoWidth(), I_GetVideoHeight());
 }
+namespace
+{
 
-static bool GetSelectedSize(int line, int* width, int* height)
+
+bool GetSelectedSize(int line, int* width, int* height)
 {
 	if (ModesItems[line].type != screenres)
 		return false;
 
-	int mode_num = (line - VM_RESSTART) * 3 + ModesItems[line].a.selmode;
+	const int mode_num = ((line - VM_RESSTART) * 3) + ModesItems[line].a.selmode;
 
-	const char* resolution_str = NULL;
+	const char* resolution_str = nullptr;
 
 	if (mode_num % 3 == 0)
 		resolution_str = ModesItems[line].b.res1;
@@ -1439,22 +1625,28 @@ static bool GetSelectedSize(int line, int* width, int* height)
 	if (!resolution_str)
 		return false;
 
-	size_t xpos = 0;
-	for (const char* s = resolution_str; s; s++, xpos++)
-		if (*s == 'x' || *s == 'X')
-			break;
+	const std::string_view resolution(resolution_str);
+	const size_t xpos = resolution.find_first_of("xX");
+	if (xpos == std::string_view::npos)
+		return false;
 
-	char width_str[5] = { 0 }, height_str[5] = { 0 };
-	strncpy(width_str, resolution_str, xpos);
-	strncpy(height_str, resolution_str + xpos + 1, 4);
+	const std::string_view width_str = resolution.substr(0, xpos);
+	const std::string_view height_str = resolution.substr(xpos + 1);
+	if (width_str.empty() || height_str.empty())
+		return false;
 
-	*width = atoi(width_str);
-	*height = atoi(height_str);
+	const std::optional<int> parsed_width = ParseNum<int>(width_str);
+	const std::optional<int> parsed_height = ParseNum<int>(height_str);
+	if (!parsed_width || !parsed_height)
+		return false;
+
+	*width = *parsed_width;
+	*height = *parsed_height;
 
 	return true;
 }
 
-static void SetModesMenu(int w, int h)
+void SetModesMenu(int w, int h)
 {
 	if (!testingmode)
 	{
@@ -1472,6 +1664,8 @@ static void SetModesMenu(int w, int h)
 
 	BuildModesList(w, h);
 }
+} // namespace
+
 
 //
 // M_ModeFlashTestText
@@ -1485,8 +1679,11 @@ void M_ModeFlashTestText()
 	else
 		ModesItems[VM_TESTLINE].label = "";
 }
+namespace
+{
 
-static void SetVidMode()
+
+void SetVidMode()
 {
 	SetModesMenu(I_GetVideoWidth(), I_GetVideoHeight());
 
@@ -1500,48 +1697,60 @@ static void SetVidMode()
 
 
 
-static cvar_t *flagsvar;
+cvar_t *flagsvar;
+} // namespace
+
 
 EXTERN_CVAR(ui_dimcolor)
 
+namespace
+{
+
 // [Russell] - Modified to send new colours
-static void M_SendUINewColor (int red, int green, int blue)
+void M_SendUINewColor (int red, int green, int blue)
 {
 	AddCommandString(fmt::format("ui_dimcolor \"{:02} {:02x} {:02}\"", red, green, blue));
 }
 
-static void M_SlideUIRed(int val)
+} // namespace
+namespace
+{
+
+
+void M_SlideUIRed(int val)
 {
 	argb_t color = V_GetColorFromString(ui_dimcolor);
 	color.setr(val);
 	M_SendUINewColor(color.getr(), color.getg(), color.getb());
 }
 
-static void M_SlideUIGreen (int val)
+void M_SlideUIGreen (int val)
 {
 	argb_t color = V_GetColorFromString(ui_dimcolor);
 	color.setg(val);
 	M_SendUINewColor(color.getr(), color.getg(), color.getb());
 }
 
-static void M_SlideUIBlue (int val)
+void M_SlideUIBlue (int val)
 {
 	argb_t color = V_GetColorFromString(ui_dimcolor);
 	color.setb(val);
 	M_SendUINewColor(color.getr(), color.getg(), color.getb());
 }
+} // namespace
+
 
 
 //
 //		Set some stuff up for the video modes menu
 //
 
-void M_OptInit (void)
+void M_OptInit()
 {
-	for (size_t i = 0; i < ARRAY_LENGTH(Depths); i++)
+	for (size_t i = 0; i < Depths.size(); i++)
 	{
 		Depths[i].value = i;
-		Depths[i].name = NULL;
+		Depths[i].name = nullptr;
 	}
 
 	switch (I_GetVideoCapabilities()->getDisplayType())
@@ -1565,7 +1774,7 @@ void M_OptInit (void)
 //
 //		Toggle messages on/off
 //
-void M_ChangeMessages (void)
+void M_ChangeMessages()
 {
 	if (show_messages)
 	{
@@ -1647,10 +1856,10 @@ void M_SwitchMenu(menu_t* menu)
 		menu->indent = widest + 6;
 	}
 
-	flagsvar = NULL;
+	flagsvar = nullptr;
 }
 
-bool M_StartOptionsMenu (void)
+bool M_StartOptionsMenu()
 {
 	M_SwitchMenu (&OptionMenu);
 	return true;
@@ -1663,11 +1872,11 @@ void M_DrawSlider (int x, int y, float leftval, float rightval, float cur, float
 	else
 		cur = std::clamp(cur, rightval, leftval);
 
-	float dist = (cur - leftval) / (rightval - leftval);
+	const float dist = (cur - leftval) / (rightval - leftval);
 
 	screen->DrawPatchClean (W_CachePatch ("LSLIDE"), x, y);
 	for (int i = 1; i < 11; i++)
-		screen->DrawPatchClean (W_CachePatch ("MSLIDE"), x + i*8, y);
+		screen->DrawPatchClean (W_CachePatch ("MSLIDE"), x + (i*8), y);
 	screen->DrawPatchClean (W_CachePatch ("RSLIDE"), x + 88, y);
 
 	screen->DrawPatchClean (W_CachePatch ("CSLIDE"), x + 5 + static_cast<int>(dist * 78.0), y);
@@ -1675,7 +1884,7 @@ void M_DrawSlider (int x, int y, float leftval, float rightval, float cur, float
 	std::string buf;
 	if (step == 0.0f)
 		return;
-	else if (step >= 1.0f)
+	if (step >= 1.0f)
 		buf = fmt::sprintf("%.0f", cur);
 	else if (step >= 0.1f)
 		buf = fmt::sprintf("%.1f", cur);
@@ -1691,12 +1900,12 @@ void M_DrawColoredSlider(int x, int y, float leftval, float rightval, float cur,
 	else
 		cur = std::clamp(cur, rightval, leftval);
 
-	float dist = (cur - leftval) / (rightval - leftval);
+	const float dist = (cur - leftval) / (rightval - leftval);
 
 	screen->DrawPatchClean(W_CachePatch ("LSLIDE"), x, y);
 
 	for (int i = 1; i < 11; i++)
-		screen->DrawPatchClean (W_CachePatch ("MSLIDE"), x + i*8, y);
+		screen->DrawPatchClean (W_CachePatch ("MSLIDE"), x + (i*8), y);
 
 	screen->DrawPatchClean (W_CachePatch ("RSLIDE"), x + 88, y);
 
@@ -1721,25 +1930,29 @@ int M_FindCurVal (float cur, value_t *values, int numvals)
 void M_OptDrawer()
 {
 	int color;
-	int y, width, i, x, ytop;
-	int theight = 0;
+	int y;
+	int width;
+	int i;
+	int x;
+	int ytop;
+	const int theight = 0;
 	menuitem_t *item;
 	patch_t *title;
 
 	const int x1 = (I_GetSurfaceWidth() / 2)-(160*CleanXfac);
 	const int y1 = (I_GetSurfaceHeight() / 2)-(100*CleanYfac);
 
-    const int x2 = (I_GetSurfaceWidth() / 2)+(160*CleanXfac);
+	const int x2 = (I_GetSurfaceWidth() / 2)+(160*CleanXfac);
 	const int y2 = (I_GetSurfaceHeight() / 2)+(100*CleanYfac);
 
 	// Background effect
 	OdamexEffect(x1,y1,x2,y2);
 
 	title = W_CachePatch (CurrentMenu->title);
-	screen->DrawPatchClean (title, 160-title->width()/2, 10);
+	screen->DrawPatchClean (title, MENU_CENTER_X - (title->width() / 2), MENU_TITLE_Y);
 
 	y = 15 + title->height();
-	ytop = y + CurrentMenu->scrolltop * 8;
+	ytop = y + (CurrentMenu->scrolltop * 8);
 
 	OptMouseRowCount = 0;
 
@@ -1760,7 +1973,7 @@ void M_OptDrawer()
 
 		if (item->type == screenres)
 		{
-			const char *str = NULL;
+			const char *str = nullptr;
 
 			for (x = 0; x < 3; x++)
 			{
@@ -1783,13 +1996,14 @@ void M_OptDrawer()
 					else
 						color = CR_RED;
 
-					screen->DrawTextCleanMove (color, 104 * x + 20, y, str);
+					screen->DrawTextCleanMove (color, (RESCOLUMN_WIDTH * x) + RESCOLUMN_TEXT_X, y, str);
 				}
 			}
 
 			if (i == CurrentItem && ((item->a.selmode != -1 && (skullAnimCounter < 6 || WaitingForKey))
 				|| WaitingForAxis || testingmode))
-				screen->DrawPatchClean (W_CachePatch ("LITLCURS"), item->a.selmode * 104 + 8, y);
+				screen->DrawPatchClean (W_CachePatch ("LITLCURS"),
+				                        (item->a.selmode * RESCOLUMN_WIDTH) + RESCOLUMN_CURSOR_X, y);
 		}
 		else
 		{
@@ -1802,22 +2016,22 @@ void M_OptDrawer()
 				break;
 
 			case redtext:
-				x = 160 - width / 2;
+				x = MENU_CENTER_X - (width / 2);
 				color = CR_RED;
 				break;
 
 			case whitetext:
-				x = 160 - width / 2;
+				x = MENU_CENTER_X - (width / 2);
 				color = CR_GREY;
 				break;
 
 			case yellowtext:
-				x = 160 - width / 2;
+				x = MENU_CENTER_X - (width / 2);
 				color = CR_YELLOW;
 				break;
 
 			case orangetext:
-				x = 160 - width / 2;
+				x = MENU_CENTER_X - (width / 2);
 				color = CR_ORANGE;
 				break;
 
@@ -1839,7 +2053,8 @@ void M_OptDrawer()
 			case cdiscrete:
 			case svdiscrete:
 			{
-				int v, vals;
+				int v;
+				int vals;
 
 				vals = static_cast<int>(item->b.leftval);
 				v = M_FindCurVal(item->a.cvar->value(), item->e.values, vals);
@@ -1871,40 +2086,40 @@ void M_OptDrawer()
 
 			case redslider:
 			{
-				argb_t color = V_GetColorFromString(*item->a.cvar);
+				const argb_t color = V_GetColorFromString(*item->a.cvar);
 				M_DrawColoredSlider(CurrentMenu->indent + 8, y, 0, 255, color.getr(), color);
 			}
 			break;
 			case greenslider:
 			{
-				argb_t color = V_GetColorFromString(*item->a.cvar);
+				const argb_t color = V_GetColorFromString(*item->a.cvar);
 				M_DrawColoredSlider(CurrentMenu->indent + 8, y, 0, 255, color.getg(), color);
 			}
 			break;
 			case blueslider:
 			{
-				argb_t color = V_GetColorFromString(*item->a.cvar);
+				const argb_t color = V_GetColorFromString(*item->a.cvar);
 				M_DrawColoredSlider(CurrentMenu->indent + 8, y, 0, 255, color.getb(), color);
 			}
 			break;
 
 			case control:
 			{
-				std::string desc = Bindings.GetNameKeys(item->b.key1, item->c.key2);
+				const std::string desc = Bindings.GetNameKeys(item->b.key1, item->c.key2);
 				screen->DrawTextCleanMove (CR_GREY, CurrentMenu->indent + 14, y, desc.c_str());
 			}
 			break;
 
 			case mapcontrol:
 			{
-				std::string desc = AutomapBindings.GetNameKeys(item->b.key1, item->c.key2);
+				const std::string desc = AutomapBindings.GetNameKeys(item->b.key1, item->c.key2);
 				screen->DrawTextCleanMove(CR_GREY, CurrentMenu->indent + 14, y, desc.c_str());
 			}
 			break;
 
 			case netdemocontrol:
 			{
-				std::string desc = NetDemoBindings.GetNameKeys(item->b.key1, item->c.key2);
+				const std::string desc = NetDemoBindings.GetNameKeys(item->b.key1, item->c.key2);
 				screen->DrawTextCleanMove(CR_GREY, CurrentMenu->indent + 14, y, desc.c_str());
 			}
 			break;
@@ -1915,9 +2130,9 @@ void M_OptDrawer()
 				const char *str;
 
 				if (item->b.leftval)
-					value = NoYes;
+					value = NoYes.data();
 				else
-					value = YesNo;
+					value = YesNo.data();
 
 				if (*item->e.flagint & item->a.flagmask)
 					str = value[1].name;
@@ -1932,7 +2147,7 @@ void M_OptDrawer()
 			{
 				std::string joyname;
 
-				size_t numjoy = I_GetJoystickCount();
+				const size_t numjoy = I_GetJoystickCount();
 
 				if(static_cast<size_t>(item->a.cvar->value()) > numjoy)
 					item->a.cvar->Set(0.0);
@@ -1976,13 +2191,16 @@ void M_OptDrawer()
 	if (CanScrollDown)
 		screen->DrawPatchClean (W_CachePatch ("LITLDN"), 3, 190);
 }
+namespace
+{
+
 
 //
 // M_OptItemSelectable
 //
 // Matches the item types the up/down key handlers skip over.
 //
-static bool M_OptItemSelectable(const menuitem_t* item)
+bool M_OptItemSelectable(const menuitem_t* item)
 {
 	switch (item->type)
 	{
@@ -1992,7 +2210,7 @@ static bool M_OptItemSelectable(const menuitem_t* item)
 	case orangetext:
 		return false;
 	case screenres:
-		return item->b.res1 != NULL;
+		return item->b.res1 != nullptr;
 	default:
 		return true;
 	}
@@ -2004,7 +2222,7 @@ static bool M_OptItemSelectable(const menuitem_t* item)
 //
 // Returns an index into OptMouseRows, or -1 if the cursor isn't over a row.
 //
-static int M_OptRowUnderMouse(int mouse_y)
+int M_OptRowUnderMouse(int mouse_y)
 {
 	for (int i = 0; i < OptMouseRowCount; i++)
 	{
@@ -2021,11 +2239,11 @@ static int M_OptRowUnderMouse(int mouse_y)
 //
 // Returns which of the three resolution columns the cursor is over.
 //
-static int M_OptScreenResColumn(int mouse_x)
+int M_OptScreenResColumn(int mouse_x)
 {
 	for (int col = 2; col > 0; col--)
 	{
-		if (mouse_x >= screen->getCleanX(104 * col + 8))
+		if (mouse_x >= screen->getCleanX((RESCOLUMN_WIDTH * col) + RESCOLUMN_CURSOR_X))
 			return col;
 	}
 
@@ -2038,7 +2256,7 @@ static int M_OptScreenResColumn(int mouse_x)
 //
 // Scrolls the visible portion of the menu without moving the selection.
 //
-static void M_OptScroll(int lines)
+void M_OptScroll(int lines)
 {
 	if (lines < 0 && CanScrollUp)
 	{
@@ -2061,7 +2279,7 @@ static void M_OptScroll(int lines)
 //
 // Sets a slider to the value the cursor was clicked at.
 //
-static void M_OptSetSliderFromMouse(menuitem_t* item, int mouse_x)
+void M_OptSetSliderFromMouse(menuitem_t* item, int mouse_x)
 {
 	const int x = CurrentMenu->indent + 8;
 	const int track_x1 = screen->getCleanX(x + SLIDER_TRACK_X);
@@ -2075,7 +2293,7 @@ static void M_OptSetSliderFromMouse(menuitem_t* item, int mouse_x)
 
 	if (item->type == slider)
 	{
-		float newval = item->b.leftval + dist * (item->c.rightval - item->b.leftval);
+		float newval = item->b.leftval + (dist * (item->c.rightval - item->b.leftval));
 
 		// Snap to the item's step so clicking produces the same set of values
 		// the arrow keys do.
@@ -2083,7 +2301,7 @@ static void M_OptSetSliderFromMouse(menuitem_t* item, int mouse_x)
 		{
 			const float step = (item->c.rightval >= item->b.leftval) ? item->d.step : -item->d.step;
 			newval = item->b.leftval +
-			         step * std::floor((newval - item->b.leftval) / step + 0.5f);
+			         (step * std::floor(((newval - item->b.leftval) / step) + 0.5f));
 		}
 
 		if (item->b.leftval < item->c.rightval)
@@ -2099,7 +2317,7 @@ static void M_OptSetSliderFromMouse(menuitem_t* item, int mouse_x)
 	else
 	{
 		// Color component sliders move in steps of 17
-		int part = static_cast<int>(dist * 255.0f + 0.5f);
+		int part = static_cast<int>(std::lround(dist * 255.0f));
 		part = ((part + 0x08) / 0x11) * 0x11;
 		part = std::clamp(part, 0, 0xFF);
 
@@ -2129,7 +2347,7 @@ static void M_OptSetSliderFromMouse(menuitem_t* item, int mouse_x)
 //
 // M_OptItemIsSlider
 //
-static bool M_OptItemIsSlider(const menuitem_t* item)
+bool M_OptItemIsSlider(const menuitem_t* item)
 {
 	return item->type == slider || item->type == redslider ||
 	       item->type == greenslider || item->type == blueslider;
@@ -2139,7 +2357,7 @@ static bool M_OptItemIsSlider(const menuitem_t* item)
 //
 // M_OptMouseClick
 //
-static void M_OptMouseClick(int mouse_x, int mouse_y)
+void M_OptMouseClick(int mouse_x, int mouse_y)
 {
 	const int row = M_OptRowUnderMouse(mouse_y);
 	if (row == -1)
@@ -2186,9 +2404,11 @@ static void M_OptMouseClick(int mouse_x, int mouse_y)
 	}
 
 	// Everything else behaves exactly as though the accept key was pressed.
-	event_t synth_ev(ev_keydown, cycles_value ? OKEY_RIGHTARROW : OKEY_ENTER, 0, 0, 0);
+	const event_t synth_ev(ev_keydown, cycles_value ? OKEY_RIGHTARROW : OKEY_ENTER, 0, 0, 0);
 	M_OptResponder(synth_ev);
 }
+} // namespace
+
 
 
 //
@@ -2200,7 +2420,8 @@ static void M_OptMouseClick(int mouse_x, int mouse_y)
 //
 void M_OptUpdateMouseItem()
 {
-	static int prev_mouse_x = -1, prev_mouse_y = -1;
+	static int prev_mouse_x = -1;
+	static int prev_mouse_y = -1;
 
 	if (ui_mouse.asInt() == 0 || WaitingForKey || WaitingForAxis)
 		return;
@@ -2211,7 +2432,8 @@ void M_OptUpdateMouseItem()
 	     !I_IsUIMouseButtonDown(OKEY_MOUSE1)))
 		OptDragItem = -1;
 
-	int mouse_x, mouse_y;
+	int mouse_x;
+	int mouse_y;
 	if (!I_GetUIMousePosition(mouse_x, mouse_y))
 		return;
 
@@ -2249,13 +2471,13 @@ void M_OptUpdateMouseItem()
 
 void M_OptResponder(const event_t& ev)
 {
-	int ch = ev.data1;
-	int mod = ev.mod;
+	const int ch = ev.data1;
+	const int mod = ev.mod;
 	const char *cmd = Bindings.GetBind(ch).c_str();
 
 	menuitem_t *item = CurrentMenu->items + CurrentItem;
 
-	bool numlock = mod & OMOD_NUM;
+	const bool numlock = (mod & OMOD_NUM) != 0;
 
 	// Waiting on a key press for control binding
 	if (WaitingForKey)
@@ -2330,7 +2552,8 @@ void M_OptResponder(const event_t& ev)
 	if (ui_mouse.asBool() && ev.type == ev_keydown &&
 	    ch >= OKEY_MOUSE1 && ch <= OKEY_MWHEELRIGHT)
 	{
-		int mouse_x, mouse_y;
+		int mouse_x;
+		int mouse_y;
 
 		if (ch == OKEY_MOUSE2)
 		{
@@ -2338,7 +2561,7 @@ void M_OptResponder(const event_t& ev)
 			M_PopMenuStack();
 			return;
 		}
-		else if (ch == OKEY_MWHEELUP)
+		if (ch == OKEY_MWHEELUP)
 			M_OptScroll(-OPT_WHEEL_LINES);
 		else if (ch == OKEY_MWHEELDOWN)
 			M_OptScroll(OPT_WHEEL_LINES);
@@ -2354,7 +2577,7 @@ void M_OptResponder(const event_t& ev)
 	    (Key_IsLeftKey(ch, numlock) || Key_IsRightKey(ch, numlock) || Key_IsAcceptKey(ch))
 		&& !demoplayback)
 	{
-			int newflags = *item->e.flagint ^ item->a.flagmask;
+			const int newflags = *item->e.flagint ^ item->a.flagmask;
 			char val[16];
 
 			snprintf (val, 16, "%d", newflags);
@@ -2476,7 +2699,7 @@ void M_OptResponder(const event_t& ev)
 		{
 			if (CanScrollDown)
 			{
-				int pagesize = VisBottom - CurrentMenu->scrollpos - CurrentMenu->scrolltop;
+				const int pagesize = VisBottom - CurrentMenu->scrollpos - CurrentMenu->scrolltop;
 				CurrentMenu->scrollpos += pagesize;
 				if (CurrentMenu->scrollpos + CurrentMenu->scrolltop + pagesize > CurrentMenu->numitems)
 				{
@@ -2527,7 +2750,7 @@ void M_OptResponder(const event_t& ev)
 			else
 				memcpy(newcolor, "00 00 00", 9);
 
-			argb_t color = V_GetColorFromString(oldcolor);
+			const argb_t color = V_GetColorFromString(oldcolor);
 			int part = 0;
 
 			if (item->type == redslider)
@@ -2574,7 +2797,7 @@ void M_OptResponder(const event_t& ev)
 			item->a.cvar->Set(item->e.values[cur].value);
 
 			// Hack hack. Rebuild list of resolutions
-			if (item->e.values == Depths)
+			if (item->e.values == Depths.data())
 				BuildModesList(I_GetVideoWidth(), I_GetVideoHeight());
 		}
 		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
@@ -2606,7 +2829,7 @@ void M_OptResponder(const event_t& ev)
 
 		case joyactive:
 		{
-			size_t numjoy = I_GetJoystickCount();
+			const size_t numjoy = I_GetJoystickCount();
 
 			if (static_cast<size_t>(item->a.cvar->value()) > numjoy)
 				item->a.cvar->Set(0.0);
@@ -2652,7 +2875,7 @@ void M_OptResponder(const event_t& ev)
 			else
 				memcpy(newcolor, "00 00 00", 9);
 
-			argb_t color = V_GetColorFromString(oldcolor);
+			const argb_t color = V_GetColorFromString(oldcolor);
 			int part = 0;
 
 			if (item->type == redslider)
@@ -2699,7 +2922,7 @@ void M_OptResponder(const event_t& ev)
 			item->a.cvar->Set(item->e.values[cur].value);
 
 			// Hack hack. Rebuild list of resolutions
-			if (item->e.values == Depths)
+			if (item->e.values == Depths.data())
 				BuildModesList(I_GetVideoWidth(), I_GetVideoHeight());
 		}
 		S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
@@ -2734,7 +2957,7 @@ void M_OptResponder(const event_t& ev)
 
 		case joyactive:
 		{
-			size_t numjoy = I_GetJoystickCount();
+			const size_t numjoy = I_GetJoystickCount();
 
 			if (static_cast<size_t>(item->a.cvar->value()) >= numjoy)
 				item->a.cvar->Set(0.0);
@@ -2771,7 +2994,8 @@ void M_OptResponder(const event_t& ev)
 		{
 			if (CurrentMenu == &ModesMenu)
 			{
-				int width, height;
+				int width;
+				int height;
 
 				if (!(item->type == screenres &&
 				      GetSelectedSize(CurrentItem, &width, &height)))
@@ -2807,7 +3031,7 @@ void M_OptResponder(const event_t& ev)
 				item->a.cvar->Set(item->e.values[cur].value);
 
 				// Hack hack. Rebuild list of resolutions
-				if (item->e.values == Depths)
+				if (item->e.values == Depths.data())
 					BuildModesList(I_GetVideoWidth(), I_GetVideoHeight());
 				S_Sound(CHAN_INTERFACE, "menu/change", 1, ATTN_NONE);
 			}
@@ -2857,7 +3081,8 @@ void M_OptResponder(const event_t& ev)
 			// Test selected resolution
 			if (CurrentMenu == &ModesMenu)
 			{
-				int width, height;
+				int width;
+				int height;
 
 				if (!(item->type == screenres && GetSelectedSize(CurrentItem, &width, &height)))
 				{
@@ -2865,7 +3090,8 @@ void M_OptResponder(const event_t& ev)
 					height = I_GetVideoHeight();
 				}
 
-				testingmode = I_MSTime() * TICRATE / 1000 + 5 * TICRATE;
+				constexpr dtime_t testduration = dtime_t{5} * TICRATE;
+				testingmode = (I_MSTime() * TICRATE / MSECS_PER_SEC) + testduration;
 				M_SetVideoMode(width, height);
 
 				S_Sound(CHAN_INTERFACE, "menu/choose", 1, ATTN_NONE);
@@ -2877,63 +3103,76 @@ void M_OptResponder(const event_t& ev)
 	if (CurrentMenu->refreshfunc)
 		(*CurrentMenu->refreshfunc)();
 }
+namespace
+{
 
-static void GoToConsole (void)
+
+void GoToConsole()
 {
 	M_ClearMenus ();
 	C_ToggleConsole ();
 }
 
-static void UpdateStuff (void)
+void UpdateStuff()
 {
 	M_SizeDisplay (0.0);
 }
+} // namespace
 
-void Reset2Defaults (void)
+
+void Reset2Defaults()
 {
 	AddCommandString ("unbindall; binddefaults");
 	cvar_t::C_SetCVarsToDefaults(CVAR_CLIENTARCHIVE);
 	UpdateStuff();
 }
 
-void Reset2Saved (void)
+void Reset2Saved()
 {
-	std::string cmd = "exec " + C_QuoteString(M_GetConfigPath());
+	const std::string cmd = "exec " + C_QuoteString(M_GetConfigPath());
 	AddCommandString(cmd);
 	UpdateStuff();
 }
+namespace
+{
 
-static void StartHUDMenu()
+
+void StartHUDMenu()
 {
 	M_SwitchMenu(&HUDMenu);
 }
 
-static void StartMessagesMenu (void)
+void StartMessagesMenu()
 {
 	M_SwitchMenu (&MessagesMenu);
 }
 
-static void StartAutomapMenu (void)
+void StartAutomapMenu()
 {
 	M_SwitchMenu (&AutomapMenu);
 }
+} // namespace
 
-void ResetCustomColors (void)
+
+void ResetCustomColors()
 {
 	AddCommandString ("resetcustomcolors");
 }
 
-void MouseSetup (void) // [Toke] for mouse menu
+void MouseSetup () // [Toke] for mouse menu
 {
 	M_SwitchMenu (&MouseMenu);
 }
 
-void JoystickSetup (void)
+void JoystickSetup()
 {
 	M_SwitchMenu (&JoystickMenu);
 }
+namespace
+{
 
-static void CustomizeControls (void)
+
+void CustomizeControls()
 {
 	M_BuildKeyList (ControlsMenu.items, ControlsMenu.numitems);
 	M_SwitchMenu (&ControlsMenu);
@@ -2941,12 +3180,14 @@ static void CustomizeControls (void)
 
 // [Russell] - Hack for getting to the player setup menu, doesn't
 // record the last menu though, unfortunately
-static void PlayerSetup (void)
+void PlayerSetup()
 {
     M_ClearMenus ();
     M_StartControlPanel ();
 	M_PlayerSetup(0);
 }
+} // namespace
+
 
 BEGIN_COMMAND (menu_keys)
 {
@@ -2956,40 +3197,45 @@ BEGIN_COMMAND (menu_keys)
 }
 END_COMMAND (menu_keys)
 
-static void VideoOptions (void)
+namespace
+{
+
+void VideoOptions()
 {
 	M_SwitchMenu (&VideoMenu);
 }
 
-void AdvMidiOptions (void)
+void AdvMidiOptions()
 {
 	M_SwitchMenu (&AdvMidiMenu);
 }
 
-void LibAdlMidiOptions (void)
+void LibAdlMidiOptions()
 {
 	M_SwitchMenu (&LibAdlMidiMenu);
 }
 
-void SoundOptions (void) // [Ralphis] for sound menu
+void SoundOptions () // [Ralphis] for sound menu
 {
 	M_SwitchMenu (&SoundMenu);
 }
 
-void CompatOptions (void) // [Ralphis] for compatibility menu
+void CompatOptions () // [Ralphis] for compatibility menu
 {
 	M_SwitchMenu (&CompatMenu);
 }
 
-void NetworkOptions (void)
+void NetworkOptions()
 {
 	M_SwitchMenu (&NetworkMenu);
 }
 
-void WeaponOptions (void)
+void WeaponOptions()
 {
 	M_SwitchMenu (&WeaponMenu);
 }
+
+} // namespace
 
 BEGIN_COMMAND (menu_display)
 {

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -27,6 +27,7 @@
 
 // Standard libc/STL includes we use in countless places
 
+#include <array>
 #include <limits>
 #include <span>
 
@@ -156,12 +157,19 @@ enum printlevel_t {
 //
 // ARRAY_LENGTH
 //
-// Safely counts the number of items in an C array.
+// Safely counts the number of items in an C array or a std::array.
 //
 template <typename T, size_t N>
-constexpr size_t ARRAY_LENGTH(T (&arr)[N])
+// NOLINTNEXTLINE(modernize-avoid-c-arrays) - the array it measures
+constexpr size_t ARRAY_LENGTH(T (&)[N]) noexcept
 {
 	return std::extent_v<T[N]>;
+}
+
+template <typename T, size_t N>
+constexpr size_t ARRAY_LENGTH(const std::array<T, N>&) noexcept
+{
+	return N;
 }
 
 

--- a/common/i_time.h
+++ b/common/i_time.h
@@ -30,6 +30,8 @@ dtime_t I_GetTime();
 // [RH] Returns current time in milliseconds.
 dtime_t I_MSTime (void);
 
+constexpr dtime_t MSECS_PER_SEC = 1000;
+
 dtime_t I_ConvertTimeToMs(dtime_t value);
 dtime_t I_ConvertTimeFromMs(dtime_t value);
 


### PR DESCRIPTION
Any edit into m_options.cpp caused clang-tidy to prompt you to rewrite the whole thing -- which is what I did here with the help of `clang-tidy --fix`.