### PR TITLE
Fix gib / death animation desync on spawn

### DIFF
--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -691,6 +691,19 @@ void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 	//              from CL_SpawnMobj.  This allows things like immediate sound effects and
 	//              secondary mobjs to work (think a noisy, instant gib spawner).
 
+	// FIXME:   Huge open question - should we do all the SetMobjState stuff after we setup the
+	//          rest of the mobj attributes?
+
+	if (msg->is_spawn_tic())
+	{
+		// Now do one advancement of the state, because that has happened between the creation of
+		// the mobj and its corresponding SpawnMobj message.  Any associated actions will execute,
+		// which is particularly important for a number of dehacked custom mobjs that do one-off
+		// things on spawn.
+		P_SetMobjState(mo, mo->info->spawnstate);
+		P_AnimationTick(mo);
+	}
+
 	statenum_t statenum = static_cast<statenum_t>(msg->current().statenum());
 
 	if (statenum >= S_NULL && states.contains(statenum))

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -704,7 +704,7 @@ void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 		P_AnimationTick(mo);
 	}
 
-	statenum_t statenum = static_cast<statenum_t>(msg->current().statenum());
+	const auto statenum = statenum_t(msg->current().statenum());
 
 	if (statenum >= S_NULL)
 	{

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -706,13 +706,25 @@ void CL_SpawnMobj(const odaproto::svc::SpawnMobj* msg)
 
 	statenum_t statenum = static_cast<statenum_t>(msg->current().statenum());
 
-	if (statenum >= S_NULL && states.contains(statenum))
+	if (statenum >= S_NULL)
 	{
-		P_SetMobjState(mo, statenum);
-
-		// Set animation tic to ensure that the initial state is consistent with the server.
-		const int32_t tics = msg->current().tics();
-		mo->tics = tics ? tics : -1;
+		auto iter = states.find(statenum);
+		if (iter != states.end())
+		{
+			// In the rare case that we do the spawnstate animation tic above and the state
+			// we ultimately wind up in has a custom action, we want to make sure that we
+			// don't inadvertently cause that custom action to fire twice by calling
+			// P_SetMobjState twice.  Please note that this double-action does not necessarily
+			// mean that the statenum must also be the spawnstate - spawnstate could have
+			// led to it!
+			if (mo->state != &iter->second)
+			{
+				P_SetMobjState(mo, statenum);
+			}
+			// Set animation tic to ensure that the initial state is consistent with the server.
+			const int32_t tics = msg->current().tics();
+			mo->tics = tics ? tics : -1;
+		}
 	}
 
 	if (serverside && mo->flags & MF_COUNTKILL)

--- a/common/p_mobj.h
+++ b/common/p_mobj.h
@@ -133,6 +133,7 @@ void P_SetThingId(AActor* mo, uint32_t newnetid);
 void P_ClearId(uint32_t id);
 void P_ResolveMobjToMobjPointers();
 
+void P_AnimationTick(AActor *mo);
 void P_XYMovement(AActor *mo);
 void P_ZMovement(AActor *mo);
 void PlayerLandedOnThing(AActor *mo, AActor *onmobj); // [CG] Used to be 'static'

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -476,11 +476,8 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 	//
 	if (mo->spawnTic == gametic)
 	{
-		// The following could and, in most cases, usually do just set the same value again.  It's
-		// those cases where they AREN'T the same value that we're really after here.
-		cur->set_statenum(mo->info->spawnstate);
 		cur->set_rndindex(mo->spawnRndindex);
-		cur->set_tics    (states[mo->info->spawnstate].tics);
+		msg.set_is_spawn_tic(true);
 	}
 
 	if (mo->type == MT_FOUNTAIN)
@@ -547,9 +544,14 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 	if ((mo->flags & MF_CORPSE) && mo->state->statenum != S_GIBS)
 	{
 		// This sets off some additional logic on the client.
+        //
+        // Please note that we also set statenum because it can happen where a mobj both spawns and
+        // instantly gibs on a single tic, especially in horde mode.  And in those cases, we don't
+        // want the special spawn
 		spawnFlags |= SVC_SM_CORPSE;
 		cur->set_frame(mo->frame);
 		cur->set_tics(mo->tics);
+		cur->set_statenum(mo->state->statenum);
 	}
 
 	msg.set_spawn_flags(spawnFlags);

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -544,14 +544,9 @@ odaproto::svc::SpawnMobj SVC_SpawnMobj(const AActor* mo)
 	if ((mo->flags & MF_CORPSE) && mo->state->statenum != S_GIBS)
 	{
 		// This sets off some additional logic on the client.
-        //
-        // Please note that we also set statenum because it can happen where a mobj both spawns and
-        // instantly gibs on a single tic, especially in horde mode.  And in those cases, we don't
-        // want the special spawn
 		spawnFlags |= SVC_SM_CORPSE;
 		cur->set_frame(mo->frame);
 		cur->set_tics(mo->tics);
-		cur->set_statenum(mo->state->statenum);
 	}
 
 	msg.set_spawn_flags(spawnFlags);

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -85,6 +85,7 @@ message SpawnMobj
 	uint32          target_netid    = 5;
 	repeated int32  args            = 6;
 	uint32          timebase_tic    = 7;
+	bool            is_spawn_tic    = 8;    // Indicates that the client must perform a spawn animation tic immediately.
 }
 
 // svc_disconnectclient


### PR DESCRIPTION
As reported [in discord here](https://discord.com/channels/236518337671200768/250157428455243777/1543712811836907581), if, in a single tic, a monster both spawns in on the server side and is killed, it's possible for the monster to wind up being predicted to remain stuck in its spawned-in states on the client side.

This was due to a fix for another problem where some dehacked custom mobjs perform a sequence of action functions in their very first tic, ultimately leading to some downstream state by the time the netcode packages up a SpawnMobj message for the mobj.  So when the SpawnMobj message went out, it contained the post-action state, which resulted in the receiving client skipping those actions, which can include a number of things that really shouldn't be skipped, including audio cues.  The fix forced the mobj to be created in its spawnstate, which executes on the mobj's first clientside tic, producing the actions.

This worked fine until encountering the case above, where the server's local mobj is also sent to the xdeathstate in its first tic after running its spawnstate, and the spawnstate overrules the xdeathstate in the SpawnMobj message.

The fix is to add a boolean field to SpawnMobj indicating that the message is going out on the very tic that it was created on the server, therefore the state being described in the message follows the first animation tic of the spawnstate, including whatever the "post-first-tic" state must be.

When the client sees this field set to true, it sends the mobj through the first tic of its spawnstate animation before checking and setting the "post-first-tic" state described by `statenum` if need be.  In the above case, this would be the xdeathstate.  In the vast majority of cases, this will be the spawnstate itself, thus we skip setting it twice.