### PR TITLE
Ensure mobj "threshold" is synched during UpdateMobj

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -1205,9 +1205,10 @@ static AActor* CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg, AActor* mo = 
 		mo->momz = update.mom.z;
 	}
 
-	mo->rndindex = update.rndindex;
-	mo->movedir = update.movedir;
+	mo->rndindex  = update.rndindex;
+	mo->movedir   = update.movedir;
 	mo->movecount = update.movecount;
+	mo->threshold = msg->threshold();
 
 	AActor* target = P_FindThingById(update.targetid);
 	if (target)
@@ -2816,11 +2817,11 @@ static void CL_WakeupMobj(const odaproto::svc::WakeupMobj* msg)
 		mo->goal = AActor::AActorPtr();
 	}
 
-	mo->angle = msg->angle();
-	mo->lastlook = msg->lastlook();
-	mo->movecount = msg->movecount();
-	mo->movedir = msg->movedir();
-	mo->pursuecount = msg->pursuecount();
+	mo->angle        = msg->angle();
+	mo->lastlook     = msg->lastlook();
+	mo->movecount    = msg->movecount();
+	mo->movedir      = msg->movedir();
+	mo->pursuecount  = msg->pursuecount();
 	mo->reactiontime = msg->reactiontime();
 	mo->special      = msg->special();
 	mo->strafecount  = msg->strafecount();

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1257,14 +1257,8 @@ void P_ResolveMobjToMobjPointers()
 {
 	auto setPointer = [](AActor::AActorPtr& destPtr, uint32_t netId)
 	{
-		if (AActor* other = P_FindThingById(netId))
-		{
-			destPtr = other->ptr();
-		}
-		else
-		{
-			destPtr = AActor::AActorPtr();
-		}
+		AActor* other = P_FindThingById(netId);
+		destPtr = other ? other->ptr() : AActor::AActorPtr();
 	};
 
 	for (auto& [actorId, otherIDs] : s_unresolvedIds)

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -657,6 +657,8 @@ static void FillUpdateMobj(odaproto::svc::UpdateMobj& msg, const AActor& mobj)
 	uint32_t flags = P_GetMobjBaselineFlags(mobj);
 	msg.set_flags(flags);
 
+	msg.set_threshold(mobj.threshold);
+
 	odaproto::Actor* act = msg.mutable_actor();
 	odaproto::Vec3* pos = act->mutable_pos();
 	odaproto::Vec3* mom = act->mutable_mom();

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -156,8 +156,9 @@ enum MobjModeEnum
 // svc_updatemobj
 message UpdateMobj
 {
-	uint32 flags = 1;
-	Actor  actor = 2;
+	uint32 flags     = 1;
+	Actor  actor     = 2;
+	uint32 threshold = 3;
 }
 
 // svc_updatemobjwithmode


### PR DESCRIPTION
This PR adds `threshold` to the UpdateMobj message, fixing one cause of "warp walk" desyncs.

`A_Chase` uses `threshold` to determine how long a monster must remain tracking a particular target before it's allowed to choose another target or adjust its "mission" in some way.  It is typically set non-zero during `P_DamageMobj`, so that it continues chasing after a player or other monster that very recently damaged it, and that function *does not run on the client side*.  However, `A_Chase` *does run* as a part of monster movement prediction.

Therefore once `threshold` counts down to zero on the client side, it stays that way forever, which allows `A_Chase` to locally predict a premature change of movement direction if the server has a non-zero value for `threshold`.  When that happens, a subsequent UpdateMobj message corrects the misprediction, but `threshold ` may still diverge for a few seconds, allowing a repeated misprediction.  Ultimately this causes the "warp walk" desync symptom.

As for other impacts, `threshold == 0` most of the time anyway, so it's no-impact for the vast majority of cases due to protobuf's zero-value optimization.  Furthermore, the client-side logic that produces the misprediction also locally rolls `rndindex`, triggering incidental downstream mispredictions.