### PR TITLE
[BUGFIX] MBF21 P_CheckAmmo retaining vanilla behavior

### DIFF
--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -298,13 +298,18 @@ bool P_EnoughAmmo(const player_t& player, weapontype_t weapon, bool switching = 
 }
 
 //
-// P_SwitchWeapon
+// P_QueueWeaponSwitch
 //
 // Changes to the player's most preferred weapon based on availibilty and ammo.
 // Note that this emulates vanilla Doom bugs relating to the amount of ammo
 // needed to switch to the BFG and SSG.
 //
-void P_SwitchWeapon(player_t& player)
+// The weapon is not lowered here -- A_WeaponReady puts it away once the current
+// firing sequence finishes.
+//
+// Returns true if a switch was queued.
+//
+bool P_QueueWeaponSwitch(player_t& player)
 {
 	const auto& prefs = ((multiplayer and not sv_allowpwo) or demoplayback) ? UserInfo::weapon_prefs_default :
 	                                                                          player.userinfo.weapon_prefs;
@@ -326,6 +331,21 @@ void P_SwitchWeapon(player_t& player)
 	{
 		// Switch to this weapon
 		player.pendingweapon = best_weapon;
+		return true;
+	}
+
+	return false;
+}
+
+//
+// P_SwitchWeapon
+//
+// Queues the switch and starts lowering the current weapon right away.
+//
+void P_SwitchWeapon(player_t& player)
+{
+	if (P_QueueWeaponSwitch(player))
+	{
 		// Now set appropriate weapon overlay.
 		P_SetPsprite(player, ps_weapon, weaponinfo[player.readyweapon].downstate);
 	}
@@ -438,6 +458,24 @@ bool P_CheckAmmo (player_t& player)
 
 	// no enough ammo with the current weapon, choose another one
 	P_SwitchWeapon(player);
+	return false;
+}
+
+//
+// P_CheckAmmoNoLower
+//
+// In Boom, vanilla's behavior of lowering the weapon immediately
+// after failing a P_CheckAmmo check is gated behind a demo_compatibility
+// check, and instead it lets A_ReadyWeapon handle lowering, which enables
+// "charging" attacks that use ammo in a loop, and have it fire if you are
+// out of ammo during the charge, instead of eating it and switching weapons.
+//
+bool P_CheckAmmoNoLower(player_t& player)
+{
+	if (P_EnoughAmmo(player, player.readyweapon))
+		return true;
+
+	P_QueueWeaponSwitch(player);
 	return false;
 }
 
@@ -957,7 +995,7 @@ void A_RefireTo(AActor* mo)
 	if (!st)
 		return;
 
-	if ((st->args[1] || P_CheckAmmo(player)) &&
+	if ((st->args[1] || P_CheckAmmoNoLower(player)) &&
 	    (player.cmd.buttons & BT_ATTACK) &&
 	    (player.pendingweapon == wp_nochange && player.health))
 	{


### PR DESCRIPTION
Fixes #1912

P_CheckAmmo was retaining its vanilla behavior to call a weapon switch immediately upon failing an ammo check. Boom (DSDA) retains this behavior but only when `demo_compatibility` is set.

This enables A_RefireTo in MBF21 to consume ammo in a weapon "charge", then upon running out of ammo, stop the loop and continue into the firing state, and letting A_WeaponReady lower the weapon instead of immediately in P_CheckAmmo.

This behavior is only exhibited for A_RefireTo, an MBF21 codepointer, and vanilla behavior is retained for everything else.