### PR TITLE
[BUGFIX] Portal Fixes

### DIFF
--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -781,6 +781,7 @@ CVAR(           r_drawnetcredibility, "0", "Add a particle to each actor indicat
                 CVARTYPE_BOOL, CVAR_NULL)
 
 CVAR_RANGE(		r_portalrecursions, "4", "Maximum depth of nested portal (skybox) views. 0 draws portal planes as regular sky.",
+				// NOLINTNEXTLINE(readability-magic-numbers) - cvar range
 				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 16.0f)
 
 #if 0

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -780,8 +780,8 @@ CVAR(			r_thingsectorlight, "0", "Things are lit according to the average of the
 CVAR(           r_drawnetcredibility, "0", "Add a particle to each actor indicating how credible the client considers the actor's position",
                 CVARTYPE_BOOL, CVAR_NULL)
 
-CVAR_RANGE(		r_portalrecursions, "16", "Maximum depth of nested portal (skybox) views. 0 draws portal planes as regular sky.",
-				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 64.0f)
+CVAR_RANGE(		r_portalrecursions, "4", "Maximum depth of nested portal (skybox) views. 0 draws portal planes as regular sky.",
+				CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 16.0f)
 
 #if 0
 CVAR(			r_drawhitboxes, "0", "Draws a box outlining every actor's hitboxes",

--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -747,6 +747,7 @@ void R_Subsector (int num)
 
 	ceilingplane = P_CeilingHeight(viewx, viewy, frontsector) > viewz ||
 		R_IsSkyFlat(frontsector->ceilingpic) ||
+		R_IsStackBoundary(frontsector->SkyboxCeiling) ||
 		(frontsector->heightsec &&
 		!(frontsector->heightsec->MoreFlags & SECF_IGNOREHEIGHTSEC) &&
 		R_IsSkyFlat(frontsector->heightsec->floorpic)) ?
@@ -767,6 +768,7 @@ void R_Subsector (int num)
 	// killough 3/16/98: add floorlightlevel
 	// killough 10/98: add support for skies transferred from sidedefs
 	floorplane = P_FloorHeight(viewx, viewy, frontsector) < viewz || // killough 3/7/98
+		R_IsStackBoundary(frontsector->SkyboxFloor) ||
 		(frontsector->heightsec &&
 		!(frontsector->heightsec->MoreFlags & SECF_IGNOREHEIGHTSEC) &&
 		R_IsSkyFlat(frontsector->heightsec->ceilingpic)) ?

--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -361,6 +361,7 @@ visplane_t *R_FindPlane (const plane_t &secplane, int picnum, int lightlevel,
 		else if (P_IdenticalPlanes(&secplane, &check->secplane) &&
 				picnum == check->picnum &&
 				lightlevel == check->lightlevel &&
+				skybox == check->skybox &&	// boundary flats draw at their own alpha
 				xoffs == check->xoffs && // killough 2/28/98: Add offset checks
 				yoffs == check->yoffs &&
 				basecolormap == check->colormap && // [RH] Add colormap check

--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -85,7 +85,7 @@ static int R_StackFlatAlpha(const AActor* mo)
 	const AActor* local = mo->tracer;
 
 	// Unpaired boundary: nothing to see through, so draw the flat as it is.
-	if (local == NULL)
+	if (local == nullptr)
 		return 255;
 
 	return std::clamp(static_cast<int>(local->args[0]), 0, 255);
@@ -99,28 +99,23 @@ bool R_IsStackBoundary(const AActor* mo)
 }
 
 // Stack points of the portal passes being rendered, innermost last.
-static std::vector<AActor*> r_ActiveStackPortals;
+std::vector<AActor*> r_ActiveStackPortals;
 
 // Is either end of this boundary's pair already being rendered?
 // If so, prevent it from being entered again.
-static bool R_IsStackPairActive(const AActor* mo)
+bool R_IsStackPairActive(const AActor* mo)
 {
-	for (const AActor* active : r_ActiveStackPortals)
+	const auto samepair = [mo](const AActor* active)
 	{
-		if (active == mo)
-			return true;
-
 		const AActor* mate = active->tracer;
+		return active == mo || (mate != nullptr && mate == mo);
+	};
 
-		if (mate != NULL && mate == mo)
-			return true;
-	}
-
-	return false;
+	return std::ranges::any_of(r_ActiveStackPortals, samepair);
 }
 
 // Does this plane render a portal pass, or only its own boundary flat?
-static bool R_IsStackPortal(const AActor* mo)
+bool R_IsStackPortal(const AActor* mo)
 {
 	return R_IsStackBoundary(mo) && !R_IsStackPairActive(mo);
 }

--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -78,18 +78,51 @@ static bool R_IsStackPoint(const AActor* mo)
 	return mo && (mo->type == MT_UPPERSTACK || mo->type == MT_LOWERSTACK);
 }
 
-// Alpha of the boundary flat drawn over a stack portal's content, from the
-// remote stack thing's arg0: 0 = invisible flat, 255 = fully opaque.
+// Alpha of the boundary flat drawn over a stack portal's content: 0 = invisible
+// flat, 255 = fully opaque.
 static int R_StackFlatAlpha(const AActor* mo)
 {
-	return std::clamp(static_cast<int>(mo->args[0]), 0, 255);
+	const AActor* local = mo->tracer;
+
+	// Unpaired boundary: nothing to see through, so draw the flat as it is.
+	if (local == NULL)
+		return 255;
+
+	return std::clamp(static_cast<int>(local->args[0]), 0, 255);
 }
 
-// Does this plane render as a portal? A boundary flat at full opacity would
-// completely hide the portal view, so skip the pass and draw it normally.
-static bool R_IsStackPortal(const AActor* mo)
+// Can the view see through this boundary? A flat at full opacity hides
+// whatever is behind it, so the plane just draws normally.
+bool R_IsStackBoundary(const AActor* mo)
 {
 	return R_IsStackPoint(mo) && R_StackFlatAlpha(mo) < 255;
+}
+
+// Stack points of the portal passes being rendered, innermost last.
+static std::vector<AActor*> r_ActiveStackPortals;
+
+// Is either end of this boundary's pair already being rendered?
+// If so, prevent it from being entered again.
+static bool R_IsStackPairActive(const AActor* mo)
+{
+	for (const AActor* active : r_ActiveStackPortals)
+	{
+		if (active == mo)
+			return true;
+
+		const AActor* mate = active->tracer;
+
+		if (mate != NULL && mate == mo)
+			return true;
+	}
+
+	return false;
+}
+
+// Does this plane render a portal pass, or only its own boundary flat?
+static bool R_IsStackPortal(const AActor* mo)
+{
+	return R_IsStackBoundary(mo) && !R_IsStackPairActive(mo);
 }
 
 visplane_t 				*floorplane;
@@ -785,6 +818,10 @@ void R_DrawPlanes (void)
 			{
 				R_RenderSkyRange(pl);
 			}
+			else if (R_IsStackBoundary(pl->skybox) && R_StackFlatAlpha(pl->skybox) > 0)
+			{
+				R_DrawStackFlatBlend(pl);
+			}
 			else
 			{
 				R_DrawSingleFlatPlane(pl);
@@ -890,6 +927,7 @@ static void R_RenderPortalView(visplane_t* pl)
 	ptrdiff_t savedds_p = ds_p - drawsegs;
 	ptrdiff_t savedfirstdrawseg = firstdrawseg - drawsegs;
 	AActor* savedcamera = camera;
+	bool pushedstackportal = false;
 
 	int i;
 
@@ -904,8 +942,10 @@ static void R_RenderPortalView(visplane_t* pl)
 
 		viewx = savedx + sky->x - mate->x;
 		viewy = savedy + sky->y - mate->y;
-		viewz = savedz + sky->z - mate->z;
+		viewz = savedz;
 		camera = sky;
+		r_ActiveStackPortals.push_back(sky);
+		pushedstackportal = true;
 	}
 	else
 	{
@@ -920,20 +960,20 @@ static void R_RenderPortalView(visplane_t* pl)
 	R_ClearPlanes(false);
 	R_ClearClipSegs();
 
-		// Set up ceiling/floor clip arrays for this visplane.
-		for (i = pl->minx; i <= pl->maxx; i++)
+	// Set up ceiling/floor clip arrays for this visplane.
+	for (i = pl->minx; i <= pl->maxx; i++)
+	{
+		if (pl->top[i] == static_cast<unsigned int>(viewheight))
 		{
-			if (pl->top[i] == static_cast<unsigned int>(viewheight))
-			{
-				ceilingclip[i] = viewheight;
-				floorclip[i] = -1;
-			}
-			else
-			{
-				ceilingclip[i] = pl->top[i];
-				floorclip[i] = pl->bottom[i] + 1;
-			}
+			ceilingclip[i] = viewheight;
+			floorclip[i] = -1;
 		}
+		else
+		{
+			ceilingclip[i] = pl->top[i];
+			floorclip[i] = pl->bottom[i] + 1;
+		}
+	}
 
 	// Create a drawseg to clip sprites to the sky plane.
 	R_ReallocDrawSegs();
@@ -966,6 +1006,9 @@ static void R_RenderPortalView(visplane_t* pl)
 	ds_p = drawsegs + savedds_p;
 
 	camera = savedcamera;
+
+	if (pushedstackportal)
+		r_ActiveStackPortals.pop_back();
 	viewx = savedx;
 	viewy = savedy;
 	viewz = savedz;
@@ -976,6 +1019,9 @@ void R_DrawPortals()
 {
 	if (visplanes[MAXVISPLANES] == NULL)
 		return;
+
+	// A render aborted mid-pass can leave entries behind.
+	r_ActiveStackPortals.clear();
 
 	// Don't let gun flashes brighten portal views
 	int savedextralight = extralight;

--- a/client/src/r_plane.cpp
+++ b/client/src/r_plane.cpp
@@ -958,7 +958,7 @@ static void R_RenderPortalView(visplane_t* pl)
 	// Set up ceiling/floor clip arrays for this visplane.
 	for (i = pl->minx; i <= pl->maxx; i++)
 	{
-		if (pl->top[i] == static_cast<unsigned int>(viewheight))
+		if (std::cmp_equal(pl->top[i], viewheight))
 		{
 			ceilingclip[i] = viewheight;
 			floorclip[i] = -1;

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -499,7 +499,7 @@ void R_RenderSolidSegRange(int start, int stop)
 		for (int x = start; x <= stop; x++)
 		{
 			const int top = std::max(ceilingclip[x], 0);
-			const int bottom = std::min({walltopf[x], floorclip[x] - 1, viewheight - 1});
+			const int bottom = std::min({walltopf[x] - 1, floorclip[x] - 1, viewheight - 1});
 
 			if (top <= bottom)
 			{

--- a/common/r_plane.h
+++ b/common/r_plane.h
@@ -60,6 +60,8 @@ R_MakeSpans
 void R_DrawPlanes (void);
 void R_DrawPortals (void);
 
+bool R_IsStackBoundary(const AActor* mo);
+
 visplane_t *R_FindPlane
 ( const plane_t	&secplane,
   int			picnum,

--- a/odalaunch/res/odamex_cvardoc.json
+++ b/odalaunch/res/odamex_cvardoc.json
@@ -2047,10 +2047,10 @@
          "type" : "boolean"
       },
       {
-         "default" : 16,
+         "default" : 4,
          "flags" : [ "NOENABLEDISABLE", "CLIENTARCHIVE" ],
          "helptext" : "Maximum depth of nested portal (skybox) views. 0 draws portal planes as regular sky.",
-         "max" : 64,
+         "max" : 16,
          "min" : 0,
          "name" : "r_portalrecursions",
          "type" : "integer"


### PR DESCRIPTION
My first time around, I didn't have a good reference wad for stacked portals. As such, I kind of went my own way with this feature, but now that I have access to maps that work in ZDaemon and Zandronum's software renderer, I can fix the bugs with this implementation that I missed first time around.

1.) Skyboxes had a sort of "1px bleed" that was similar to the midtex gap, but instead of midtex it'd render 1px of sky within a skybox. Fixed (and also verified the midtex gap was still fixed).

2.) Fixed the portal camera adding the subtracted Z value of the upper and lower stacked things. This should simply be viewz and let the camera only move within x/y of the stacked sectors.

3.) We now track which skybox we're currently in for recursion, to avoid a skybox pass from re-entering the skybox its already in.

4.) Draw a new visplane at a new skybox, to get that skybox's boundary flat rendering properly.

5.) Get boundary flat's alpha from the source stacked portal thing instead of its mate.

6.) Reduced `r_portalrecursions` default to 4 from 16, and max from 64 to 16.

Here's the updated skybox_test wad with portals and recursive skyboxes to test it.

https://www.dropbox.com/scl/fi/529m8bk6euju172cs703t/skybox_test3.zip?rlkey=048rhsmbb6k4xqfiptsvme1sy&st=tymgjcbg&dl=0