### PR TITLE
Linux/BSD install fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,12 @@ if(NOT APPLE)
     install(FILES ${CONFIG_SAMPLES}
       DESTINATION ${CMAKE_INSTALL_DATADIR}/odamex/config-samples
       COMPONENT common)
+    install(FILES packaging/linux/net.odamex.Odamex.metainfo.xml
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo
+      COMPONENT common)
+    install(FILES packaging/linux/net.odamex.Odamex.releases.xml
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo/releases
+      COMPONENT common)
 
     option(ODAMEX_COMPONENT_PACKAGES "Create several rpm/deb packages for repository maintainers." OFF)
     if(ODAMEX_COMPONENT_PACKAGES)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -333,6 +333,20 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     install(TARGETS odamex
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
       COMPONENT client)
+    install(FILES ${CMAKE_SOURCE_DIR}/packaging/linux/net.odamex.Odamex.Client.desktop
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/applications
+      COMPONENT client)
+    install(FILES ${CMAKE_SOURCE_DIR}/media/icon_odamex_512.png
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps
+      RENAME net.odamex.Odamex.Client.png
+      COMPONENT client)
+    install(FILES ${CMAKE_SOURCE_DIR}/media/icon_odademo_512.png
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/mimetypes
+      RENAME net.odamex.Odamex-application-odamex-demo.png
+      COMPONENT client)
+    install(FILES ${CMAKE_SOURCE_DIR}/packaging/linux/net.odamex.Odamex-mime.xml
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages
+      COMPONENT client)
   endif()
 endif()
 

--- a/odalaunch/CMakeLists.txt
+++ b/odalaunch/CMakeLists.txt
@@ -118,11 +118,11 @@ if(wxWidgets_FOUND)
       COMPONENT odalaunch)
     install(FILES ${CMAKE_SOURCE_DIR}/packaging/linux/net.odamex.Odamex.Launcher.desktop
       DESTINATION ${CMAKE_INSTALL_DATADIR}/applications
-      COMPONENT client)
+      COMPONENT odalaunch)
     install(FILES ${CMAKE_SOURCE_DIR}/media/icon_odalaunch_512.png
       DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps
       RENAME net.odamex.Odamex.Launcher.png
-      COMPONENT client)
+      COMPONENT odalaunch)
   endif()
 endif()
 

--- a/odalaunch/CMakeLists.txt
+++ b/odalaunch/CMakeLists.txt
@@ -116,6 +116,13 @@ if(wxWidgets_FOUND)
     install(TARGETS odalaunch
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
       COMPONENT odalaunch)
+    install(FILES ${CMAKE_SOURCE_DIR}/packaging/linux/net.odamex.Odamex.Launcher.desktop
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/applications
+      COMPONENT client)
+    install(FILES ${CMAKE_SOURCE_DIR}/media/icon_odalaunch_512.png
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps
+      RENAME net.odamex.Odamex.Launcher.png
+      COMPONENT client)
   endif()
 endif()
 

--- a/packaging/flatpak/flatpak-post-install.sh
+++ b/packaging/flatpak/flatpak-post-install.sh
@@ -13,41 +13,6 @@ set -x
 # Install timidity config
 install -Dm644 packaging/flatpak/timidity.cfg /app/etc/timidity.cfg
 
-# Install the AppStream metadata file.
-projectId=net.odamex.Odamex
-metadataDir=/app/share/metainfo
-install -Dm644 packaging/linux/$projectId.metainfo.xml -t $metadataDir/
-install -Dm644 packaging/linux/$projectId.releases.xml -t $metadataDir/releases/
-
-# Install the odd demo filetype
-iconDir=/app/share/icons/hicolor/512x512/mimetypes
-install -Dm644 media/icon_odademo_512.png $iconDir/$projectId-application-odamex-demo.png
-mimeDir=/app/share/mime/packages/
-install -Dm644 packaging/linux/$projectId-mime.xml $mimeDir/$projectId-mime.xml
-
-# Install the icons and .desktop files for the executables
-oda_install() {
-    local projectIdExt=$1
-    local executableName=$2
-
-    # Install the icon.
-    iconDir=/app/share/icons/hicolor/512x512/apps
-    install -Dm644 media/icon_${executableName}_512.png $iconDir/$projectId.$projectIdExt.png
-
-    # Install the desktop file.
-    local desktopFileDir=/app/share/applications
-    install -Dm644 packaging/linux/$projectId.$projectIdExt.desktop -t $desktopFileDir/
-}
-
-# Client app
-oda_install Client odamex
-
-# Server app
-oda_install Server odasrv
-
-# Launcher app
-oda_install Launcher odalaunch
-
 # Install helper script
 install -Dm755 packaging/flatpak/select-exe.sh /app/bin/select-exe
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -101,6 +101,13 @@ else()
   install(TARGETS odasrv
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     COMPONENT server)
+  install(FILES ${CMAKE_SOURCE_DIR}/packaging/linux/net.odamex.Odamex.Server.desktop
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/applications
+    COMPONENT server)
+  install(FILES ${CMAKE_SOURCE_DIR}/media/icon_odasrv_512.png
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps
+    RENAME net.odamex.Odamex.Server.png
+    COMPONENT server)
 endif()
 
 if(TARGET odasrv)


### PR DESCRIPTION
Currently, we only install metainfo, icons, desktop files, and mimetypes through a special script for Flatpak builds. These should be installed through a normal `cmake --install`, for users who prefer compiling themselves or for 3rd party packaging.