### PR TITLE
[Feature] Add classic Skulltag springpads

### DIFF
--- a/common/info.h
+++ b/common/info.h
@@ -1541,6 +1541,7 @@ enum mobjtype_t: int32_t {
 	// mobjtype nums breaks version compatibility
 	MT_UPPERSTACK,
     MT_LOWERSTACK,
+	MT_SPRINGPAD,
 
     // --------------------------------------------------------------------- //
 

--- a/common/info.h
+++ b/common/info.h
@@ -1483,12 +1483,12 @@ enum mobjtype_t: int32_t {
     MT_NODE,        //Added by MC:
     MT_WATERZONE,
     MT_SECRETTRIGGER,
-    // MT_UPPERSTACK,
-    // MT_LOWERSTACK,
+    MT_UPPERSTACK,
+    MT_LOWERSTACK,
     MT_SKYVIEWPOINT,
     MT_SKYPICKER,
     MT_SECTORSILENCER,
-
+	MT_SPRINGPAD,
 
     // -----------------------------------
     //    [Toke - CTF]
@@ -1535,13 +1535,6 @@ enum mobjtype_t: int32_t {
     MT_CAREPACK,
 	MT_EXTRALIFE,
 	MT_RESTEAMMATE,
-
-	// TODO: 13.0.0, delete these and uncomment the earlier ones
-	// for 12.3 they have to be here because modifying internal
-	// mobjtype nums breaks version compatibility
-	MT_UPPERSTACK,
-    MT_LOWERSTACK,
-	MT_SPRINGPAD,
 
     // --------------------------------------------------------------------- //
 

--- a/common/odainfo.cpp
+++ b/common/odainfo.cpp
@@ -1015,6 +1015,21 @@ mobjinfo_t odamobjinfo[] = {
 		.flags            = MF_SPECIAL,
 		.name             = "MT_RESTEAMMATE",
 	},
+	{
+		// MT_SPRINGPAD
+		.type             = MT_SPRINGPAD,
+		.doomednum        = 5068,
+		.spawnstate       = S_TNT1,
+		.spawnhealth      = 1000,
+		.reactiontime     = 8,
+		.radius           = 20_fx,
+		.height           = 16_fx,
+		.cdheight         = 16_fx,
+		.mass             = 100,
+		.flags            = MF_NOBLOCKMAP | MF_NOSECTOR | MF_NOGRAVITY,
+		.flags2           = MF2_DONTDRAW,
+		.name             = "MT_SPRINGPAD",
+	},
 
 	// ----------- odamex mobjinfo end -----------
 };

--- a/common/odainfo.cpp
+++ b/common/odainfo.cpp
@@ -471,6 +471,22 @@ mobjinfo_t odamobjinfo[] = {
 		.name             = "MT_SECTORSILENCER",
 	},
 
+{
+		// MT_SPRINGPAD
+		.type             = MT_SPRINGPAD,
+		.doomednum        = 5068,
+		.spawnstate       = S_TNT1,
+		.spawnhealth      = 1000,
+		.reactiontime     = 8,
+		.radius           = 20_fx,
+		.height           = 16_fx,
+		.cdheight         = 16_fx,
+		.mass             = 100,
+		.flags            = MF_NOBLOCKMAP | MF_NOSECTOR | MF_NOGRAVITY,
+		.flags2           = MF2_DONTDRAW,
+		.name             = "MT_SPRINGPAD",
+	},
+
 	// [Toke - CTF] Blue Socket
 	{
 		//  MT_BSOK
@@ -1014,21 +1030,6 @@ mobjinfo_t odamobjinfo[] = {
 		.mass             = 100,
 		.flags            = MF_SPECIAL,
 		.name             = "MT_RESTEAMMATE",
-	},
-	{
-		// MT_SPRINGPAD
-		.type             = MT_SPRINGPAD,
-		.doomednum        = 5068,
-		.spawnstate       = S_TNT1,
-		.spawnhealth      = 1000,
-		.reactiontime     = 8,
-		.radius           = 20_fx,
-		.height           = 16_fx,
-		.cdheight         = 16_fx,
-		.mass             = 100,
-		.flags            = MF_NOBLOCKMAP | MF_NOSECTOR | MF_NOGRAVITY,
-		.flags2           = MF2_DONTDRAW,
-		.name             = "MT_SPRINGPAD",
 	},
 
 	// ----------- odamex mobjinfo end -----------

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2160,6 +2160,7 @@ static bool P_ClipMovementToFloor(AActor* mo)
 		    P_FloorHeight(mo->x, mo->y, mo->subsector->sector) == mo->floorz)
 			A_TriggerAction(mo->subsector->sector->SecActTarget, mo, SECSPAC_HitFloor);
 
+		// [RV] Bounce actors upward at their landing velocity.
 		if (!(mo->flags & MF_MISSILE) && mo->floorsector->flags & SECF_SPRINGPAD)
 		{
 			mo->momz = -mo->momz;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -2160,6 +2160,13 @@ static bool P_ClipMovementToFloor(AActor* mo)
 		    P_FloorHeight(mo->x, mo->y, mo->subsector->sector) == mo->floorz)
 			A_TriggerAction(mo->subsector->sector->SecActTarget, mo, SECSPAC_HitFloor);
 
+		if (!(mo->flags & MF_MISSILE) && mo->floorsector->flags & SECF_SPRINGPAD)
+		{
+			mo->momz = -mo->momz;
+			mo->z = mo->floorz;
+			return true;
+		}
+
 		// Lost Soul hit the floor
 		if (mo->flags & MF_SKULLFLY && P_CorrectLostSoulBounce())
 			mo->momz = -mo->momz;
@@ -3513,12 +3520,13 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 	                      (mthing.type >= 9992 && mthing.type <= 9999);
 	const bool isSoundSource = (mthing.type >= 14001 && mthing.type <= 14065);
 	const bool isMusicChanger = (mthing.type >= 14100 && mthing.type <= 14165);
+	const bool isSpringPad = inSpawnMap && spawn_map[mthing.type]->type == MT_SPRINGPAD;
 
 	// only servers control spawning of items
 	// EXCEPT the client must spawn Type 14 (teleport exit) and player spawn points for avatars.
 	// otherwise teleporters or avatars won't work well.
 	// Also spawn sector special things, fixes some other teleport issues.
-	if (!serverside && !(isPlayerCoopSpawnPoint || isTeleportDest || isSecAct || isSoundSource || isMusicChanger))
+	if (!serverside && !(isPlayerCoopSpawnPoint || isTeleportDest || isSecAct || isSoundSource || isMusicChanger || isSpringPad))
 	{
 		return;
 	}
@@ -3656,6 +3664,12 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 	// check for appropriate skill level
 	if (!(mthing.flags & G_GetCurrentSkill().spawn_filter))
 		return;
+
+	if (isSpringPad)
+	{
+		P_PointInSubsector(mthing.x << FRACBITS, mthing.y << FRACBITS)->sector->flags |= SECF_SPRINGPAD;
+		return;
+	}
 
 	// [RH] sound sequence overrides
 	if (mthing.type >= 1400 && mthing.type < 1410)

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -623,14 +623,15 @@ void P_MovePlayer (player_t& player)
 		}
 		else if (sv_allowjump && player.mo->onground && !player.jumpTics)
 		{
-			player.mo->momz += 8*FRACUNIT;
+			const bool springpad = player.mo->floorsector->flags & SECF_SPRINGPAD;
+			player.mo->momz += springpad ? 4*FRACUNIT : 8*FRACUNIT;
 
 //			[SL] No jumping sound...
 //			if(!player.spectator)
 //				UV_SoundAvoidPlayer(player.mo, CHAN_VOICE, "player/male/jump1", ATTN_NORM);
 
             player.mo->flags2 &= ~MF2_ONMOBJ;
-            player.jumpTics = 18;
+            player.jumpTics = springpad ? 0 : 18;
 		}
 	}
 }

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -118,7 +118,8 @@ enum
 // Ceiling/floor flags
 enum
 {
-	SECF_ABSLIGHTING	= 1		// floor/ceiling light is absolute, not relative
+	SECF_ABSLIGHTING	= 1,	// floor/ceiling light is absolute, not relative
+	SECF_SPRINGPAD		= 2		// floor bounces actors at their landing velocity
 };
 
 // Misc sector flags


### PR DESCRIPTION
Add support for classic Skulltag springpads. This is the only map sector thing that I think exists in classic ST (at least, in the versions we'd be looking to reproduce). Ednum 5068.