### PR TITLE
Skip empty demos during the demoloop

### DIFF
--- a/client/src/cl_game.cpp
+++ b/client/src/cl_game.cpp
@@ -1983,7 +1983,7 @@ void G_DoPlayDemo(bool justStreamInput)
 			Z_Free(demobuffer);
 
 		PrintFmt(PRINT_WARNING, "DOOM Demo file too short\n");
-		gameaction = ga_fullconsole;
+		gameaction = singledemo ? ga_fullconsole : ga_nothing;
 		return;
 	}
 


### PR DESCRIPTION
We already skip over unrecognized formats, so this is more consistent with that as well as with ports like Woof. It's also just annoying for players who have a wad that happens to have an empty demo to have it suddenly jump to the fullscreen console if they sit on the title screen for too long.