### PR TITLE
[BUGFIX] Last Device Tracking

### DIFF
--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -56,6 +56,7 @@ bool tab_keydown = false;	// [ML] Actual status of tab key
 #endif
 
 EXTERN_CVAR(ui_mouse)
+EXTERN_CVAR(joy_gamepadmode)
 
 static IInputSubsystem* input_subsystem = NULL;
 
@@ -322,6 +323,14 @@ keydevice_t I_GetKeyDevice(int key)
 namespace
 {
 
+// joy_gamepadmode
+enum
+{
+	GAMEPADMODE_AUTO,			// whichever device was used last
+	GAMEPADMODE_IGNOREMOUSE,	// mouse input does not switch away from the gamepad
+	GAMEPADMODE_ALWAYS,			// always name gamepad buttons
+};
+
 keydevice_t last_input_device = KEYDEV_KEYBOARD;
 
 //
@@ -329,14 +338,22 @@ keydevice_t last_input_device = KEYDEV_KEYBOARD;
 //
 void I_TrackLastInputDevice(const event_t& ev)
 {
+	const bool ignore_mouse = joy_gamepadmode.asInt() == GAMEPADMODE_IGNOREMOUSE;
+
 	switch (ev.type)
 	{
 	case ev_keydown:
 	case ev_keyup:
-		last_input_device = I_GetKeyDevice(ev.data1);
+	{
+		const keydevice_t device = I_GetKeyDevice(ev.data1);
+		if (ignore_mouse && device == KEYDEV_MOUSE)
+			break;
+		last_input_device = device;
 		break;
+	}
 	case ev_mouse:
-		last_input_device = KEYDEV_MOUSE;
+		if (!ignore_mouse)
+			last_input_device = KEYDEV_MOUSE;
 		break;
 	case ev_joystick:
 		if (ev.data3 != 0)
@@ -355,6 +372,9 @@ void I_TrackLastInputDevice(const event_t& ev)
 //
 keydevice_t I_GetLastInputDevice()
 {
+	if (joy_gamepadmode.asInt() == GAMEPADMODE_ALWAYS)
+		return KEYDEV_JOYSTICK;
+
 	return last_input_device;
 }
 

--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -323,14 +323,6 @@ keydevice_t I_GetKeyDevice(int key)
 namespace
 {
 
-// joy_gamepadmode
-enum
-{
-	GAMEPADMODE_AUTO,			// whichever device was used last
-	GAMEPADMODE_IGNOREMOUSE,	// mouse input does not switch away from the gamepad
-	GAMEPADMODE_ALWAYS,			// always name gamepad buttons
-};
-
 keydevice_t last_input_device = KEYDEV_KEYBOARD;
 
 //

--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -306,6 +306,55 @@ std::string I_GetKeyName(int key)
 
 
 //
+// I_GetKeyDevice
+//
+// Returns the kind of device the given key code comes from.
+//
+keydevice_t I_GetKeyDevice(int key)
+{
+	if (key >= OKEY_MOUSE1 && key <= OKEY_MWHEELRIGHT)
+		return KEYDEV_MOUSE;
+	if (key >= OKEY_JOY1 && key <= OKEY_HAT8)
+		return KEYDEV_JOYSTICK;
+	return KEYDEV_KEYBOARD;
+}
+
+static keydevice_t last_input_device = KEYDEV_KEYBOARD;
+
+//
+// I_GetLastInputDevice
+//
+// Returns the device the player used most recently, so that on-screen prompts
+// can name the controls the player actually has in hand.
+//
+keydevice_t I_GetLastInputDevice()
+{
+	return last_input_device;
+}
+
+//
+// I_TrackLastInputDevice
+//
+static void I_TrackLastInputDevice(const event_t& ev)
+{
+	switch (ev.type)
+	{
+	case ev_keydown:
+	case ev_keyup:
+		last_input_device = I_GetKeyDevice(ev.data1);
+		break;
+	case ev_mouse:
+		last_input_device = KEYDEV_MOUSE;
+		break;
+	case ev_joystick:
+		if (ev.data3 != 0)
+			last_input_device = KEYDEV_JOYSTICK;
+		break;
+	}
+}
+
+
+//
 // I_FlushInput
 //
 // Eat all pending input from outside the game
@@ -720,6 +769,7 @@ void I_GetEvents(bool mouseOnly)
 	while (input_subsystem->hasEvent())
 	{
 		input_subsystem->getEvent(&ev);
+		I_TrackLastInputDevice(ev);
 		D_PostEvent(ev);
 	}
 }

--- a/client/sdl/i_input.cpp
+++ b/client/sdl/i_input.cpp
@@ -319,23 +319,15 @@ keydevice_t I_GetKeyDevice(int key)
 	return KEYDEV_KEYBOARD;
 }
 
-static keydevice_t last_input_device = KEYDEV_KEYBOARD;
-
-//
-// I_GetLastInputDevice
-//
-// Returns the device the player used most recently, so that on-screen prompts
-// can name the controls the player actually has in hand.
-//
-keydevice_t I_GetLastInputDevice()
+namespace
 {
-	return last_input_device;
-}
+
+keydevice_t last_input_device = KEYDEV_KEYBOARD;
 
 //
 // I_TrackLastInputDevice
 //
-static void I_TrackLastInputDevice(const event_t& ev)
+void I_TrackLastInputDevice(const event_t& ev)
 {
 	switch (ev.type)
 	{
@@ -351,6 +343,19 @@ static void I_TrackLastInputDevice(const event_t& ev)
 			last_input_device = KEYDEV_JOYSTICK;
 		break;
 	}
+}
+
+} // namespace
+
+//
+// I_GetLastInputDevice
+//
+// Returns the device the player used most recently, so that on-screen prompts
+// can name the controls the player actually has in hand.
+//
+keydevice_t I_GetLastInputDevice()
+{
+	return last_input_device;
 }
 
 

--- a/client/sdl/i_input.h
+++ b/client/sdl/i_input.h
@@ -45,6 +45,16 @@ void I_CloseJoystick();
 std::string I_GetKeyName(int key);
 int I_GetKeyFromName(const std::string& name);
 
+enum keydevice_t
+{
+	KEYDEV_KEYBOARD,
+	KEYDEV_MOUSE,
+	KEYDEV_JOYSTICK,
+};
+
+keydevice_t I_GetKeyDevice(int key);
+keydevice_t I_GetLastInputDevice();
+
 void I_GetEvents(bool mouseOnly);
 
 

--- a/client/sdl/i_input.h
+++ b/client/sdl/i_input.h
@@ -52,6 +52,14 @@ enum keydevice_t
 	KEYDEV_JOYSTICK,
 };
 
+// joy_gamepadmode
+enum gamepadmode_t
+{
+	GAMEPADMODE_AUTO,			// follow whichever device was used last
+	GAMEPADMODE_IGNOREMOUSE,	// mouse input does not switch away from the gamepad
+	GAMEPADMODE_ALWAYS,			// always name gamepad buttons
+};
+
 keydevice_t I_GetKeyDevice(int key);
 keydevice_t I_GetLastInputDevice();
 

--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -456,16 +456,21 @@ int OKeyBindings::GetKeysForCommand(const char* cmd, int* first, int* second)
 }
 
 
+namespace
+{
+
 //
 // C_KeyMatchesDevice
 //
 // Keyboard and mouse binds are interchangeable here - a player on either one
 // is not looking for a gamepad prompt.
 //
-static bool C_KeyMatchesDevice(int key, keydevice_t device)
+bool C_KeyMatchesDevice(int key, keydevice_t device)
 {
 	return (I_GetKeyDevice(key) == KEYDEV_JOYSTICK) == (device == KEYDEV_JOYSTICK);
 }
+
+} // namespace
 
 //
 // OKeyBindings::GetKeysForCommandByLastDevice

--- a/client/src/c_bind.cpp
+++ b/client/src/c_bind.cpp
@@ -456,6 +456,46 @@ int OKeyBindings::GetKeysForCommand(const char* cmd, int* first, int* second)
 }
 
 
+//
+// C_KeyMatchesDevice
+//
+// Keyboard and mouse binds are interchangeable here - a player on either one
+// is not looking for a gamepad prompt.
+//
+static bool C_KeyMatchesDevice(int key, keydevice_t device)
+{
+	return (I_GetKeyDevice(key) == KEYDEV_JOYSTICK) == (device == KEYDEV_JOYSTICK);
+}
+
+//
+// OKeyBindings::GetKeysForCommandByLastDevice
+//
+// Returns every key bound to cmd, with the keys belonging to the device the
+// player used last placed first.
+//
+std::vector<int> OKeyBindings::GetKeysForCommandByLastDevice(const char* cmd)
+{
+	const keydevice_t device = I_GetLastInputDevice();
+
+	std::vector<int> keys;
+	std::vector<int> other_keys;
+
+	for (const auto& [key, binding] : Binds)
+	{
+		if (binding.empty() || stricmp(cmd, binding.c_str()) != 0)
+			continue;
+
+		if (C_KeyMatchesDevice(key, device))
+			keys.push_back(key);
+		else
+			other_keys.push_back(key);
+	}
+
+	keys.insert(keys.end(), other_keys.begin(), other_keys.end());
+	return keys;
+}
+
+
 std::string OKeyBindings::GetNameKeys(int first, int second)
 {
 	if (!first && !second)
@@ -526,29 +566,21 @@ const std::string &OKeyBindings::GetBind (int key)
 
 /*
 C_GetKeyStringsFromCommand
-Finds binds from a command and returns it into a std::string .
+Finds binds from a command and returns it into a std::string.
+Prefers the bind on the input device the player used last.
 - If TRUE, second arg returns up to 2 keys. ("x OR y")
 */
 std::string OKeyBindings::GetKeynameFromCommand(const char* cmd, bool bTwoEntries)
 {
-	int first = -1;
-	int second = -1;
+	const std::vector<int> keys = GetKeysForCommandByLastDevice(cmd);
 
-	GetKeysForCommand(cmd, &first, &second);
-
-	if (!first && !second)
+	if (keys.empty())
 		return "<??\?>";
 
 	if (bTwoEntries)
-		return GetNameKeys(first, second);
-	else
-	{
-		if (!first && second)
-			return I_GetKeyName(second);
-		else
-			return I_GetKeyName(first);
-	}
-	return "<??\?>";
+		return GetNameKeys(keys[0], keys.size() > 1 ? keys[1] : 0);
+
+	return I_GetKeyName(keys[0]);
 }
 
 

--- a/client/src/c_bind.h
+++ b/client/src/c_bind.h
@@ -57,6 +57,7 @@ public :
 	const std::string &GetBind(int key);			// Returns string bound to given key (NULL if none)
 	std::string GetNameKeys(int first, int second);
 	int  GetKeysForCommand(const char* cmd, int* first, int* second);
+	std::vector<int> GetKeysForCommandByLastDevice(const char* cmd);
 	std::string GetKeynameFromCommand(const char* cmd, bool bTwoEntries = false);
 
 	void ArchiveBindings(FILE* f);

--- a/client/src/c_bind.h
+++ b/client/src/c_bind.h
@@ -25,6 +25,8 @@
 #pragma once
 
 
+#include <vector>
+
 #include "hashtable.h"
 #include "d_event.h"
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -352,6 +352,13 @@ CVAR (joy_invert, "0", "", CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE)
 
 CVAR_RANGE (joy_deadzone, "0.20", "", CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE,  0.0f, 0.75f)
 
+CVAR_RANGE(joy_gamepadmode, "0",
+		"Sets the behavior of on-screen prompts of when to name gamepad buttons instead of keyboard keys.\n"
+		"0 - Follow whichever device was used last\n"
+		"1 - Mouse input does not switch away from the gamepad\n"
+		"2 - Always show gamepad keys",
+		CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
+
 CVAR_RANGE(joy_lefttrigger_deadzone, "0.2", "Sets the required pressure to trigger a press on the left trigger (Analog controllers only)",
 					CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.01f, 1.0f)
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -26,6 +26,7 @@
 
 #include "am_map.h"
 #include "s_sound.h"
+#include "i_input.h"
 #include "i_music.h"
 
 // Automap
@@ -357,7 +358,7 @@ CVAR_RANGE(joy_gamepadmode, "0",
 		"0 - Follow whichever device was used last\n"
 		"1 - Mouse input does not switch away from the gamepad\n"
 		"2 - Always show gamepad keys",
-		CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
+		CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, GAMEPADMODE_AUTO, GAMEPADMODE_ALWAYS)
 
 CVAR_RANGE(joy_lefttrigger_deadzone, "0.2", "Sets the required pressure to trigger a press on the left trigger (Analog controllers only)",
 					CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.01f, 1.0f)

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -190,6 +190,7 @@ EXTERN_CVAR (snd_votesfx)
 // Joystick menu -- Hyper_Eye
 void JoystickSetup();
 EXTERN_CVAR (use_joystick)
+EXTERN_CVAR (joy_gamepadmode)
 EXTERN_CVAR (joy_active)
 EXTERN_CVAR (joy_forwardaxis)
 EXTERN_CVAR (joy_strafeaxis)
@@ -600,13 +601,20 @@ namespace
  *=======================================*/
 
 // NOLINTBEGIN(readability-magic-numbers) - the numbers are the data
-std::array<menuitem_t, 11> JoystickItems = {{
+std::array<value_t, 3> GamepadModes = {{
+	{ .value = 0.0, .name = "Auto"},
+	{ .value = 1.0, .name = "Ignore Mouse"},
+	{ .value = 2.0, .name = "Always"}
+}};
+
+std::array<menuitem_t, 12> JoystickItems = {{
 	{ .type = discrete,	.label = "Use Joystick", .a = {.cvar = &use_joystick},		.b = {.leftval = ARRAY_LENGTH(OnOff)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
 	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
 	{ .type = joyactive,	.label = "Active Joystick", .a = {.cvar = &joy_active},		.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
 	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
 	{ .type = discrete,	.label = "Always FreeLook", .a = {.cvar = &joy_freelook},		.b = {.leftval = ARRAY_LENGTH(OnOff)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
 	{ .type = discrete,	.label = "Invert Look Axis", .a = {.cvar = &joy_invert},		.b = {.leftval = ARRAY_LENGTH(OnOff)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = OnOff.data()}},
+	{ .type = discrete,	.label = "Show Gamepad Buttons", .a = {.cvar = &joy_gamepadmode},		.b = {.leftval = ARRAY_LENGTH(GamepadModes)},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = GamepadModes.data()}},
 	{ .type = redtext,	.label = " ", .a = {.cvar = nullptr},				.b = {.leftval = 0.0},		.c = {.rightval = 0.0},		.d = {.step = 0.0},		.e = {.values = nullptr}},
 	{ .type = whitetext,	.label = "Sensitivity Settings", .a = {.cvar = nullptr}, 				.b = {.leftval = 0.0}, 		.c = {.rightval = 0.0}, 		.d = {.step = 0.0}, 		.e = {.values = nullptr}},
 	{ .type = slider,	.label = "Turn Sensitivity", .a = {.cvar = &joy_sensitivity},	.b = {.leftval = 1.0},		.c = {.rightval = 30.0},		.d = {.step = 1.0},		.e = {.values = nullptr}},

--- a/odalaunch/res/odamex_cvardoc.json
+++ b/odalaunch/res/odamex_cvardoc.json
@@ -1677,6 +1677,15 @@
          "type" : "boolean"
       },
       {
+         "default" : 0,
+         "flags" : [ "NOENABLEDISABLE", "CLIENTARCHIVE" ],
+         "helptext" : "Sets the behavior of on-screen prompts of when to name gamepad buttons instead of keyboard keys.\n0 - Follow whichever device was used last\n1 - Mouse input does not switch away from the gamepad\n2 - Always show gamepad keys",
+         "max" : 2,
+         "min" : 0,
+         "name" : "joy_gamepadmode",
+         "type" : "integer"
+      },
+      {
          "default" : 0.0,
          "flags" : [ "CLIENTARCHIVE" ],
          "helptext" : "",


### PR DESCRIPTION
Fixes #1886 

Odamex has a tendency to show the first bind recorded when trying to get a key in GetKeynameFromCommand.

This PR keeps track of the last input device (mouse/keyboard/joystick) and shows binds from that device if at all possible. The keys matching the device will show first, and the other bindings that use keys from other devices will show last (if 2 keys are requested to be shown).

For simplicity, mouse and keyboard are treated as one device, and joystick is treated as a separate device.

This has the tendency for a user who combines both gamepad and mouse input (I have seen setups where the left hand is on a gamepad directional pad, and right hand is used to click the mouse) to have the key prompts jump around to both gamepad and keyboard keys. I added the var `joy_gamepadmode` in order to customize this behavior for gamepad users who may use these types of setups.

Before:
<img width="1278" height="748" alt="image" src="https://github.com/user-attachments/assets/8c38ad22-0a9d-4b7d-be48-3a16a3beeff0" />


After:
<img width="1281" height="749" alt="image" src="https://github.com/user-attachments/assets/d2a35005-2c30-4b00-9763-065d43c11ff1" />
