### PR TITLE
[BUGFIX] Attempt to use loaded WADs before looking for new ones

### DIFF
--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -625,6 +625,48 @@ static bool FindIWAD(OResFile& out)
 }
 
 /**
+ * @brief Find an already loaded resource file that satisfies a wanted file.
+ *
+ * Files passed by full path stay loaded from directories that are not part
+ * of the search path, so a later reload that only knows the basename cannot
+ * resolve them again.  Match on hash instead.
+ *
+ * @param out Output OResFile. On error, this object is not touched.
+ * @param wanted Wanted file to satisfy.
+ * @param loaded Currently loaded files to search.
+ * @return True if a loaded file matched, otherwise false.
+ */
+static bool FindLoadedFile(OResFile& out, const OWantFile& wanted,
+                           const OResFiles& loaded)
+{
+	const OMD5Hash& hash = wanted.getWantedMD5();
+	if (hash.empty())
+	{
+		// Without a hash we have no way to know the file is the right one.
+		return false;
+	}
+
+	for (const auto& file : loaded)
+	{
+		if (file.getMD5() != hash)
+		{
+			continue;
+		}
+
+		if (!M_FileExists(file.getFullpath()))
+		{
+			// Where'd it go?
+			continue;
+		}
+
+		out = file;
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * @brief Load files that are assumed to be resolved, in the correct order,
  *        and complete.
  *
@@ -771,7 +813,8 @@ void D_LoadResourceFiles(const OWantFiles& newwadfiles, const OWantFiles& newpat
 	for (const auto& wantfile : newwadfiles)
 	{
 		OResFile file;
-		if (!M_ResolveWantedFile(file, wantfile))
+		if (!M_ResolveWantedFile(file, wantfile) &&
+		    !FindLoadedFile(file, wantfile, ::wadfiles))
 		{
 			// Give more useful information when trying to load an IWAD.
 			const bool isCommercial = CommercialIWADWarning(wantfile);
@@ -794,7 +837,8 @@ void D_LoadResourceFiles(const OWantFiles& newwadfiles, const OWantFiles& newpat
 	for (const auto& wantfile : newpatchfiles)
 	{
 		OResFile file;
-		if (!M_ResolveWantedFile(file, wantfile))
+		if (!M_ResolveWantedFile(file, wantfile) &&
+		    !FindLoadedFile(file, wantfile, ::patchfiles))
 		{
 			::missingfiles.push_back(wantfile);
 			PrintFmt(PRINT_WARNING, "Could not resolve patch file \"{}\".",

--- a/common/d_main.cpp
+++ b/common/d_main.cpp
@@ -636,7 +636,7 @@ static bool FindIWAD(OResFile& out)
  * @param loaded Currently loaded files to search.
  * @return True if a loaded file matched, otherwise false.
  */
-static bool FindLoadedFile(OResFile& out, const OWantFile& wanted,
+bool FindLoadedFile(OResFile& out, const OWantFile& wanted,
                            const OResFiles& loaded)
 {
 	const OMD5Hash& hash = wanted.getWantedMD5();


### PR DESCRIPTION
Fixes #1547.

In D_LoadResourceFiles, when attempting to resolve patches or WADs, we search the directories that are known to us (DOOMWADPATH, Steam install directories, etc) for WADs but we do not check to see if we have already loaded the WAD we need when a server provides its hashes to load the WADs in question. If you don't have paths set this usually results in failing to connect to a server once it loses the path to the loaded IWAD on a nonstandard path and can't find a new one, despite having the correct one the entire time.

```
[02:38:12] Logging in file C:\Users\Blair\source\repos\odamex-new\out\build\x64-Debug\odamex\odamex.log started Wed Aug 26 02:38:12 2026
[02:38:12] 
[02:38:12] cl_color is write protected.
[02:38:12] Unknown command "0"
[02:38:12] Unknown command "1"
[02:38:12] Unknown command "2"
[02:38:12] Unknown command "0"
[02:38:12] Unknown command "1"
[02:38:12] Unknown command "2"
[02:38:12] Unknown command "3"
[02:38:12] Unknown command "4"
[02:38:12] 
[02:38:12] 
[02:38:12] DOOM 2: Hell on Earth
[02:38:12] 
[02:38:12] adding C:\Users\Blair\source\repos\odamex-new\out\build\x64-Debug\odamex\odamex.wad (455 lumps)
[02:38:12] adding C:\Games\Doom\newwad\doom2.wad (2919 lumps)
[02:38:12] I_Init: Init hardware.
[02:38:12] I_InitSound: Initializing SDL's sound subsystem
[02:38:12] I_InitSound: Using SDL's audio driver (wasapi)
[02:38:12] I_InitSound: Initializing SDL_mixer
[02:38:12] I_InitSound: Using 32 channels (freq:44100, fmt:32784, chan:2)
[02:38:12] I_InitSound: sound module ready
[02:38:12] 0: MMSystem, Microsoft MIDI Mapper
[02:38:12] 1: MMSystem, Microsoft GS Wavetable Synth
[02:38:12] I_InitMusic: Music playback enabled using PortMidi.
[02:38:12] V_Init: rendering mode "direct3d"
[02:38:12] I_InitHardware: native resolution: 2560x1440 32bpp (window)
[02:38:12] I_InitInput: initializing SDL 2.0 keyboard
[02:38:12] I_InitInput: initializing SDL 2.0 mouse
[02:38:12] Z_Init: Using native allocator with OZone bookkeeping.
[02:38:13] V_Init: using windows video driver.
[02:38:13] R_Init: Init DOOM refresh daemon.
[02:38:13] M_Init: Init miscellaneous info.
[02:38:13] P_Init: Init Playloop state.
[02:38:13] S_Init: Setting up sound.
[02:38:13] S_Init: default sfx volume is 0.5
[02:38:13] S_Init: default music volume is 0
[02:38:13] ST_Init: Init status bar.
[02:38:13] r_optimize detected "sse2"
[02:38:13] 0: MMSystem, Microsoft MIDI Mapper
[02:38:13] 1: MMSystem, Microsoft GS Wavetable Synth
[02:38:13] I_InitMusic: Music playback enabled using PortMidi.
[02:38:13] CL_DownloadInit: Init HTTP subsystem (libcurl 8.16.0)
[02:38:13] D_CheckNetGame: Checking network game status.
[02:38:13] Bound to local port 10667
[02:38:13] 
[02:38:13]  Odamex Client Initialized 
[02:38:13] 
[02:38:13] Connecting to 127.0.0.1:10666...
[02:38:13] Found server at 127.0.0.1:10666.
[02:38:13] 
[02:38:13] > Hostname: [WDL] doomleague.org - Monday Night Horde
[02:38:13] > DOOM2.WAD
[02:38:13]    25E1459CA71D321525F84628F45CA8CD
[02:38:13] > ODAHORDE_230421.WAD
[02:38:13]    CB596D80C4465158B40ADD73CD26C5D8
[02:38:13] > Map: MAP01
[02:38:13] > Server Version 13.0.0
[02:38:13] 
[02:38:13] Could not resolve resource file "ODAHORDE_230421.WAD".
[02:38:13] 
[02:38:13] DOOM 2: Hell on Earth
[02:38:13] 
[02:38:13] adding C:\Users\Blair\source\repos\odamex-new\out\build\x64-Debug\odamex\odamex.wad (455 lumps)
[02:38:13] adding C:\Games\Doom\newwad\doom2.wad (2919 lumps)
[02:38:13] Need to download "ODAHORDE_230421.WAD", disconnecting from server...
[02:38:13] Checking for file at https://doomshack.org/uploads/ODAHORDE_230421.WAD...
[02:38:18] Checking for file at https://doomshack.org/uploads/odahorde_230421.wad...
[02:38:23] Checking for file at https://doomshack.org/uploads/ODAHORDE_230421.WAD...
[02:38:28] Could not find ODAHORDE_230421.WAD at https://doomshack.org/uploads/ (Timeout was reached)...
[02:38:28] Checking for file at http://grandpachuck.org/files/wads/ODAHORDE_230421.WAD...
[02:38:28] Checking for file at http://grandpachuck.org/files/wads/odahorde_230421.wad...
[02:38:29] Checking for file at http://grandpachuck.org/files/wads/ODAHORDE_230421.WAD...
[02:38:29] Could not find ODAHORDE_230421.WAD at http://grandpachuck.org/files/wads/ (HTTP response code said error)...
[02:38:29] Checking for file at https://downloadbox.captainpollutiontv.de/DooM/WADSEEKER/ODAHORDE_230421.WAD...
[02:38:29] Checking for file at https://downloadbox.captainpollutiontv.de/DooM/WADSEEKER/odahorde_230421.wad...
[02:38:29] Checking for file at https://downloadbox.captainpollutiontv.de/DooM/WADSEEKER/ODAHORDE_230421.WAD...
[02:38:30] Could not find ODAHORDE_230421.WAD at https://downloadbox.captainpollutiontv.de/DooM/WADSEEKER/ (SSL peer certificate or SSH remote key was not OK)...
[02:38:30] Checking for file at https://static.audrealms.org/wads/ODAHORDE_230421.WAD...
[02:38:31] Checking for file at https://static.audrealms.org/wads/odahorde_230421.wad...
[02:38:33] Found file at https://audrealms.org/zandronum/download.php?file=odahorde_230421.wad.
[02:38:33] Downloading https://audrealms.org/zandronum/download.php?file=odahorde_230421.wad...
[02:38:38] Saved to location "C:\Users\Blair\source\repos\odamex-new\out\build\x64-Debug\odamex\downloads\ODAHORDE_230421.WAD".
[02:38:38] Download completed at 4.54 MB/s.
[02:38:38] Connecting to 127.0.0.1:10666...
[02:38:38] Found server at 127.0.0.1:10666.
[02:38:38] 
[02:38:38] > Hostname: [WDL] doomleague.org - Monday Night Horde
[02:38:38] > DOOM2.WAD
[02:38:38]    25E1459CA71D321525F84628F45CA8CD
[02:38:38] > ODAHORDE_230421.WAD
[02:38:38]    CB596D80C4465158B40ADD73CD26C5D8
[02:38:38] > Map: MAP01
[02:38:38] > Server Version 13.0.0
[02:38:38] 
[02:38:38] 
[02:38:38] 
[02:38:38] DOOM 2: Hell on Earth
[02:38:38] 
[02:38:38] adding C:\Users\Blair\source\repos\odamex-new\out\build\x64-Debug\odamex\odamex.wad (455 lumps)
[02:38:38] adding C:\Games\Doom\newwad\doom2.wad (2919 lumps)
[02:38:38] adding C:\Users\Blair\source\repos\odamex-new\out\build\x64-Debug\odamex\downloads\ODAHORDE_230421.WAD (3037 lumps)
[02:38:38] adding DEHACKED lump
[02:38:38]  (DeHackEd patch)
[02:38:38] Joining server...
[02:38:38] Requesting server state...
[02:38:38] Wave 1: "From Parthoris With Love"
[02:38:38] 
[02:38:38] 
[02:38:38] MAP01: "Bled Simple" by Ralphis
[02:38:38] 
[02:38:38] Player has connected.
[02:38:38] 
[02:38:45] Configuration saved to C:\Users\Blair\source\repos\odamex-new\out\build\x64-Debug\odamex\odamex.cfg.
```