### PR TITLE
Make the client and server executables depend on the wad at the target level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,9 @@ include(OdamexCvarDoc)
 # Libraries
 add_subdirectory(libraries)
 
+# WAD building
+add_subdirectory(wad)
+
 # Subdirectories for Odamex projects
 if(BUILD_CLIENT OR BUILD_SERVER OR BUILD_TESTS)
   add_subdirectory(common)
@@ -218,16 +221,6 @@ endif()
 
 # The "cvardocs" target refreshes the committed documentation on demand.
 odamex_cvardoc_add_targets()
-
-# WAD building
-add_subdirectory(wad)
-
-if (TARGET odamex AND TARGET odawad)
-    add_dependencies(odamex odawad)
-endif()
-if (TARGET odasrv AND TARGET odawad)
-    add_dependencies(odasrv odawad)
-endif()
 
 # Bash completion
 add_subdirectory(completion)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,13 @@ odamex_cvardoc_add_targets()
 # WAD building
 add_subdirectory(wad)
 
+if (TARGET odamex AND TARGET odawad)
+    add_dependencies(odamex odawad)
+endif()
+if (TARGET odasrv AND TARGET odawad)
+    add_dependencies(odasrv odawad)
+endif()
+
 # Bash completion
 add_subdirectory(completion)
 

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -250,6 +250,10 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     endif()
   endif()
 
+  if (TARGET odawad)
+      add_dependencies(odamex odawad)
+  endif()
+
   odamex_copy_libs(odamex)
 
   set(MACOSX_BUNDLE_BUNDLE_NAME ${CMAKE_PROJECT_NAME})

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -275,7 +275,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
       add_custom_command(
         TARGET odamex
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE_DIR:odamex>/odamex.wad" ${CMAKE_CURRENT_BINARY_DIR}/odamex.app/Contents/MacOS)
+        COMMAND ${CMAKE_COMMAND} -E copy "${ODAMEX_ARTIFACT_DIR}/odamex.wad" ${CMAKE_CURRENT_BINARY_DIR}/odamex.app/Contents/MacOS)
     endif()
 
     set_directory_properties(

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -275,7 +275,7 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
       add_custom_command(
         TARGET odamex
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/wad/odamex.wad ${CMAKE_CURRENT_BINARY_DIR}/odamex.app/Contents/MacOS)
+        COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE_DIR:odamex>/odamex.wad" ${CMAKE_CURRENT_BINARY_DIR}/odamex.app/Contents/MacOS)
     endif()
 
     set_directory_properties(

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -57,6 +57,10 @@ endif()
 
 target_link_libraries(odasrv fmt::fmt tinylibs ZLIB::ZLIB odamex-common odaproto minilzo cpptrace::cpptrace)
 
+if (TARGET odawad)
+    add_dependencies(odasrv odawad)
+endif()
+
 if(USE_INTERNAL_JSONCPP)
   target_link_libraries(odasrv jsoncpp_static)
 else()


### PR DESCRIPTION
This is so that narrowed builds of the executables that use the wad ensure the wad is brought up to date if necessary.