### PR TITLE
Resolve mobj-to-mobj pointers following netdemo/savegame snapshot load

### DIFF
--- a/common/dthinker.cpp
+++ b/common/dthinker.cpp
@@ -82,6 +82,8 @@ void DThinker::SerializeAll (FArchive &arc, bool hubLoad)
 			arc >> more;
 		}
 
+		P_ResolveMobjToMobjPointers();
+
 		// killough 3/26/98: Spawn icon landings:
 		P_SpawnBrainTargets ();
 	}

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1438,13 +1438,13 @@ void AActor::Serialize (FArchive &arc)
 
 		P_SetThingId(this, newnetid);
 
-		s_unresolvedIds.emplace(std::make_pair(uint32_t(netid),
+		s_unresolvedIds.emplace(netid,
 		                        ReferencedMobjIdsType
 		                        {
 		                            .targetId    = targetId,
 		                            .goalId      = goalId,
 		                            .lastEnemyId = lastEnemyId
-		                        }));
+		                        });
 
 		uint32_t trans;
 		arc >> trans;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1243,16 +1243,41 @@ void AActor::RunThink ()
 
 namespace
 {
-    struct ReferencedMobjIdsType
-    {
-        uint32_t targetId   { 0 };
-        uint32_t goalId     { 0 };
-        uint32_t lastEnemyId{ 0 };
-    };
+	struct ReferencedMobjIdsType
+	{
+		uint32_t targetId   { 0 };
+		uint32_t goalId     { 0 };
+		uint32_t lastEnemyId{ 0 };
+	};
 
-    std::unordered_map<uint32_t, ReferencedMobjIdsType> s_unresolvedIds;
+	std::unordered_map<uint32_t, ReferencedMobjIdsType> s_unresolvedIds;
 }
 
+void P_ResolveMobjToMobjPointers()
+{
+	auto setPointer = [](AActor::AActorPtr& destPtr, uint32_t netId)
+	{
+		if (AActor* other = P_FindThingById(netId))
+		{
+			destPtr = other->ptr();
+		}
+		else
+		{
+			destPtr = AActor::AActorPtr();
+		}
+	};
+
+	for (auto& [actorId, otherIDs] : s_unresolvedIds)
+	{
+		if (AActor* actorPtr = P_FindThingById(actorId))
+		{
+			setPointer(actorPtr->target,    otherIDs.targetId);
+			setPointer(actorPtr->goal,      otherIDs.goalId);
+			setPointer(actorPtr->lastenemy, otherIDs.lastEnemyId);
+		}
+	}
+	s_unresolvedIds.clear();
+}
 
 void AActor::Serialize (FArchive &arc)
 {
@@ -1382,8 +1407,8 @@ void AActor::Serialize (FArchive &arc)
 			>> movedir
 			>> visdir
 			>> movecount
-			>> targetId /*>> target->netid*/
-			>> lastEnemyId /*>> lastenemy->netid*/
+			>> targetId
+			>> lastEnemyId
 			>> reactiontime
 			>> threshold
 			>> playerid
@@ -1396,7 +1421,7 @@ void AActor::Serialize (FArchive &arc)
 			>> args[2]
 			>> args[3]
 			>> args[4]
-			>> goalId /*>> goal->netid*/
+			>> goalId
 			>> translucency
 			>> waterlevel
 			>> gear

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1340,6 +1340,7 @@ void AActor::Serialize (FArchive &arc)
 		unsigned dummy;
 		unsigned playerid;
 		int newnetid;
+		int dummyInt;
 		AActor* tmptracer;
 
 		arc >> newnetid
@@ -1401,7 +1402,7 @@ void AActor::Serialize (FArchive &arc)
 			>> spawnRndindex
 			>> mode
 			>> updatedDuringLocalTic
-			>> updatedDuringServerTic
+			>> dummyInt //This used to be updatedDuringServerTic, but that caused netdemo desyncs.  FIXME: header tics
 			>> spawnTic
 			>> mobjtic
 			>> credibility;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1241,6 +1241,18 @@ void AActor::RunThink ()
 	}
 }
 
+namespace
+{
+    struct ReferencedMobjIdsType
+    {
+        uint32_t targetId   { 0 };
+        uint32_t goalId     { 0 };
+        uint32_t lastEnemyId{ 0 };
+    };
+
+    std::unordered_map<uint32_t, ReferencedMobjIdsType> s_unresolvedIds;
+}
+
 
 void AActor::Serialize (FArchive &arc)
 {
@@ -1257,11 +1269,6 @@ void AActor::Serialize (FArchive &arc)
 			<< z
 			<< pitch
 			<< angle
-
-			// [SL] Removed AActor::roll
-			// delete this next time saved-game compatibilty changes
-			<< 0
-
 			<< sprite
 			<< frame
 			<< effects
@@ -1287,8 +1294,8 @@ void AActor::Serialize (FArchive &arc)
 			<< movedir
 			<< visdir
 			<< movecount
-			/*<< target ? target->netid : 0*/
-			/*<< lastenemy ? lastenemy->netid : 0*/
+			<< (target ? target->netid : uint32_t(0))
+			<< (lastenemy ? lastenemy->netid : uint32_t(0))
 			<< reactiontime
 			<< threshold
 			<< playerid
@@ -1301,8 +1308,7 @@ void AActor::Serialize (FArchive &arc)
 			<< args[2]
 			<< args[3]
 			<< args[4]
-			/*<< goal ? goal->netid : 0*/
-			<< 0_u32
+			<< (goal ? goal->netid : uint32_t(0))
 			<< translucency
 			<< waterlevel
 			<< gear
@@ -1337,11 +1343,13 @@ void AActor::Serialize (FArchive &arc)
 	}
 	else
 	{
-		unsigned dummy;
 		unsigned playerid;
 		int newnetid;
 		int dummyInt;
 		AActor* tmptracer;
+		uint32_t targetId;
+		uint32_t goalId;
+		uint32_t lastEnemyId;
 
 		arc >> newnetid
 			>> x
@@ -1349,11 +1357,6 @@ void AActor::Serialize (FArchive &arc)
 			>> z
 			>> pitch
 			>> angle
-
-			// [SL] Removed AActor::roll
-			// delete this next time saved-game compatibilty changes
-			>> dummy
-
 			>> sprite
 			>> frame
 			>> effects
@@ -1379,8 +1382,8 @@ void AActor::Serialize (FArchive &arc)
 			>> movedir
 			>> visdir
 			>> movecount
-			/*>> target->netid*/
-			/*>> lastenemy->netid*/
+			>> targetId /*>> target->netid*/
+			>> lastEnemyId /*>> lastenemy->netid*/
 			>> reactiontime
 			>> threshold
 			>> playerid
@@ -1393,8 +1396,7 @@ void AActor::Serialize (FArchive &arc)
 			>> args[2]
 			>> args[3]
 			>> args[4]
-			/*>> goal->netid*/
-			>> dummy
+			>> goalId /*>> goal->netid*/
 			>> translucency
 			>> waterlevel
 			>> gear
@@ -1410,6 +1412,14 @@ void AActor::Serialize (FArchive &arc)
 		tracer.init(tmptracer);
 
 		P_SetThingId(this, newnetid);
+
+		s_unresolvedIds.emplace(std::make_pair(uint32_t(netid),
+		                        ReferencedMobjIdsType
+		                        {
+		                            .targetId    = targetId,
+		                            .goalId      = goalId,
+		                            .lastEnemyId = lastEnemyId
+		                        }));
 
 		uint32_t trans;
 		arc >> trans;

--- a/common/p_mobj.h
+++ b/common/p_mobj.h
@@ -131,6 +131,7 @@ void P_ClearAllNetIds();
 AActor* P_FindThingById(uint32_t id);
 void P_SetThingId(AActor* mo, uint32_t newnetid);
 void P_ClearId(uint32_t id);
+void P_ResolveMobjToMobjPointers();
 
 void P_XYMovement(AActor *mo);
 void P_ZMovement(AActor *mo);


### PR DESCRIPTION
This PR includes two changes to resolve netdemo desyncs pertaining to mobj states.

- Resolve `target`, `goal`, and `lastenemy` mobj-to-mobj pointers upon loading a game state snapshot from a netdemo or savegame.
- Workaround a stale server tic check that can cause netdemo desyncs.

The first change involved adding a post-processing step to `DThinker::SerializeAll` after loading all thinkers.

The second change ignores the mobj's recorded server tic number from the snapshot because there are no server packets to compare against when playing back a netdemo.  This workaround is temporary because a subsequent PR is going to incorporate the tic numbers as a new netdemo-specific message.