### PR TITLE
Update MessageQueue and OdaMessenger APIs so that the queues control what happens to the messages

### DIFF
--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -93,7 +93,7 @@ void NetDemo::reset()
 
 	filename = "";
 	header = netdemo_header4_t{};
-	captured.clear();
+	captured.Clear();
 }
 
 //
@@ -373,23 +373,19 @@ bool NetDemo::startRecording(const std::string &filename)
 	{
 		// write a simulation of the connection sequence since the server
 		// has already sent it to the client and it wasn't captured
-		static buf_t tempbuf(NETDEMO_STARTUP_PACKET_SIZE);
 
 		// Fake the launcher query response
-		SZ_Clear(&tempbuf);
-		writeLauncherSequence(&tempbuf);
-		capture(&tempbuf);
-		writeMessages();
+		{
+			buf_t& launcherBuffer = captured.Obtain();
+			writeLauncherSequence(&launcherBuffer);
+			writeMessages();
+		}
 
 		// Fake the server's side of the connection sequence
-		SZ_Clear(&tempbuf);
-		writeConnectionSequence(&tempbuf);
-		capture(&tempbuf);
+		writeConnectionSequence();
 		writeMessages();
 
-		SZ_Clear(&tempbuf);
-		MSG_WriteSVCBuffer(&tempbuf, odaproto::clc::NetDemoLoadSnap());
-		capture(&tempbuf);
+		captured.Write( odaproto::clc::NetDemoLoadSnap() );
 		writeMessages();
 
 		// Record any additional messages (usually a full update if auto-recording))
@@ -588,21 +584,6 @@ bool NetDemo::stopPlaying()
 	return true;
 }
 
-//
-// writeLocalCmd()
-//
-//   Generates a message indicating the current position and angle of the
-//   consoleplayer, taking the place of ticcmds.
-void NetDemo::writeLocalCmd(buf_t *netbuffer) const
-{
-	// Record the local player's data
-	player_t& player = consoleplayer();
-	if (not player.mo)
-		return;
-
-	MSG_WriteSVCBuffer(netbuffer, CLC_NetdemoCap(player, localcmds[gametic % MAXSAVETICS], ::messenger));
-}
-
 
 void NetDemo::writeChunk(const byte *data, size_t size, netdemo_message_t type)
 {
@@ -678,8 +659,6 @@ void NetDemo::writeMessages()
 	if (!isRecording())
 		return;
 
-	static buf_t netbuf_localcmd(1024);
-
 	if (atSnapshotInterval())
 	{
 		writeSnapshotData(snapbuf);
@@ -688,28 +667,29 @@ void NetDemo::writeMessages()
 
 	if (connected)
 	{
-		// Write the console player's game data
-		SZ_Clear(&netbuf_localcmd);
-		writeLocalCmd(&netbuf_localcmd);
-		captured.push_back(netbuf_localcmd);
+		// Record the local player's data
+		player_t& player = consoleplayer();
+		if (player.mo)
+		{
+			captured.Write( CLC_NetdemoCap(player, localcmds[gametic % MAXSAVETICS], ::messenger) );
+		}
 	}
 
-	auto output_buf = std::make_unique<byte[]>(captured.size() * MAX_UDP_PACKET);
+	outputBuffer.clear();
 
-	uint32_t output_len = 0;
-	while (!captured.empty())
+	if (outputBuffer.maxsize() < captured.SizeInBytes())
 	{
-		buf_t netbuf(captured.front());
-		uint32_t len = netbuf.BytesLeftToRead();
-
-		byte *chunk = netbuf.ReadChunk(len);
-		memcpy(&output_buf[output_len], chunk, len);
-		output_len += len;
-
-		captured.pop_front();
+		outputBuffer.resize(captured.SizeInBytes());
 	}
 
-	writeChunk(output_buf.get(), output_len, NetDemo::msg_packet);
+	while (captured.SizeInMessages() > 0)
+	{
+		outputBuffer.WriteChunk(captured.Front().ptr(),
+		                        captured.Front().size());
+		captured.Pop();
+	}
+
+	writeChunk(outputBuffer.ptr(), outputBuffer.size(), NetDemo::msg_packet);
 }
 
 
@@ -860,7 +840,8 @@ void NetDemo::capture(const buf_t* inputbuffer)
 
 	if (inputbuffer->size() > 0)
 	{
-		captured.emplace_back(*inputbuffer);
+		buf_t& buffer = captured.Obtain();
+		buffer.WriteChunk(inputbuffer->ptr(), inputbuffer->size());
 	}
 }
 
@@ -870,7 +851,8 @@ void NetDemo::capture(const std::basic_string<byte>& buffer)
 	{
 		if (buffer.size() > 0)
 		{
-			captured.emplace_back(buffer);
+			buf_t& queueBuffer = captured.Obtain();
+			queueBuffer.WriteChunk(buffer.data(), buffer.length());
 		}
 	}
 }
@@ -879,9 +861,7 @@ void NetDemo::capturePacketHeader(const PacketHeaderType& header)
 {
 	if (isRecording())
 	{
-		workingBuffer.clear();
-		MSG_WriteSVCBuffer(& workingBuffer, MSG_Header(header));
-		captured.emplace_back(workingBuffer);
+		captured.Write( MSG_Header(header) );
 	}
 }
 
@@ -1023,24 +1003,28 @@ void NetDemo::writeLauncherSequence(buf_t *netbuffer)
 
 extern int last_svgametic;
 
-void NetDemo::writeConnectionSequence(buf_t *netbuffer)
+void NetDemo::writeConnectionSequence()
 {
 	const player_t& player = consoleplayer();
 
-	PacketHeaderType header {0};
+    {
+        buf_t& headerBuffer = captured.Obtain();
 
-	header.originatorTic  = last_svgametic;
-	header.destinationTic = player.tic;
+        PacketHeaderType header {0};
 
-	// Please note that we pack the header in proper socket-style for the connection sequence
-	// because the netdemo connection playback actually uses the messenger via CL_Connect.
-	header.Pack(*netbuffer);
+        header.originatorTic  = last_svgametic;
+        header.destinationTic = player.tic;
+
+        // Please note that we pack the header in proper socket-style for the connection sequence
+        // because the netdemo connection playback actually uses the messenger via CL_Connect.
+        header.Pack(headerBuffer);
+    }
 
 	// Server sends our player id and digest
-	MSG_WriteSVCBuffer(netbuffer, SVC_ConsolePlayer(player, digest));
+	captured.Write( SVC_ConsolePlayer(player, digest) );
 
 	// our userinfo
-	MSG_WriteSVCBuffer(netbuffer, SVC_UserInfo(player, player.GameTime));
+	captured.Write( SVC_UserInfo(player, player.GameTime) );
 
 	// Server sends its settings
 	cvar_t *var = GetFirstCvar();
@@ -1048,19 +1032,19 @@ void NetDemo::writeConnectionSequence(buf_t *netbuffer)
 	{
 		if (var->flags() & CVAR_SERVERINFO)
 		{
-			MSG_WriteSVCBuffer(netbuffer, SVC_ServerSettings(*var));
+			captured.Write( SVC_ServerSettings(*var) );
 		}
 		var = var->GetNext();
 	}
 
 	// Server tells everyone if we're a spectator
-	MSG_WriteSVCBuffer(netbuffer, SVC_PlayerMembers(player, SVC_PM_SPECTATOR));
+	captured.Write( SVC_PlayerMembers(player, SVC_PM_SPECTATOR) );
 
 	// Server sends wads & map name
-	MSG_WriteSVCBuffer(netbuffer, SVC_LoadMap(wadfiles, patchfiles, level.mapname.c_str(), level.time));
+	captured.Write( SVC_LoadMap(wadfiles, patchfiles, level.mapname.c_str(), level.time) );
 
 	// Server spawns the player
-	MSG_WriteSVCBuffer(netbuffer, SVC_SpawnPlayer(player));
+	captured.Write( SVC_SpawnPlayer(player) );
 }
 
 

--- a/client/src/cl_demo.cpp
+++ b/client/src/cl_demo.cpp
@@ -1007,18 +1007,18 @@ void NetDemo::writeConnectionSequence()
 {
 	const player_t& player = consoleplayer();
 
-    {
-        buf_t& headerBuffer = captured.Obtain();
+	{
+		buf_t& headerBuffer = captured.Obtain();
 
-        PacketHeaderType header {0};
+		PacketHeaderType header {0};
 
-        header.originatorTic  = last_svgametic;
-        header.destinationTic = player.tic;
+		header.originatorTic  = last_svgametic;
+		header.destinationTic = player.tic;
 
-        // Please note that we pack the header in proper socket-style for the connection sequence
-        // because the netdemo connection playback actually uses the messenger via CL_Connect.
-        header.Pack(headerBuffer);
-    }
+		// Please note that we pack the header in proper socket-style for the connection sequence
+		// because the netdemo connection playback actually uses the messenger via CL_Connect.
+		header.Pack(headerBuffer);
+	}
 
 	// Server sends our player id and digest
 	captured.Write( SVC_ConsolePlayer(player, digest) );

--- a/client/src/cl_demo.h
+++ b/client/src/cl_demo.h
@@ -4,6 +4,7 @@
 #include <fstream>
 
 #include "i_net.h"
+#include "MessageQueue.h"
 
 struct PacketHeaderType;
 
@@ -105,7 +106,7 @@ private:
 	void reset();
 
 	void writeLauncherSequence(buf_t *netbuffer);
-	void writeConnectionSequence(buf_t *netbuffer);
+	void writeConnectionSequence();
 
 	void readSnapshotData(std::vector<byte>& buf);
 	void writeSnapshotData(std::vector<byte>& buf);
@@ -130,7 +131,6 @@ private:
 
 	bool readSnapshot(SnapshotVector::const_iterator snap);
 
-	void writeLocalCmd(buf_t *netbuffer) const;
 	bool readMessageHeader(netdemo_message_t &type, uint32_t &len, uint32_t &tic);
 	void readMessageBody(buf_t *netbuffer, uint32_t len);
 
@@ -195,13 +195,14 @@ private:
 	std::string     filename{ };
 	std::fstream    demofp  { };
 
-	std::deque<buf_t> captured {};
+	MessageQueue      captured {};
 	buf_t             workingBuffer {MAX_UDP_PACKET};
 
 	netdemo_header4_t   header        {};
 	SnapshotVector      snapshot_index{};
 	SnapshotVector      map_index     {};
 
+	buf_t               outputBuffer    { NETDEMO_STARTUP_PACKET_SIZE };
 	std::vector<byte>   snapbuf         { };
 	int                 netdemotic      { 0 };
 	int                 pause_netdemotic{ 0 };

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -65,6 +65,7 @@
 #include "p_acs.h"
 #include "i_input.h"
 #include "i_time.h"
+#include "msg_pack.h"
 
 #include "g_gametype.h"
 #include "cl_parse.h"
@@ -1641,7 +1642,10 @@ void CL_SendUserInfo(buf_t& netBuf)
 {
 	D_SetupUserInfo();
 
-	MSG_WriteSVCBuffer(&netBuf, CLC_UserInfo(consoleplayer().userinfo));
+	if (not simulated_connection)
+	{
+		MSG_Pack(netBuf, CLC_UserInfo(consoleplayer().userinfo));
+	}
 
 	// Refresh Player Translations AFTER sending the new status to the server.
 	CL_RebuildAllPlayerTranslations();

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2314,7 +2314,7 @@ void CL_SendCmd(void)
 		// GhostlyDeath -- If we are spectating, tell the server of our new position
 		if (player.spectator)
 		{
-			MSG_WriteSVC(messenger.NetBuf(), CLC_SpectateUpdate(player));
+			messenger.BestEffort().Write (CLC_SpectateUpdate(player));
 		}
 
 		if (closestNonCredibleVisSprite)

--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -491,7 +491,7 @@ static void CL_GracefulClientInitiatedDisconnect()
 	// Again, make sure that we allow for immediate retransmits.
 	messenger.SetRetransmitDelay(0);
 
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_DisconnectMe());
+	messenger.Reliable().Write(CLC_DisconnectMe());
 	messenger.SendAll(gametic, serveraddr);
 
 	const dtime_t disconnectStartTime   = I_GetTime();
@@ -654,7 +654,7 @@ void CL_CheckDisplayPlayer(void)
 		// server doesnt know about clientside freecam, dont tell it
 		if (not displayplayer().isFreecam && newid != freecamplayer_id)
 		{
-			MSG_WriteSVC(messenger.ReliableBuf(), CLC_Spy(newid));
+			messenger.Reliable().Write(CLC_Spy(newid));
 		}
 		displayplayer_id = newid;
 
@@ -1004,7 +1004,7 @@ END_COMMAND (playerinfo)
 BEGIN_COMMAND (kill)
 {
     if (sv_allowcheats || G_IsCoopGame())
-        MSG_WriteSVC(messenger.ReliableBuf(), CLC_Kill());
+        messenger.Reliable().Write(CLC_Kill());
     else
         PrintFmt("You must run the server with '+set sv_allowcheats 1' or disable sv_keepkeys to enable this command.\n");
 }
@@ -1064,7 +1064,7 @@ BEGIN_COMMAND (rcon)
 	{
 		const std::string_view commandString {args, std::min(size_t(256), strlen(args)) };
 
-		MSG_WriteSVC(messenger.ReliableBuf(), CLC_Rcon(commandString));
+		messenger.Reliable().Write(CLC_Rcon(commandString));
 	}
 }
 END_COMMAND (rcon)
@@ -1074,7 +1074,7 @@ BEGIN_COMMAND (rcon_password)
 {
 	if (connected && argc > 1)
 	{
-		MSG_WriteSVC(messenger.ReliableBuf(), CLC_RconPassword(MD5SUM(std::string(argv[1]) + digest)));
+		messenger.Reliable().Write(CLC_RconPassword(MD5SUM(std::string(argv[1]) + digest)));
 	}
 }
 END_COMMAND (rcon_password)
@@ -1083,7 +1083,7 @@ BEGIN_COMMAND (rcon_logout)
 {
 	if (connected)
 	{
-		MSG_WriteSVC(messenger.ReliableBuf(), CLC_RconLogout());
+		messenger.Reliable().Write(CLC_RconLogout());
 	}
 }
 END_COMMAND (rcon_logout)
@@ -1120,14 +1120,14 @@ BEGIN_COMMAND (spectate)
 	// Only send message if currently not a spectator, or to remove from play queue
 	if (!spectator || consoleplayer().QueuePosition > 0)
 	{
-		MSG_WriteSVC(messenger.ReliableBuf(), CLC_SpectateBegin());
+		messenger.Reliable().Write(CLC_SpectateBegin());
 	}
 }
 END_COMMAND (spectate)
 
 BEGIN_COMMAND(ready)
 {
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_Netcmd("ready"));
+	messenger.Reliable().Write(CLC_Netcmd("ready"));
 }
 END_COMMAND(ready)
 
@@ -1154,7 +1154,7 @@ BEGIN_COMMAND(netcmd)
 		return;
 	}
 
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_Netcmd(argv+1, argv + argc));
+	messenger.Reliable().Write(CLC_Netcmd(argv+1, argv + argc));
 }
 END_COMMAND(netcmd)
 
@@ -1166,7 +1166,7 @@ BEGIN_COMMAND (join)
 	//	return;
 	//}
 
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_SpectateEnd());
+	messenger.Reliable().Write(CLC_SpectateEnd());
 }
 END_COMMAND (join)
 
@@ -2321,7 +2321,7 @@ void CL_SendCmd(void)
 		{
 			closestNonCredibleVisSprite->mo->credibility.Challenge();
 
-			MSG_WriteSVC(messenger.ReliableBuf(), CLC_SendMobjUpdate(closestNonCredibleVisSprite->mo->netid));
+			messenger.Reliable().Write(CLC_SendMobjUpdate(closestNonCredibleVisSprite->mo->netid));
 			closestNonCredibleVisSprite = nullptr;
 		}
 
@@ -2331,7 +2331,7 @@ void CL_SendCmd(void)
 		// when sending svc_updatelocalplayer so the client knows which ticcmds
 		// need to be used for client's positional prediction and item data reconciliation.
 		currentNetcmd.set_tic(gametic);
-		MSG_WriteSVC(messenger.ReliableBuf(), currentNetcmd);
+		messenger.Reliable().Write(currentNetcmd);
 	}
 
 	if (netdemo.isRecording())
@@ -2394,7 +2394,7 @@ void CL_PlayerTimes()
 //
 void CL_SendCheat(int cheats)
 {
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_Cheat(cheats));
+	messenger.Reliable().Write(CLC_Cheat(cheats));
 }
 
 //
@@ -2402,7 +2402,7 @@ void CL_SendCheat(int cheats)
 //
 void CL_SendGiveCheat(const char* item)
 {
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_CheatGive(item));
+	messenger.Reliable().Write(CLC_CheatGive(item));
 }
 
 //
@@ -2410,7 +2410,7 @@ void CL_SendGiveCheat(const char* item)
 //
 void CL_SendSummonCheat(const char* summon)
 {
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_CheatSummon(summon));
+	messenger.Reliable().Write(CLC_CheatSummon(summon));
 }
 
 //
@@ -2418,7 +2418,7 @@ void CL_SendSummonCheat(const char* summon)
 //
 void CL_SendSummonFriendCheat(const char* summon)
 {
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_CheatSummonFriend(summon));
+	messenger.Reliable().Write(CLC_CheatSummonFriend(summon));
 }
 
 

--- a/client/src/cl_maplist.cpp
+++ b/client/src/cl_maplist.cpp
@@ -251,7 +251,7 @@ void MaplistCache::defer_query(const std::vector<std::string> &query,
 	if (this->deferred_queries.empty()) {
 		// Only send out a maplist status packet if we don't already have a
 		// deferred query in progress.
-		MSG_WriteSVC(messenger.ReliableBuf(), CLC_Maplist(this->status));
+		messenger.Reliable().Write(CLC_Maplist(this->status));
 
 		this->status = MAPLIST_WAIT;
 		this->timeout = I_MSTime() + (1000 * 3);
@@ -270,7 +270,7 @@ void MaplistCache::status_handler(maplist_status_t status) {
 	case MAPLIST_OUTDATED:
 		// If our cache is out-of-date and we are able to request
 		// an updated maplist, request one.
-		MSG_WriteSVC(messenger.ReliableBuf(), CLC_MaplistUpdate());
+		messenger.Reliable().Write(CLC_MaplistUpdate());
 
 		[[fallthrough]];
 	case MAPLIST_EMPTY:

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -486,7 +486,7 @@ void CL_LevelLocals(const odaproto::svc::LevelLocals* msg)
 //
 void CL_PingRequest(const odaproto::svc::PingRequest* msg)
 {
-	MSG_WriteSVC(messenger.NetBuf(), CLC_PingReply(msg->ms_time()));
+	messenger.HighPriority().Write (CLC_PingReply(msg->ms_time()));
 }
 
 //

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -486,7 +486,7 @@ void CL_LevelLocals(const odaproto::svc::LevelLocals* msg)
 //
 void CL_PingRequest(const odaproto::svc::PingRequest* msg)
 {
-	messenger.HighPriority().Write (CLC_PingReply(msg->ms_time()));
+	messenger.BestEffort().Write (CLC_PingReply(msg->ms_time()));
 }
 
 //

--- a/client/src/cl_vote.cpp
+++ b/client/src/cl_vote.cpp
@@ -151,7 +151,7 @@ void CMD_MapVoteCallback(const maplist_qrows_t &result) {
 	std::ostringstream index;
 	index << result[0].first;
 
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_CallVote(VOTE_MAP, index.str()));
+	messenger.Reliable().Write(CLC_CallVote(VOTE_MAP, index.str()));
 }
 
 void CMD_RandmapVoteErrback(const std::string &error) {
@@ -169,7 +169,7 @@ void CMD_RandmapVoteCallback(const maplist_qrows_t &result) {
 		return;
 	}
 
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_CallVote(VOTE_RANDMAP));
+	messenger.Reliable().Write(CLC_CallVote(VOTE_RANDMAP));
 }
 
 //////// CONSOLE COMMANDS ////////
@@ -261,7 +261,7 @@ BEGIN_COMMAND(callvote) {
 		return;
 	}
 
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_CallVote(votecmd, arguments));
+	messenger.Reliable().Write(CLC_CallVote(votecmd, arguments));
 
 } END_COMMAND(callvote)
 
@@ -277,7 +277,7 @@ BEGIN_COMMAND(vote_yes)
 	}
 
 	std::array cmd { "vote", "yes" };
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_Netcmd(cmd.begin(), cmd.end()));
+	messenger.Reliable().Write(CLC_Netcmd(cmd.begin(), cmd.end()));
 
 	if (snd_votesfx)
 		S_Sound(CHAN_INTERFACE, "ui/vote/yes", 1.0f, ATTN_NONE);
@@ -296,7 +296,7 @@ BEGIN_COMMAND(vote_no)
 	}
 
 	std::array cmd { "vote", "no" };
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_Netcmd(cmd.begin(), cmd.end()));
+	messenger.Reliable().Write(CLC_Netcmd(cmd.begin(), cmd.end()));
 
 	if (snd_votesfx)
 		S_Sound(CHAN_INTERFACE, "ui/vote/no", 1.0f, ATTN_NONE);

--- a/client/src/d_netinfo.cpp
+++ b/client/src/d_netinfo.cpp
@@ -224,7 +224,7 @@ void D_UserInfoChanged (cvar_t *cvar)
 		D_SetupUserInfo();
 
 	if (connected)
-		CL_SendUserInfo(messenger.ReliableBuf().Obtain());
+		CL_SendUserInfo(messenger.Reliable().Obtain());
 }
 
 FArchive &operator<< (FArchive &arc, UserInfo &info)

--- a/client/src/hu_stuff.cpp
+++ b/client/src/hu_stuff.cpp
@@ -605,9 +605,9 @@ static void ShoveChatStr (const std::string& str, byte visibility)
 	if (str.length() == 0)
 		return;
 
-    const std::string_view visiblePortion {str.begin(), str.begin() + std::min(str.length(), size_t(MAX_CHATSTR_LEN))};
+	const std::string_view visiblePortion {str.begin(), str.begin() + std::min(str.length(), size_t(MAX_CHATSTR_LEN))};
 
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_Say(visiblePortion, visibility));
+	messenger.Reliable().Write(CLC_Say(visiblePortion, visibility));
 }
 
 static void ShovePrivMsg(byte pid, const std::string& str)
@@ -618,7 +618,7 @@ static void ShovePrivMsg(byte pid, const std::string& str)
 
 	const std::string_view visiblePortion {str.begin(), str.begin() + std::min(str.length(), size_t(MAX_CHATSTR_LEN))};
 
-	MSG_WriteSVC(messenger.ReliableBuf(), CLC_PrivMsg(pid, visiblePortion));
+	messenger.Reliable().Write(CLC_PrivMsg(pid, visiblePortion));
 }
 
 BEGIN_COMMAND (messagemode)

--- a/common/MessageQueue.cpp
+++ b/common/MessageQueue.cpp
@@ -22,6 +22,10 @@
 
 #include "MessageQueue.h"
 
+#include "msg_map.h"
+
+#include <google/protobuf/message.h>
+
 buf_t& MessageQueue::Obtain()
 {
 	if (m_queue.size() > 0)
@@ -53,6 +57,44 @@ void MessageQueue::Emplace(buf_t& io_str)
 
 	obtainedBuffer.swap(io_str);
 	io_str.clear();
+}
+
+void MessageQueue::Write(msg_t id, const std::string& msg)
+{
+	if (simulated_connection)
+		return;
+
+	buf_t& buffer = Obtain();
+	buffer.WriteUnVarint(id);
+	buffer.WriteUnVarint(msg.size());
+	buffer.WriteChunk(msg.data(), msg.size());
+}
+
+void MessageQueue::Write(const google::protobuf::Message& msg)
+{
+	if (simulated_connection)
+		return;
+
+	if (not msg.SerializeToString(& m_serializationBuffer))
+	{
+		PrintFmt(
+		    PRINT_WARNING,
+		    "WARNING: Could not serialize message \"{}\".  This is most likely a bug.\n",
+		    msg.GetDescriptor()->full_name());
+		return;
+	}
+
+	const msg_t header = MSG_ResolveDescriptor(msg.GetDescriptor());
+	if (header == msg_noop)
+	{
+		PrintFmt(PRINT_WARNING,
+		         "WARNING: Could not find svc header for message \"{}\".  This is most "
+		         "likely a bug.\n",
+		         msg.GetDescriptor()->full_name());
+		return;
+	}
+
+	Write(header, m_serializationBuffer);
 }
 
 void MessageQueue::PopFromQueueToFreeStack()

--- a/common/MessageQueue.cpp
+++ b/common/MessageQueue.cpp
@@ -22,9 +22,7 @@
 
 #include "MessageQueue.h"
 
-#include "msg_map.h"
-
-#include <google/protobuf/message.h>
+#include "msg_pack.h"
 
 buf_t& MessageQueue::Obtain()
 {
@@ -51,23 +49,13 @@ buf_t& MessageQueue::Obtain()
 	return m_queue.back();
 }
 
-void MessageQueue::Emplace(buf_t& io_str)
-{
-	buf_t& obtainedBuffer = MessageQueue::Obtain();
-
-	obtainedBuffer.swap(io_str);
-	io_str.clear();
-}
-
 void MessageQueue::Write(msg_t id, const std::string& msg)
 {
 	if (simulated_connection)
 		return;
 
 	buf_t& buffer = Obtain();
-	buffer.WriteUnVarint(id);
-	buffer.WriteUnVarint(msg.size());
-	buffer.WriteChunk(msg.data(), msg.size());
+	buffer.WriteMessage(id, msg);
 }
 
 void MessageQueue::Write(const google::protobuf::Message& msg)
@@ -75,26 +63,10 @@ void MessageQueue::Write(const google::protobuf::Message& msg)
 	if (simulated_connection)
 		return;
 
-	if (not msg.SerializeToString(& m_serializationBuffer))
+	if (const auto messageId = MSG_Pack(m_serializationBuffer, msg))
 	{
-		PrintFmt(
-		    PRINT_WARNING,
-		    "WARNING: Could not serialize message \"{}\".  This is most likely a bug.\n",
-		    msg.GetDescriptor()->full_name());
-		return;
+		Write(*messageId, m_serializationBuffer);
 	}
-
-	const msg_t header = MSG_ResolveDescriptor(msg.GetDescriptor());
-	if (header == msg_noop)
-	{
-		PrintFmt(PRINT_WARNING,
-		         "WARNING: Could not find svc header for message \"{}\".  This is most "
-		         "likely a bug.\n",
-		         msg.GetDescriptor()->full_name());
-		return;
-	}
-
-	Write(header, m_serializationBuffer);
 }
 
 void MessageQueue::PopFromQueueToFreeStack()

--- a/common/MessageQueue.h
+++ b/common/MessageQueue.h
@@ -40,6 +40,9 @@ class MessageQueue
 		buf_t& Obtain();
 		void Emplace(buf_t& io_str);
 
+		void Write(const google::protobuf::Message& msg);
+		void Write(msg_t id, const std::string& msg);
+
 		// Using messages.
 		const buf_t& Front() const { return m_queue.front(); }
 

--- a/common/MessageQueue.h
+++ b/common/MessageQueue.h
@@ -38,7 +38,6 @@ class MessageQueue
 
 		// Pushing messages
 		buf_t& Obtain();
-		void Emplace(buf_t& io_str);
 
 		void Write(const google::protobuf::Message& msg);
 		void Write(msg_t id, const std::string& msg);

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -190,7 +190,7 @@ class OdaMessenger
 				/// Returns the number of bytes sent as part of this retransmission cycle.
 				size_t SendRetransmissions() { return m_messengerRef.SendRetransmissions (m_currentTic, m_dest); }
 
-				/// Assembles the messages queued up via ReliableBuf and NetBuf into packets and sends them.  If the
+				/// Assembles the messages queued up via Reliable() and NetBuf into packets and sends them.  If the
 				/// tic budget is exhausted, then the remaining Reliable content remains enqueued for subsequent Send
 				/// calls, but the NetBuf / best-effort messages are discarded.
 				///
@@ -216,7 +216,7 @@ class OdaMessenger
 
 		/// Return the requested message queue.  Use these queues to Obtain new messages into which to pack
 		/// new outgoing data.
-		MessageQueue& ReliableBuf() { return m_outgoingReliableQueue; }
+		MessageQueue& Reliable() { return m_outgoingReliableQueue; }
 		MessageQueue& NetBuf() { return m_outgoingNonReliableQueue; }
 		MessageQueue& HighBuf() { return m_outgoingHighNonReliableQueue; }
 

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -173,7 +173,7 @@ class OdaMessenger
 				Sender(Sender&&)            = delete;
 				Sender& operator=(Sender&&) = delete;
 
-				/// Assembles the messages queued up via HighBuf() into packets and sends them.  If the tic budget is
+				/// Assembles the messages queued up via HighPriority() into packets and sends them.  If the tic budget is
 				/// exhausted, then the remaining HighPriority content remains enqueued for subsequent Send calls.
 				///
 				/// Returns the number of bytes sent.
@@ -190,9 +190,9 @@ class OdaMessenger
 				/// Returns the number of bytes sent as part of this retransmission cycle.
 				size_t SendRetransmissions() { return m_messengerRef.SendRetransmissions (m_currentTic, m_dest); }
 
-				/// Assembles the messages queued up via Reliable() and NetBuf into packets and sends them.  If the
+				/// Assembles the messages queued up via Reliable() and BestEffort() into packets and sends them.  If the
 				/// tic budget is exhausted, then the remaining Reliable content remains enqueued for subsequent Send
-				/// calls, but the NetBuf / best-effort messages are discarded.
+				/// calls, but the best-effort messages are discarded.
 				///
 				/// Return values:
 				///  ACCEPT - Normal result: Packet(s) were sent as needed without hitting a cap.
@@ -217,8 +217,8 @@ class OdaMessenger
 		/// Return the requested message queue.  Use these queues to Obtain new messages into which to pack
 		/// new outgoing data.
 		MessageQueue& Reliable() { return m_outgoingReliableQueue; }
-		MessageQueue& NetBuf() { return m_outgoingNonReliableQueue; }
-		MessageQueue& HighBuf() { return m_outgoingHighNonReliableQueue; }
+		MessageQueue& BestEffort() { return m_outgoingNonReliableQueue; }
+		MessageQueue& HighPriority() { return m_outgoingHighNonReliableQueue; }
 
 		/// Discard all outgoing data that has yet to be sent.
 		void Clear()

--- a/common/com_misc.cpp
+++ b/common/com_misc.cpp
@@ -41,7 +41,7 @@ void COM_PushToast(const toast_t& toast)
 #if defined(SERVER_APP)
 	for (auto& player : ::players)
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_Toast(toast));
+		player.client.messenger->Reliable().Write(SVC_Toast(toast));
 	}
 #elif defined(CLIENT_APP)
 	hud::PushToast(toast);

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -541,7 +541,7 @@ static void GiveWins(player_t& player, int wins)
 	{
 		if (!it->ingame())
 			continue;
-		MSG_WriteSVC(it->client.messenger->ReliableBuf(), SVC_PlayerMembers(player, SVC_PM_SCORE));
+		it->client.messenger->Reliable().Write(SVC_PlayerMembers(player, SVC_PM_SCORE));
 	}
 }
 

--- a/common/g_gametype.cpp
+++ b/common/g_gametype.cpp
@@ -541,7 +541,7 @@ static void GiveWins(player_t& player, int wins)
 	{
 		if (!it->ingame())
 			continue;
-		it->client.messenger->Reliable().Write(SVC_PlayerMembers(player, SVC_PM_SCORE));
+		it->client.messenger->Reliable().Write( SVC_PlayerMembers(player, SVC_PM_SCORE));
 	}
 }
 
@@ -561,7 +561,7 @@ static void GiveTeamWins(team_t team, int wins)
 	{
 		if (!player.ingame())
 			continue;
-		MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_TeamMembers(team));
+		player.client.messenger->BestEffort().Write( SVC_TeamMembers(team));
 	}
 }
 

--- a/common/g_spree.cpp
+++ b/common/g_spree.cpp
@@ -325,7 +325,7 @@ void SpreeManager::setSpreeBreaker(const AActor* source, const player_t* target)
 	if (sv_showsprees)
 	{
 		// Broadcast to all clients
-		MSG_BroadcastSVC(CLBUF_NET, SVC_SpreeBreaker(breaker, level, type, 0), -1);
+		MSG_BroadcastSVC(CLBUF_RELIABLE, SVC_SpreeBreaker(breaker, level, type, 0), -1);
 	}
 	#endif
 
@@ -445,7 +445,7 @@ bool SpreeManager::checkForSpreeUpdates(const int playerId, const std::string pl
 		if (sv_showsprees)
 		{
 			// Broadcast to all clients
-			MSG_BroadcastSVC(CLBUF_NET, SVC_Spree(newRecord, 0), -1);
+			MSG_BroadcastSVC(CLBUF_RELIABLE, SVC_Spree(newRecord, 0), -1);
 		}
 #endif
 		return true;
@@ -477,7 +477,7 @@ bool SpreeManager::checkForSpreeUpdates(const int playerId, const std::string pl
 			if (sv_showsprees)
 			{
 				// Broadcast to all clients
-				MSG_BroadcastSVC(CLBUF_NET, SVC_Spree(record, 0), -1);
+				MSG_BroadcastSVC(CLBUF_RELIABLE, SVC_Spree(record, 0), -1);
 			}
 #endif
 			return true;

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -687,7 +687,7 @@ void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& ms
 			continue;
 
 		// Select the correct buffer.
-		buf_t& b = buf == CLBUF_RELIABLE ? player.client.messenger->ReliableBuf().Obtain() : player.client.messenger->NetBuf().Obtain();
+		buf_t& b = buf == CLBUF_RELIABLE ? player.client.messenger->Reliable().Obtain() : player.client.messenger->NetBuf().Obtain();
 
 		WriteMiniHeader(b, header, buffer.data(), buffer.size());
 	}

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -686,10 +686,10 @@ void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& ms
 		if (static_cast<int>(player.id) == skipPlayer)
 			continue;
 
-		// Select the correct buffer.
-		buf_t& b = buf == CLBUF_RELIABLE ? player.client.messenger->Reliable().Obtain() : player.client.messenger->NetBuf().Obtain();
+		// Select the correct queue.
+		MessageQueue& queue = buf == CLBUF_RELIABLE ? player.client.messenger->Reliable() : player.client.messenger->BestEffort();
 
-		WriteMiniHeader(b, header, buffer.data(), buffer.size());
+		queue.Write(header, buffer);
 	}
 }
 

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -71,7 +71,7 @@ typedef int SOCKET;
 
 #include "i_system.h"
 #include "i_net.h"
-#include "msg_map.h"
+#include "msg_pack.h"
 #include "d_player.h"
 #include "m_alloc.h"
 
@@ -579,37 +579,22 @@ void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& ms
 		return;
 
 	static std::string buffer;
-	if (!msg.SerializeToString(&buffer))
+
+	if (const auto messageId = MSG_Pack(buffer, msg))
 	{
-		PrintFmt(
-		    PRINT_WARNING,
-		    "WARNING: Could not serialize message \"{}\".  This is most likely a bug.\n",
-		    msg.GetDescriptor()->full_name());
-		return;
-	}
+		for (auto& player : players)
+		{
+			if (!player.ingame())
+				continue;
 
-	msg_t header = MSG_ResolveDescriptor(msg.GetDescriptor());
-	if (header == msg_noop)
-	{
-		PrintFmt(PRINT_WARNING,
-		         "WARNING: Could not find svc header for message \"{}\".  This is most "
-		         "likely a bug.\n",
-		         msg.GetDescriptor()->full_name());
-		return;
-	}
+			if (static_cast<int>(player.id) == skipPlayer)
+				continue;
 
-	for (auto& player : players)
-	{
-		if (!player.ingame())
-			continue;
+			// Select the correct queue.
+			MessageQueue& queue = buf == CLBUF_RELIABLE ? player.client.messenger->Reliable() : player.client.messenger->BestEffort();
 
-		if (static_cast<int>(player.id) == skipPlayer)
-			continue;
-
-		// Select the correct queue.
-		MessageQueue& queue = buf == CLBUF_RELIABLE ? player.client.messenger->Reliable() : player.client.messenger->BestEffort();
-
-		queue.Write(header, buffer);
+			queue.Write(*messageId, buffer);
+		}
 	}
 }
 

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -587,7 +587,7 @@ void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& ms
 			if (!player.ingame())
 				continue;
 
-			if (static_cast<int>(player.id) == skipPlayer)
+			if (std::cmp_equal(player.id, skipPlayer))
 				continue;
 
 			// Select the correct queue.

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -609,42 +609,6 @@ void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg)
 	WriteMiniHeader(*b, header, buffer.data(), buffer.size());
 }
 
-void MSG_WriteSVC(MessageQueue& io_queue, const google::protobuf::Message& msg)
-{
-	if (simulated_connection)
-		return;
-
-	std::string& buffer = io_queue.GetSerializationBufferRef();
-	if (!msg.SerializeToString(&buffer))
-	{
-		PrintFmt(
-		    PRINT_WARNING,
-		    "WARNING: Could not serialize message \"{}\".  This is most likely a bug.\n",
-		    msg.GetDescriptor()->full_name());
-		return;
-	}
-
-	msg_t header = MSG_ResolveDescriptor(msg.GetDescriptor());
-	if (header == msg_noop)
-	{
-		PrintFmt(PRINT_WARNING,
-		         "WARNING: Could not find svc header for message \"{}\".  This is most "
-		         "likely a bug.\n",
-		         msg.GetDescriptor()->full_name());
-		return;
-	}
-
-#if 0
-	PrintFmt("{} ({})\n, {}\n",
-		::msg_info[header].getName(), msg.ByteSize(),
-		msg.ShortDebugString());
-#endif
-
-	buf_t& b = io_queue.Obtain();
-
-	WriteMiniHeader(b, header, buffer.data(), buffer.size());
-}
-
 /**
  * @brief Broadcast message to all players.
  *

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -565,50 +565,6 @@ void MSG_WriteChunk (buf_t *b, const void *p, size_t l)
 	b->WriteChunk(static_cast<const char*>(p), l);
 }
 
-namespace
-{
-	void WriteMiniHeader(buf_t& b, msg_t messageId, const void* data, size_t length)
-	{
-		b.WriteUnVarint(messageId);
-		b.WriteUnVarint(length);
-		b.WriteChunk(data, length);
-	}
-}
-
-void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg)
-{
-	if (simulated_connection)
-		return;
-
-	static std::string buffer;
-	if (!msg.SerializeToString(&buffer))
-	{
-		PrintFmt(
-		    PRINT_WARNING,
-		    "WARNING: Could not serialize message \"{}\".  This is most likely a bug.\n",
-		    msg.GetDescriptor()->full_name());
-		return;
-	}
-
-	msg_t header = MSG_ResolveDescriptor(msg.GetDescriptor());
-	if (header == msg_noop)
-	{
-		PrintFmt(PRINT_WARNING,
-		         "WARNING: Could not find svc header for message \"{}\".  This is most "
-		         "likely a bug.\n",
-		         msg.GetDescriptor()->full_name());
-		return;
-	}
-
-#if 0
-	PrintFmt("{} ({})\n, {}\n",
-		::msg_info[header].getName(), msg.ByteSize(),
-		msg.ShortDebugString());
-#endif
-
-	WriteMiniHeader(*b, header, buffer.data(), buffer.size());
-}
-
 /**
  * @brief Broadcast message to all players.
  *

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -840,7 +840,6 @@ void MSG_WriteFloat(buf_t *b, float);
 void MSG_WriteString (buf_t *b, const char *s);
 void MSG_WriteHexString(buf_t *b, const char *s);
 void MSG_WriteChunk (buf_t *b, const void *p, size_t l);
-void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg);
 void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& msg,
                       const int skipPlayer = -1);
 

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -833,7 +833,6 @@ void MSG_WriteFloat(buf_t *b, float);
 void MSG_WriteString (buf_t *b, const char *s);
 void MSG_WriteHexString(buf_t *b, const char *s);
 void MSG_WriteChunk (buf_t *b, const void *p, size_t l);
-void MSG_WriteSVC(MessageQueue& io_queue, const google::protobuf::Message& msg);
 void MSG_WriteSVCBuffer(buf_t* b, const google::protobuf::Message& msg);
 void MSG_BroadcastSVC(const clientBuf_e buf, const google::protobuf::Message& msg,
                       const int skipPlayer = -1);

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -782,13 +782,13 @@ public:
 
 	byte *SZ_GetSpace(size_t length)
 	{
-		if (writepos + length >= maxsize())
+		if (writepos + length > maxsize())
 		{
 			clear();
 			overflowed = true;
-#if defined(ODAMEX_DEBUG)
+
 			PrintFmt(PRINT_HIGH, "SZ_GetSpace: overflow\n");
-#endif
+
 		}
 
 		byte *ret = &data[writepos];

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -529,6 +529,13 @@ public:
 		}
 	}
 
+	void WriteMessage(msg_t messageId, const std::string& msg)
+	{
+		WriteUnVarint(messageId);
+		WriteUnVarint(msg.length());
+		WriteChunk(msg.data(), msg.length());
+	}
+
 	int ReadByte()
 	{
 		if(readpos+1 > cursize)

--- a/common/msg_pack.cpp
+++ b/common/msg_pack.cpp
@@ -27,3 +27,12 @@ std::optional<msg_t> MSG_Pack(std::string& serializationBuffer, const google::pr
 
 	return header;
 }
+
+void MSG_Pack(buf_t& serializationBuffer, const google::protobuf::Message& msg)
+{
+	std::string buffer;
+	if (const auto messageId = MSG_Pack(buffer, msg))
+	{
+		serializationBuffer.WriteMessage(*messageId, buffer);
+	}
+}

--- a/common/msg_pack.cpp
+++ b/common/msg_pack.cpp
@@ -1,3 +1,25 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 2026 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  General utility for packing protocol messages to string or net buffer
+//
+//-----------------------------------------------------------------------------
+
 #include "msg_pack.h"
 
 #include "msg_map.h"

--- a/common/msg_pack.cpp
+++ b/common/msg_pack.cpp
@@ -1,0 +1,29 @@
+#include "msg_pack.h"
+
+#include "msg_map.h"
+
+#include <google/protobuf/message.h>
+
+std::optional<msg_t> MSG_Pack(std::string& serializationBuffer, const google::protobuf::Message& msg)
+{
+	if (not msg.SerializeToString(& serializationBuffer))
+	{
+		PrintFmt(
+		    PRINT_WARNING,
+		    "WARNING: Could not serialize message \"{}\".  This is most likely a bug.\n",
+		    msg.GetDescriptor()->full_name());
+		return std::nullopt;
+	}
+
+	const msg_t header = MSG_ResolveDescriptor(msg.GetDescriptor());
+	if (header == msg_noop)
+	{
+		PrintFmt(PRINT_WARNING,
+		         "WARNING: Could not find svc header for message \"{}\".  This is most "
+		         "likely a bug.\n",
+		         msg.GetDescriptor()->full_name());
+		return std::nullopt;
+	}
+
+	return header;
+}

--- a/common/msg_pack.h
+++ b/common/msg_pack.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+#include "i_net.h"
+
+namespace google
+{
+    namespace protobuf
+    {
+        class Message;
+    }
+}
+
+std::optional<msg_t> MSG_Pack(std::string& serializationBuffer, const google::protobuf::Message& msg);

--- a/common/msg_pack.h
+++ b/common/msg_pack.h
@@ -26,12 +26,9 @@
 
 #include "i_net.h"
 
-namespace google
+namespace google::protobuf
 {
-	namespace protobuf
-	{
-		class Message;
-	}
+	class Message;
 }
 
 std::optional<msg_t> MSG_Pack(std::string& serializationBuffer, const google::protobuf::Message& msg);

--- a/common/msg_pack.h
+++ b/common/msg_pack.h
@@ -1,3 +1,25 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 2026 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  General utility for packing protocol messages to string or net buffer
+//
+//-----------------------------------------------------------------------------
+
 #pragma once
 
 #include <string>

--- a/common/msg_pack.h
+++ b/common/msg_pack.h
@@ -13,3 +13,4 @@ namespace google
 }
 
 std::optional<msg_t> MSG_Pack(std::string& serializationBuffer, const google::protobuf::Message& msg);
+void                 MSG_Pack(buf_t&       serializationBuffer, const google::protobuf::Message& msg);

--- a/common/msg_pack.h
+++ b/common/msg_pack.h
@@ -28,10 +28,10 @@
 
 namespace google
 {
-    namespace protobuf
-    {
-        class Message;
-    }
+	namespace protobuf
+	{
+		class Message;
+	}
 }
 
 std::optional<msg_t> MSG_Pack(std::string& serializationBuffer, const google::protobuf::Message& msg);

--- a/common/p_horde.cpp
+++ b/common/p_horde.cpp
@@ -349,7 +349,7 @@ class HordeState
 				if (player->lives < g_lives)
 				{
 					player->lives += 1;
-					MSG_WriteSVC(player->client.messenger->ReliableBuf(), SVC_PlayerInfo(*player));
+					player->client.messenger->Reliable().Write(SVC_PlayerInfo(*player));
 					MSG_BroadcastSVC(CLBUF_RELIABLE,
 					                 SVC_PlayerMembers(*player, SVC_PM_LIVES),
 					                 player->id);
@@ -364,7 +364,7 @@ class HordeState
 			for (const auto& player : queued)
 			{
 				player->lives = 1;
-				MSG_WriteSVC(player->client.messenger->ReliableBuf(), SVC_PlayerInfo(*player));
+				player->client.messenger->Reliable().Write(SVC_PlayerInfo(*player));
 				MSG_BroadcastSVC(CLBUF_RELIABLE,
 				                 SVC_PlayerMembers(*player, SVC_PM_LIVES), player->id);
 			}

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -108,7 +108,7 @@ static void PersistPlayerDamage(const player_t& p)
 		if (!player.ingame())
 			continue;
 
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerMembers(p, SVC_PM_DAMAGE));
+		player.client.messenger->Reliable().Write(SVC_PlayerMembers(p, SVC_PM_DAMAGE));
 	}
 }
 
@@ -135,7 +135,7 @@ static void PersistPlayerScore(player_t& p, const bool lives, const bool score)
 		if (!player.ingame())
 			continue;
 
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerMembers(p, flags));
+		player.client.messenger->Reliable().Write(SVC_PlayerMembers(p, flags));
 	}
 }
 
@@ -669,7 +669,7 @@ static void P_ResurrectPlayerPowerUp(player_t& player)
 	                   player.userinfo.netname, pl->userinfo.netname);
 
 	// Send a res sound directly to this player.
-	MSG_WriteSVC(pl->client.messenger->ReliableBuf(), SVC_PlayerInfo(*pl));
+	pl->client.messenger->Reliable().Write(SVC_PlayerInfo(*pl));
 	S_PlayerSound(pl, NULL, CHAN_INTERFACE, "misc/plraise", ATTN_NONE);
 
 	MSG_BroadcastSVC(CLBUF_RELIABLE, SVC_PlayerMembers(*pl, SVC_PM_LIVES),
@@ -692,7 +692,7 @@ static void P_AwardExtraLifePowerUp(player_t& player)
 	                   player.userinfo.netname);
 
 	player.lives += 1;
-	MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerInfo(player));
+	player.client.messenger->Reliable().Write(SVC_PlayerInfo(player));
 	MSG_BroadcastSVC(CLBUF_RELIABLE, SVC_PlayerMembers(player, SVC_PM_LIVES),
 	                 player.id);
 }

--- a/common/p_interaction.cpp
+++ b/common/p_interaction.cpp
@@ -150,7 +150,7 @@ static void PersistTeamScore(team_t team)
 	{
 		if (!player.ingame())
 			continue;
-		MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_TeamMembers(team));
+		player.client.messenger->Reliable().Write( SVC_TeamMembers(team));
 	}
 }
 

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -3160,7 +3160,7 @@ void P_RailAttack(AActor *source, int damage, int offset)
 			if (!mo || mo == source)
 				continue;
 
-			MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_RailTrail(start, end));
+			player.client.messenger->Reliable().Write( SVC_RailTrail(start, end));
 		}
 	}
 }

--- a/common/p_switch.cpp
+++ b/common/p_switch.cpp
@@ -265,7 +265,7 @@ void P_UpdateButtons(client_t *cl)
 		// record that we acted on this line:
 		actedlines[l] = true;
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Switch(lines[l], state, timer));
+		cl->messenger->Reliable().Write(SVC_Switch(lines[l], state, timer));
 	}
 
 	for (int l=0; l<numlines; l++)
@@ -273,7 +273,7 @@ void P_UpdateButtons(client_t *cl)
 		// update all button state except those that have actors assigned:
 		if (!actedlines[l] && lines[l].wastoggled)
 		{
-			MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Switch(lines[l], 0, 0));
+			cl->messenger->Reliable().Write(SVC_Switch(lines[l], 0, 0));
 		}
 	}
 }

--- a/master/i_net.h
+++ b/master/i_net.h
@@ -25,6 +25,8 @@
 #ifndef __I_NET_H__
 #define __I_NET_H__
 
+#include <cstddef>
+
 // Max packet size to send and receive, in bytes
 #define	MAX_UDP_PACKET	1400
 

--- a/master/i_net.h
+++ b/master/i_net.h
@@ -242,7 +242,7 @@ public:
 
 	byte *SZ_GetSpace(size_t length)
 	{
-		if (cursize + length >= allocsize)
+		if (cursize + length > allocsize)
 		{
 			clear();
 			overflowed = true;

--- a/server/src/c_console.cpp
+++ b/server/src/c_console.cpp
@@ -184,7 +184,7 @@ size_t C_BasePrint(const int printlevel, const char* color_code, const std::stri
 		if (cl->allow_rcon && (printlevel == PRINT_HIGH || printlevel == PRINT_WARNING ||
 		                       printlevel == PRINT_ERROR))
 		{
-			MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Print(PRINT_WARNING, newStr));
+			cl->messenger->Reliable().Write(SVC_Print(PRINT_WARNING, newStr));
 		}
 	}
 

--- a/server/src/sv_ctf.cpp
+++ b/server/src/sv_ctf.cpp
@@ -96,10 +96,10 @@ void SV_CTFEvent(team_t f, flag_score_t event, player_t& who)
 	{
 		client_t* cl = &(player.client);
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_CTFEvent(event, f, who));
+		cl->messenger->Reliable().Write (SVC_CTFEvent(event, f, who));
 		if (event == SCORE_CAPTURE)
 		{
-			MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_CTFRefresh(tv, false));
+			cl->messenger->Reliable().Write (SVC_CTFRefresh(tv, false));
 		}
 	}
 }
@@ -112,7 +112,7 @@ void CTF_Connect(player_t &player)
 {
 	client_t *cl = &player.client;
 
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_CTFRefresh(TeamQuery().execute(), true));
+	cl->messenger->Reliable().Write (SVC_CTFRefresh(TeamQuery().execute(), true));
 }
 
 //

--- a/server/src/sv_level.cpp
+++ b/server/src/sv_level.cpp
@@ -392,7 +392,7 @@ void G_DoNewGame()
 		if(!(player.ingame()))
 			continue;
 
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(),
+		player.client.messenger->Reliable().Write (
 		             SVC_LoadMap(::wadfiles, ::patchfiles, d_mapname.c_str(), 0));
 	}
 
@@ -682,7 +682,7 @@ void G_DoResetLevel(bool full_reset)
 			continue;
 
 		client_t* cl = &(player.client);
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), odaproto::svc::ResetMap());
+		cl->messenger->Reliable().Write (odaproto::svc::ResetMap());
 	}
 
 	// Unserialize saved snapshot
@@ -858,7 +858,7 @@ void G_DoLoadLevel (int position)
 			// [AM] Make sure the clients are updated on the new ready state
 			for (Players::iterator pit = players.begin();pit != players.end();++pit)
 			{
-				MSG_WriteSVC(pit->client.messenger->ReliableBuf(),
+				pit->client.messenger->Reliable().Write (
 				             SVC_PlayerMembers(*it, SVC_PM_READY));
 			}
 		}

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1809,10 +1809,10 @@ void SV_SendMovingSectorUpdate(player_t& player, sector_t* sector)
 		switch (floorMover)
 		{
 			case SEC_FLOOR:
-				MSG_WriteSVC(outgoingMessageQueue, SVC_MovingSectorFloor(*sector));
+				outgoingMessageQueue.Write( SVC_MovingSectorFloor(*sector));
 				break;
 			case SEC_PLAT:
-				MSG_WriteSVC(outgoingMessageQueue, SVC_MovingSectorPlat(*sector));
+				outgoingMessageQueue.Write( SVC_MovingSectorPlat(*sector));
 				break;
 			default:
 				break;
@@ -1828,16 +1828,16 @@ void SV_SendMovingSectorUpdate(player_t& player, sector_t* sector)
 		switch (ceilingMover)
 		{
 			case SEC_DOOR:
-				MSG_WriteSVC(outgoingMessageQueue, SVC_MovingSectorDoor(*sector));
+				outgoingMessageQueue.Write( SVC_MovingSectorDoor(*sector));
 				break;
 			case SEC_CEILING:
-				MSG_WriteSVC(outgoingMessageQueue, SVC_MovingSectorCeiling(*sector));
+				outgoingMessageQueue.Write( SVC_MovingSectorCeiling(*sector));
 				break;
 			case SEC_ELEVATOR:
-				MSG_WriteSVC(outgoingMessageQueue, SVC_MovingSectorElevator(*sector));
+				outgoingMessageQueue.Write( SVC_MovingSectorElevator(*sector));
 				break;
 			case SEC_PILLAR:
-				MSG_WriteSVC(outgoingMessageQueue, SVC_MovingSectorPillar(*sector));
+				outgoingMessageQueue.Write( SVC_MovingSectorPillar(*sector));
 				break;
 			default:
 				break;
@@ -3247,12 +3247,12 @@ static void ImmediateUpdateMobj(AActor& mobj, TransportEnum transport)
 				case AwarenessEnum::ALWAYS_AWARE:      [[ fallthrough ]];
 				case AwarenessEnum::FULLY_AWARE:
 					mobj.updatedDuringLocalTic = gametic;
-					MSG_WriteSVC(fullAwareQueue, message);
+					fullAwareQueue.Write( message);
 					break;
 
 				case AwarenessEnum::SEMI_AWARE:
 					mobj.updatedDuringLocalTic = gametic;
-					MSG_WriteSVC(semiAwareQueue, message);
+					semiAwareQueue.Write( message);
 					break;
 			}
 		}

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -2306,9 +2306,14 @@ void SV_ConnectClient()
 		static buf_t smallbuf(1024);
 		if (smallbuf.size() == 0)
 		{
+			MessageQueue smallQueue;
 			PacketHeaderType header(0);
+
+			smallQueue.Write( SVC_Disconnect("Server is full\n") );
+
 			header.Pack(smallbuf);
-			MSG_WriteSVCBuffer(&smallbuf, SVC_Disconnect("Server is full\n"));
+			smallbuf.WriteChunk(smallQueue.Front().ptr(),
+			                    smallQueue.Front().size());
 		}
 
 		NET_SendPacket(smallbuf, net_from);

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -150,8 +150,7 @@ CVAR_FUNC_IMPL (sv_maxclients)
 	{
 		if (count <= 0)
 		{
-			MSG_WriteSVC(
-			    it->client.messenger->ReliableBuf(),
+			it->client.messenger->Reliable().Write (
 			    SVC_Print(PRINT_CHAT,
 			              "Client limit reduced. Please try connecting again later.\n"));
 
@@ -191,7 +190,7 @@ CVAR_FUNC_IMPL (sv_maxplayers)
 
 				for (Players::iterator pit = players.begin(); pit != players.end(); ++pit)
 				{
-					MSG_WriteSVC(pit->client.messenger->ReliableBuf(),
+					pit->client.messenger->Reliable().Write (
 					             SVC_PlayerMembers(*it, SVC_PM_SPECTATOR));
 				}
 
@@ -199,8 +198,7 @@ CVAR_FUNC_IMPL (sv_maxplayers)
 				SV_BroadcastPrintFmt(PRINT_HIGH, "{} became a spectator. ({})\n",
 					it->userinfo.netname, status);
 
-				MSG_WriteSVC(
-				    it->client.messenger->ReliableBuf(),
+				it->client.messenger->Reliable().Write (
 				    SVC_Print(PRINT_HIGH,
 				              "Active player limit reduced. You are now a spectator!\n"));
 			}
@@ -483,7 +481,7 @@ static void SendLevelState(SerializedLevelState sls)
 	for (auto& player : players)
 	{
 		client_t& cl = player.client;
-		MSG_WriteSVC(cl.messenger->ReliableBuf(), SVC_LevelState(sls));
+		cl.messenger->Reliable().Write (SVC_LevelState(sls));
 	}
 }
 
@@ -1006,18 +1004,18 @@ void SV_MidPrint(const char* msg, player_t* p, int msgtime)
 {
 	client_t* cl = &p->client;
 
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_MidPrint(msg, msgtime));
+	cl->messenger->Reliable().Write (SVC_MidPrint(msg, msgtime));
 }
 
 void SV_BasePrint(client_t* cl, const int printlevel, const std::string& str)
 {
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Print(static_cast<printlevel_t>(printlevel), str));
+	cl->messenger->Reliable().Write (SVC_Print(static_cast<printlevel_t>(printlevel), str));
 }
 
 void SV_BasePrintAllPlayers(const int printlevel, const std::string& str)
 {
 	for (auto& player : players)
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_Print(static_cast<printlevel_t>(printlevel), str));
+		player.client.messenger->Reliable().Write (SVC_Print(static_cast<printlevel_t>(printlevel), str));
 }
 
 void SV_BasePrintButPlayer(const int printlevel, const int player_id, const std::string& str)
@@ -1031,7 +1029,7 @@ void SV_BasePrintButPlayer(const int printlevel, const int player_id, const std:
 		if (cl == excluded_client)
 			continue;
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Print(static_cast<printlevel_t>(printlevel), str));
+		cl->messenger->Reliable().Write (SVC_Print(static_cast<printlevel_t>(printlevel), str));
 	}
 }
 
@@ -1052,7 +1050,7 @@ void SV_Sound (const AActor *mo, byte channel, const char *name, byte attenuatio
 	{
 		client_t* cl = &(player.client);
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_PlaySound(PlaySoundType(mo), channel, sfx_id,
+		cl->messenger->Reliable().Write (SVC_PlaySound(PlaySoundType(mo), channel, sfx_id,
 		                                             1.0f, attenuation));
 	}
 }
@@ -1070,7 +1068,7 @@ void SV_Sound(player_t& pl, const AActor* mo, const byte channel, const char* na
 
 	client_t *cl = &pl.client;
 
-	MSG_WriteSVC(cl->messenger->ReliableBuf(),
+	cl->messenger->Reliable().Write (
 	             SVC_PlaySound(PlaySoundType(mo), channel, sfx_id, 1.0f, attenuation));
 }
 
@@ -1100,7 +1098,7 @@ void UV_SoundAvoidPlayer (const AActor *mo, byte channel, const char *name, byte
 
 		client_t* cl = &(player.client);
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_PlaySound(PlaySoundType(mo), channel, sfx_id,
+		cl->messenger->Reliable().Write (SVC_PlaySound(PlaySoundType(mo), channel, sfx_id,
 		                                             1.0f, attenuation));
 	}
 }
@@ -1125,7 +1123,7 @@ void SV_SoundTeam (byte channel, const char* name, byte attenuation, int team)
 		{
 			client_t* cl = &(player.client);
 
-			MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_PlaySound(PlaySoundType(), channel, sfx_id,
+			cl->messenger->Reliable().Write (SVC_PlaySound(PlaySoundType(), channel, sfx_id,
 			                                             1.0f, attenuation));
 		}
 	}
@@ -1148,7 +1146,7 @@ void SV_Sound (fixed_t x, fixed_t y, byte channel, const char *name, byte attenu
 
 		client_t* cl = &(player.client);
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_PlaySound(PlaySoundType(x, y), channel, sfx_id,
+		cl->messenger->Reliable().Write (SVC_PlaySound(PlaySoundType(x, y), channel, sfx_id,
 		                                             1.0f, attenuation));
 	}
 }
@@ -1161,7 +1159,7 @@ void SV_UpdateFrags(const player_t &player)
 	for (Players::iterator it = players.begin();it != players.end();++it)
 	{
 		client_t *cl = &(it->client);
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_PlayerMembers(player, SVC_PM_SCORE));
+		cl->messenger->Reliable().Write (SVC_PlayerMembers(player, SVC_PM_SCORE));
 	}
 }
 
@@ -1170,7 +1168,7 @@ void SV_UpdateFrags(const player_t &player)
 //
 void SV_SendUserInfo (const player_t &player, client_t* cl)
 {
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_UserInfo(player, time(nullptr) - player.JoinTime));
+	cl->messenger->Reliable().Write (SVC_UserInfo(player, time(nullptr) - player.JoinTime));
 }
 
 /**
@@ -1373,7 +1371,7 @@ void SV_ForceSetTeam (player_t &who, team_t team)
 	who.userinfo.team = team;
 	PrintFmt(PRINT_HIGH, "Forcing {} to {} team\n", who.userinfo.netname.c_str(), team == TEAM_NONE ? "NONE" : V_GetTeamColor(team).c_str());
 
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ForceTeam(team));
+	cl->messenger->Reliable().Write (SVC_ForceTeam(team));
 }
 
 //
@@ -1464,7 +1462,7 @@ bool SV_ApplyAwareness(player_t& player, AActor* mo, AwarenessEnum awarenessLeve
 
 	if (awarenessLevel == AwarenessEnum::NOT_AWARE)
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_RemoveMobj(*mo));
+		player.client.messenger->Reliable().Write (SVC_RemoveMobj(*mo));
 		return true;
 	}
 
@@ -1476,7 +1474,7 @@ bool SV_ApplyAwareness(player_t& player, AActor* mo, AwarenessEnum awarenessLeve
 			{
 				if (mo == ::voodoostarts[i].mobj)
 				{
-					MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_ConfigureAvatar(::voodoostarts[i].mapThing, mo->netid));
+					player.client.messenger->Reliable().Write (SVC_ConfigureAvatar(::voodoostarts[i].mapThing, mo->netid));
 					return false;   // does NOT count towards the spawn quota!
 				}
 			}
@@ -1486,11 +1484,11 @@ bool SV_ApplyAwareness(player_t& player, AActor* mo, AwarenessEnum awarenessLeve
 
 		if (not mo->player or mo->player->playerstate != PST_LIVE)
 		{
-			MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_SpawnMobj(mo));
+			player.client.messenger->Reliable().Write (SVC_SpawnMobj(mo));
 		}
 		else
 		{
-			MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_SpawnPlayer(*mo->player));
+			player.client.messenger->Reliable().Write (SVC_SpawnPlayer(*mo->player));
 		}
 		return true;
 	}
@@ -1661,7 +1659,7 @@ void SV_BroadcastNoiseAlert(const sector_t& sector)
 	// the server.
 	for (auto& player : players)
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_NoiseAlert(sector));
+		player.client.messenger->Reliable().Write (SVC_NoiseAlert(sector));
 	}
 }
 
@@ -1672,7 +1670,7 @@ void SV_UpdateSector(client_t* cl, int sectornum)
 	// Only update moveable sectors to clients
 	if (sector != nullptr && sector->moveable)
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_UpdateSector(*sector));
+		cl->messenger->Reliable().Write (SVC_UpdateSector(*sector));
 	}
 }
 
@@ -1689,7 +1687,7 @@ void SV_UpdateSectorProperties(client_t* cl, int sectornum)
 	// Only update sectors with changes
 	if (sector != nullptr && sector->SectorChanges)
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_SectorProperties(*sector));
+		cl->messenger->Reliable().Write (SVC_SectorProperties(*sector));
 	}
 }
 
@@ -1713,7 +1711,7 @@ void SV_UpdateSectors(client_t* cl)
 		if (!sector.SectorChanges)
 			continue;
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_SectorProperties(sector));
+		cl->messenger->Reliable().Write (SVC_SectorProperties(sector));
 	}
 }
 
@@ -1806,7 +1804,7 @@ void SV_SendMovingSectorUpdate(player_t& player, sector_t* sector)
 	if (floorMover != SEC_INVALID)
 	{
 		const bool    floorIsCompleted     = P_MovingFloorCompleted  (sector);
-		MessageQueue& outgoingMessageQueue = floorIsCompleted ? player.client.messenger->ReliableBuf() :
+		MessageQueue& outgoingMessageQueue = floorIsCompleted ? player.client.messenger->Reliable() :
 		                                                        player.client.messenger->HighBuf();
 		switch (floorMover)
 		{
@@ -1824,7 +1822,7 @@ void SV_SendMovingSectorUpdate(player_t& player, sector_t* sector)
 	if (ceilingMover != SEC_INVALID)
 	{
 		const bool    ceilingIsCompleted   = P_MovingCeilingCompleted(sector);
-		MessageQueue& outgoingMessageQueue = ceilingIsCompleted ? player.client.messenger->ReliableBuf() :
+		MessageQueue& outgoingMessageQueue = ceilingIsCompleted ? player.client.messenger->Reliable() :
 		                                                          player.client.messenger->HighBuf();
 
 		switch (ceilingMover)
@@ -1880,7 +1878,7 @@ void SV_LineStateUpdate(client_t *cl)
 	{
 		if (line.PropertiesChanged)
 		{
-			MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_LineUpdate(line));
+			cl->messenger->Reliable().Write (SVC_LineUpdate(line));
 		}
 
 		if (!line.SidedefChanged)
@@ -1894,7 +1892,7 @@ void SV_LineStateUpdate(client_t *cl)
 				if (!currentSideDef->SidedefChanges)
 					continue;
 
-				MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_LineSideUpdate(line, sideNum));
+				cl->messenger->Reliable().Write (SVC_LineSideUpdate(line, sideNum));
 			}
 		}
 	}
@@ -1906,56 +1904,56 @@ void SV_ThinkerUpdate(client_t* cl)
 	DScroller* scroller;
 	while ((scroller = scrollIter.Next()))
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ThinkerUpdate(scroller));
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(scroller));
 	}
 
 	TThinkerIterator<DFireFlicker> fireIter;
 	DFireFlicker* fireFlicker;
 	while ((fireFlicker = fireIter.Next()))
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ThinkerUpdate(fireFlicker));
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(fireFlicker));
 	}
 
 	TThinkerIterator<DFlicker> flickerIter;
 	DFlicker* flicker;
 	while ((flicker = flickerIter.Next()))
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ThinkerUpdate(flicker));
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(flicker));
 	}
 
 	TThinkerIterator<DLightFlash> lightFlashIter;
 	DLightFlash* lightFlash;
 	while ((lightFlash = lightFlashIter.Next()))
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ThinkerUpdate(lightFlash));
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(lightFlash));
 	}
 
 	TThinkerIterator<DStrobe> strobeIter;
 	DStrobe* strobe;
 	while ((strobe = strobeIter.Next()))
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ThinkerUpdate(strobe));
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(strobe));
 	}
 
 	TThinkerIterator<DGlow> glowIter;
 	DGlow* glow;
 	while ((glow = glowIter.Next()))
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ThinkerUpdate(glow));
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(glow));
 	}
 
 	TThinkerIterator<DGlow2> glow2Iter;
 	DGlow2* glow2;
 	while ((glow2 = glow2Iter.Next()))
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ThinkerUpdate(glow2));
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(glow2));
 	}
 
 	TThinkerIterator<DPhased> phasedIter;
 	DPhased* phased;
 	while ((phased = phasedIter.Next()))
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ThinkerUpdate(phased));
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(phased));
 	}
 }
 
@@ -1977,10 +1975,10 @@ void SV_ClientFullUpdate(player_t &pl)
 {
 	client_t *cl = &pl.client;
 
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), odaproto::svc::FullUpdateStart());
+	cl->messenger->Reliable().Write (odaproto::svc::FullUpdateStart());
 
 	// Send the player all level locals.
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_LevelLocals(::level, SVC_MSG_ALL));
+	cl->messenger->Reliable().Write (SVC_LevelLocals(::level, SVC_MSG_ALL));
 
 	// send player's info to the client
 	for (Players::iterator it = players.begin();it != players.end();++it)
@@ -1992,17 +1990,17 @@ void SV_ClientFullUpdate(player_t &pl)
 	}
 
 	// update levelstate
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_LevelState(::levelstate.serialize()));
+	cl->messenger->Reliable().Write (SVC_LevelState(::levelstate.serialize()));
 
 	// update all player members
 	for (Players::iterator it = players.begin(); it != players.end(); ++it)
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_PlayerMembers(*it, SVC_MSG_ALL));
+		cl->messenger->Reliable().Write (SVC_PlayerMembers(*it, SVC_MSG_ALL));
 
 	// [deathz0r] send team frags/captures if teamplay is enabled
 	if (G_IsTeamGame())
 	{
 		for (int i = 0; i < NUMTEAMS; i++)
-			MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_TeamMembers(static_cast<team_t>(i)));
+			cl->messenger->Reliable().Write (SVC_TeamMembers(static_cast<team_t>(i)));
 	}
 
 	int hiddenUpdates = 0;
@@ -2038,7 +2036,7 @@ void SV_ClientFullUpdate(player_t &pl)
 
 		for (const auto& [playerId, record] : sprees.getSpreeRecords())
 		{
-			MSG_WriteSVC(cl->messenger->ReliableBuf(),
+			cl->messenger->Reliable().Write (
 			             SVC_Spree(record, ::gametic - record.spreeStartTic));
 		}
 
@@ -2046,14 +2044,14 @@ void SV_ClientFullUpdate(player_t &pl)
 
 		if (breaker.spreeEndedPlayerId != -1)
 		{
-			MSG_WriteSVC(cl->messenger->ReliableBuf(),
+			cl->messenger->Reliable().Write (
 			             SVC_SpreeBreaker(breaker, breaker.spreeEndedLevel,
 			                              breaker.spreeEndedType,
 			                              ::gametic - breaker.spreeEndedTic));
 		}
 	}
 
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), odaproto::svc::FullUpdateDone());
+	cl->messenger->Reliable().Write (odaproto::svc::FullUpdateDone());
 
 	SV_ArmInventoryMonitors(pl);
 
@@ -2074,14 +2072,14 @@ void SV_UpdateSecret(sector_t& sector, player_t &player)
 	{
 		client_t* cl = &(it->client);
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_LevelLocals(::level, SVC_LL_SECRETS));
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_PlayerMembers(player, SVC_PM_SCORE));
+		cl->messenger->Reliable().Write (SVC_LevelLocals(::level, SVC_LL_SECRETS));
+		cl->messenger->Reliable().Write (SVC_PlayerMembers(player, SVC_PM_SCORE));
 
 		if (&*it == &player)
 			continue;
 
 		if (!(sector.special & SECRET_MASK) && sector.secretsector)
-			MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_SecretEvent(player, sector));
+			cl->messenger->Reliable().Write (SVC_SecretEvent(player, sector));
 	}
 }
 
@@ -2107,7 +2105,7 @@ static void SendServerSettings(player_t& pl)
 		{
 			odaproto::svc::ServerSettings settings = SVC_ServerSettings(*var);
 
-			MSG_WriteSVC(cl->messenger->ReliableBuf(), settings);
+			cl->messenger->Reliable().Write (settings);
 		}
 
 		var = var->GetNext();
@@ -2194,9 +2192,9 @@ bool SV_CheckClientVersion(client_t *cl, Players::iterator it)
 		// GhostlyDeath -- Now we tell them our built up message and boot em
 		cl->displaydisconnect = false;	// Don't spam the players
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Print(PRINT_WARNING, msg));
+		cl->messenger->Reliable().Write (SVC_Print(PRINT_WARNING, msg));
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Disconnect());
+		cl->messenger->Reliable().Write (SVC_Disconnect());
 
 		SV_SendPacket(*it);
 
@@ -2390,8 +2388,7 @@ void SV_ConnectClient()
 	{
 		PrintFmt("{} disconnected (password failed).\n", NET_AdrToString(net_from));
 
-		MSG_WriteSVC(
-		    cl->messenger->ReliableBuf(),
+		cl->messenger->Reliable().Write (
 		    SVC_Print(PRINT_HIGH,
 		              "Server is passworded, no password specified or bad password.\n"));
 
@@ -2401,7 +2398,7 @@ void SV_ConnectClient()
 	}
 
 	// send consoleplayer number
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_ConsolePlayer(*player, cl->digest));
+	cl->messenger->Reliable().Write (SVC_ConsolePlayer(*player, cl->digest));
 	SV_SendPacket(*player);
 }
 
@@ -2432,19 +2429,19 @@ void SV_ConnectClient2(player_t& player)
 		player.spectator = true;
 		for (Players::iterator pit = players.begin(); pit != players.end(); ++pit)
 		{
-			MSG_WriteSVC(pit->client.messenger->ReliableBuf(),
+			pit->client.messenger->Reliable().Write (
 			             SVC_PlayerMembers(player, SVC_PM_SPECTATOR));
 		}
 	}
 
 	// Send a map name
-	MSG_WriteSVC(player.client.messenger->ReliableBuf(),
+	player.client.messenger->Reliable().Write (
 	             SVC_LoadMap(::wadfiles, ::patchfiles, level.mapname.c_str(), level.time));
 
 	// [SL] 2011-12-07 - Force the player to jump to intermission if not in a level
 	if (gamestate == GS_INTERMISSION)
 	{
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), odaproto::svc::ExitLevel());
+		cl->messenger->Reliable().Write (odaproto::svc::ExitLevel());
 	}
 
 	G_DoReborn(player);
@@ -2455,7 +2452,7 @@ void SV_ConnectClient2(player_t& player)
 	// tell others clients about it
 	for (Players::iterator pit = players.begin(); pit != players.end(); ++pit)
 	{
-		MSG_WriteSVC(pit->client.messenger->ReliableBuf(), SVC_ConnectClient(player));
+		pit->client.messenger->Reliable().Write (SVC_ConnectClient(player));
 	}
 
 	// Notify this player of other player's queue positions
@@ -2518,7 +2515,7 @@ void SV_DisconnectClient(player_t &who)
 	for (auto& player : players)
 	{
 		client_t &cl = player.client;
-		MSG_WriteSVC(cl.messenger->ReliableBuf(), SVC_DisconnectClient(who));
+		cl.messenger->Reliable().Write (SVC_DisconnectClient(who));
 	}
 
 	// Put the disconnecting client's final message on the wire right away.
@@ -2560,7 +2557,7 @@ void SV_DropClient(player_t &who)
 {
 	client_t *cl = &who.client;
 
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Disconnect());
+	cl->messenger->Reliable().Write (SVC_Disconnect());
 
 	SV_SendPacket(who);
 
@@ -2579,7 +2576,7 @@ static void SV_SendAndFlushClientsFinalSignal(const google::protobuf::Message& f
 	for (auto& player : players)
 	{
 		player.client.messenger->Clear();
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), finalMessage);
+		player.client.messenger->Reliable().Write (finalMessage);
 		SV_SendPacket(player);
 
 		// Move the client's messenger to the departing messenger manager.
@@ -2639,7 +2636,7 @@ void SV_ExitLevel()
 {
 	for (auto& player : players)
 	{
-		MSG_WriteSVC((player.client.messenger->ReliableBuf()), odaproto::svc::ExitLevel());
+		player.client.messenger->Reliable().Write (odaproto::svc::ExitLevel());
 	}
 }
 
@@ -2959,7 +2956,7 @@ void SVC_TeamSay(player_t &player, const char* message)
 		if (spectator || it->userinfo.team != player.userinfo.team)
 			continue;
 
-		MSG_WriteSVC(it->client.messenger->ReliableBuf(), SVC_Say(true, player.id, message));
+		it->client.messenger->Reliable().Write (SVC_Say(true, player.id, message));
 	}
 }
 
@@ -2987,7 +2984,7 @@ void SVC_SpecSay(player_t &player, const char* message)
 		if (!spectator)
 			continue;
 
-		MSG_WriteSVC(it->client.messenger->ReliableBuf(), SVC_Say(true, player.id, message));
+		it->client.messenger->Reliable().Write (SVC_Say(true, player.id, message));
 	}
 }
 
@@ -3010,7 +3007,7 @@ void SVC_Say(player_t &player, const char* message)
 		if (!validplayer(*it))
 			continue;
 
-		MSG_WriteSVC(it->client.messenger->ReliableBuf(), SVC_Say(false, player.id, message));
+		it->client.messenger->Reliable().Write (SVC_Say(false, player.id, message));
 	}
 }
 
@@ -3030,13 +3027,13 @@ void SVC_PrivMsg(player_t &player, player_t &dplayer, const char* message)
 		PrintFmt(PRINT_CHAT, "<PRIVMSG> {} (to {}): {}\n",
 				player.userinfo.netname, dplayer.userinfo.netname, message);
 
-	MSG_WriteSVC(dplayer.client.messenger->ReliableBuf(), SVC_Say(true, player.id, message));
+	dplayer.client.messenger->Reliable().Write (SVC_Say(true, player.id, message));
 
 	// [AM] Send a duplicate message to the sender, so he knows the message
 	//      went through.
 	if (player.id != dplayer.id)
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_Say(true, player.id, message));
+		player.client.messenger->Reliable().Write (SVC_Say(true, player.id, message));
 	}
 }
 
@@ -3238,8 +3235,8 @@ static void ImmediateUpdateMobj(AActor& mobj, TransportEnum transport)
 		if (player.ingame() and SV_IsPlayerAllowedToSee(player, &mobj))
 		{
 			MessageQueue& fullAwareQueue = transport == TransportEnum::BEST_EFFORT ? player.client.messenger->NetBuf()
-			                                                                       : player.client.messenger->ReliableBuf();
-			MessageQueue& semiAwareQueue = transport == TransportEnum::RELIABLE ? player.client.messenger->ReliableBuf()
+			                                                                       : player.client.messenger->Reliable();
+			MessageQueue& semiAwareQueue = transport == TransportEnum::RELIABLE ? player.client.messenger->Reliable()
                                                                                 : player.client.messenger->NetBuf();
 			switch (mobj.playersAware.Get(player.id))
 			{
@@ -3293,7 +3290,7 @@ void SV_WakeupMobj(const AActor* mo, bool mustPlaySeeSound)
 					break;
 
 				default:
-					MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_WakeupMobj(mo, mustPlaySeeSound));
+					player.client.messenger->Reliable().Write (SVC_WakeupMobj(mo, mustPlaySeeSound));
 					break;
 			}
 		}
@@ -3314,7 +3311,7 @@ void SV_UpdateMobjState(const AActor* mo)
 					break;
 
 				default:
-					MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_MobjState(mo));
+					player.client.messenger->Reliable().Write (SVC_MobjState(mo));
 					break;
 			}
 		}
@@ -3376,7 +3373,7 @@ void SV_UpdateGametype(player_t& player)
 		if (player.hordeInfo != info)
 		{
 			player.hordeInfo = info;
-			MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_HordeInfo(info));
+			player.client.messenger->Reliable().Write (SVC_HordeInfo(info));
 		}
 	}
 }
@@ -3439,7 +3436,7 @@ void SV_UpdateMonsterRespawnCount()
 	for (auto& player : players)
 	{
 		client_t* cl = &(player.client);
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_LevelLocals(::level, SVC_LL_MONSTER_RESPAWNS));
+		cl->messenger->Reliable().Write (SVC_LevelLocals(::level, SVC_LL_MONSTER_RESPAWNS));
 	}
 }
 
@@ -3469,7 +3466,7 @@ void SV_UpdatePing(client_t* cl)
 		if (!(player.ingame()))
 			continue;
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_UpdatePing(player));
+		cl->messenger->Reliable().Write (SVC_UpdatePing(player));
 	}
 }
 
@@ -3533,7 +3530,7 @@ void SV_SendPlayerStateUpdate(client_t* client, player_t* player)
 	}
 	else
 	{
-		MSG_WriteSVC(client->messenger->ReliableBuf(), SVC_PlayerInfo(*player));
+		client->messenger->Reliable().Write (SVC_PlayerInfo(*player));
 	}
 }
 
@@ -3643,32 +3640,32 @@ static void SV_SendMonitoredInventoryChanges(player_t& player)
 	const bool readyWeaponWasChanged   = player.readyweaponMonitor.EvaluateAsChanged();
 	if (pendingWeaponWasChanged or readyWeaponWasChanged)
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerWeaponSelection(player));
+		player.client.messenger->Reliable().Write (SVC_PlayerWeaponSelection(player));
 	}
 
 	if (player.weaponOwnedMonitors.EvaluateAsChanged())
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerWeaponOwned(player));
+		player.client.messenger->Reliable().Write (SVC_PlayerWeaponOwned(player));
 	}
 
 	if (player.ammoMonitors.EvaluateAsChanged())
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerAmmo(player));
+		player.client.messenger->Reliable().Write (SVC_PlayerAmmo(player));
 	}
 
 	if (player.maxAmmoMonitors.EvaluateAsChanged())
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerMaxAmmo(player));
+		player.client.messenger->Reliable().Write (SVC_PlayerMaxAmmo(player));
 	}
 
 	if (player.powerMonitors.EvaluateAsChanged())
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerPowers(player));
+		player.client.messenger->Reliable().Write (SVC_PlayerPowers(player));
 	}
 
 	if (player.pspriteMonitors.EvaluateAsChanged())
 	{
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerPsprites(player));
+		player.client.messenger->Reliable().Write (SVC_PlayerPsprites(player));
 	}
 }
 
@@ -3783,7 +3780,7 @@ void SV_WriteCommandsForPlayer(player_t& player)
 			// Now in this case we're okay with *potentially* going overbudget or behind-by-one tic,
 			// because the player has a mobj that's multiple seconds out of date.  Being a even little
 			// late is better than that.
-			MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_UpdateMobjWithMode(*sortedMobjIter->actorPtr));
+			player.client.messenger->Reliable().Write (SVC_UpdateMobjWithMode(*sortedMobjIter->actorPtr));
 			player.requestedNetIdUpdate = 0;
 		}
 	}
@@ -4077,7 +4074,7 @@ void SV_JoinPlayer(player_t& player, bool silent)
 		if (!it->ingame())
 			continue;
 
-		MSG_WriteSVC(it->client.messenger->ReliableBuf(), SVC_PlayerMembers(player, SVC_MSG_ALL));
+		it->client.messenger->Reliable().Write (SVC_PlayerMembers(player, SVC_MSG_ALL));
 	}
 
 	// Everything is set, now warn everyone the player joined.
@@ -4112,7 +4109,7 @@ void SV_SpecPlayer(player_t &player, bool silent)
 	player.spectator = true;
 	for (Players::iterator it = ::players.begin(); it != ::players.end(); ++it)
 	{
-		MSG_WriteSVC(it->client.messenger->ReliableBuf(),
+		it->client.messenger->Reliable().Write (
 		             SVC_PlayerMembers(player, SVC_PM_SPECTATOR));
 	}
 
@@ -4231,7 +4228,7 @@ void SV_SetReady(player_t &player, bool setting, bool silent)
 		// Broadcast the new ready state to all connected players.
 		for (Players::iterator it = players.begin();it != players.end();++it)
 		{
-			MSG_WriteSVC(it->client.messenger->ReliableBuf(),
+			it->client.messenger->Reliable().Write (
 			             SVC_PlayerMembers(player, SVC_PM_READY));
 		}
 	}
@@ -4378,7 +4375,7 @@ void SV_RConPassword (player_t& player, const std::string& challenge)
 	else
 	{
 		PrintFmt(PRINT_HIGH, "RCON login failure from {} - {}", player.userinfo.netname, NET_AdrToString(cl->address));
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Print(PRINT_HIGH, "Bad password\n"));
+		cl->messenger->Reliable().Write (SVC_Print(PRINT_HIGH, "Bad password\n"));
 	}
 }
 
@@ -4762,7 +4759,7 @@ void SV_TouchSpecial(AActor& special, player_t& player)
 		SV_AwarenessUpdate(player, &special, AwarenessEnum::FULLY_AWARE);
 	}
 
-	MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_TouchSpecial(special));
+	player.client.messenger->Reliable().Write (SVC_TouchSpecial(special));
 }
 
 void SV_PlayerTimes (void)
@@ -5112,7 +5109,7 @@ void OnChangedSwitchTexture (line_t *line, int useAgain)
 	{
 		client_t *cl = &(player.client);
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Switch(*line, state, time));
+		cl->messenger->Reliable().Write (SVC_Switch(*line, state, time));
 	}
 }
 
@@ -5126,7 +5123,7 @@ void SV_OnActivatedLine(line_t* line, AActor* mo, const int side,
 		if (player.mo == mo or not player.ingame())
 			continue;
 
-		MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_ActivateLine(line, mo, side, activationType));
+		player.client.messenger->Reliable().Write (SVC_ActivateLine(line, mo, side, activationType));
 	}
 }
 
@@ -5135,7 +5132,7 @@ void SV_SendDamagePlayer(player_t* damagedPlayer, const AActor* inflictor, int h
 	// No check for awareness.  All players always stay informed about all players.
 	for (auto& destinationPlayer : players)
 	{
-		MSG_WriteSVC(destinationPlayer.client.messenger->ReliableBuf(),
+		destinationPlayer.client.messenger->Reliable().Write (
 		             SVC_DamagePlayer(*damagedPlayer, inflictor, healthDamage, armorDamage));
 	}
 }
@@ -5149,7 +5146,7 @@ void SV_SendDamageMobj(AActor *target, int pain)
 	{
 		if (SV_IsPlayerAllowedToSee(player, target))
 		{
-			MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_DamageMobj(target, pain));
+			player.client.messenger->Reliable().Write (SVC_DamageMobj(target, pain));
 		}
 	}
 }
@@ -5166,7 +5163,7 @@ void SV_SendKillMobj(const AActor *source, const AActor *target, const AActor *i
 		// they're only barely aware of the mobj.
 		if (SV_IsPlayerAllowedToSee(player, target))
 		{
-			MSG_WriteSVC(player.client.messenger->ReliableBuf(),
+			player.client.messenger->Reliable().Write (
 			             SVC_KillMobj(source, target, inflictor, ::MeansOfDeath, joinkill));
 		}
 	}
@@ -5183,7 +5180,7 @@ void SV_SendRaiseMobj(const AActor* source, const AActor* corpse)
 		// they're only barely aware of the mobj.
 		if (SV_IsPlayerAllowedToSee(player, corpse))
 		{
-			MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_RaiseMobj(source, corpse));
+			player.client.messenger->Reliable().Write (SVC_RaiseMobj(source, corpse));
 		}
 	}
 }
@@ -5203,7 +5200,7 @@ void SV_SendDestroyActor(const AActor *mo)
 			// generate any more traffic to fill up the pipes.
 			if (mo->playersAware.IsAware(player.id))
 			{
-				MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_RemoveMobj(*mo));
+				player.client.messenger->Reliable().Write (SVC_RemoveMobj(*mo));
 			}
 		}
 	}
@@ -5222,14 +5219,14 @@ void SV_ExplodeMissile(AActor *mo)
 			case AwarenessEnum::ALWAYS_AWARE:  [[ fallthrough ]];      // See everything.
 			case AwarenessEnum::FULLY_AWARE:
 				mo->updatedDuringLocalTic = gametic;
-				MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_UpdateMobj(*mo));
-				MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_ExplodeMissile(*mo));
+				player.client.messenger->Reliable().Write (SVC_UpdateMobj(*mo));
+				player.client.messenger->Reliable().Write (SVC_ExplodeMissile(*mo));
 				break;
 
 			case AwarenessEnum::SEMI_AWARE:                            // See an explosion, maybe even in the correct position.
 				mo->updatedDuringLocalTic = gametic;
 				MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_UpdateMobj(*mo));
-				MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_ExplodeMissile(*mo));
+				player.client.messenger->Reliable().Write (SVC_ExplodeMissile(*mo));
 				break;
 
 			case AwarenessEnum::BARELY_AWARE:                          // See an explosion, almost certainly in the wrong position.
@@ -5246,7 +5243,7 @@ void SV_ExplodeMissile(AActor *mo)
 //
 void SV_SendPlayerInfo(player_t& player)
 {
-	MSG_WriteSVC(player.client.messenger->ReliableBuf(), SVC_PlayerInfo(player));
+	player.client.messenger->Reliable().Write (SVC_PlayerInfo(player));
 }
 
 //
@@ -5408,7 +5405,7 @@ void SV_SendPlayerQueuePositions(player_t* dest, bool initConnect)
 
 void SV_SendPlayerQueuePosition(const player_t* source, player_t* dest)
 {
-	MSG_WriteSVC((dest->client.messenger->ReliableBuf()), SVC_PlayerQueuePos(*source));
+	dest->client.messenger->Reliable().Write (SVC_PlayerQueuePos(*source));
 }
 
 bool CompareQueuePosition(const player_t* p1, const player_t* p2)
@@ -5441,7 +5438,7 @@ void SV_SendExecuteLineSpecial(byte special, const line_t* line, const AActor* a
 		client_t* cl = &player.client;
 
 		int args[5] = { arg0, arg1, arg2, arg3, arg4 };
-		MSG_WriteSVC(cl->messenger->ReliableBuf(),
+		cl->messenger->Reliable().Write (
 		             SVC_ExecuteLineSpecial(special, line, activator, args));
 	}
 }
@@ -5464,7 +5461,7 @@ void SV_ACSExecuteSpecial(byte special, const AActor* activator, const char* pri
 
 		client_t* cl = &player.client;
 
-		MSG_WriteSVC(cl->messenger->ReliableBuf(),
+		cl->messenger->Reliable().Write (
 		             SVC_ExecuteACSSpecial(special, activator, print, args));
 	}
 }

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1805,7 +1805,7 @@ void SV_SendMovingSectorUpdate(player_t& player, sector_t* sector)
 	{
 		const bool    floorIsCompleted     = P_MovingFloorCompleted  (sector);
 		MessageQueue& outgoingMessageQueue = floorIsCompleted ? player.client.messenger->Reliable() :
-		                                                        player.client.messenger->HighBuf();
+		                                                        player.client.messenger->HighPriority();
 		switch (floorMover)
 		{
 			case SEC_FLOOR:
@@ -1823,7 +1823,7 @@ void SV_SendMovingSectorUpdate(player_t& player, sector_t* sector)
 	{
 		const bool    ceilingIsCompleted   = P_MovingCeilingCompleted(sector);
 		MessageQueue& outgoingMessageQueue = ceilingIsCompleted ? player.client.messenger->Reliable() :
-		                                                          player.client.messenger->HighBuf();
+		                                                          player.client.messenger->HighPriority();
 
 		switch (ceilingMover)
 		{
@@ -1867,9 +1867,9 @@ void SV_UpdateMovingSectors(player_t &player)
 //
 void SV_SendGametic(client_t& client)
 {
-	MSG_WriteSVC(client.messenger->HighBuf(), SVC_ServerGametic(gametic,
-	                                                           client.messenger->GetPendingAckCount(),
-	                                                           client.messenger->GetReliableOverloadCount()));
+	client.messenger->HighPriority().Write( SVC_ServerGametic(gametic,
+	                                                          client.messenger->GetPendingAckCount(),
+	                                                          client.messenger->GetReliableOverloadCount()));
 }
 
 void SV_LineStateUpdate(client_t *cl)
@@ -3169,7 +3169,7 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 	                                     sortedMobjIter->distanceSquared < HYPER_AWARENESS_CUTOFF_SQUARED;
 	if (isHyperAware)
 	{
-		MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_UpdateMobjWithMode(*mo));
+		player.client.messenger->BestEffort().Write( SVC_UpdateMobjWithMode(*mo));
 	}
 	else
 	{
@@ -3208,7 +3208,7 @@ void SV_UpdateMissiles(player_t& player, const std::vector<player_t::ActorDistan
 					break;
 
 				default:
-					MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_UpdateMobjWithMode(*mo));
+					player.client.messenger->BestEffort().Write( SVC_UpdateMobjWithMode(*mo));
 					break;
 			}
 		}
@@ -3234,10 +3234,10 @@ static void ImmediateUpdateMobj(AActor& mobj, TransportEnum transport)
 	{
 		if (player.ingame() and SV_IsPlayerAllowedToSee(player, &mobj))
 		{
-			MessageQueue& fullAwareQueue = transport == TransportEnum::BEST_EFFORT ? player.client.messenger->NetBuf()
+			MessageQueue& fullAwareQueue = transport == TransportEnum::BEST_EFFORT ? player.client.messenger->BestEffort()
 			                                                                       : player.client.messenger->Reliable();
 			MessageQueue& semiAwareQueue = transport == TransportEnum::RELIABLE ? player.client.messenger->Reliable()
-                                                                                : player.client.messenger->NetBuf();
+                                                                                : player.client.messenger->BestEffort();
 			switch (mobj.playersAware.Get(player.id))
 			{
 				case AwarenessEnum::NOT_AWARE:         [[ fallthrough ]];
@@ -3347,7 +3347,7 @@ void SV_UpdateMonsters(player_t& player, AActor *mo)
 				break;
 
 			default:
-				MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_UpdateMobjWithMode(*mo));
+				player.client.messenger->BestEffort().Write( SVC_UpdateMobjWithMode(*mo));
 				break;
 		}
 	}
@@ -3360,7 +3360,7 @@ void SV_UpdateAvatars(player_t& player)
 		if (voodooInfo.mobj and ((voodooInfo.mobj->netid + gametic) % 7) == 0)
 		{
 			voodooInfo.mobj->updatedDuringLocalTic = gametic;    // Avoid a potential duplicate send.
-			MSG_WriteSVC(player.client.messenger->HighBuf(), SVC_UpdateMobj(*voodooInfo.mobj));
+			player.client.messenger->HighPriority().Write( SVC_UpdateMobj(*voodooInfo.mobj));
 		}
 	}
 }
@@ -3425,7 +3425,7 @@ void SV_SendPingRequest(client_t* cl)
 	if (!P_AtInterval(100))
 		return;
 
-	MSG_WriteSVC(cl->messenger->HighBuf(), SVC_PingRequest());
+	cl->messenger->HighPriority().Write( SVC_PingRequest());
 }
 
 void SV_UpdateMonsterRespawnCount()
@@ -3526,7 +3526,7 @@ void SV_SendPlayerStateUpdate(client_t* client, player_t* player)
 
 	if (client != &player->client)
 	{
-		MSG_WriteSVC(client->messenger->HighBuf(), SVC_PlayerState(*player));
+		client->messenger->HighPriority().Write( SVC_PlayerState(*player));
 	}
 	else
 	{
@@ -3693,7 +3693,7 @@ void SV_WriteCommandsForPlayer(player_t& player)
 		if(not SV_IsPlayerAllowedToSee(player, otherPlayer.mo))
 			continue;
 
-		MSG_WriteSVC(player.client.messenger->HighBuf(), SVC_MovePlayer(otherPlayer));
+		player.client.messenger->HighPriority().Write( SVC_MovePlayer(otherPlayer));
 	}
 
 	// Send inventory stuff.
@@ -3963,7 +3963,7 @@ void SV_UpdateConsolePlayer(player_t &player)
 	if (not player.spectator)
 	{
 		// client player will update his position if packets were missed
-		MSG_WriteSVC(cl->messenger->HighBuf(), SVC_UpdateLocalPlayer(*mo));
+		cl->messenger->HighPriority().Write( SVC_UpdateLocalPlayer(*mo));
 	}
 
 	SV_UpdateMovingSectors(player);
@@ -4688,7 +4688,7 @@ static void TimeCheck()
 	if (P_AtInterval(1 * TICRATE)) // every second
 	{
 		for (auto& player : players)
-			MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_LevelLocals(level, SVC_LL_TIME));
+			player.client.messenger->Reliable().Write( SVC_LevelLocals(level, SVC_LL_TIME));
 	}
 }
 
@@ -4702,7 +4702,7 @@ static void IntermissionTimeCheck()
 	{
 		for (auto& player : players)
 		{
-			MSG_WriteSVC((player.client.messenger->NetBuf()), SVC_IntTimeLeft(level.inttimeleft));
+			player.client.messenger->Reliable().Write( SVC_IntTimeLeft(level.inttimeleft));
 		}
 	}
 }
@@ -5225,12 +5225,12 @@ void SV_ExplodeMissile(AActor *mo)
 
 			case AwarenessEnum::SEMI_AWARE:                            // See an explosion, maybe even in the correct position.
 				mo->updatedDuringLocalTic = gametic;
-				MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_UpdateMobj(*mo));
+				player.client.messenger->BestEffort().Write( SVC_UpdateMobj(*mo));
 				player.client.messenger->Reliable().Write (SVC_ExplodeMissile(*mo));
 				break;
 
 			case AwarenessEnum::BARELY_AWARE:                          // See an explosion, almost certainly in the wrong position.
-				MSG_WriteSVC(player.client.messenger->NetBuf(), SVC_ExplodeMissile(*mo));
+				player.client.messenger->BestEffort().Write( SVC_ExplodeMissile(*mo));
 				break;
 		}
 	}

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -504,7 +504,7 @@ void SV_Maplist(player_t &player, maplist_status_t status) {
 	case MAPLIST_OK:
 		// Valid statuses
 		DPrintFmt("SV_Maplist: Sending status {} to pid {}\n", status, player.id);
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_Maplist(status));
+		cl->messenger->Reliable().Write (SVC_Maplist(status));
 	default:
 		// Invalid statuses
 		return;
@@ -529,7 +529,7 @@ void SV_MaplistIndex(player_t &player) {
 		}
 	}
 
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_MaplistIndex(count, this_index, next_index));
+	cl->messenger->Reliable().Write (SVC_MaplistIndex(count, this_index, next_index));
 }
 
 // Send a full maplist update to a specific player
@@ -541,7 +541,7 @@ void SV_MaplistUpdate(player_t &player, maplist_status_t status) {
 	case MAPLIST_TIMEOUT:
 		// Valid statuses that don't require the packet logic
 		DPrintFmt("SV_MaplistUpdate: Sending status {} to pid {}\n", status, player.id);
-		MSG_WriteSVC(cl->messenger->ReliableBuf(), SVC_MaplistUpdate(status, nullptr));
+		cl->messenger->Reliable().Write (SVC_MaplistUpdate(status, nullptr));
 		return;
 	case MAPLIST_OUTDATED:
 		// Valid statuses that need the packet logic
@@ -557,8 +557,8 @@ void SV_MaplistUpdate(player_t &player, maplist_status_t status) {
 
 	odaproto::svc::MaplistUpdate update = SVC_MaplistUpdate(MAPLIST_OUTDATED, &maplist);
 
-    // FIXME:  Does this need to be fragmented?  Could this be too large??
-	MSG_WriteSVC(cl->messenger->ReliableBuf(), update);
+	// FIXME:  Does this need to be fragmented?  Could this be too large??
+	cl->messenger->Reliable().Write (update);
 
 	// Update the timeout to ensure the player doesn't abuse the server
 	Maplist::instance().set_timeout(player.id);

--- a/server/src/sv_vote.cpp
+++ b/server/src/sv_vote.cpp
@@ -1056,7 +1056,7 @@ static void SV_VoteUpdate(player_t &player)
 
 	client_t* cl = &player.client;
 
-	MSG_WriteSVC(cl->messenger->NetBuf(), SVC_VoteUpdate(::vote->serialize()));
+	cl->messenger->Reliable().Write( SVC_VoteUpdate(::vote->serialize()));
 }
 
 // Send a full vote update to everybody

--- a/tests/unit-tests/test/t_MessageQueue.cpp
+++ b/tests/unit-tests/test/t_MessageQueue.cpp
@@ -42,19 +42,6 @@ TEST_F(MessageQueueFixture, BasicByteSize)
     REQUIRE(2 == m_queue.SizeInBytes());
     REQUIRE(1 == m_queue.SizeInMessages());
 
-    buf_t outsideBuffer { 100 };
-
-    outsideBuffer.WriteLong(4);
-
-    REQUIRE(2 == m_queue.SizeInBytes());
-    REQUIRE(1 == m_queue.SizeInMessages());
-
-    m_queue.Emplace(outsideBuffer);
-
-    REQUIRE(6 == m_queue.SizeInBytes());
-    REQUIRE(2 == m_queue.SizeInMessages());
-
-    m_queue.Pop();
     m_queue.Pop();
 
     REQUIRE(0 == m_queue.SizeInBytes());


### PR DESCRIPTION
This PR implements the API change briefly discussed in discord, where the knowledge of how to put a message into the queue lives in the queue class itself, rather than a function that calls the queue.  This allows a future `LargeMessage` queue to actually be an entirely different class and the caller doesn't have to know about that.

Additionally, this PR:

- Fixes a long-standing bug in `buf_t` where a "perfect fit" set of writes can incorrectly flag an overflow,
- switches `NetDemo` over to using a plain old netcode `MessageQueue` as its message-capture data structure, and use `buf_t` for building write buffers instead of bespoke heap byte arrays, all of which help with tic-to-tic buffer reuse,
- provisions some structural changes - specifically, moving more protobuf special knowledge out of the general `i_net` module and consolidating it down to one function in `msg_pack` - to help ease a future shift away from protobuf, and
- switches more infrequent, event-like messages over to being reliable.