### PR TITLE
Record packet headers with timing info into netdemos

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -25,7 +25,7 @@
 
 #include "odamex.h"
 
-#include "cl_main.h"
+#include "cl_parse.h"
 #include "p_ctf.h"
 #include "d_player.h"
 #include "m_argv.h"

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -37,6 +37,7 @@
 #include "st_stuff.h"
 #include "p_mobj.h"
 #include "clc_message.h"
+#include "msg_message.h"
 #include "svc_message.h"
 #include "g_gametype.h"
 #include "g_game.h"
@@ -874,6 +875,15 @@ void NetDemo::capture(const std::basic_string<byte>& buffer)
 	}
 }
 
+void NetDemo::capturePacketHeader(const PacketHeaderType& header)
+{
+	if (isRecording())
+	{
+		workingBuffer.clear();
+		MSG_WriteSVCBuffer(& workingBuffer, MSG_Header(header));
+		captured.emplace_back(workingBuffer);
+	}
+}
 
 //
 // writeLauncherSequence()

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -5,6 +5,8 @@
 
 #include "i_net.h"
 
+struct PacketHeaderType;
+
 class NetDemo
 {
 public:
@@ -30,6 +32,7 @@ public:
 	void readMessages(buf_t* netbuffer);
 	void capture(const buf_t* netbuffer);
 	void capture(const std::basic_string<byte>& buffer);
+	void capturePacketHeader(const PacketHeaderType& header);
 	void writeMapChange();
 	void writeIntermission();
 
@@ -193,6 +196,7 @@ private:
 	std::fstream    demofp  { };
 
 	std::deque<buf_t> captured {};
+	buf_t             workingBuffer {MAX_UDP_PACKET};
 
 	netdemo_header4_t   header        {};
 	SnapshotVector      snapshot_index{};

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2255,6 +2255,7 @@ MessageResultEnum CL_AcceptNetMessage()
 	{
 		if (netdemo.isRecording())
 		{
+			netdemo.capturePacketHeader(::messenger.GetCurrentReceivedPacketHeader());
 			netdemo.capture(&::net_message);
 		}
 

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2091,8 +2091,10 @@ bool CL_Connect()
 	else
 	{
 		PrintFmt("Requesting server state...\n");
-		messenger.NextReceivedPacket(::net_message);
-		CL_ParseCommands();
+		if (messenger.NextReceivedPacket(::net_message))
+		{
+			CL_ParseCommands(messenger.GetCurrentReceivedPacketHeader());
+		}
 	}
 
 	messenger.SendAll(gametic, ::serveraddr);
@@ -2256,7 +2258,7 @@ MessageResultEnum CL_AcceptNetMessage()
 			netdemo.capture(&::net_message);
 		}
 
-		CL_ParseCommands();
+		CL_ParseCommands(::messenger.GetCurrentReceivedPacketHeader());
 
 		if (gameaction == ga_fullconsole) // Host_EndGame was called
 		{
@@ -2277,108 +2279,11 @@ MessageResultEnum CL_ProcessCurrentAvailableMessages()
 	return result;
 }
 
-
 void CL_Clear()
 {
 	size_t left = MSG_BytesLeft();
 	MSG_ReadChunk(left);
 }
-
-static std::string SVCName(msg_t header)
-{
-	std::string svc = ::msg_info[header].getName();
-	if (svc.empty())
-	{
-		svc = fmt::sprintf("svc_%u", header);
-	}
-	return svc;
-}
-
-//
-// CL_ParseCommands
-//
-void CL_ParseCommands()
-{
-	while (connected)
-	{
-		if (::net_message.BytesLeftToRead() == 0)
-		{
-			break;
-		}
-
-		// When echoing server gametic back to it, use the tic that comes from the High Priority packet.
-		// This is because the High Priority packet is always live and comes out every tic.  It's totally
-		// possible for the server to go without sending anything Reliable or Best-Effort if things are
-		// all-quiet.
-		if (messenger.GetCurrentReceivedIsHighPriority())
-		{
-			messenger.SetDestinationTic(messenger.GetCurrentReceivedRemoteTic());
-		}
-
-		const size_t          byteStart = ::net_message.BytesRead();
-		const ParseResultType result    = CL_ParseCommand();
-
-		const parseError_e processResult = result.code == PERR_OK ?
-			CL_ProcessCommand(result) :
-			result.code;
-
-		if (processResult != PERR_OK or ::net_message.overflowed)
-		{
-			const Protos& protos = CL_GetTicProtos();
-
-			std::string err;
-			if (result.code == PERR_UNKNOWN_HEADER)
-			{
-				err = "Unknown message header";
-			}
-			else if (result.code == PERR_UNKNOWN_MESSAGE)
-			{
-				err = "Message is not known to message decoder";
-			}
-			else if (result.code == PERR_BAD_DECODE)
-			{
-				err = "Could not decode message";
-			}
-			else if (::net_message.overflowed)
-			{
-				err = "Message overflowed";
-			}
-			else
-			{
-				err = "Unknown error";
-			}
-
-			if (!protos.empty())
-			{
-				PrintFmt(PRINT_WARNING, "CL_ParseCommands: {}\n", err);
-
-				for (Protos::const_iterator it = protos.begin(); it != protos.end(); ++it)
-				{
-					char latest = (it == protos.end() - 1) ? '>' : ' ';
-					ptrdiff_t idx = it - protos.begin() + 1;
-					std::string svc = SVCName(it->header);
-					size_t siz = it->size;
-					PrintFmt(PRINT_WARNING, "{:c} {:>2d} [{}] {}b\n", latest, idx, svc,
-					         siz);
-				}
-			}
-			else
-			{
-				PrintFmt(PRINT_WARNING, "CL_ParseCommands: {}\n", err);
-			}
-
-			CL_QuitNetGame(NQ_PROTO);
-		}
-
-		// Measure length of each message, so we can keep track of bandwidth.
-		if (::net_message.BytesRead() < byteStart)
-		{
-			PrintFmt("CL_ParseCommands: end byte ({}) < start byte ({})\n",
-			         ::net_message.BytesRead(), byteStart);
-		}
-	}
-}
-
 
 void CL_SaveCmd(void)
 {

--- a/client/src/cl_main.h
+++ b/client/src/cl_main.h
@@ -68,7 +68,6 @@ void CL_Reconnect(netQuitReason_e reason);
 void CL_InitNetwork (void);
 void CL_RequestConnectInfo(void);
 bool CL_PrepareConnect();
-void CL_ParseCommands(void);
 MessageResultEnum CL_ReadPacketHeader();
 MessageResultEnum CL_AcceptNetMessage();
 MessageResultEnum CL_ProcessCurrentAvailableMessages();

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -123,6 +123,11 @@ void P_PlayerLeavesGame(player_t* player);
 void P_SetPsprite(player_t& player, int position, int32_t stnum);
 void P_SetButtonTexture(line_t* line, short texture);
 
+namespace
+{
+	PacketHeaderType s_currentHeader;
+}
+
 /**
  * @brief Unpack a bitfield into an array of booleans.
  */
@@ -3510,7 +3515,6 @@ const Protos& CL_GetTicProtos()
 	return ::protos;
 }
 
-
 /**
  * @brief Read a server message off the wire.
  */
@@ -3566,6 +3570,7 @@ parseError_e CL_ProcessCommand(const ParseResultType& parsedCommand)
 
 		/* clang-format off */
 		SV_MSG(msg_noop, CL_Noop, odaproto::Noop);
+
 		SV_MSG(svc_disconnect, CL_Disconnect, odaproto::svc::Disconnect);
 		SV_MSG(svc_playerinfo, CL_PlayerInfo, odaproto::svc::PlayerInfo);
 		SV_MSG(svc_moveplayer, CL_MovePlayer, odaproto::svc::MovePlayer);
@@ -3656,6 +3661,109 @@ parseError_e CL_ProcessCommand(const ParseResultType& parsedCommand)
 
 	RecordProto(static_cast<msg_t>(parsedCommand.cmd), parsedCommand.msg.get());
 	return PERR_OK;
+}
+
+namespace
+{
+	std::string SVCName(msg_t header)
+	{
+		std::string svc = ::msg_info[header].getName();
+		if (svc.empty())
+		{
+			svc = fmt::sprintf("svc_%u", header);
+		}
+		return svc;
+	}
+}
+
+//
+// CL_ParseCommands
+//
+void CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader)
+{
+	if (optionalHeader)
+	{
+		s_currentHeader = *optionalHeader;
+	}
+
+	while (connected)
+	{
+		if (::net_message.BytesLeftToRead() == 0)
+		{
+			break;
+		}
+
+		// When echoing server gametic back to it, use the tic that comes from the High Priority packet.
+		// This is because the High Priority packet is always live and comes out every tic.  It's totally
+		// possible for the server to go without sending anything Reliable or Best-Effort if things are
+		// all-quiet.
+		if (messenger.GetCurrentReceivedIsHighPriority())
+		{
+			messenger.SetDestinationTic(messenger.GetCurrentReceivedRemoteTic());
+		}
+
+		const size_t          byteStart = ::net_message.BytesRead();
+		const ParseResultType result    = CL_ParseCommand();
+
+		const parseError_e processResult = result.code == PERR_OK ?
+			CL_ProcessCommand(result) :
+			result.code;
+
+		if (processResult != PERR_OK or ::net_message.overflowed)
+		{
+			const Protos& protos = CL_GetTicProtos();
+
+			std::string err;
+			if (result.code == PERR_UNKNOWN_HEADER)
+			{
+				err = "Unknown message header";
+			}
+			else if (result.code == PERR_UNKNOWN_MESSAGE)
+			{
+				err = "Message is not known to message decoder";
+			}
+			else if (result.code == PERR_BAD_DECODE)
+			{
+				err = "Could not decode message";
+			}
+			else if (::net_message.overflowed)
+			{
+				err = "Message overflowed";
+			}
+			else
+			{
+				err = "Unknown error";
+			}
+
+			if (!protos.empty())
+			{
+				PrintFmt(PRINT_WARNING, "CL_ParseCommands: {}\n", err);
+
+				for (Protos::const_iterator it = protos.begin(); it != protos.end(); ++it)
+				{
+					char latest = (it == protos.end() - 1) ? '>' : ' ';
+					ptrdiff_t idx = it - protos.begin() + 1;
+					std::string svc = SVCName(it->header);
+					size_t siz = it->size;
+					PrintFmt(PRINT_WARNING, "{:c} {:>2d} [{}] {}b\n", latest, idx, svc,
+					         siz);
+				}
+			}
+			else
+			{
+				PrintFmt(PRINT_WARNING, "CL_ParseCommands: {}\n", err);
+			}
+
+			CL_QuitNetGame(NQ_PROTO);
+		}
+
+		// Measure length of each message, so we can keep track of bandwidth.
+		if (::net_message.BytesRead() < byteStart)
+		{
+			PrintFmt("CL_ParseCommands: end byte ({}) < start byte ({})\n",
+			         ::net_message.BytesRead(), byteStart);
+		}
+	}
 }
 
 VERSION_CONTROL (cl_parse_cpp, "$Id$")

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -122,16 +122,18 @@ void P_ExplodeMissile(AActor* mo);
 void P_PlayerLeavesGame(player_t* player);
 void P_SetPsprite(player_t& player, int position, int32_t stnum);
 void P_SetButtonTexture(line_t* line, short texture);
+void P_SpawnAvatars();
 
 namespace
 {
-	PacketHeaderType s_currentHeader;
-}
+
+PacketHeaderType s_currentHeader;
+
 
 /**
  * @brief Unpack a bitfield into an array of booleans.
  */
-static void UnpackBoolArray(std::span<bool> bools, uint32_t in)
+void UnpackBoolArray(std::span<bool> bools, uint32_t in)
 {
 	for (size_t i = 0; i < bools.size(); i++)
 	{
@@ -142,7 +144,7 @@ static void UnpackBoolArray(std::span<bool> bools, uint32_t in)
 /**
  * @brief Common code for activating a line.
  */
-static void ActivateLine(AActor* mo, line_s* line, byte side,
+void ActivateLine(AActor* mo, line_s* line, byte side,
                          LineActivationType activationType, const bool bossaction,
                          byte special = 0, int arg0 = 0, int arg1 = 0, int arg2 = 0,
                          int arg3 = 0, int arg4 = 0)
@@ -193,11 +195,11 @@ static void ActivateLine(AActor* mo, line_s* line, byte side,
 /**
  * @brief msg_noop - Nothing to see here. Move along.
  */
-static void CL_Noop(const odaproto::Noop* msg)
+void CL_Noop(const odaproto::Noop* msg)
 {
 }
 
-static void CL_Header(const odaproto::Header* msg)
+void CL_Header(const odaproto::Header* msg)
 {
 	s_currentHeader.sequence        = msg->sequence();
 	s_currentHeader.originatorTic   = msg->originator_tic();
@@ -209,7 +211,7 @@ static void CL_Header(const odaproto::Header* msg)
 /**
  * @brief svc_disconnect - Disconnect a client from the server.
  */
-static void CL_Disconnect(const odaproto::svc::Disconnect* msg)
+void CL_Disconnect(const odaproto::svc::Disconnect* msg)
 {
 	if (!msg->message().empty())
 	{
@@ -226,7 +228,7 @@ static void CL_Disconnect(const odaproto::svc::Disconnect* msg)
 /**
  * @brief svc_playerinfo - Your personal arsenal, as supplied by the server.
  */
-static void CL_PlayerInfo(const odaproto::svc::PlayerInfo* msg)
+void CL_PlayerInfo(const odaproto::svc::PlayerInfo* msg)
 {
 	player_t& player = consoleplayer();
 
@@ -314,7 +316,7 @@ static void CL_PlayerInfo(const odaproto::svc::PlayerInfo* msg)
 /**
  * @brief svc_moveplayer - Move a player.
  */
-static void CL_MovePlayer(const odaproto::svc::MovePlayer* msg)
+void CL_MovePlayer(const odaproto::svc::MovePlayer* msg)
 {
 	byte who = msg->playerid();
 	player_t& p = idplayer(who);
@@ -396,7 +398,7 @@ static void CL_MovePlayer(const odaproto::svc::MovePlayer* msg)
 	p.snapshots.addSnapshot(newsnap);
 }
 
-static void CL_UpdateLocalPlayer(const odaproto::svc::UpdateLocalPlayer* msg)
+void CL_UpdateLocalPlayer(const odaproto::svc::UpdateLocalPlayer* msg)
 {
 	player_t& p = consoleplayer();
 
@@ -434,7 +436,7 @@ static void CL_UpdateLocalPlayer(const odaproto::svc::UpdateLocalPlayer* msg)
 }
 
 // Set level locals.
-static void CL_LevelLocals(const odaproto::svc::LevelLocals* msg)
+void CL_LevelLocals(const odaproto::svc::LevelLocals* msg)
 {
 	uint32_t flags = msg->flags();
 
@@ -479,7 +481,7 @@ static void CL_LevelLocals(const odaproto::svc::LevelLocals* msg)
 // [SL] 2011-05-11 - Changed from CL_ResendSvGametic to CL_SendPingReply
 // for clarity since it sends timestamps, not gametics.
 //
-static void CL_PingRequest(const odaproto::svc::PingRequest* msg)
+void CL_PingRequest(const odaproto::svc::PingRequest* msg)
 {
 	MSG_WriteSVC(messenger.NetBuf(), CLC_PingReply(msg->ms_time()));
 }
@@ -488,7 +490,7 @@ static void CL_PingRequest(const odaproto::svc::PingRequest* msg)
 // CL_UpdatePing
 // Update ping value
 //
-static void CL_UpdatePing(const odaproto::svc::UpdatePing* msg)
+void CL_UpdatePing(const odaproto::svc::UpdatePing* msg)
 {
 	player_t& p = idplayer(msg->pid());
 	if (!validplayer(p))
@@ -500,7 +502,7 @@ static void CL_UpdatePing(const odaproto::svc::UpdatePing* msg)
 //
 // CL_SpawnMobj
 //
-static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
+void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 {
 	// Read baseline
 
@@ -854,7 +856,7 @@ static void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 //
 // CL_DisconnectClient
 //
-static void CL_DisconnectClient(const odaproto::svc::DisconnectClient* msg)
+void CL_DisconnectClient(const odaproto::svc::DisconnectClient* msg)
 {
 	player_t& player = idplayer(msg->pid());
 	if (players.empty() || !validplayer(player))
@@ -899,7 +901,7 @@ static void CL_DisconnectClient(const odaproto::svc::DisconnectClient* msg)
 // Read wad & deh filenames and map name from the server and loads
 // the appropriate wads & map.
 //
-static void CL_LoadMap(const odaproto::svc::LoadMap* msg)
+void CL_LoadMap(const odaproto::svc::LoadMap* msg)
 {
 	ClientReplay::getInstance().reset();
 	bool splitnetdemo =
@@ -1045,7 +1047,7 @@ static void CL_LoadMap(const odaproto::svc::LoadMap* msg)
 		netdemo.writeMapChange();
 }
 
-static void CL_ConsolePlayer(const odaproto::svc::ConsolePlayer* msg)
+void CL_ConsolePlayer(const odaproto::svc::ConsolePlayer* msg)
 {
 	::displayplayer_id = ::consoleplayer_id = msg->pid();
 	::digest = msg->digest();
@@ -1054,7 +1056,7 @@ static void CL_ConsolePlayer(const odaproto::svc::ConsolePlayer* msg)
 //
 // CL_ExplodeMissile
 //
-static void CL_ExplodeMissile(const odaproto::svc::ExplodeMissile* msg)
+void CL_ExplodeMissile(const odaproto::svc::ExplodeMissile* msg)
 {
 	AActor* mo = P_FindThingById(msg->netid());
 
@@ -1067,7 +1069,7 @@ static void CL_ExplodeMissile(const odaproto::svc::ExplodeMissile* msg)
 //
 // CL_RemoveMobj
 //
-static void CL_RemoveMobj(const odaproto::svc::RemoveMobj* msg)
+void CL_RemoveMobj(const odaproto::svc::RemoveMobj* msg)
 {
 	uint32_t netid = msg->netid();
 
@@ -1084,7 +1086,7 @@ static void CL_RemoveMobj(const odaproto::svc::RemoveMobj* msg)
 //
 // CL_SetupUserInfo
 //
-static void CL_UserInfo(const odaproto::svc::UserInfo* msg)
+void CL_UserInfo(const odaproto::svc::UserInfo* msg)
 {
 	player_t* p = &CL_FindPlayer(msg->pid());
 
@@ -1239,7 +1241,7 @@ static AActor* CL_UpdateMobj(const odaproto::svc::UpdateMobj* msg, AActor* mo = 
 	return mo;
 }
 
-static void CL_UpdateMobjWithMode(const odaproto::svc::UpdateMobjWithMode* msg)
+void CL_UpdateMobjWithMode(const odaproto::svc::UpdateMobjWithMode* msg)
 {
 	AActor* mo = P_FindThingById(msg->update().actor().netid());
 
@@ -1301,7 +1303,7 @@ static void CL_UpdateMobjWithMode(const odaproto::svc::UpdateMobjWithMode* msg)
 //
 // CL_SpawnPlayer
 //
-static void CL_SpawnPlayer(const odaproto::svc::SpawnPlayer* msg)
+void CL_SpawnPlayer(const odaproto::svc::SpawnPlayer* msg)
 {
 	const size_t playernum = msg->pid();
 	const size_t netid = msg->actor().netid();
@@ -1430,7 +1432,7 @@ static void CL_SpawnPlayer(const odaproto::svc::SpawnPlayer* msg)
 //
 // CL_DamagePlayer
 //
-static void CL_DamagePlayer(const odaproto::svc::DamagePlayer* msg)
+void CL_DamagePlayer(const odaproto::svc::DamagePlayer* msg)
 {
 	const uint32_t  netid        = msg->netid();
 	const uint32_t  attackerid   = msg->inflictorid();
@@ -1496,7 +1498,7 @@ extern int MeansOfDeath;
 //
 // CL_KillMobj
 //
-static void CL_KillMobj(const odaproto::svc::KillMobj* msg)
+void CL_KillMobj(const odaproto::svc::KillMobj* msg)
 {
 	const uint32_t srcid    = msg->source_netid();
 	const uint32_t tgtid    = msg->target_netid();
@@ -1568,7 +1570,7 @@ static void CL_KillMobj(const odaproto::svc::KillMobj* msg)
 //
 // CL_RaiseMobj
 //
-static void CL_RaiseMobj(const odaproto::svc::RaiseMobj* msg)
+void CL_RaiseMobj(const odaproto::svc::RaiseMobj* msg)
 {
 	uint32_t srcid = msg->source_netid();
 	uint32_t cpsid = msg->corpse().netid();
@@ -1626,7 +1628,7 @@ static void CL_RaiseMobj(const odaproto::svc::RaiseMobj* msg)
 // CL_UpdateSector
 // Updates floorheight and ceilingheight of a sector.
 //
-static void CL_UpdateSector(const odaproto::svc::UpdateSector* msg)
+void CL_UpdateSector(const odaproto::svc::UpdateSector* msg)
 {
 	int sectornum = msg->sectornum();
 	fixed_t floorheight = msg->sector().floor_height();
@@ -1663,7 +1665,7 @@ static void CL_UpdateSector(const odaproto::svc::UpdateSector* msg)
 //
 // CL_Print
 //
-static void CL_Print(const odaproto::svc::Print* msg)
+void CL_Print(const odaproto::svc::Print* msg)
 {
 	byte level = msg->level();
 	const std::string& str = msg->message();
@@ -1694,7 +1696,7 @@ static void CL_Print(const odaproto::svc::Print* msg)
 /**
  * @brief Updates less-vital members of a player struct.
  */
-static void CL_PlayerMembers(const odaproto::svc::PlayerMembers* msg)
+void CL_PlayerMembers(const odaproto::svc::PlayerMembers* msg)
 {
 	player_t& p = CL_FindPlayer(msg->pid());
 	byte flags = msg->flags();
@@ -1741,7 +1743,7 @@ static void CL_PlayerMembers(const odaproto::svc::PlayerMembers* msg)
 //
 // [deathz0r] Receive team frags/captures
 //
-static void CL_TeamMembers(const odaproto::svc::TeamMembers* msg)
+void CL_TeamMembers(const odaproto::svc::TeamMembers* msg)
 {
 	team_t team = static_cast<team_t>(msg->team());
 	int points = msg->points();
@@ -1756,7 +1758,7 @@ static void CL_TeamMembers(const odaproto::svc::TeamMembers* msg)
 	info->RoundWins = roundWins;
 }
 
-static void CL_ActivateLine(const odaproto::svc::ActivateLine* msg)
+void CL_ActivateLine(const odaproto::svc::ActivateLine* msg)
 {
 	int linenum = msg->linenum();
 	AActor* mo = P_FindThingById(msg->activator_netid());
@@ -1775,7 +1777,7 @@ static void CL_ActivateLine(const odaproto::svc::ActivateLine* msg)
 // Sector movers
 //
 
-static void CL_MovingSectorElevator(const odaproto::svc::MovingSectorElevator* msg)
+void CL_MovingSectorElevator(const odaproto::svc::MovingSectorElevator* msg)
 {
 	int sectornum = msg->sector();
 
@@ -1809,7 +1811,7 @@ static void CL_MovingSectorElevator(const odaproto::svc::MovingSectorElevator* m
 	sector_snaps[sectornum].addSnapshot(snap);
 }
 
-static void CL_MovingSectorPillar(const odaproto::svc::MovingSectorPillar* msg)
+void CL_MovingSectorPillar(const odaproto::svc::MovingSectorPillar* msg)
 {
 	int sectornum = msg->sector();
 
@@ -1843,7 +1845,7 @@ static void CL_MovingSectorPillar(const odaproto::svc::MovingSectorPillar* msg)
 	sector_snaps[sectornum].addSnapshot(snap);
 }
 
-static void CL_MovingSectorCeiling(const odaproto::svc::MovingSectorCeiling* msg)
+void CL_MovingSectorCeiling(const odaproto::svc::MovingSectorCeiling* msg)
 {
 	int sectornum = msg->sector();
 
@@ -1875,7 +1877,7 @@ static void CL_MovingSectorCeiling(const odaproto::svc::MovingSectorCeiling* msg
 	sector_snaps[sectornum].addSnapshot(snap);
 }
 
-static void CL_MovingSectorDoor(const odaproto::svc::MovingSectorDoor* msg)
+void CL_MovingSectorDoor(const odaproto::svc::MovingSectorDoor* msg)
 {
 	int sectornum = msg->sector();
 
@@ -1908,7 +1910,7 @@ static void CL_MovingSectorDoor(const odaproto::svc::MovingSectorDoor* msg)
 	sector_snaps[sectornum].addSnapshot(snap);
 }
 
-static void CL_MovingSectorFloor(const odaproto::svc::MovingSectorFloor* msg)
+void CL_MovingSectorFloor(const odaproto::svc::MovingSectorFloor* msg)
 {
 	int sectornum = msg->sector();
 
@@ -1950,7 +1952,7 @@ static void CL_MovingSectorFloor(const odaproto::svc::MovingSectorFloor* msg)
 	sector_snaps[sectornum].addSnapshot(snap);
 }
 
-static void CL_MovingSectorPlat(const odaproto::svc::MovingSectorPlat* msg)
+void CL_MovingSectorPlat(const odaproto::svc::MovingSectorPlat* msg)
 {
 	int sectornum = msg->sector();
 
@@ -1984,7 +1986,7 @@ static void CL_MovingSectorPlat(const odaproto::svc::MovingSectorPlat* msg)
 //
 // CL_Sound
 //
-static void CL_PlaySound(const odaproto::svc::PlaySound* msg)
+void CL_PlaySound(const odaproto::svc::PlaySound* msg)
 {
 	int channel = msg->channel();
 	int sfx_id = msg->sfxid();
@@ -2013,12 +2015,12 @@ static void CL_PlaySound(const odaproto::svc::PlaySound* msg)
 	}
 }
 
-static void CL_Reconnect(const odaproto::svc::Reconnect* msg)
+void CL_Reconnect(const odaproto::svc::Reconnect* msg)
 {
 	CL_Reconnect(NQ_SERVER_DROP);
 }
 
-static void CL_ExitLevel(const odaproto::svc::ExitLevel* msg)
+void CL_ExitLevel(const odaproto::svc::ExitLevel* msg)
 {
 	gameaction = ga_completed;
 
@@ -2028,7 +2030,7 @@ static void CL_ExitLevel(const odaproto::svc::ExitLevel* msg)
 		netdemo.writeIntermission();
 }
 
-static void CL_TouchSpecial(const odaproto::svc::TouchSpecial* msg)
+void CL_TouchSpecial(const odaproto::svc::TouchSpecial* msg)
 {
 	uint32_t id = msg->netid();
 	AActor* mo = P_FindThingById(id);
@@ -2079,7 +2081,7 @@ static void CL_TouchSpecial(const odaproto::svc::TouchSpecial* msg)
 //	Allows server to force set a players team setting
 // ---------------------------------------------------------------------------------------------------------
 
-static void CL_ForceTeam(const odaproto::svc::ForceTeam* msg)
+void CL_ForceTeam(const odaproto::svc::ForceTeam* msg)
 {
 	team_t t = static_cast<team_t>(msg->team());
 
@@ -2097,7 +2099,7 @@ static void CL_ForceTeam(const odaproto::svc::ForceTeam* msg)
 // CL_Switch
 // denis - switch state and timing
 // Note: this will also be called for doors
-static void CL_Switch(const odaproto::svc::Switch* msg)
+void CL_Switch(const odaproto::svc::Switch* msg)
 {
 	int l = msg->linenum();
 	byte switchactive = msg->switch_active();
@@ -2137,7 +2139,7 @@ static void CL_Switch(const odaproto::svc::Switch* msg)
  * Handle the svc_say server message, which contains a message from another
  * client with a player id attached to it.
  */
-static void CL_Say(const odaproto::svc::Say* msg)
+void CL_Say(const odaproto::svc::Say* msg)
 {
 	byte message_visibility = msg->visibility();
 	byte player_id = msg->pid();
@@ -2192,7 +2194,7 @@ static void CL_Say(const odaproto::svc::Say* msg)
 	}
 }
 
-static void CL_CTFRefresh(const odaproto::svc::CTFRefresh* msg)
+void CL_CTFRefresh(const odaproto::svc::CTFRefresh* msg)
 {
 	// clear player flags client may have imagined
 	for (auto& player : players)
@@ -2234,7 +2236,7 @@ static void CL_CTFRefresh(const odaproto::svc::CTFRefresh* msg)
 	}
 }
 
-static void CL_CTFEvent(const odaproto::svc::CTFEvent* msg)
+void CL_CTFEvent(const odaproto::svc::CTFEvent* msg)
 {
 	// Range checking on events.
 	if (msg->event() <= SCORE_REFRESH || msg->event() >= NUM_CTF_SCORE)
@@ -2341,7 +2343,7 @@ static void CL_CTFEvent(const odaproto::svc::CTFEvent* msg)
 // CL_SecretEvent
 // Client interpretation of a secret found by another player
 //
-static void CL_SecretEvent(const odaproto::svc::SecretEvent* msg)
+void CL_SecretEvent(const odaproto::svc::SecretEvent* msg)
 {
 	player_t& player = idplayer(msg->pid());
 	int sectornum = static_cast<int>(msg->sectornum());
@@ -2369,7 +2371,7 @@ static void CL_SecretEvent(const odaproto::svc::SecretEvent* msg)
 		S_Sound(CHAN_INTERFACE, "misc/secret", 1, ATTN_NONE);
 }
 
-static void CL_ServerSettings(const odaproto::svc::ServerSettings* msg)
+void CL_ServerSettings(const odaproto::svc::ServerSettings* msg)
 {
 	cvar_t *var = NULL, *prev = NULL;
 
@@ -2403,7 +2405,7 @@ static void CL_ServerSettings(const odaproto::svc::ServerSettings* msg)
 //
 // CL_ConnectClient
 //
-static void CL_ConnectClient(const odaproto::svc::ConnectClient* msg)
+void CL_ConnectClient(const odaproto::svc::ConnectClient* msg)
 {
 	player_t& player = idplayer(msg->pid());
 
@@ -2420,7 +2422,7 @@ static void CL_ConnectClient(const odaproto::svc::ConnectClient* msg)
 }
 
 // Print a message in the middle of the screen
-static void CL_MidPrint(const odaproto::svc::MidPrint* msg)
+void CL_MidPrint(const odaproto::svc::MidPrint* msg)
 {
 	C_MidPrint(msg->message().c_str(), NULL, msg->time());
 }
@@ -2432,7 +2434,7 @@ static void CL_MidPrint(const odaproto::svc::MidPrint* msg)
 // sent back to the server with the next cmd.
 //
 // [SL] 2011-05-11
-static void CL_ServerGametic(const odaproto::svc::ServerGametic* msg)
+void CL_ServerGametic(const odaproto::svc::ServerGametic* msg)
 {
 	::last_svgametic = msg->tic();
 
@@ -2447,7 +2449,7 @@ static void CL_ServerGametic(const odaproto::svc::ServerGametic* msg)
 // CL_UpdateIntTimeLeft
 // Changes the value of level.inttimeleft
 //
-static void CL_IntTimeLeft(const odaproto::svc::IntTimeLeft* msg)
+void CL_IntTimeLeft(const odaproto::svc::IntTimeLeft* msg)
 {
 	::level.inttimeleft = msg->timeleft(); // convert from seconds to tics
 }
@@ -2458,7 +2460,7 @@ static void CL_IntTimeLeft(const odaproto::svc::IntTimeLeft* msg)
 // Takes care of any business that needs to be done once the client has a full
 // view of the game world.
 //
-static void CL_FullUpdateDone(const odaproto::svc::FullUpdateDone* msg)
+void CL_FullUpdateDone(const odaproto::svc::FullUpdateDone* msg)
 {
 	::hasReceivedFullUpdate = true;
 	::isReceivingFullUpdate = false;
@@ -2467,7 +2469,7 @@ static void CL_FullUpdateDone(const odaproto::svc::FullUpdateDone* msg)
 //
 // CL_RailTrail
 //
-static void CL_RailTrail(const odaproto::svc::RailTrail* msg)
+void CL_RailTrail(const odaproto::svc::RailTrail* msg)
 {
 	v3double_t start, end;
 
@@ -2482,7 +2484,7 @@ static void CL_RailTrail(const odaproto::svc::RailTrail* msg)
 	P_DrawRailTrail(start, end);
 }
 
-static void CL_PlayerState(const odaproto::svc::PlayerState* msg)
+void CL_PlayerState(const odaproto::svc::PlayerState* msg)
 {
 	byte id = msg->player().playerid();
 	int health = msg->player().health();
@@ -2572,7 +2574,7 @@ static void CL_PlayerState(const odaproto::svc::PlayerState* msg)
 /**
  * @brief Set local levelstate.
  */
-static void CL_LevelState(const odaproto::svc::LevelState* msg)
+void CL_LevelState(const odaproto::svc::LevelState* msg)
 {
 	// Set local levelstate.
 	SerializedLevelState sls;
@@ -2585,9 +2587,7 @@ static void CL_LevelState(const odaproto::svc::LevelState* msg)
 	::levelstate.unserialize(sls);
 }
 
-void P_SpawnAvatars();
-
-static void CL_ResetMap(const odaproto::svc::ResetMap* msg)
+void CL_ResetMap(const odaproto::svc::ResetMap* msg)
 {
 	ClientReplay::getInstance().reset();
 
@@ -2647,7 +2647,7 @@ static void CL_ResetMap(const odaproto::svc::ResetMap* msg)
 		netdemo.writeMapChange();
 }
 
-static void CL_PlayerQueuePos(const odaproto::svc::PlayerQueuePos* msg)
+void CL_PlayerQueuePos(const odaproto::svc::PlayerQueuePos* msg)
 {
 	player_t& player = idplayer(msg->pid());
 	byte queuePos = msg->queuepos();
@@ -2667,13 +2667,13 @@ static void CL_PlayerQueuePos(const odaproto::svc::PlayerQueuePos* msg)
 	player.QueuePosition = queuePos;
 }
 
-static void CL_FullUpdateStart(const odaproto::svc::FullUpdateStart* msg)
+void CL_FullUpdateStart(const odaproto::svc::FullUpdateStart* msg)
 {
 	::hasReceivedFullUpdate = false;
 	::isReceivingFullUpdate = true;
 }
 
-static void CL_LineUpdate(const odaproto::svc::LineUpdate* msg)
+void CL_LineUpdate(const odaproto::svc::LineUpdate* msg)
 {
 	int linenum = msg->linenum();
 	short flags = msg->flags();
@@ -2690,7 +2690,7 @@ static void CL_LineUpdate(const odaproto::svc::LineUpdate* msg)
 /**
  * @brief Update sector properties dynamically.
  */
-static void CL_SectorProperties(const odaproto::svc::SectorProperties* msg)
+void CL_SectorProperties(const odaproto::svc::SectorProperties* msg)
 {
 	int secnum = msg->sectornum();
 	uint32_t changes = msg->changes();
@@ -2766,7 +2766,7 @@ static void CL_SectorProperties(const odaproto::svc::SectorProperties* msg)
 	}
 }
 
-static void CL_LineSideUpdate(const odaproto::svc::LineSideUpdate* msg)
+void CL_LineSideUpdate(const odaproto::svc::LineSideUpdate* msg)
 {
 	int linenum = msg->linenum();
 	int side = msg->side();
@@ -2803,7 +2803,7 @@ static void CL_LineSideUpdate(const odaproto::svc::LineSideUpdate* msg)
 	}
 }
 
-static void CL_WakeupMobj(const odaproto::svc::WakeupMobj* msg)
+void CL_WakeupMobj(const odaproto::svc::WakeupMobj* msg)
 {
 	AActor* mo = P_FindThingById(msg->netid());
 
@@ -2852,7 +2852,7 @@ static void CL_WakeupMobj(const odaproto::svc::WakeupMobj* msg)
 //
 // CL_SetMobjState
 //
-static void CL_SetMobjState(const odaproto::svc::MobjState* msg)
+void CL_SetMobjState(const odaproto::svc::MobjState* msg)
 {
 	AActor* mo = P_FindThingById(msg->netid());
 	int s = msg->mostate();
@@ -2866,7 +2866,7 @@ static void CL_SetMobjState(const odaproto::svc::MobjState* msg)
 //
 // CL_DamageMobj
 //
-static void CL_DamageMobj(const odaproto::svc::DamageMobj* msg)
+void CL_DamageMobj(const odaproto::svc::DamageMobj* msg)
 {
 	uint32_t netid = msg->netid();
 	int health = msg->health();
@@ -2883,7 +2883,7 @@ static void CL_DamageMobj(const odaproto::svc::DamageMobj* msg)
 		P_SetMobjState(mo, mo->info->painstate);
 }
 
-static void CL_ExecuteLineSpecial(const odaproto::svc::ExecuteLineSpecial* msg)
+void CL_ExecuteLineSpecial(const odaproto::svc::ExecuteLineSpecial* msg)
 {
 	byte special = msg->special();
 	int linenum = msg->linenum();
@@ -2905,7 +2905,7 @@ static void CL_ExecuteLineSpecial(const odaproto::svc::ExecuteLineSpecial* msg)
 	             arg4);
 }
 
-static void CL_ExecuteACSSpecial(const odaproto::svc::ExecuteACSSpecial* msg)
+void CL_ExecuteACSSpecial(const odaproto::svc::ExecuteACSSpecial* msg)
 {
 	byte special = msg->special();
 	uint32_t netid = msg->activator_netid();
@@ -2990,7 +2990,7 @@ static void CL_ExecuteACSSpecial(const odaproto::svc::ExecuteACSSpecial* msg)
 /**
  * @brief Update a thinker.
  */
-static void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
+void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 {
 	switch (msg->thinker_case())
 	{
@@ -3101,7 +3101,7 @@ static void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 	}
 }
 
-static void CL_VoteUpdate(const odaproto::svc::VoteUpdate* msg)
+void CL_VoteUpdate(const odaproto::svc::VoteUpdate* msg)
 {
 	vote_result_t result = static_cast<vote_result_t>(msg->result());
 
@@ -3122,7 +3122,7 @@ static void CL_VoteUpdate(const odaproto::svc::VoteUpdate* msg)
 }
 
 // Got a packet that contains the maplist status
-static void CL_Maplist(const odaproto::svc::Maplist* msg)
+void CL_Maplist(const odaproto::svc::Maplist* msg)
 {
 	// The update status might require us to bail out.
 	maplist_status_t status = static_cast<maplist_status_t>(msg->status());
@@ -3133,7 +3133,7 @@ static void CL_Maplist(const odaproto::svc::Maplist* msg)
 }
 
 // Got a packet that contains a chunk of the maplist.
-static void CL_MaplistUpdate(const odaproto::svc::MaplistUpdate* msg)
+void CL_MaplistUpdate(const odaproto::svc::MaplistUpdate* msg)
 {
 	// The update status might require us to bail out.
 	maplist_status_t status = static_cast<maplist_status_t>(msg->status());
@@ -3175,7 +3175,7 @@ static void CL_MaplistUpdate(const odaproto::svc::MaplistUpdate* msg)
 }
 
 // Got a packet that contains the next and current index.
-static void CL_MaplistIndex(const odaproto::svc::MaplistIndex* msg)
+void CL_MaplistIndex(const odaproto::svc::MaplistIndex* msg)
 {
 	if (msg->count() > 0)
 	{
@@ -3191,7 +3191,7 @@ static void CL_MaplistIndex(const odaproto::svc::MaplistIndex* msg)
 	}
 }
 
-static void CL_Toast(const odaproto::svc::Toast* msg)
+void CL_Toast(const odaproto::svc::Toast* msg)
 {
 	toast_t toast;
 	toast.flags = msg->flags();
@@ -3206,7 +3206,7 @@ static void CL_Toast(const odaproto::svc::Toast* msg)
 	COM_PushToast(toast);
 }
 
-static void CL_HordeInfo(const odaproto::svc::HordeInfo* msg)
+void CL_HordeInfo(const odaproto::svc::HordeInfo* msg)
 {
 	hordeInfo_t info;
 
@@ -3224,7 +3224,7 @@ static void CL_HordeInfo(const odaproto::svc::HordeInfo* msg)
 	P_SetHordeInfo(info);
 }
 
-static void CL_Spree(const odaproto::svc::Spree* msg)
+void CL_Spree(const odaproto::svc::Spree* msg)
 {
 	int playerId = msg->pid();
 	int spreeLevel = msg->spree_level();
@@ -3246,7 +3246,7 @@ static void CL_Spree(const odaproto::svc::Spree* msg)
 	}
 }
 
-static void CL_SpreeBreaker(const odaproto::svc::SpreeBreaker* msg)
+void CL_SpreeBreaker(const odaproto::svc::SpreeBreaker* msg)
 {
 	SpreeBreaker_t breaker;
 
@@ -3262,7 +3262,7 @@ static void CL_SpreeBreaker(const odaproto::svc::SpreeBreaker* msg)
 	SpreeManager::getInstance().setRawSpreeBreaker(breaker, level, type, ticsAgo);
 }
 
-static void CL_NoiseAlert(const odaproto::svc::NoiseAlert* msg)
+void CL_NoiseAlert(const odaproto::svc::NoiseAlert* msg)
 {
 	const uint32_t sectorIndex = msg->sectornum();
 
@@ -3279,7 +3279,7 @@ static void CL_NoiseAlert(const odaproto::svc::NoiseAlert* msg)
 	}
 }
 
-static void CL_PlayerAmmo(const odaproto::svc::PlayerAmmo* msg)
+void CL_PlayerAmmo(const odaproto::svc::PlayerAmmo* msg)
 {
 	std::array<int, NUMAMMO> ammo;
 	std::copy(msg->ammo().begin(),
@@ -3293,7 +3293,7 @@ static void CL_PlayerAmmo(const odaproto::svc::PlayerAmmo* msg)
 	}
 }
 
-static void CL_PlayerMaxAmmo(const odaproto::svc::PlayerMaxAmmo* msg)
+void CL_PlayerMaxAmmo(const odaproto::svc::PlayerMaxAmmo* msg)
 {
 	std::array<int, NUMAMMO> maxammo;
 	std::copy(msg->maxammo().begin(),
@@ -3309,7 +3309,7 @@ static void CL_PlayerMaxAmmo(const odaproto::svc::PlayerMaxAmmo* msg)
 	}
 }
 
-static void CL_PlayerWeaponOwned(const odaproto::svc::PlayerWeaponOwned* msg)
+void CL_PlayerWeaponOwned(const odaproto::svc::PlayerWeaponOwned* msg)
 {
 	std::array<bool, NUMWEAPONS> weaponowned;
 	std::copy(msg->weaponowned().begin(),
@@ -3325,7 +3325,7 @@ static void CL_PlayerWeaponOwned(const odaproto::svc::PlayerWeaponOwned* msg)
 	}
 }
 
-static void CL_PlayerWeaponSelection(const odaproto::svc::PlayerWeaponSelection* msg)
+void CL_PlayerWeaponSelection(const odaproto::svc::PlayerWeaponSelection* msg)
 {
 	if (rollerState.ResolveWeaponSelection(msg->player_tic(),
 	                                       static_cast<weapontype_t>(msg->readyweapon()),
@@ -3337,7 +3337,7 @@ static void CL_PlayerWeaponSelection(const odaproto::svc::PlayerWeaponSelection*
 	}
 }
 
-static void CL_PlayerPowers(const odaproto::svc::PlayerPowers* msg)
+void CL_PlayerPowers(const odaproto::svc::PlayerPowers* msg)
 {
 	std::array<int, NUMPOWERS> powers;
 	std::copy(msg->powers().begin(),
@@ -3354,7 +3354,7 @@ static void CL_PlayerPowers(const odaproto::svc::PlayerPowers* msg)
 
 }
 
-static void CL_PlayerPsprites(const odaproto::svc::PlayerPsprites* msg)
+void CL_PlayerPsprites(const odaproto::svc::PlayerPsprites* msg)
 {
 	std::array<PspriteStateType, NUMPSPRITES> psprites;
 
@@ -3373,7 +3373,7 @@ static void CL_PlayerPsprites(const odaproto::svc::PlayerPsprites* msg)
 	}
 }
 
-static void CL_ConfigureAvatar(const odaproto::svc::ConfigureAvatar* msg)
+void CL_ConfigureAvatar(const odaproto::svc::ConfigureAvatar* msg)
 {
     MapThing avatarMapthing;
 
@@ -3438,7 +3438,7 @@ static void CL_ConfigureAvatar(const odaproto::svc::ConfigureAvatar* msg)
 	}
 }
 
-static void CL_NetdemoCap(const odaproto::clc::NetdemoCap* msg)
+void CL_NetdemoCap(const odaproto::clc::NetdemoCap* msg)
 {
 	odaproto::clc::PlayerInput& currentInputMessage = localcmds[gametic % MAXSAVETICS];
 	currentInputMessage.ParseFromString(msg->packed_player_input());
@@ -3473,12 +3473,12 @@ static void CL_NetdemoCap(const odaproto::clc::NetdemoCap* msg)
 	}
 }
 
-static void CL_NetDemoStop(const odaproto::clc::NetDemoStop* msg)
+void CL_NetDemoStop(const odaproto::clc::NetDemoStop* msg)
 {
 	::netdemo.stopPlaying();
 }
 
-static void CL_NetDemoLoadSnap(const odaproto::clc::NetDemoLoadSnap* msg)
+void CL_NetDemoLoadSnap(const odaproto::clc::NetDemoLoadSnap* msg)
 {
 	AddCommandString("netprevmap");
 }
@@ -3489,7 +3489,7 @@ static void CL_NetDemoLoadSnap(const odaproto::clc::NetDemoLoadSnap* msg)
 
 Protos protos;
 
-static void RecordProto(const msg_t header, google::protobuf::Message* msg)
+void RecordProto(const msg_t header, google::protobuf::Message* msg)
 {
 	static int protostic;
 
@@ -3519,6 +3519,8 @@ static void RecordProto(const msg_t header, google::protobuf::Message* msg)
 	}
 	::protos.push_back(proto);
 }
+
+}   // end of the big honking anonymous namespace.
 
 const Protos& CL_GetTicProtos()
 {
@@ -3750,7 +3752,7 @@ void CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader)
 			{
 				PrintFmt(PRINT_WARNING, "CL_ParseCommands: {}\n", err);
 
-				for (Protos::const_iterator it = protos.begin(); it != protos.end(); ++it)
+				for (auto it = protos.begin(); it != protos.end(); ++it)
 				{
 					char latest = (it == protos.end() - 1) ? '>' : ' ';
 					ptrdiff_t idx = it - protos.begin() + 1;

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -204,8 +204,8 @@ void CL_Header(const odaproto::Header* msg)
 	s_currentHeader.sequence        = msg->sequence();
 	s_currentHeader.originatorTic   = msg->originator_tic();
 	s_currentHeader.destinationTic  = msg->destination_tic();
-	s_currentHeader.reliableSize    = msg->reliable_size();
-	s_currentHeader.flags           = msg->flags();
+	s_currentHeader.reliableSize    = static_cast<uint16_t>(msg->reliable_size());
+	s_currentHeader.flags           = static_cast<uint16_t>(msg->flags());
 }
 
 /**

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -197,6 +197,15 @@ static void CL_Noop(const odaproto::Noop* msg)
 {
 }
 
+static void CL_Header(const odaproto::Header* msg)
+{
+	s_currentHeader.sequence        = msg->sequence();
+	s_currentHeader.originatorTic   = msg->originator_tic();
+	s_currentHeader.destinationTic  = msg->destination_tic();
+	s_currentHeader.reliableSize    = msg->reliable_size();
+	s_currentHeader.flags           = msg->flags();
+}
+
 /**
  * @brief svc_disconnect - Disconnect a client from the server.
  */
@@ -3570,6 +3579,7 @@ parseError_e CL_ProcessCommand(const ParseResultType& parsedCommand)
 
 		/* clang-format off */
 		SV_MSG(msg_noop, CL_Noop, odaproto::Noop);
+		SV_MSG(msg_header, CL_Header, odaproto::Header);
 
 		SV_MSG(svc_disconnect, CL_Disconnect, odaproto::svc::Disconnect);
 		SV_MSG(svc_playerinfo, CL_PlayerInfo, odaproto::svc::PlayerInfo);

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2015,12 +2015,12 @@ void CL_PlaySound(const odaproto::svc::PlaySound* msg)
 	}
 }
 
-void CL_Reconnect(const odaproto::svc::Reconnect* msg)
+void CL_Reconnect( [[ maybe_unused ]] const odaproto::svc::Reconnect* msg)
 {
 	CL_Reconnect(NQ_SERVER_DROP);
 }
 
-void CL_ExitLevel(const odaproto::svc::ExitLevel* msg)
+void CL_ExitLevel( [[ maybe_unused ]] const odaproto::svc::ExitLevel* msg)
 {
 	gameaction = ga_completed;
 
@@ -2460,7 +2460,7 @@ void CL_IntTimeLeft(const odaproto::svc::IntTimeLeft* msg)
 // Takes care of any business that needs to be done once the client has a full
 // view of the game world.
 //
-void CL_FullUpdateDone(const odaproto::svc::FullUpdateDone* msg)
+void CL_FullUpdateDone( [[ maybe_unused ]] const odaproto::svc::FullUpdateDone* msg)
 {
 	::hasReceivedFullUpdate = true;
 	::isReceivingFullUpdate = false;
@@ -2587,7 +2587,7 @@ void CL_LevelState(const odaproto::svc::LevelState* msg)
 	::levelstate.unserialize(sls);
 }
 
-void CL_ResetMap(const odaproto::svc::ResetMap* msg)
+void CL_ResetMap( [[ maybe_unused ]] const odaproto::svc::ResetMap* msg)
 {
 	ClientReplay::getInstance().reset();
 
@@ -2667,7 +2667,7 @@ void CL_PlayerQueuePos(const odaproto::svc::PlayerQueuePos* msg)
 	player.QueuePosition = queuePos;
 }
 
-void CL_FullUpdateStart(const odaproto::svc::FullUpdateStart* msg)
+void CL_FullUpdateStart( [[ maybe_unused ]] const odaproto::svc::FullUpdateStart* msg)
 {
 	::hasReceivedFullUpdate = false;
 	::isReceivingFullUpdate = true;
@@ -3473,12 +3473,12 @@ void CL_NetdemoCap(const odaproto::clc::NetdemoCap* msg)
 	}
 }
 
-void CL_NetDemoStop(const odaproto::clc::NetDemoStop* msg)
+void CL_NetDemoStop( [[ maybe_unused ]] const odaproto::clc::NetDemoStop* msg)
 {
 	::netdemo.stopPlaying();
 }
 
-void CL_NetDemoLoadSnap(const odaproto::clc::NetDemoLoadSnap* msg)
+void CL_NetDemoLoadSnap( [[ maybe_unused ]] const odaproto::clc::NetDemoLoadSnap* msg)
 {
 	AddCommandString("netprevmap");
 }

--- a/client/src/cl_parse.h
+++ b/client/src/cl_parse.h
@@ -24,10 +24,12 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "msg_parse.h"
+#include "PacketHeaderType.h"
 
 struct Proto
 {
@@ -49,3 +51,6 @@ typedef std::vector<Proto> Protos;
 const Protos& CL_GetTicProtos();
 ParseResultType CL_ParseCommand();
 parseError_e    CL_ProcessCommand(const ParseResultType& parsedCommand);
+void            CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader = std::nullopt);
+
+void CL_SetCurrentHeaderForParse(const PacketHeaderType& packetHeader);

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -67,6 +67,8 @@ class OdaMessenger
 		/// to NextReceivedPacket().  From call to call of NextReceivedPacket(), these
 		/// values should be expected to change and reflect the tic numbers contained
 		/// within and associated with the messages contained in that packet.
+		const PacketHeaderType& GetCurrentReceivedPacketHeader() const { return m_receivedHeader; }
+
 		int  GetCurrentReceivedPacketSequenceNumber() const { return m_receivedHeader.sequence; }
 		int  GetCurrentReceivedRemoteTic() const            { return m_receivedHeader.originatorTic; }
 		int  GetCurrentReceivedLocalTic() const             { return m_receivedHeader.destinationTic; }

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -575,14 +575,6 @@ namespace
 	}
 }
 
-void MSG_WriteRawMsgBuffer(buf_t& b, msg_t messageId, const void* data, size_t length)
-{
-	if (simulated_connection)
-		return;
-
-	WriteMiniHeader(b, messageId, data, length);
-}
-
 void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg)
 {
 	if (simulated_connection)

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -977,6 +977,7 @@ static void InitNetMessageFormats()
 {
 	// Server Messages.
 	MSG_INFO(msg_noop);
+	MSG_INFO(msg_header);
 
 	MSG_INFO(svc_disconnect);
 	MSG_INFO(svc_playerinfo);

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -565,6 +565,24 @@ void MSG_WriteChunk (buf_t *b, const void *p, size_t l)
 	b->WriteChunk(static_cast<const char*>(p), l);
 }
 
+namespace
+{
+	void WriteMiniHeader(buf_t& b, msg_t messageId, const void* data, size_t length)
+	{
+		b.WriteUnVarint(messageId);
+		b.WriteUnVarint(length);
+		b.WriteChunk(data, length);
+	}
+}
+
+void MSG_WriteRawMsgBuffer(buf_t& b, msg_t messageId, const void* data, size_t length)
+{
+	if (simulated_connection)
+		return;
+
+	WriteMiniHeader(b, messageId, data, length);
+}
+
 void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg)
 {
 	if (simulated_connection)
@@ -596,9 +614,7 @@ void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg)
 		msg.ShortDebugString());
 #endif
 
-	b->WriteUnVarint(header);
-	b->WriteUnVarint(buffer.size());
-	b->WriteChunk(buffer.data(), buffer.size());
+	WriteMiniHeader(*b, header, buffer.data(), buffer.size());
 }
 
 void MSG_WriteSVC(MessageQueue& io_queue, const google::protobuf::Message& msg)
@@ -632,11 +648,9 @@ void MSG_WriteSVC(MessageQueue& io_queue, const google::protobuf::Message& msg)
 		msg.ShortDebugString());
 #endif
 
-    buf_t& b = io_queue.Obtain();
+	buf_t& b = io_queue.Obtain();
 
-	b.WriteUnVarint(header);
-	b.WriteUnVarint(buffer.size());
-	b.WriteChunk(buffer.data(), buffer.size());
+	WriteMiniHeader(b, header, buffer.data(), buffer.size());
 }
 
 /**
@@ -683,9 +697,7 @@ void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& ms
 		// Select the correct buffer.
 		buf_t& b = buf == CLBUF_RELIABLE ? player.client.messenger->ReliableBuf().Obtain() : player.client.messenger->NetBuf().Obtain();
 
-		b.WriteUnVarint(header);
-		b.WriteUnVarint(buffer.size());
-		b.WriteChunk(buffer.data(), buffer.size());
+		WriteMiniHeader(b, header, buffer.data(), buffer.size());
 	}
 }
 

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -207,6 +207,7 @@ enum msg_t
 {
 	msg_noop,
 	msg_ack,
+	msg_header,
 
 	clc_netdemocap,         // netdemos - NullPoint
 	clc_netdemostop,        // netdemos - NullPoint
@@ -836,6 +837,7 @@ void MSG_WriteSVC(MessageQueue& io_queue, const google::protobuf::Message& msg);
 void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg);
 void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& msg,
                       const int skipPlayer = -1);
+void MSG_WriteRawMsgBuffer(buf_t& b, msg_t messageId, const void* data, size_t length);
 
 int MSG_BytesLeft(void);
 int MSG_PeekByte (void);

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -837,7 +837,6 @@ void MSG_WriteSVC(MessageQueue& io_queue, const google::protobuf::Message& msg);
 void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg);
 void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& msg,
                       const int skipPlayer = -1);
-void MSG_WriteRawMsgBuffer(buf_t& b, msg_t messageId, const void* data, size_t length);
 
 int MSG_BytesLeft(void);
 int MSG_PeekByte (void);

--- a/common/msg_map.cpp
+++ b/common/msg_map.cpp
@@ -58,7 +58,8 @@ static void MapProto(const msg_t header, const google::protobuf::Descriptor* des
  */
 static void InitMap()
 {
-	MapProto(msg_noop, odaproto::Noop::descriptor());
+	MapProto(msg_noop,   odaproto::Noop::descriptor());
+	MapProto(msg_header, odaproto::Header::descriptor());
 
 	MapProto(svc_disconnect, odaproto::svc::Disconnect::descriptor());
 	MapProto(svc_playerinfo, odaproto::svc::PlayerInfo::descriptor());

--- a/common/msg_message.cpp
+++ b/common/msg_message.cpp
@@ -1,0 +1,38 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 2026 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  Builders for sender-agnostic messages
+//
+//-----------------------------------------------------------------------------
+
+#include "msg_message.h"
+
+#include "PacketHeaderType.h"
+
+odaproto::Header MSG_Header(const PacketHeaderType& i_header)
+{
+	odaproto::Header msg;
+
+	msg.set_sequence        (i_header.sequence);
+	msg.set_originator_tic  (i_header.originatorTic);
+	msg.set_destination_tic (i_header.destinationTic);
+	msg.set_reliable_size   (i_header.reliableSize);
+	msg.set_flags           (i_header.flags);
+
+	return msg;
+}

--- a/common/msg_message.h
+++ b/common/msg_message.h
@@ -1,0 +1,29 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 2026 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  Builders for sender-agnostic messages
+//
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#include "common.pb.h"
+
+struct PacketHeaderType;
+
+odaproto::Header MSG_Header(const PacketHeaderType& i_header);

--- a/odaproto/common.proto
+++ b/odaproto/common.proto
@@ -11,6 +11,16 @@ message Noop
 {
 }
 
+// msg_header
+message Header
+{
+	int32   sequence        = 1;
+	int32   originator_tic  = 2;
+	int32   destination_tic = 3;
+	uint32  reliable_size   = 4;
+	uint32  flags           = 5;
+}
+
 message Color
 {
 	int32 r = 1;


### PR DESCRIPTION
This PR records packet headers into netdemos in sequence with all the messages it already records.  This causes the server tic and client tic-of-validity round-trip timing information to be captured and usable for netdemo replication of all rollbacks and validity checks experienced by the client during the game.

<img width="495" height="353" alt="image" src="https://github.com/user-attachments/assets/3617bec9-0932-4b4b-b7a6-8f41cf0b1ebe" />

In the above image, we see the `msg_header` for a high-priority packet (as indicated by the `flags: 2`) with its sequence number, the server tic at the time the content was generated, and the client tic that was current / valid on the server at the time the content was generated.  The high priority content includes a `svc_servergametic` message (which is slated to be repurposed as a metrics reporting message) and a `svc_updatelocalplayer` message.

Following that, we see a second `msg_header`.  This indicates the reception of a second packet in the frame:

<img width="460" height="319" alt="image" src="https://github.com/user-attachments/assets/b82921aa-ce3f-4b9f-bf0b-514bbe120354" />

This packet indicates that it is reliable (via `reliable_size: 44`) and it is the next packet in the overall reliability-based sequence.  We see from the tic information that it was generated in the same tic as the server and its content is the result of having processed the input that was generated on client tic `214`.

If we take a look at the player attribute info/rollback messages, we see that the embedded client tic exactly matches the tic indicated by the header.

<img width="428" height="251" alt="image" src="https://github.com/user-attachments/assets/2dceb6c8-7b05-45ab-bc57-807e396c7e65" />

<img width="404" height="273" alt="image" src="https://github.com/user-attachments/assets/4050e208-fca9-4f80-958b-42162a80b7cd" />

<img width="420" height="431" alt="image" src="https://github.com/user-attachments/assets/38500c3a-2af3-40cf-a582-1380bad0cda0" />

<img width="429" height="324" alt="image" src="https://github.com/user-attachments/assets/bf61add4-ae2f-4c39-a375-6ebe6dd80368" />

In total, not only does this allow us to eventually remove duplicated `player_tic` and `client_tic` fields from multiple messages (in a subsequent PR), but this also allows someone reviewing a netdemo to understand whether packets have gone missing, best-effort packets are received out-of-order, when retransmissions occur, and what server-to-client messages were affected by each.