### PR TITLE
[BUGFIX] `spawninv` command allows clientside modification of `g_spawninv` in multiplayer

### DIFF
--- a/common/g_spawninv.cpp
+++ b/common/g_spawninv.cpp
@@ -711,6 +711,12 @@ BEGIN_COMMAND(spawninv)
 {
 	static const char* ammonames[] = {"Bullets", "Shells", "Rockets", "Cells"};
 
+	if (not serverside)
+	{
+		PrintFmt("Spawn inventory is under server control");
+		return;
+	}
+
 	if (argc < 2)
 	{
 		SpawninvHelp();


### PR DESCRIPTION
Without this, players can change their spawninv, which will get applied on respawn. Since it's client-only and true inventory state is managed by the server, it can't be used for cheating but it does cause temporary inventory desyncs.