### PR TITLE
CMake: switch the common library to using PUBLIC sources and consolidate common dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # CMake >= 3.13 needed for -S and -B params in library compilation.
-# CMake >= 3.19 needed for policy CMP0112: target-dependent generator expressions
-#               do not implicitly add target-level dependencies.
+# CMake >= 3.19 needed for:
+#               - policy CMP0112: target-dependent generator expressions
+#                 do not implicitly add target-level dependencies.
+#               - add_library(<name> INTERFACE) plus PUBLIC target_sources.
 # CMake >= 3.20 needed for restricted set of generator expressions allowed in custom command OUTPUT args.
 #
 # Note that if you are running Linux, there are many ways to get newer
@@ -190,8 +192,8 @@ add_subdirectory(wad)
 
 # Subdirectories for Odamex projects
 if(BUILD_CLIENT OR BUILD_SERVER OR BUILD_TESTS)
-  add_subdirectory(common)
   add_subdirectory(odaproto)
+  add_subdirectory(common)
 endif()
 if(BUILD_CLIENT)
   add_subdirectory(client)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -47,6 +47,9 @@ source_group("Client" FILES ${CLIENT_SOURCES})
 source_group("SDL" FILES ${CLIENT_SDL_SOURCES})
 source_group("GUI" FILES ${CLIENT_GUI_SOURCES})
 
+get_target_property(COMMON_SOURCES odacommon INTERFACE_SOURCES)
+source_group("Common" FILES ${COMMON_SOURCES})
+
 # Client definitions
 include_directories(${COMMON_DIR} ${CLIENT_DIR})
 

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -216,16 +216,6 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     target_link_libraries(odamex SDL2 mpg123 modplug vorbisfile vorbis opusfile opus ogg EGL glapi drm_nouveau nx m)
   endif()
 
-  # X11 configuration
-  # TODO: do we need to update this at all for wayland?
-  if (UNIX AND NOT APPLE)
-    find_package(X11)
-    if (X11_FOUND)
-      target_compile_definitions(odamex PRIVATE X11)
-      target_link_libraries(odamex X11::X11)
-    endif()
-  endif()
-
   if (TARGET odawad)
       add_dependencies(odamex odawad)
   endif()

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -15,9 +15,6 @@ endif()
 # Enable default SIMD settings for standard builds.
 option(USE_DEFAULT_SIMD "Use default SIMD optimization settings" ON)
 
-# #define CLIENT_APP for use in the source code
-add_definitions(-DCLIENT_APP)
-
 # Client
 set(CLIENT_DIR sdl src)
 file(GLOB CLIENT_SOURCES src/*.cpp src/*.h)
@@ -47,26 +44,14 @@ source_group("Client" FILES ${CLIENT_SOURCES})
 source_group("SDL" FILES ${CLIENT_SDL_SOURCES})
 source_group("GUI" FILES ${CLIENT_GUI_SOURCES})
 
-get_target_property(COMMON_SOURCES odacommon INTERFACE_SOURCES)
-source_group("Common" FILES ${COMMON_SOURCES})
+get_target_property(COMMON_DIRS     odacommon INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(COMMON_SOURCES  odacommon INTERFACE_SOURCES)
 
-# Client definitions
-include_directories(${COMMON_DIR} ${CLIENT_DIR})
+source_group("Common" FILES ${COMMON_SOURCES})
 
 # Make sure we don't find libraries that are in Program Files/Odamex
 if(WIN32)
   list(REMOVE_ITEM CMAKE_SYSTEM_PREFIX_PATH ${CMAKE_INSTALL_PREFIX})
-endif()
-
-# X11 configuration
-# TODO: do we need to update this at all for wayland?
-if(UNIX AND NOT APPLE)
-  find_package(X11)
-  if(X11_FOUND)
-    add_definitions(-DX11)
-    include_directories(${X11_INCLUDE_DIR})
-    link_libraries(${X11_LIBRARIES})
-  endif()
 endif()
 
 # PortMidi configuration
@@ -141,8 +126,13 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     set(TEXTSCREEN_HEADERS ${TEXTSCREEN_DIR}/txt_sdl.h ${TEXTSCREEN_DIR}/txt_main.h)
     set(TEXTSCREEN_SOURCES ${TEXTSCREEN_DIR}/txt_sdl.cpp)
 
-    include_directories(${TEXTSCREEN_DIR})
     add_library(${TEXTSCREEN_LIBRARY} STATIC ${TEXTSCREEN_SOURCES} ${TEXTSCREEN_HEADERS})
+    target_include_directories(${TEXTSCREEN_LIBRARY}
+        PUBLIC
+            ${TEXTSCREEN_DIR}
+        PRIVATE
+            ${COMMON_DIRS}
+        )
   endif()
 
   if(TARGET SDL::SDL)
@@ -151,18 +141,13 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     target_link_libraries(${TEXTSCREEN_LIBRARY} SDL2::SDL2)
   endif()
 
-  if (NOT GCONSOLE)
-    target_include_directories(${TEXTSCREEN_LIBRARY} PRIVATE ../common)
-  else()
-    include_directories(../common)
-  endif()
-
   add_executable(odamex MACOSX_BUNDLE WIN32
     ${CLIENT_SOURCES} ${CLIENT_SDL_SOURCES} ${CLIENT_GUI_SOURCES})
   odamex_target_settings(TARGET odamex)
   odamex_target_errors(odamex)
 
   target_link_libraries(odamex odacommon)
+  target_include_directories(odamex PRIVATE src sdl)
   target_compile_definitions(odamex PRIVATE CLIENT_APP)
 
   if(USE_DEFAULT_SIMD)
@@ -231,8 +216,14 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     target_link_libraries(odamex SDL2 mpg123 modplug vorbisfile vorbis opusfile opus ogg EGL glapi drm_nouveau nx m)
   endif()
 
-  if(UNIX AND X11_FOUND AND NOT APPLE)
-      target_link_libraries(odamex X11)
+  # X11 configuration
+  # TODO: do we need to update this at all for wayland?
+  if (UNIX AND NOT APPLE)
+    find_package(X11)
+    if (X11_FOUND)
+      target_compile_definitions(odamex PRIVATE X11)
+      target_link_libraries(odamex X11::X11)
+    endif()
   endif()
 
   if (TARGET odawad)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -43,9 +43,7 @@ if(NOT GCONSOLE)
 endif()
 
 # Tag source files with correct directories
-get_target_property(COMMON_SOURCES odamex-common INTERFACE_SOURCES)
 source_group("Client" FILES ${CLIENT_SOURCES})
-source_group("Common" FILES ${COMMON_SOURCES})
 source_group("SDL" FILES ${CLIENT_SDL_SOURCES})
 source_group("GUI" FILES ${CLIENT_GUI_SOURCES})
 
@@ -157,9 +155,12 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
   endif()
 
   add_executable(odamex MACOSX_BUNDLE WIN32
-    ${CLIENT_SOURCES} ${CLIENT_SDL_SOURCES} ${COMMON_SOURCES} ${CLIENT_GUI_SOURCES})
+    ${CLIENT_SOURCES} ${CLIENT_SDL_SOURCES} ${CLIENT_GUI_SOURCES})
   odamex_target_settings(TARGET odamex)
   odamex_target_errors(odamex)
+
+  target_link_libraries(odamex odacommon)
+  target_compile_definitions(odamex PRIVATE CLIENT_APP)
 
   if(USE_DEFAULT_SIMD)
     if(ODAMEX_TARGET_ARCH STREQUAL "amd64")
@@ -193,8 +194,6 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     set_target_properties(odamex PROPERTIES LINK_FLAGS "/MANIFEST:NO")
   endif()
 
-  target_link_libraries(odamex ${TEXTSCREEN_LIBRARY})
-  target_link_libraries(odamex odamex-common odaproto tinylibs)
   if(TARGET SDL::SDL)
     target_link_libraries(odamex SDL::SDL)
     if(TARGET SDL::SDLmain)
@@ -219,35 +218,18 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
     endif()
   endif()
 
-  if(USE_INTERNAL_JSONCPP)
-    target_link_libraries(odamex jsoncpp_static)
-  else()
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(JSONCPP jsoncpp REQUIRED IMPORTED_TARGET)
-    target_link_libraries(odamex PkgConfig::JSONCPP)
-  endif()
-
   if(ENABLE_PORTMIDI)
     target_link_libraries(odamex ${PORTMIDI_LIBRARY})
   endif()
 
-  target_link_libraries(odamex ZLIB::ZLIB PNG::PNG fmt::fmt minilzo cpptrace::cpptrace libADLMIDI::ADLMIDI_static curl_interface)
+  target_link_libraries(odamex ${TEXTSCREEN_LIBRARY} PNG::PNG libADLMIDI::ADLMIDI_static curl_interface)
 
-  if(WIN32)
-    target_link_libraries(odamex winmm wsock32 shlwapi)
-  elseif(APPLE)
-    target_link_libraries(odamex ${APPLE_FRAMEWORKS})
-  elseif(NSWITCH)
+  if(NSWITCH)
     target_link_libraries(odamex SDL2 mpg123 modplug vorbisfile vorbis opusfile opus ogg EGL glapi drm_nouveau nx m)
-  elseif(SOLARIS)
-    target_link_libraries(odamex socket nsl)
   endif()
 
-  if(UNIX AND NOT APPLE)
-    target_link_libraries(odamex rt)
-    if(X11_FOUND)
+  if(UNIX AND X11_FOUND AND NOT APPLE)
       target_link_libraries(odamex X11)
-    endif()
   endif()
 
   if (TARGET odawad)
@@ -265,6 +247,8 @@ if(TARGET SDL2::SDL2 OR TARGET SDL::SDL)
   set(MACOSX_BUNDLE_GUI_IDENTIFIER net.odamex.odamex)
 
   if(APPLE)
+    target_link_libraries(odamex ${APPLE_FRAMEWORKS})
+
     add_custom_command(
       TARGET odamex
       POST_BUILD

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -3,15 +3,34 @@ file(GLOB COMMON_SOURCES *.cpp)
 
 configure_file(git_describe.h.in "${CMAKE_CURRENT_BINARY_DIR}/git_describe.h")
 
-add_library(odamex-common INTERFACE)
-target_sources(odamex-common INTERFACE ${COMMON_SOURCES} ${COMMON_HEADERS})
-target_include_directories(odamex-common INTERFACE . ${CMAKE_CURRENT_BINARY_DIR})
-
-if(UNIX)
+if (UNIX)
   include(CheckSymbolExists)
   check_symbol_exists(backtrace "execinfo.h" HAVE_BACKTRACE)
+endif()
 
-  if(HAVE_BACKTRACE)
-    target_compile_definitions(odamex-common INTERFACE HAVE_BACKTRACE)
-  endif()
+add_library(odacommon INTERFACE)
+target_sources(odacommon PUBLIC  ${COMMON_SOURCES} ${COMMON_HEADERS} "${CMAKE_CURRENT_BINARY_DIR}/git_describe.h")
+
+target_include_directories(odacommon INTERFACE . ${CMAKE_CURRENT_BINARY_DIR})
+if (HAVE_BACKTRACE)
+    target_compile_definitions(odacommon INTERFACE HAVE_BACKTRACE)
+endif()
+
+target_link_libraries(odacommon INTERFACE odaproto fmt::fmt tinylibs ZLIB::ZLIB minilzo cpptrace::cpptrace)
+
+if (WIN32)
+    target_link_libraries(odacommon INTERFACE winmm wsock32 shlwapi)
+elseif (SOLARIS)
+    target_link_libraries(odacommon INTERFACE socket nsl)
+endif()
+if (UNIX AND NOT APPLE)
+    target_link_libraries(odacommon INTERFACE rt)
+endif()
+
+if(USE_INTERNAL_JSONCPP)
+    target_link_libraries(odacommon INTERFACE jsoncpp_static)
+else()
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(JSONCPP jsoncpp REQUIRED IMPORTED_TARGET)
+  target_link_libraries(odasrv odacommon PkgConfig::JSONCPP)
 endif()

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -9,7 +9,7 @@ if (UNIX)
 endif()
 
 add_library(odacommon INTERFACE)
-target_sources(odacommon PUBLIC  ${COMMON_SOURCES} ${COMMON_HEADERS} "${CMAKE_CURRENT_BINARY_DIR}/git_describe.h")
+target_sources(odacommon PUBLIC ${COMMON_SOURCES} ${COMMON_HEADERS} "${CMAKE_CURRENT_BINARY_DIR}/git_describe.h")
 
 target_include_directories(odacommon INTERFACE . ${CMAKE_CURRENT_BINARY_DIR})
 if (HAVE_BACKTRACE)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -11,9 +11,6 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 endif()
 
-# #define SERVER_APP for use in the source code
-add_definitions(-DSERVER_APP)
-
 # Server
 file(GLOB SERVER_SOURCES src/*.cpp src/*.h)
 if(WIN32)
@@ -22,28 +19,24 @@ if(WIN32)
   list(APPEND SERVER_WIN32_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/server.rc")
 endif()
 
-# Tag source files with correct directories
-get_target_property(COMMON_SOURCES odamex-common INTERFACE_SOURCES)
-source_group("Common" FILES ${COMMON_SOURCES})
-source_group("Server" FILES ${SERVER_SOURCES})
-source_group("Win32" FILES ${SERVER_WIN32_SOURCES})
-
-# Server definitions
-if(USE_MINIUPNP)
-  add_definitions(-DODA_HAVE_MINIUPNP)
-endif()
-
-if(WIN32 AND NOT MSVC)
-  add_definitions(-DWINVER=0x0500)
-endif()
-
-add_executable(odasrv
-  ${COMMON_SOURCES} ${SERVER_SOURCES} ${SERVER_WIN32_SOURCES})
+add_executable(odasrv ${SERVER_SOURCES} ${SERVER_WIN32_SOURCES})
 odamex_target_settings(TARGET odasrv)
 odamex_target_errors(odasrv)
 
+target_link_libraries(odasrv odacommon)
+target_compile_definitions(odasrv PRIVATE SERVER_APP)
+
+# Server definitions
+if (USE_MINIUPNP)
+    target_compile_definitions(odasrv PRIVATE ODA_HAVE_MINIUPNP)
+endif()
+
+if (WIN32 AND NOT MSVC)
+    target_compile_definitions(odasrv PRIVATE WINVER=0x0500)
+endif()
+
 target_include_directories(odasrv PRIVATE src)
-if(WIN32)
+if (WIN32)
   target_include_directories(odasrv PRIVATE win32)
 
   # We need to call SetProcessInformation to disable power throttling,
@@ -55,18 +48,8 @@ if(WIN32)
   set_target_properties(odasrv PROPERTIES LINK_FLAGS "/MANIFEST:NO")
 endif()
 
-target_link_libraries(odasrv fmt::fmt tinylibs ZLIB::ZLIB odamex-common odaproto minilzo cpptrace::cpptrace)
-
 if (TARGET odawad)
     add_dependencies(odasrv odawad)
-endif()
-
-if(USE_INTERNAL_JSONCPP)
-  target_link_libraries(odasrv jsoncpp_static)
-else()
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(JSONCPP jsoncpp REQUIRED IMPORTED_TARGET)
-  target_link_libraries(odasrv PkgConfig::JSONCPP)
 endif()
 
 if(USE_MINIUPNP)
@@ -79,17 +62,9 @@ if(USE_MINIUPNP)
   endif()
 endif()
 
-if(WIN32)
-  target_link_libraries(odasrv winmm wsock32 shlwapi)
-elseif(SOLARIS)
-  target_link_libraries(odasrv socket nsl)
-elseif(UNIX)
+if(UNIX)
   find_package(Threads REQUIRED)
   target_link_libraries(odasrv pthread)
-endif()
-
-if(UNIX AND NOT APPLE)
-  target_link_libraries(odasrv rt)
 endif()
 
 if(APPLE)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -26,6 +26,11 @@ odamex_target_errors(odasrv)
 target_link_libraries(odasrv odacommon)
 target_compile_definitions(odasrv PRIVATE SERVER_APP)
 
+get_target_property(COMMON_SOURCES odacommon INTERFACE_SOURCES)
+source_group("Common" FILES ${COMMON_SOURCES})
+source_group("Server" FILES ${SERVER_SOURCES})
+source_group("Win32" FILES ${SERVER_WIN32_SOURCES})
+
 # Server definitions
 if (USE_MINIUPNP)
     target_compile_definitions(odasrv PRIVATE ODA_HAVE_MINIUPNP)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -5,19 +5,11 @@ if(COMMAND cmake_policy)
   cmake_policy(SET CMP0005 NEW)
 endif(COMMAND cmake_policy)
 
-# #define TEST_APP for use in the source code
-add_definitions(-DTEST_APP)
-add_definitions(-DODAMEX_NO_GITVER)
-
 file(GLOB TEST_SOURCES src/*.cpp src/*.h test/*.cpp test/*.h)
 
 set(COMMON_DIR "${CMAKE_SOURCE_DIR}/common")
 
-get_target_property(COMMON_SOURCES odamex-common INTERFACE_SOURCES)
 source_group("Test" FILES ${TEST_SOURCES})
-source_group("Common" FILES ${COMMON_SOURCES})
-
-include_directories(${COMMON_DIR} src)
 
 add_executable(odagtest
     ${COMMON_SOURCES}
@@ -25,23 +17,10 @@ add_executable(odagtest
     "${CMAKE_SOURCE_DIR}/client/src/PlayerStateRoller.cpp"
     "${CMAKE_SOURCE_DIR}/client/src/PlayerStateRoller.h"
     )
-target_include_directories(odagtest PRIVATE "${CMAKE_SOURCE_DIR}/client/src")
+target_include_directories(odagtest PRIVATE src "${CMAKE_SOURCE_DIR}/client/src")
 
-target_link_libraries(odagtest GTest::gtest_main)
-target_link_libraries(odagtest fmt::fmt tinylibs ZLIB::ZLIB odamex-common odaproto minilzo curl_interface cpptrace::cpptrace)
-if(USE_INTERNAL_JSONCPP)
-  target_link_libraries(odagtest jsoncpp_static)
-else()
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(JSONCPP jsoncpp REQUIRED IMPORTED_TARGET)
-  target_link_libraries(odagtest PkgConfig::JSONCPP)
-endif()
-
-if(WIN32)
-  target_link_libraries(odagtest winmm wsock32 shlwapi)
-elseif(UNIX AND NOT APPLE)
-  target_link_libraries(odagtest rt)
-endif()
+target_link_libraries(odagtest GTest::gtest_main odacommon curl_interface)
+target_compile_definitions(odagtest PRIVATE TEST_APP ODAMEX_NO_GITVER)
 
 odamex_target_settings(TARGET odagtest NO_DEPLOYMENT_ARTIFACT)
 odamex_target_errors(odagtest)


### PR DESCRIPTION
The prime driver for this is to let CMake replicate the common sources to the executable targets directly and resolve a dependency issue caused by being explicitly added to the executable targets.

This includes the cleanup items:

- Let `odacommon` bring its dependencies with it.
- Switch from more of the old CMake commands to CMake 3's metatarget based commands.
- Remove direct dependency on X11 libs.
