### PR TITLE
Fix Mouse Setup text clipping past left edge.

### DIFF
--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -510,8 +510,8 @@ static menuitem_t MouseItems[] =
 	{ redtext,	" "								, {NULL},				{0.0},	{0.0},		{0.0},		{NULL}},
 	{ discrete,	"Horizontal Movement"			, {&lookstrafe},		{2.0},	{0.0},		{0.0},		{OnOff}},
 	{ discrete,	"Vertical Movement"				, {&novert},			{2.0},	{0.0},		{0.0},		{OffOn}},
-	{ slider,	"Horizontal Movement Speed"		, {&m_side},			{0.0},	{15},		{0.5},		{NULL}},
-	{ slider,	"Vertical Movement Speed"		, {&m_forward},			{0.0},	{15},		{0.5},		{NULL}},
+	{ slider,	"Horizontal Movement Spd."		, {&m_side},			{0.0},	{15},		{0.5},		{NULL}},
+	{ slider,	"Vertical Movement Spd."		, {&m_forward},			{0.0},	{15},		{0.5},		{NULL}},
 	{ redtext,	" "								, {NULL},				{0.0},	{0.0},		{0.0},		{NULL}},
 	{ more,		"Reset mouse to defaults"		, {NULL},				{0.0},	{0.0},		{0.0},		{(value_t *)M_ResetMouseValues}},
 };


### PR DESCRIPTION
This is to fix an issue where text strings can clip past the left edge in the "Mouse Setup" menu. On larger resolutions, it looks unsightly. On lower resolutions, the text disappears altogether.

<img width="1280" height="720" alt="Menu_Mouse_Setup_1280x720" src="https://github.com/user-attachments/assets/a6417428-d7ca-49ed-8ab9-f4672e050355" />

Before (1280x720)

<img width="640" height="480" alt="Odamex_mouse_640x480" src="https://github.com/user-attachments/assets/68d319c1-6c6c-4404-8641-61e847a6fcff" />

Before (640x480)

<img width="640" height="480" alt="Menu_Mouse_Setup_fix" src="https://github.com/user-attachments/assets/0c2e0d95-5973-4f0c-a724-9c68e7cd7606" />

After (640x480)