### PR TITLE
Hide the best-effort packet deferrment behind a preprocessor macro check.

### DIFF
--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -104,6 +104,22 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 
 	if (bestEffortSize > 0)
 	{
+		if (bestEffortSize > m_immediateReceiveBuffer.maxsize())
+		{
+			m_immediateReceiveBuffer.resize(bestEffortSize + 1);    // +1 because that's what buf_t needs...
+		}
+
+		// IMPORTANT NOTE:  The best-effort packet queuing and deferred reception is a part of a future
+		//                  broader mobj rollback reconciliation feature.  We disable it for now because
+		//                  if we don't have mobj rollback enabled, then it can cause updates that should
+		//                  be handled in a timely manner to be deferred if network latency jitter or packet
+		//                  loss is prevalent, causing a visible backwards stutter on missiles and other
+		//                  things.
+		//
+		//                  Do not enable the following until holistic rollback is implemented.
+
+#ifdef ODAMESSENGER_ENABLE_BE_PACKET_QUEUE
+
 		// One subtlety: Best effort / normal-priority messages that are "too old" are still handled
 		//               because they could still have data mobjs that's more current than the mobjs'
 		//               last reliable update, which could be even older.
@@ -116,11 +132,6 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 		const bool isNormalPriority = not isHighPriority;
 		const bool isHighTooOld     = isHighPriority   and realSequence >= 0 and realSequence < m_currentReceivedPacketSequenceNumber;
 		const bool isNormalTooNew   = isNormalPriority and realSequence > m_currentReceivedPacketSequenceNumber;
-
-		if (bestEffortSize > m_immediateReceiveBuffer.maxsize())
-		{
-			m_immediateReceiveBuffer.resize(bestEffortSize + 1);    // +1 because that's what buf_t needs...
-		}
 
 		// No matter what, we want to handle any acks and ping requests that are in the packet
 		// immediately, regardless of whether they're older or newer than expected.  These are
@@ -176,6 +187,15 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 			m_immediateReceiveSequenceNumber = realSequence;
 			return MessageResultEnum::ACCEPT;
 		}
+
+#else // ... we're not deferring best-effort packet reception.  Do it immediately!
+
+		m_immediateReceiveBuffer.WriteChunk(io_rawBuf.ReadChunk(bestEffortSize), bestEffortSize);
+		m_immediateReceiveSequenceNumber = header.sequence;
+		return MessageResultEnum::ACCEPT;
+
+#endif
+
 	}
 
 	return MessageResultEnum::DEFER;


### PR DESCRIPTION
Welp, allowing deferred Best Effort packet reception was a nice idea, but it was premature.  In order to not do an ultimate "step backwards" when jitter or packet loss gets bad enough, we have to actually rollback mobj state and do holistic re-prediction.

So, that feature is disabled for now, with all best effort receptions happening immediately, which protobreak has been doing for quite a while now.