### PR TITLE
[CHANGE] Improve warmup/countdown handling for duels with rounds

### DIFF
--- a/client/src/st_new.cpp
+++ b/client/src/st_new.cpp
@@ -1801,7 +1801,7 @@ void LevelStateHUD()
 	}
 	case LevelState::PREROUND_COUNTDOWN: {
 		lines.title = fmt::sprintf("Round " TEXTCOLOR_YELLOW " %d", ::levelstate.getRound());
-		if (g_preroundreset)
+		if (g_preroundreset || G_IsMatchDuelGame())
 		{
 			lines.subtitle[0] = fmt::sprintf("Round begins in " TEXTCOLOR_GREEN "%d",
 			                                 ::levelstate.getCountdown());

--- a/common/g_levelstate.cpp
+++ b/common/g_levelstate.cpp
@@ -459,7 +459,10 @@ void LevelState::tic()
 			G_DeferedFullReset();
 
 			m_roundNumber += 1;
-			setState(LevelState::getStartOfRoundState());
+			if (sv_warmup && G_IsMatchDuelGame())
+				setState(LevelState::INGAME);
+			else
+				setState(LevelState::getStartOfRoundState());
 
 			if (g_rounds)
 				printRoundStart();


### PR DESCRIPTION
What it says on the tin. This only applies to duels and is narrow in scope. Modified after several years of feedback on the "match duel" WDL servers. Does not alter behavior of any other modes.

EDIT: To be more clear, currently you have to sit through two countdowns at the outset of the round. It's jarring and weird. This also changes the "Weapons unlocked in _n_" line to reflect that the next round begins instead. The "Weapons unlocked" message is more applicable to other modes like LMS, not duel.