### PR TITLE
[BUGFIX] `show_messages` affects chat

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -123,17 +123,18 @@ static struct NotifyText
 } NotifyStrings[NUMNOTIFIES];
 
 // Default Printlevel
-std::array<int, 9> PrintColors =
-{	CR_RED,		// Pickup
-	CR_GOLD,	// Obituaries
-	CR_GRAY,	// Messages
-	CR_GREEN,	// Chat
-	CR_GREEN,	// Team chat
+constexpr std::array PrintColors =
+{
+	CR_RED,    // Pickup
+	CR_GOLD,   // Obituaries
+	CR_GRAY,   // Messages
+	CR_GREEN,  // Chat
+	CR_GREEN,  // Team chat
 
-	CR_GOLD,	// Server chat
-	CR_YELLOW,	// Warning messages
-	CR_RED,		// Critical messages
-	CR_GOLD,	// Centered Messages
+	CR_GOLD,   // Server chat
+	CR_YELLOW, // Warning messages
+	CR_RED,    // Critical messages
+	CR_GOLD,   // Centered Messages
 };
 
 

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -118,13 +118,12 @@ int V_TextScaleYAmount();
 static struct NotifyText
 {
 	int timeout;
-	int printlevel;
+	printlevel_t printlevel;
 	byte text[256];
 } NotifyStrings[NUMNOTIFIES];
 
 // Default Printlevel
-#define PRINTLEVELS 9 //(5 + 3)
-int PrintColors[PRINTLEVELS] =
+std::array<int, 9> PrintColors =
 {	CR_RED,		// Pickup
 	CR_GOLD,	// Obituaries
 	CR_GRAY,	// Messages
@@ -151,7 +150,7 @@ class ConsoleLine
 public:
 	ConsoleLine();
 	ConsoleLine(const std::string& _text, const std::string& _color_code = "\034-",	// TEXTCOLOR_ESCAPE
-			int _print_level = PRINT_HIGH);
+			printlevel_t _print_level = PRINT_HIGH);
 
 	void join(const ConsoleLine& other);
 	ConsoleLine split(size_t max_width);
@@ -160,7 +159,7 @@ public:
 	std::string		text;
 	std::string		color_code;
 	bool			wrapped;
-	int				print_level;
+	printlevel_t	print_level;
 	int				timeout;
 };
 
@@ -178,7 +177,7 @@ ConsoleLine::ConsoleLine()
 }
 
 ConsoleLine::ConsoleLine(const std::string& _text, const std::string& _color_code,
-                         int _print_level)
+                         printlevel_t _print_level)
     : text(_text), color_code(_color_code), wrapped(false), print_level(_print_level),
       timeout(gametic + int(con_notifytime * TICRATE))
 {
@@ -915,7 +914,7 @@ CVAR_FUNC_IMPL(msg4color)
 
 CVAR_FUNC_IMPL(msgmidcolor)
 {
-	setmsgcolor(PRINTLEVELS-1, var.cstring());
+	setmsgcolor(PrintColors.size()-1, var.cstring());
 }
 
 CVAR_FUNC_IMPL(con_scaletext)
@@ -1142,7 +1141,7 @@ static void setmsgcolor(int index, const char *color)
 // Prioritise messages on top of screen
 // Break up the lines so that they wrap around the screen boundary
 //
-void C_AddNotifyString(int printlevel, const char* color_code, const char* source)
+void C_AddNotifyString(printlevel_t printlevel, const char* color_code, const char* source)
 {
 	static enum
 	{
@@ -1156,8 +1155,21 @@ void C_AddNotifyString(int printlevel, const char* color_code, const char* sourc
 
 	const size_t len = strlen(source);
 
-	if ((printlevel != 128 && !show_messages) || len == 0 ||
-		(gamestate != GS_LEVEL && gamestate != GS_INTERMISSION) )
+	if (not show_messages)
+	{
+		switch (printlevel)
+		{
+			case PRINT_SHOWALWAYS:
+			case PRINT_CHAT:
+			case PRINT_TEAMCHAT:
+			case PRINT_SERVERCHAT:
+				break;
+			default:
+				return;
+		}
+	}
+
+	if (len == 0 || (gamestate != GS_LEVEL && gamestate != GS_INTERMISSION) )
 		return;
 
 	// Do not display filtered chat messages
@@ -1233,7 +1245,7 @@ static size_t C_PrintStringStdOut(std::string str)
 // Provide our own Printf() that is sensitive of the
 // console status (in or out of game).
 //
-static size_t C_PrintString(int printlevel, const char* color_code, const char* outline)
+static size_t C_PrintString(printlevel_t printlevel, const char* color_code, const char* outline)
 {
 	if (I_VideoInitialized() && !midprinting)
 	{
@@ -1248,7 +1260,7 @@ static size_t C_PrintString(int printlevel, const char* color_code, const char* 
 	if (printlevel == PRINT_FILTERCHAT)
 		printlevel = PRINT_CHAT;
 
-	if (printlevel == PRINT_FILTERHIGH)
+	if (printlevel == PRINT_FILTERHIGH || printlevel == PRINT_SHOWALWAYS)
 		printlevel = PRINT_HIGH;
 
 	const char* line_start = outline;
@@ -1258,9 +1270,12 @@ static size_t C_PrintString(int printlevel, const char* color_code, const char* 
 	// ...unless it's supposed to be formatted bold.
 	static char printlevel_color_code[3];
 
-	if (color_code && color_code[1] != '+' && printlevel >= 0 && printlevel < PRINTLEVELS)
+	// TODO: have a proper mapping of printlevel to color instead of converting print levels above and then indexing directly with it
+	const auto printcolorindex = static_cast<size_t>(printlevel);
+
+	if (color_code && color_code[1] != '+' && printcolorindex >= 0 && printcolorindex < PrintColors.size())
 	{
-		snprintf(printlevel_color_code, sizeof(printlevel_color_code), "\034%c", 'a' + PrintColors[printlevel]);
+		snprintf(printlevel_color_code, sizeof(printlevel_color_code), "\034%c", 'a' + PrintColors[printcolorindex]);
 		color_code = printlevel_color_code;
 	}
 
@@ -1279,7 +1294,8 @@ static size_t C_PrintString(int printlevel, const char* color_code, const char* 
 		str[len] = '\0';
 
 		const bool wrap_new_line = *line_end != '\n';
-		ConsoleLine new_line(str, color_code, wrap_new_line);
+		ConsoleLine new_line(str, color_code);
+		new_line.wrapped = wrap_new_line;
 
 		// Add a new line to ConsoleLineList if the last line in ConsoleLineList
 		// ends in \n, or add onto the last line if does not.
@@ -1364,7 +1380,7 @@ void C_LogString(const std::string& str)
 
 } // namespace
 
-size_t C_BasePrint(const int printlevel, const char* color_code, const std::string& str)
+size_t C_BasePrint(const printlevel_t printlevel, const char* color_code, const std::string& str)
 {
 	extern bool gameisdead;
 	if (gameisdead)
@@ -1522,14 +1538,14 @@ static void C_DrawNotifyText()
 	{
 		if (notify.timeout > gametic)
 		{
-			if (!show_messages && notify.printlevel != 128)
+			if (!show_messages && notify.printlevel != PRINT_SHOWALWAYS)
 				continue;
 
 			int color;
-			if (notify.printlevel >= PRINTLEVELS)
+			if (static_cast<size_t>(notify.printlevel) >= PrintColors.size())
 				color = CR_RED;
 			else
-				color = PrintColors[notify.printlevel];
+				color = PrintColors[static_cast<size_t>(notify.printlevel)];
 
 			screen->DrawTextStretched(color, 0, ypos, notify.text,
 						V_TextScaleXAmount(), V_TextScaleYAmount());
@@ -2072,7 +2088,7 @@ static bool C_HandleKey(const event_t& ev)
 		History.addString(text);
 		History.resetPosition();
 
-		PrintFmt(127, "]{}\n", text);
+		PrintFmt(PRINT_HIGH, "]{}\n", text);
 		AddCommandString(text);
 		CmdLine.clear();
 	}
@@ -2222,7 +2238,7 @@ static bool C_HandleKey(const event_t& ev)
 			History.addString(CmdLine.text);
 			History.resetPosition();
 
-			PrintFmt(127, "]{}\n", CmdLine.text.c_str());
+			PrintFmt(PRINT_HIGH, "]{}\n", CmdLine.text.c_str());
 			AddCommandString(CmdLine.text.c_str());
 			CmdLine.clear();
 			CmdCompletions.clear();
@@ -2417,7 +2433,7 @@ void C_DrawMid()
 
 		for (int i = 0; i < MidLines; i++, y += line_height)
 		{
-			screen->DrawTextStretched(PrintColors[PRINTLEVELS-1],
+			screen->DrawTextStretched(PrintColors.back(),
 					x - xscale * (MidMsg[i].width / 2),
 					y, reinterpret_cast<byte*>(MidMsg[i].string), xscale, yscale);
 		}

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -123,7 +123,7 @@ static struct NotifyText
 } NotifyStrings[NUMNOTIFIES];
 
 // Default Printlevel
-constexpr std::array PrintColors =
+std::array PrintColors =
 {
 	CR_RED,    // Pickup
 	CR_GOLD,   // Obituaries
@@ -1294,7 +1294,7 @@ static size_t C_PrintString(printlevel_t printlevel, const char* color_code, con
 		strncpy(str, line_start, len);
 		str[len] = '\0';
 
-		const bool wrap_new_line = *line_end != '\n';
+		const bool wrap_new_line = *line_end != '\n' || len > ConCols;
 		ConsoleLine new_line(str, color_code);
 		new_line.wrapped = wrap_new_line;
 

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -51,6 +51,7 @@
 
 #include <list>
 #include <algorithm>
+#include <utility>
 
 #ifdef __SWITCH__
 #include "nx_io.h"
@@ -150,7 +151,7 @@ class ConsoleLine
 {
 public:
 	ConsoleLine();
-	ConsoleLine(const std::string& _text, const std::string& _color_code = "\034-",	// TEXTCOLOR_ESCAPE
+	ConsoleLine(std::string _text, std::string _color_code = "\034-",	// TEXTCOLOR_ESCAPE
 			printlevel_t _print_level = PRINT_HIGH);
 
 	void join(const ConsoleLine& other);
@@ -177,9 +178,9 @@ ConsoleLine::ConsoleLine()
 {
 }
 
-ConsoleLine::ConsoleLine(const std::string& _text, const std::string& _color_code,
+ConsoleLine::ConsoleLine(std::string  _text, std::string  _color_code,
                          printlevel_t _print_level)
-    : text(_text), color_code(_color_code), wrapped(false), print_level(_print_level),
+    : text(std::move(_text)), color_code(std::move(_color_code)), wrapped(false), print_level(_print_level),
       timeout(gametic + int(con_notifytime * TICRATE))
 {
 }
@@ -886,36 +887,46 @@ static void TabComplete(TabCompleteDirection dir)
 	TabCycleStart();
 }
 
-static void setmsgcolor(int index, const char *color);
+namespace
+{
+
+void setmsgcolor(int index, int color)
+{
+	if (color < 0 || color >= NUM_TEXT_COLORS)
+		color = 0;
+	PrintColors[index] = static_cast<EColorRange>(color);
+}
+
+}
 
 CVAR_FUNC_IMPL(msg0color)
 {
-	setmsgcolor(0, var.cstring());
+	setmsgcolor(0, var.asInt());
 }
 
 CVAR_FUNC_IMPL(msg1color)
 {
-	setmsgcolor(1, var.cstring());
+	setmsgcolor(1, var.asInt());
 }
 
 CVAR_FUNC_IMPL(msg2color)
 {
-	setmsgcolor(2, var.cstring());
+	setmsgcolor(2, var.asInt());
 }
 
 CVAR_FUNC_IMPL(msg3color)
 {
-	setmsgcolor(3, var.cstring());
+	setmsgcolor(3, var.asInt());
 }
 
 CVAR_FUNC_IMPL(msg4color)
 {
-	setmsgcolor(4, var.cstring());
+	setmsgcolor(4, var.asInt());
 }
 
 CVAR_FUNC_IMPL(msgmidcolor)
 {
-	setmsgcolor(PrintColors.size()-1, var.cstring());
+	setmsgcolor(PrintColors.size()-1, var.asInt());
 }
 
 CVAR_FUNC_IMPL(con_scaletext)
@@ -1127,22 +1138,13 @@ static void C_SetConsoleDimensions(int width, int height)
 	}
 }
 
-static void setmsgcolor(int index, const char *color)
-{
-	int i = atoi(color);
-	if (i < 0 || i >= NUM_TEXT_COLORS)
-		i = 0;
-	PrintColors[index] = i;
-}
-
-
 //
 // C_AddNotifyString
 //
 // Prioritise messages on top of screen
 // Break up the lines so that they wrap around the screen boundary
 //
-void C_AddNotifyString(printlevel_t printlevel, const char* color_code, const char* source)
+void C_AddNotifyString(printlevel_t printlevel, const char* /*color_code*/, const char* source)
 {
 	static enum
 	{
@@ -1223,13 +1225,16 @@ void C_AddNotifyString(printlevel_t printlevel, const char* color_code, const ch
 	}
 }
 
+namespace
+{
+
 //
 // C_PrintStringStdOut
 //
 // Prints the given string to stdout, stripping away any color markup
 // escape codes.
 //
-static size_t C_PrintStringStdOut(std::string str)
+size_t C_PrintStringStdOut(std::string str)
 {
 	StripColorCodes(str);
 
@@ -1246,7 +1251,7 @@ static size_t C_PrintStringStdOut(std::string str)
 // Provide our own Printf() that is sensitive of the
 // console status (in or out of game).
 //
-static size_t C_PrintString(printlevel_t printlevel, const char* color_code, const char* outline)
+size_t C_PrintString(printlevel_t printlevel, const char* color_code, const char* outline)
 {
 	if (I_VideoInitialized() && !midprinting)
 	{
@@ -1325,9 +1330,6 @@ static size_t C_PrintString(printlevel_t printlevel, const char* color_code, con
 
 	return strlen(outline);
 }
-
-namespace
-{
 
 // struct tm counts years from 1900.
 constexpr int TM_YEAR_BASE = 1900;
@@ -2239,8 +2241,8 @@ static bool C_HandleKey(const event_t& ev)
 			History.addString(CmdLine.text);
 			History.resetPosition();
 
-			PrintFmt(PRINT_HIGH, "]{}\n", CmdLine.text.c_str());
-			AddCommandString(CmdLine.text.c_str());
+			PrintFmt(PRINT_HIGH, "]{}\n", CmdLine.text);
+			AddCommandString(CmdLine.text);
 			CmdLine.clear();
 			CmdCompletions.clear();
 
@@ -2435,7 +2437,7 @@ void C_DrawMid()
 		for (int i = 0; i < MidLines; i++, y += line_height)
 		{
 			screen->DrawTextStretched(PrintColors.back(),
-					x - xscale * (MidMsg[i].width / 2),
+					x - (xscale * (MidMsg[i].width / 2)),
 					y, reinterpret_cast<byte*>(MidMsg[i].string), xscale, yscale);
 		}
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -375,6 +375,8 @@ CVAR(				mute_spectators, "0", "Mute spectators chat.",
 CVAR(				mute_enemies, "0", "Mute enemy players chat.",
 					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
+CVAR(				mute_chat, "0", "Mute all player chat.",
+					CVARTYPE_BOOL, CVAR_CLIENTARCHIVE)
 
 // Maximum number of clients who can connect to the server
 CVAR (sv_maxclients,       "0", "maximum clients who can connect to server", CVARTYPE_BYTE, CVAR_SERVERINFO | CVAR_LATCH | CVAR_NOENABLEDISABLE)

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -168,6 +168,7 @@ EXTERN_CVAR (cl_predictsectors)
 
 EXTERN_CVAR (mute_spectators)
 EXTERN_CVAR (mute_enemies)
+EXTERN_CVAR (mute_chat)
 
 EXTERN_CVAR (cl_autoaim)
 
@@ -412,6 +413,7 @@ void CL_QuitNetGame(const netQuitReason_e reason)
 
 	mute_spectators = 0.f;
 	mute_enemies = 0.f;
+	mute_chat = 0.f;
 
 	{
 		// [jsd] unlink player pointers from AActors; solves crash in R_ProjectSprites after a svc_disconnect message.

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -90,6 +90,7 @@ EXTERN_CVAR(cl_team)
 EXTERN_CVAR(hud_revealsecrets)
 EXTERN_CVAR(mute_enemies)
 EXTERN_CVAR(mute_spectators)
+EXTERN_CVAR(mute_chat)
 EXTERN_CVAR(show_messages)
 EXTERN_CVAR(co_novileghosts)
 EXTERN_CVAR(sv_sharekeys)
@@ -1669,7 +1670,7 @@ void CL_UpdateSector(const odaproto::svc::UpdateSector* msg)
 //
 void CL_Print(const odaproto::svc::Print* msg)
 {
-	byte level = msg->level();
+	const auto level = static_cast<printlevel_t>(msg->level());
 	const std::string& str = msg->message();
 
 	// Disallow getting NORCON messages
@@ -1686,7 +1687,7 @@ void CL_Print(const odaproto::svc::Print* msg)
 	else
 		PrintFmt(level, "{}", str);
 
-	if (show_messages)
+	if (not mute_chat)
 	{
 		if (level == PRINT_CHAT || level == PRINT_SERVERCHAT)
 			S_Sound(CHAN_INTERFACE, gameinfo.chatSound, 1, ATTN_NONE);
@@ -2165,6 +2166,9 @@ void CL_Say(const odaproto::svc::Say* msg)
 		    (G_IsFFAGame() ||
 		     (G_IsTeamGame() && player.userinfo.team != consoleplayer().userinfo.team)))
 			filtermessage = true;
+
+		if (mute_chat)
+			filtermessage = true;
 	}
 
 	const std::string& name = player.userinfo.netname;
@@ -2178,7 +2182,7 @@ void CL_Say(const odaproto::svc::Say* msg)
 		else
 			PrintFmt(publicmsg, "{}: {}\n", name, message);
 
-		if (show_messages && !filtermessage)
+		if (mute_chat && !filtermessage)
 		{
 			if (cl_chatsounds == 1)
 				S_Sound(CHAN_INTERFACE, gameinfo.chatSound, 1, ATTN_NONE);
@@ -2191,7 +2195,7 @@ void CL_Say(const odaproto::svc::Say* msg)
 		else
 			PrintFmt(publicteammsg, "{}: {}\n", name, message);
 
-		if (show_messages && cl_chatsounds && !filtermessage)
+		if (!mute_chat && cl_chatsounds && !filtermessage)
 			S_Sound(CHAN_INTERFACE, "misc/teamchat", 1, ATTN_NONE);
 	}
 }

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1782,12 +1782,12 @@ void M_ChangeMessages()
 {
 	if (show_messages)
 	{
-		PrintFmt(128, "{}\n", GStrings(MSGOFF));
+		PrintFmt(PRINT_SHOWALWAYS, "{}\n", GStrings(MSGOFF));
 		show_messages.Set (0.0f);
 	}
 	else
 	{
-		PrintFmt(128, "{}\n", GStrings(MSGON));
+		PrintFmt(PRINT_SHOWALWAYS, "{}\n", GStrings(MSGON));
 		show_messages.Set (1.0f);
 	}
 }

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -113,6 +113,7 @@ EXTERN_CVAR (gammalevel)
 EXTERN_CVAR (language)
 EXTERN_CVAR (mute_spectators)
 EXTERN_CVAR (mute_enemies)
+EXTERN_CVAR (mute_chat)
 EXTERN_CVAR (wi_oldintermission)
 
 // [electricbrass - Menu] HUD Menu
@@ -1295,6 +1296,7 @@ menuitem_t MessagesItems[] = {
 	{ .type = discrete,	.label = "Death messages",		.a = {.cvar = &message_showobituaries},	.b = {.leftval = OnOff.size()}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OnOff.data()}},
 	{ .type = discrete,	.label = "Spectator messages",	.a = {.cvar = &mute_spectators},	.b = {.leftval = OffOn.size()}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OffOn.data()}},
 	{ .type = discrete,	.label = "Enemy messages",		.a = {.cvar = &mute_enemies},	.b = {.leftval = OffOn.size()}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OffOn.data()}},
+	{ .type = discrete,	.label = "All player messages",		.a = {.cvar = &mute_chat},	.b = {.leftval = OffOn.size()}, .c = {.rightval = 0.0},   .d = {.step = 0.0},	.e = {.values = OffOn.data()}},
 
 	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
 	{ .type = yellowtext, .label = "Message Colors",		.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},

--- a/common/c_console.h
+++ b/common/c_console.h
@@ -56,7 +56,7 @@ void C_NewModeAdjust (void);
 void C_Ticker (void);
 void C_DisplayTicker(void);
 
-void C_AddNotifyString (int printlevel, const char *s);
+void C_AddNotifyString (printlevel_t printlevel, const char *s);
 void C_DrawConsole (void);
 void C_ToggleConsole (void);
 void C_FullConsole (void);

--- a/common/doomfunc.h
+++ b/common/doomfunc.h
@@ -33,12 +33,12 @@
 
 struct client_t;
 
-void SV_BasePrint(client_t* cl, const int printlevel, const std::string& str);
-void SV_BasePrintAllPlayers(const int printlevel, const std::string& str);
-void SV_BasePrintButPlayer(const int printlevel, const int player_id, const std::string& str);
+void SV_BasePrint(client_t* cl, const printlevel_t printlevel, const std::string& str);
+void SV_BasePrintAllPlayers(const printlevel_t printlevel, const std::string& str);
+void SV_BasePrintButPlayer(const printlevel_t printlevel, const int player_id, const std::string& str);
 #endif
 
-size_t C_BasePrint(const int printlevel, const char* color_code, const std::string& str);
+size_t C_BasePrint(const printlevel_t printlevel, const char* color_code, const std::string& str);
 
 template <typename... ARGS>
 size_t PrintFmt(fmt::format_string<ARGS...> format, ARGS&&... args)
@@ -47,7 +47,7 @@ size_t PrintFmt(fmt::format_string<ARGS...> format, ARGS&&... args)
 }
 
 template <typename... ARGS>
-size_t PrintFmt(const int printlevel, fmt::format_string<ARGS...> format, ARGS&&... args)
+size_t PrintFmt(const printlevel_t printlevel, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	return C_BasePrint(printlevel, TEXTCOLOR_NORMAL, fmt::format(format, std::forward<ARGS>(args)...));
 }
@@ -79,7 +79,7 @@ size_t DPrintFmt(fmt::format_string<ARGS...> format, ARGS&&... args)
  * @param args printf-style arguments.
  */
 template <typename... ARGS>
-void SV_BroadcastPrintFmt(int printlevel, fmt::format_string<ARGS...> format, ARGS&&... args)
+void SV_BroadcastPrintFmt(printlevel_t printlevel, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	if (!serverside)
 		return;
@@ -112,7 +112,7 @@ void SV_BroadcastPrintFmt(fmt::format_string<ARGS...> format, ARGS&&... args)
 
 #ifdef SERVER_APP
 template <typename... ARGS>
-void SV_BroadcastPrintFmtButPlayer(int printlevel, int player_id, fmt::format_string<ARGS...> format, ARGS&&... args)
+void SV_BroadcastPrintFmtButPlayer(printlevel_t printlevel, int player_id, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	std::string string = fmt::format(format, std::forward<ARGS>(args)...);
 	C_BasePrint(printlevel, TEXTCOLOR_NORMAL, string); // print to the console
@@ -126,7 +126,7 @@ void SV_BroadcastPrintFmtButPlayer(int printlevel, int player_id, fmt::format_st
 
 // Print directly to a specific client.
 template <typename... ARGS>
-void SV_ClientPrintFmt(client_t *cl, int level, fmt::format_string<ARGS...> format, ARGS&&... args)
+void SV_ClientPrintFmt(client_t *cl, printlevel_t level, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	SV_BasePrint(cl, level, fmt::format(format, std::forward<ARGS>(args)...));
 }

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -124,7 +124,8 @@ constexpr uint32_t BIT_MASK(uint32_t a, uint32_t b)
 }
 
 // game print flags
-enum printlevel_t {
+enum class printlevel_t : uint8_t
+{
 	PRINT_PICKUP,		// Pickup messages
 	PRINT_OBITUARY,		// Death messages
 	PRINT_HIGH,			// Regular messages
@@ -141,8 +142,12 @@ enum printlevel_t {
 	PRINT_FILTERCHAT,	// Filter the message to not be displayed ingame, but only in the console (ugly hack)
 	PRINT_FILTERHIGH,	// Filter the message to not be displayed ingame, but only in the console (ugly hack)
 
+	PRINT_SHOWALWAYS,	// Same as PRINT_HIGH but always shown regardless of whether show_messages is enabled
+
 	PRINT_MAXPRINT
 };
+
+using enum printlevel_t;
 
 //
 // MIN

--- a/common/doomtype.h
+++ b/common/doomtype.h
@@ -126,23 +126,23 @@ constexpr uint32_t BIT_MASK(uint32_t a, uint32_t b)
 // game print flags
 enum class printlevel_t : uint8_t
 {
-	PRINT_PICKUP,		// Pickup messages
-	PRINT_OBITUARY,		// Death messages
-	PRINT_HIGH,			// Regular messages
+	PRINT_PICKUP,     // Pickup messages
+	PRINT_OBITUARY,   // Death messages
+	PRINT_HIGH,       // Regular messages
 
-	PRINT_CHAT,			// Chat messages
-	PRINT_TEAMCHAT,		// Chat messages from a teammate
-	PRINT_SERVERCHAT,	// Chat messages from the server
+	PRINT_CHAT,       // Chat messages
+	PRINT_TEAMCHAT,   // Chat messages from a teammate
+	PRINT_SERVERCHAT, // Chat messages from the server
 
-	PRINT_WARNING,		// Warning messages
-	PRINT_ERROR,		// Fatal error messages
+	PRINT_WARNING,    // Warning messages
+	PRINT_ERROR,      // Fatal error messages
 
-	PRINT_NORCON,		// Do NOT send the message to any rcon client.
+	PRINT_NORCON,     // Do NOT send the message to any rcon client.
 
-	PRINT_FILTERCHAT,	// Filter the message to not be displayed ingame, but only in the console (ugly hack)
-	PRINT_FILTERHIGH,	// Filter the message to not be displayed ingame, but only in the console (ugly hack)
+	PRINT_FILTERCHAT, // Filter the message to not be displayed ingame, but only in the console (ugly hack)
+	PRINT_FILTERHIGH, // Filter the message to not be displayed ingame, but only in the console (ugly hack)
 
-	PRINT_SHOWALWAYS,	// Same as PRINT_HIGH but always shown regardless of whether show_messages is enabled
+	PRINT_SHOWALWAYS, // Same as PRINT_HIGH but always shown regardless of whether show_messages is enabled
 
 	PRINT_MAXPRINT
 };

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -887,7 +887,7 @@ odaproto::svc::Print SVC_Print(printlevel_t level, const std::string& str)
 {
 	odaproto::svc::Print msg;
 
-	msg.set_level(level);
+	msg.set_level(static_cast<byte>(level));
 	msg.set_message(str);
 
 	return msg;

--- a/odalaunch/res/odamex_cvardoc.json
+++ b/odalaunch/res/odamex_cvardoc.json
@@ -1905,6 +1905,13 @@
       {
          "default" : false,
          "flags" : [ "CLIENTARCHIVE" ],
+         "helptext" : "Mute all player chat.",
+         "name" : "mute_chat",
+         "type" : "boolean"
+      },
+      {
+         "default" : false,
+         "flags" : [ "CLIENTARCHIVE" ],
          "helptext" : "Mute enemy players chat.",
          "name" : "mute_enemies",
          "type" : "boolean"

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -99,7 +99,10 @@ char *TimeStamp()
 
 EXTERN_CVAR(log_color)
 
-static size_t PrintString(printlevel_t printlevel, std::string str)
+namespace
+{
+
+size_t PrintString(printlevel_t printlevel, std::string str)
 {
 	StripColorCodes(str);
 
@@ -152,6 +155,8 @@ static size_t PrintString(printlevel_t printlevel, std::string str)
 
 	return str.length();
 }
+
+} // namespace
 
 extern bool gameisdead;
 

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -58,8 +58,6 @@ struct History
 
 static struct History *HistTail = NULL;
 
-#define PRINTLEVELS 5
-
 EXTERN_CVAR (log_fulltimestamps)
 
 char *TimeStamp()
@@ -101,7 +99,7 @@ char *TimeStamp()
 
 EXTERN_CVAR(log_color)
 
-static size_t PrintString(int printlevel, std::string str)
+static size_t PrintString(printlevel_t printlevel, std::string str)
 {
 	StripColorCodes(str);
 
@@ -157,7 +155,7 @@ static size_t PrintString(int printlevel, std::string str)
 
 extern bool gameisdead;
 
-size_t C_BasePrint(const int printlevel, const char* color_code, const std::string& str)
+size_t C_BasePrint(const printlevel_t printlevel, const char* color_code, const std::string& str)
 {
 	(void)color_code;
 	if (gameisdead)

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -231,7 +231,7 @@ CVAR_FUNC_IMPL (sv_maxplayersperteam)
 				if (normalcount > var)
 				{
 					SV_SetPlayerSpec(player, true);
-					SV_PlayerPrintFmt(player.id, PRINT_HIGH, "Active player limit reduced. You are now a spectator!\n");
+					SV_PlayerPrintFmt(PRINT_HIGH, player.id, "Active player limit reduced. You are now a spectator!\n");
 				}
 			}
 		}
@@ -1011,18 +1011,18 @@ void SV_MidPrint(const char* msg, player_t* p, int msgtime)
 	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_MidPrint(msg, msgtime));
 }
 
-void SV_BasePrint(client_t* cl, const int printlevel, const std::string& str)
+void SV_BasePrint(client_t* cl, const printlevel_t printlevel, const std::string& str)
 {
 	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Print(static_cast<printlevel_t>(printlevel), str));
 }
 
-void SV_BasePrintAllPlayers(const int printlevel, const std::string& str)
+void SV_BasePrintAllPlayers(const printlevel_t printlevel, const std::string& str)
 {
 	for (auto& player : players)
 		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_Print(static_cast<printlevel_t>(printlevel), str));
 }
 
-void SV_BasePrintButPlayer(const int printlevel, const int player_id, const std::string& str)
+void SV_BasePrintButPlayer(const printlevel_t printlevel, const int player_id, const std::string& str)
 {
 	for (auto& player : players)
 	{

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -300,9 +300,6 @@ CVAR_FUNC_IMPL(sv_sharekeys)
 	}
 }
 
-client_c clients;
-
-
 #define CLIENT_TIMEOUT 65 // 65 seconds
 
 void SV_UpdateConsolePlayer(player_t &player);

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -57,8 +57,6 @@ void SV_DrawScores();
 void SV_ServerSettingChange();
 bool SV_IsPlayerAllowedToSee(const player_t &pl, const AActor *mobj);
 
-void SV_BasePrint(client_t* cl, const printlevel_t printlevel, const std::string& str);
-
 // Print directly to a specific player.
 template <typename... ARGS>
 void SV_PlayerPrintFmt(printlevel_t level, int player_id, fmt::format_string<ARGS...> format, ARGS&&... args)

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -38,16 +38,6 @@ extern bool keysfound[NUMCARDS];
 // retransmissions.
 constexpr int MAX_PING = 999;
 
-class client_c
-{
-public:
-
-	size_t size() { return players.size(); }
-	client_c() {}
-};
-
-extern client_c clients;
-
 void SV_InitNetwork (void);
 void SV_SendAndFlushDisconnectSignal();
 void SV_SendAndFlushReconnectSignal();

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -57,11 +57,11 @@ void SV_DrawScores();
 void SV_ServerSettingChange();
 bool SV_IsPlayerAllowedToSee(const player_t &pl, const AActor *mobj);
 
-void SV_BasePrint(client_t* cl, const int printlevel, const std::string& str);
+void SV_BasePrint(client_t* cl, const printlevel_t printlevel, const std::string& str);
 
 // Print directly to a specific player.
 template <typename... ARGS>
-void SV_PlayerPrintFmt(int level, int player_id, fmt::format_string<ARGS...> format, ARGS&&... args)
+void SV_PlayerPrintFmt(printlevel_t level, int player_id, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	client_t* cl = &idplayer(player_id).client;
 	SV_ClientPrintFmt(cl, level, format, std::forward<ARGS>(args)...);
@@ -69,7 +69,7 @@ void SV_PlayerPrintFmt(int level, int player_id, fmt::format_string<ARGS...> for
 
 // Print to all spectators
 template <typename... ARGS>
-void SV_SpectatorPrintFmt(int level, fmt::format_string<ARGS...> format, ARGS&&... args)
+void SV_SpectatorPrintFmt(printlevel_t level, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	std::string string = fmt::format(format, std::forward<ARGS>(args)...);
 	PrintFmt(level, "{}", string);  // print to the console
@@ -87,7 +87,7 @@ void SV_SpectatorPrintFmt(int level, fmt::format_string<ARGS...> format, ARGS&&.
 }
 
 template <typename... ARGS>
-void SV_TeamPrintFmt(int level, int who, fmt::format_string<ARGS...> format, ARGS&&... args)
+void SV_TeamPrintFmt(printlevel_t level, int who, fmt::format_string<ARGS...> format, ARGS&&... args)
 {
 	if (sv_gametype != GM_TEAMDM && sv_gametype != GM_CTF)
 		return;

--- a/tests/unit-tests/src/t_stubs.cpp
+++ b/tests/unit-tests/src/t_stubs.cpp
@@ -128,7 +128,7 @@ void RefreshPalettes (void) {}
 void V_RefreshColormaps() {}
 
 void C_MidPrint (const char *msg, player_t *p, int msgtime) {}
-size_t C_BasePrint(const printlevel_t printlevel, const char* color_code, const std::string& str) { return 0; }
+size_t C_BasePrint(const printlevel_t /*printlevel*/, const char* /*color_code*/, const std::string& /*str*/) { return 0; }
 
 void S_NoiseDebug() {}
 void S_Init(float sfxVolume, float musicVolume) {}

--- a/tests/unit-tests/src/t_stubs.cpp
+++ b/tests/unit-tests/src/t_stubs.cpp
@@ -128,7 +128,7 @@ void RefreshPalettes (void) {}
 void V_RefreshColormaps() {}
 
 void C_MidPrint (const char *msg, player_t *p, int msgtime) {}
-size_t C_BasePrint(const int printlevel, const char* color_code, const std::string& str) { return 0; }
+size_t C_BasePrint(const printlevel_t printlevel, const char* color_code, const std::string& str) { return 0; }
 
 void S_NoiseDebug() {}
 void S_Init(float sfxVolume, float musicVolume) {}


### PR DESCRIPTION
Fixes #1921

To mute all chat messages, a new `mute_chat` cvar has been added.

I have also changed `printlevel_t` to be an `enum class`, which revealed a couple other bugs that are fixed here as well:
1. The player limit reduced message when lowering `sv_maxplayersperteam` is now sent to the correct player(s) instead of always being sent to player 2. The printlevel is now always `PRINT_HIGH` instead of using the id of the player.
2. Whatever was going on in the client `C_PrintString` where the printlevel was being set to pickup or obituary depending on line wrapping. I haven't looked into what issues this caused exactly, but it was definitely wrong.