### PR TITLE
[BUGFIX] Fast monsters set wrong under certain circumstances when switching wads

### DIFF
--- a/client/src/cl_level.cpp
+++ b/client/src/cl_level.cpp
@@ -90,9 +90,6 @@ extern bool r_underwater;
 extern int mousex, mousey, joyforward, joystrafe, joyturn, joylook, Impulse;
 extern bool sendpause, sendsave, sendcenterview;
 
-
-bool isFast = false;
-
 //
 // G_InitNew
 // Can be called by the startup code or the menu task,
@@ -248,47 +245,7 @@ void G_InitNew (const char *mapname)
 	}
 
 	const bool wantFast = sv_fastmonsters || G_GetCurrentSkill().fast_monsters;
-	if (wantFast != isFast)
-	{
-		if (wantFast)
-		{
-			for (auto&& [_, state] : states)
-			{
-				if (state.flags & STATEF_SKILL5FAST &&
-				    (state.tics != 1 || demoplayback))
-					state.tics >>= 1; // don't change 1->0 since it causes cycles
-			}
-
-			for (auto&& [_, minfo] : mobjinfo)
-			{
-				if (minfo.altspeed != NO_ALTSPEED)
-				{
-					int swap = minfo.speed;
-					minfo.speed = minfo.altspeed;
-					minfo.altspeed = swap;
-				}
-			}
-		}
-		else
-		{
-			for (auto&& [_, state] : states)
-			{
-				if (state.flags & STATEF_SKILL5FAST)
-					state.tics <<= 1; // don't change 1->0 since it causes cycles
-			}
-
-			for (auto&& [_, minfo] : mobjinfo)
-			{
-				if (minfo.altspeed != NO_ALTSPEED)
-				{
-					int swap = minfo.altspeed;
-					minfo.altspeed = minfo.speed;
-					minfo.speed = swap;
-				}
-			}
-		}
-		isFast = wantFast;
-	}
+	G_SetFast(wantFast);
 
 	if (!savegamerestore)
 	{

--- a/common/d_dehacked.cpp
+++ b/common/d_dehacked.cpp
@@ -36,6 +36,7 @@
 #include "d_dehacked.h"
 #include "m_doomobjcontainer.h"
 #include "d_items.h"
+#include "g_game.h"
 #include "gstrings.h"
 #include "i_system.h"
 #include "info.h"
@@ -809,6 +810,9 @@ static void BackupData(void)
 		return;
 	}
 
+	// Make sure we undo any nightmare speed changes
+	G_SetFast(false);
+
 	// backup sprites
 	for (int i = 0; i < ::NUMSPRITES; i++)
 	{
@@ -848,9 +852,6 @@ void D_UndoDehPatch()
 	SoundMap = std::move(doomBackup.backupSoundMap);
 
 	D_BuildSpawnMap();
-
-	extern bool isFast;
-	isFast = false;
 
 	weaponinfo = doomBackup.backupWeaponInfo;
 	clipammo   = doomBackup.backupClipAmmo;

--- a/common/g_game.cpp
+++ b/common/g_game.cpp
@@ -21,7 +21,40 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <utility>
 
 #include "odamex.h"
 
 #include "g_game.h"
+
+void G_SetFast(const bool wantFast)
+{
+	static bool isFast = false;
+	if (wantFast != isFast)
+	{
+		for (auto&& [_, minfo] : mobjinfo)
+		{
+			if (minfo.altspeed != NO_ALTSPEED)
+				std::swap(minfo.speed, minfo.altspeed);
+		}
+
+		if (wantFast)
+		{
+			for (auto&& [_, state] : states)
+			{
+				if (state.flags & STATEF_SKILL5FAST && (state.tics != 1 || demoplayback))
+					state.tics >>= 1; // don't change 1->0 since it causes cycles
+			}
+		}
+		else
+		{
+			for (auto&& [_, state] : states)
+			{
+				if (state.flags & STATEF_SKILL5FAST)
+					state.tics <<= 1;
+			}
+		}
+
+		isFast = wantFast;
+	}
+}

--- a/common/g_game.h
+++ b/common/g_game.h
@@ -67,6 +67,8 @@ void G_AddViewAngle(int yaw);
 void G_AddViewPitch(int pitch);
 bool G_ShouldIgnoreMouseInput();
 
+void G_SetFast(const bool wantFast);
+
 extern int mapchange;
 
 inline bool timingdemo; // if true, exit with report on completion

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -127,8 +127,6 @@ void SV_UpdateMobjBestEffort(AActor* mo);
 void SV_UpdateMonsterRespawnCount();
 void SV_WakeupMobj(const AActor* mo, bool mustPlaySeeSound);
 
-extern bool isFast;
-
 //
 // ENEMY THINKING
 // Enemies are always spawned

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -90,8 +90,6 @@ bool firstmapinit = true; // Nes - Avoid drawing same init text during every reb
 extern bool sendpause;
 
 
-bool isFast = false;
-
 //
 // G_InitNew
 // Can be called by the startup code or the menu task,
@@ -484,47 +482,7 @@ void G_InitNew(const char *mapname)
 	}
 
 	const bool wantFast = sv_fastmonsters || G_GetCurrentSkill().fast_monsters;
-	if (wantFast != isFast)
-	{
-		if (wantFast)
-		{
-			for (auto&& [_, state] : states)
-			{
-				if (state.flags & STATEF_SKILL5FAST &&
-				    (state.tics != 1 || demoplayback))
-					state.tics >>= 1; // don't change 1->0 since it causes cycles
-			}
-
-			for (auto&& [_, minfo] : mobjinfo)
-			{
-				if (minfo.altspeed != NO_ALTSPEED)
-				{
-					int swap = minfo.speed;
-					minfo.speed = minfo.altspeed;
-					minfo.altspeed = swap;
-				}
-			}
-		}
-		else
-		{
-			for (auto&& [_, state] : states)
-			{
-				if (state.flags & STATEF_SKILL5FAST)
-					state.tics <<= 1; // don't change 1->0 since it causes cycles
-			}
-
-			for (auto&& [_, minfo] : mobjinfo)
-			{
-				if (minfo.altspeed != NO_ALTSPEED)
-				{
-					int swap = minfo.altspeed;
-					minfo.altspeed = minfo.speed;
-					minfo.speed = swap;
-				}
-			}
-		}
-		isFast = wantFast;
-	}
+	G_SetFast(wantFast);
 
 	// [SL] 2011-05-11 - Reset all reconciliation system data for unlagging
 	Unlag::getInstance().reset();

--- a/tests/unit-tests/src/t_stubs.cpp
+++ b/tests/unit-tests/src/t_stubs.cpp
@@ -46,7 +46,6 @@ wbstartstruct_t wminfo;
 
 bool predicting;
 int demostartgametic;
-bool isFast;
 int gametic;
 gamestate_t gamestate;
 


### PR DESCRIPTION
Currently, `D_UndoDehPatch` always forces `isFast` to false, even if the backup data was saved while `isFast` is true. Simply removing this would still have issues where monsters with modified speeds in a new dehacked patch might be already in their non-fast state while trying to undo the fastness. The solution is to simply always reset everything to be non-fast just before backing up data before loading a new deh patch.