### PR TITLE
[BUGFIX] Add am_ovscalelock to keep the minimap square

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -2452,6 +2452,8 @@ void AM_Drawer()
 		case 2:
 			f_h = std::min(f_w, v_height);
 			break;
+		default:
+			break;
 		}
 
 		switch (loc)

--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -146,6 +146,7 @@ EXTERN_CVAR(am_ovbackcolor)
 EXTERN_CVAR(am_ovbackalpha)
 EXTERN_CVAR(am_ovscalewidth)
 EXTERN_CVAR(am_ovscaleheight)
+EXTERN_CVAR(am_ovscalelock)
 EXTERN_CVAR(am_ovlocation)
 
 EXTERN_CVAR(netdebug_automap)
@@ -2435,12 +2436,23 @@ void AM_Drawer()
 		const int v_width = R_ViewWidth(surface_width, surface_height);
 		const int v_height = R_ViewHeight(surface_width, surface_height);
 		const int loc = am_ovlocation;
+		const int lock = am_ovscalelock;
 
 		int x_offset = 0;
 		int y_offset = 0;
 
 		f_w = v_width * am_ovscalewidth;
 		f_h = v_height * am_ovscaleheight;
+
+		switch (lock)
+		{
+		case 1:
+			f_w = std::min(f_h, v_width);
+			break;
+		case 2:
+			f_h = std::min(f_w, v_height);
+			break;
+		}
 
 		switch (loc)
 		{

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -205,6 +205,9 @@ CVAR_RANGE(				am_ovscalewidth, "0.25", "Scale width of overlay minimap",
 CVAR_RANGE(				am_ovscaleheight, "0.5", "Scale height of overlay minimap",
 						CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 1.0f)
 
+CVAR_RANGE(				am_ovscalelock, "0", "Overlay minimap scale lock (0:None, 1:Width, 2:Height)",
+						CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
+
 CVAR_RANGE(				am_ovlocation, "1", "Overlay minimap location (0:LeftTop, 1:LeftMid, 2:LeftBot, 3:RightTop, 4:RightMid, 5:RightBot)",
 						CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 5.0f)
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -205,7 +205,7 @@ CVAR_RANGE(				am_ovscalewidth, "0.25", "Scale width of overlay minimap",
 CVAR_RANGE(				am_ovscaleheight, "0.5", "Scale height of overlay minimap",
 						CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 1.0f)
 
-CVAR_RANGE(				am_ovscalelock, "0", "Overlay minimap scale lock (0:None, 1:Width, 2:Height)",
+CVAR_RANGE(				am_ovscalelock, "2", "Overlay minimap scale lock (0:None, 1:Width, 2:Height)",
 						// NOLINTNEXTLINE(readability-magic-numbers) - cvar range
 						CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
 

--- a/client/src/cl_cvarlist.cpp
+++ b/client/src/cl_cvarlist.cpp
@@ -206,6 +206,7 @@ CVAR_RANGE(				am_ovscaleheight, "0.5", "Scale height of overlay minimap",
 						CVARTYPE_FLOAT, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 1.0f)
 
 CVAR_RANGE(				am_ovscalelock, "0", "Overlay minimap scale lock (0:None, 1:Width, 2:Height)",
+						// NOLINTNEXTLINE(readability-magic-numbers) - cvar range
 						CVARTYPE_BYTE, CVAR_CLIENTARCHIVE | CVAR_NOENABLEDISABLE, 0.0f, 2.0f)
 
 CVAR_RANGE(				am_ovlocation, "1", "Overlay minimap location (0:LeftTop, 1:LeftMid, 2:LeftBot, 3:RightTop, 4:RightMid, 5:RightBot)",

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -1367,7 +1367,7 @@ std::array<value_t, 6> MinimapLocations = {{
 	{ .value = 5.0, .name = "Right Bottom"},
 }};
 
-std::array<value_t, 6> MinimapScaleLock = {{
+std::array<value_t, 3> MinimapScaleLock = {{
 	{.value = 0.0, .name = "None"},
 	{.value = 1.0, .name = "Width"},
 	{.value = 2.0, .name = "Height"},

--- a/client/src/m_options.cpp
+++ b/client/src/m_options.cpp
@@ -996,6 +996,7 @@ EXTERN_CVAR (hud_demobar)
 EXTERN_CVAR(hud_targetnames)
 EXTERN_CVAR(am_ovminimap)
 EXTERN_CVAR(am_ovlocation)
+EXTERN_CVAR(am_ovscalelock)
 EXTERN_CVAR(am_ovscalewidth)
 EXTERN_CVAR(am_ovscaleheight)
 
@@ -1362,7 +1363,13 @@ std::array<value_t, 6> MinimapLocations = {{
 	{ .value = 5.0, .name = "Right Bottom"},
 }};
 
-std::array<menuitem_t, 22> AutomapItems = {{
+std::array<value_t, 6> MinimapScaleLock = {{
+	{.value = 0.0, .name = "None"},
+	{.value = 1.0, .name = "Width"},
+	{.value = 2.0, .name = "Height"},
+}};
+
+std::array<menuitem_t, 23> AutomapItems = {{
 	{ .type = discrete, .label = "Rotate automap",		.a = {.cvar = &am_rotate},		   	.b = {.leftval = OnOff.size()}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
 	{ .type = discrete, .label = "Overlay automap",		.a = {.cvar = &am_overlay},			.b = {.leftval = Overlays.size()}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = Overlays.data()}},
 	{ .type = redtext,	.label = " ",					.a = {.cvar = nullptr},					.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0}, .e = {.values = nullptr}},
@@ -1385,6 +1392,7 @@ std::array<menuitem_t, 22> AutomapItems = {{
 	{ .type = yellowtext, .label = "Overlay Minimap Options", .a = {.cvar = nullptr},			.b = {.leftval = 0.0}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = nullptr}},
 	{ .type = discrete, .label = "Enable Minimap",		.a = {.cvar = &am_ovminimap},		.b = {.leftval = OnOff.size()}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = OnOff.data()}},
 	{ .type = discrete, .label = "Location",				.a = {.cvar = &am_ovlocation},		.b = {.leftval = MinimapLocations.size()}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = MinimapLocations.data()}},
+	{ .type = discrete, .label = "Scale Lock",				.a = {.cvar = &am_ovscalelock},		.b = {.leftval = MinimapScaleLock.size()}, .c = {.rightval = 0.0},	.d = {.step = 0.0},  .e = {.values = MinimapScaleLock.data()}},
 	{ .type = slider,	.label = "Scale Width",			.a = {.cvar = &am_ovscalewidth},		.b = {.leftval = 0.0}, .c = {.rightval = 1.0},	.d = {.step = 0.05}, .e = {.values = nullptr}},
 	{ .type = slider,	.label = "Scale Height",			.a = {.cvar = &am_ovscaleheight},	.b = {.leftval = 0.0}, .c = {.rightval = 1.0},	.d = {.step = 0.05}, .e = {.values = nullptr}},
 }};

--- a/odalaunch/res/odamex_cvardoc.json
+++ b/odalaunch/res/odamex_cvardoc.json
@@ -156,6 +156,15 @@
          "type" : "number"
       },
       {
+         "default" : 0,
+         "flags" : [ "NOENABLEDISABLE", "CLIENTARCHIVE" ],
+         "helptext" : "Overlay minimap scale lock (0:None, 1:Width, 2:Height)",
+         "max" : 2,
+         "min" : 0,
+         "name" : "am_ovscalelock",
+         "type" : "integer"
+      },
+      {
          "default" : 0.25,
          "flags" : [ "NOENABLEDISABLE", "CLIENTARCHIVE" ],
          "helptext" : "Scale width of overlay minimap",

--- a/odalaunch/res/odamex_cvardoc.json
+++ b/odalaunch/res/odamex_cvardoc.json
@@ -156,7 +156,7 @@
          "type" : "number"
       },
       {
-         "default" : 0,
+         "default" : 2,
          "flags" : [ "NOENABLEDISABLE", "CLIENTARCHIVE" ],
          "helptext" : "Overlay minimap scale lock (0:None, 1:Width, 2:Height)",
          "max" : 2,


### PR DESCRIPTION
Fixes #1956 

This adds the cvar and menu option for am_ovscalelock. Use it to lock the width or height of the minimap so that it stays square when switching to the fullscreen HUD.
