### PR TITLE
[BUGFIX] Better CONCHARS handling

### DIFF
--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -934,7 +934,10 @@ EXTERN_CVAR(con_scrlock)
 
 static constexpr int CONCHARS_GLYPH_DIM = 8;
 static constexpr int CONCHARS_COUNT = 256;
-static constexpr int CONCHARS_GLYPH_BYTES = CONCHARS_GLYPH_DIM * CONCHARS_GLYPH_DIM * 2;
+
+static constexpr int CONCHARS_ROW_BYTES = 2 * CONCHARS_GLYPH_DIM;
+static constexpr int CONCHARS_GLYPH_BYTES = CONCHARS_GLYPH_DIM * CONCHARS_ROW_BYTES;
+static constexpr size_t CONCHARS_BYTES = static_cast<size_t>(CONCHARS_COUNT) * CONCHARS_GLYPH_BYTES;
 static constexpr palindex_t CONCHARS_TRANSCOLOR = 0xF7;
 
 //
@@ -951,7 +954,8 @@ static constexpr palindex_t CONCHARS_TRANSCOLOR = 0xF7;
 bool C_BlendConCharsSheet(int lumpnum)
 {
 	const patch_t* patch = W_CachePatch(lumpnum);
-	const int width = patch->width(), height = patch->height();
+	const int width = patch->width();
+	const int height = patch->height();
 
 	// W_CachePatch hands back an empty 0x0 header for lumps that aren't patches
 	// at all, so this rejects those along with sheets of the wrong shape
@@ -964,23 +968,26 @@ bool C_BlendConCharsSheet(int lumpnum)
 	const int glyph_count =
 		std::min(cols * (height / CONCHARS_GLYPH_DIM), CONCHARS_COUNT);
 
-	// Draw the sheet into a linear byte buffer with a background of 0xF7
+	// Draw the sheet into a linear byte buffer with a background of
+	// 'CONCHARS_TRANSCOLOR' so glyph pixels can be told from empty space
 	IWindowSurface* temp_surface = I_AllocateSurface(width, height, 8);
 	temp_surface->lock();
 
-	for (int y = 0; y < height; y++)
-		memset(temp_surface->getBuffer() + y * temp_surface->getPitchInPixels(),
-		       CONCHARS_TRANSCOLOR, width);
+	// the surface is 8bpp, so its pitch is both bytes and pixels per row
+	const ptrdiff_t pitch = temp_surface->getPitch();
+
+	for (ptrdiff_t y = 0; y < height; y++)
+		memset(temp_surface->getBuffer() + (y * pitch), CONCHARS_TRANSCOLOR, width);
 
 	const DCanvas* canvas = temp_surface->getDefaultCanvas();
 	canvas->DrawPatch(patch, 0, 0);
 
-	for (int i = 0; i < glyph_count; i++)
+	for (ptrdiff_t i = 0; i < glyph_count; i++)
 	{
-		byte* dest = ConChars + i * CONCHARS_GLYPH_BYTES;
+		byte* dest = ConChars + (i * CONCHARS_GLYPH_BYTES);
 		const byte* source = temp_surface->getBuffer() +
-		                     (i % cols) * CONCHARS_GLYPH_DIM +
-		                     (i / cols) * CONCHARS_GLYPH_DIM * temp_surface->getPitch();
+		                     ((i / cols) * CONCHARS_GLYPH_DIM * pitch) +
+		                     ((i % cols) * CONCHARS_GLYPH_DIM);
 
 		for (int z = 0; z < CONCHARS_GLYPH_DIM; z++)
 		{
@@ -990,17 +997,17 @@ bool C_BlendConCharsSheet(int lumpnum)
 				if (val == CONCHARS_TRANSCOLOR)
 				{
 					dest[a] = 0x00;
-					dest[a + 8] = 0xff;
+					dest[a + CONCHARS_GLYPH_DIM] = 0xff;
 				}
 				else
 				{
 					dest[a] = val;
-					dest[a + 8] = 0x00;
+					dest[a + CONCHARS_GLYPH_DIM] = 0x00;
 				}
 			}
 
-			dest += 16;
-			source += temp_surface->getPitch();
+			dest += CONCHARS_ROW_BYTES;
+			source += pitch;
 		}
 	}
 
@@ -1018,13 +1025,17 @@ bool C_BlendConCharsSheet(int lumpnum)
 //
 void C_InitConCharsFont()
 {
-	ConChars = new byte[CONCHARS_COUNT * CONCHARS_GLYPH_BYTES];
+	ConChars = new byte[CONCHARS_BYTES];
 
 	// characters that no sheet supplies stay fully transparent
-	for (int i = 0; i < CONCHARS_COUNT * CONCHARS_GLYPH_DIM; i++)
+	for (ptrdiff_t i = 0; i < CONCHARS_COUNT; i++)
 	{
-		memset(ConChars + i * 16, 0x00, 8);
-		memset(ConChars + i * 16 + 8, 0xff, 8);
+		byte* dest = ConChars + (i * CONCHARS_GLYPH_BYTES);
+		for (int z = 0; z < CONCHARS_GLYPH_DIM; z++, dest += CONCHARS_ROW_BYTES)
+		{
+			memset(dest, 0x00, CONCHARS_GLYPH_DIM);
+			memset(dest + CONCHARS_GLYPH_DIM, 0xff, CONCHARS_GLYPH_DIM);
+		}
 	}
 
 	int sheets = 0;
@@ -1038,9 +1049,9 @@ void C_InitConCharsFont()
 		}
 
 		const int filenum = W_GetLumpFile(lumpnum);
-		const char* filename = filenum >= 0 && filenum < static_cast<int>(wadfiles.size())
-		                           ? wadfiles[filenum].getBasename().c_str()
-		                           : "an unknown file";
+		const char* filename = "an unknown file";
+		if (filenum >= 0 && std::cmp_less(filenum, wadfiles.size()))
+			filename = wadfiles[static_cast<size_t>(filenum)].getBasename().c_str();
 
 		PrintFmt(PRINT_WARNING,
 		         "CONCHARS in {} is not a grid of 8x8 glyphs, ignoring it.\n",
@@ -1059,7 +1070,7 @@ void C_InitConCharsFont()
 void C_ShutdownConCharsFont()
 {
 	delete [] ConChars;
-	ConChars = NULL;
+	ConChars = nullptr;
 }
 
 //

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1046,14 +1046,9 @@ void C_InitConCharsFont()
 			continue;
 		}
 
-		const int filenum = W_GetLumpFile(lumpnum);
-		const char* filename = "an unknown file";
-		if (filenum >= 0 && std::cmp_less(filenum, wadfiles.size()))
-			filename = wadfiles[static_cast<size_t>(filenum)].getBasename().c_str();
-
 		PrintFmt(PRINT_WARNING,
 		         "CONCHARS in {} is not a grid of 8x8 glyphs, ignoring it.\n",
-		         filename);
+		         W_LumpFileName(lumpnum));
 	}
 
 	if (sheets == 0)

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -957,9 +957,9 @@ bool C_BlendConCharsSheet(int lumpnum)
 
 	// W_CachePatch hands back an empty 0x0 header for lumps that aren't patches
 	// at all, so this rejects those along with sheets of the wrong shape
-	if (width < CONCHARS_GLYPH_DIM || width % CONCHARS_GLYPH_DIM != 0 ||
-		height < CONCHARS_GLYPH_DIM || height % CONCHARS_GLYPH_DIM != 0 ||
-		patch->leftoffset() != 0 || patch->topoffset() != 0)
+	if (width < CONCHARS_GLYPH_DIM or width % CONCHARS_GLYPH_DIM != 0 or
+		height < CONCHARS_GLYPH_DIM or height % CONCHARS_GLYPH_DIM != 0 or
+		patch->leftoffset() != 0 or patch->topoffset() != 0)
 		return false;
 
 	const int cols = width / CONCHARS_GLYPH_DIM;

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -932,62 +932,124 @@ CVAR_FUNC_IMPL(con_scaletext)
 // con_scrlock 2 = Nothing brings scroll to the bottom.
 EXTERN_CVAR(con_scrlock)
 
-//
-// C_InitConCharsFont
-//
-// Loads the CONCHARS lump from disk and converts it to the format used by
-// the console for printing text.
-//
-void C_InitConCharsFont()
-{
-	static palindex_t transcolor = 0xF7;
+static constexpr int CONCHARS_GLYPH_DIM = 8;
+static constexpr int CONCHARS_COUNT = 256;
+static constexpr int CONCHARS_GLYPH_BYTES = CONCHARS_GLYPH_DIM * CONCHARS_GLYPH_DIM * 2;
+static constexpr palindex_t CONCHARS_TRANSCOLOR = 0xF7;
 
-	// Load the CONCHARS lump and convert it from patch_t format
-	// to a raw linear byte buffer with a background color of 'transcolor'
-	IWindowSurface* temp_surface = I_AllocateSurface(128, 128, 8);
+//
+// C_BlendConCharsSheet
+//
+// Converts one CONCHARS lump into the format used by the console and writes it
+// over the characters the sheet covers, leaving the rest of the font alone.
+// We attempt to support all CONCHAR lumps with all ports here.
+// Odamex's own is 16x16 and supplies all 256 chars (with support chars), while
+// sheets written for other ports are usually 32x4 and only cover only ASCII chars.
+//
+// Returns false if the lump isn't a usable sheet.
+//
+bool C_BlendConCharsSheet(int lumpnum)
+{
+	const patch_t* patch = W_CachePatch(lumpnum);
+	const int width = patch->width(), height = patch->height();
+
+	// W_CachePatch hands back an empty 0x0 header for lumps that aren't patches
+	// at all, so this rejects those along with sheets of the wrong shape
+	if (width < CONCHARS_GLYPH_DIM || width % CONCHARS_GLYPH_DIM != 0 ||
+		height < CONCHARS_GLYPH_DIM || height % CONCHARS_GLYPH_DIM != 0 ||
+		patch->leftoffset() != 0 || patch->topoffset() != 0)
+		return false;
+
+	const int cols = width / CONCHARS_GLYPH_DIM;
+	const int glyph_count =
+		std::min(cols * (height / CONCHARS_GLYPH_DIM), CONCHARS_COUNT);
+
+	// Draw the sheet into a linear byte buffer with a background of 0xF7
+	IWindowSurface* temp_surface = I_AllocateSurface(width, height, 8);
 	temp_surface->lock();
 
-	// fill with color 'transcolor'
-	for (int y = 0; y < 128; y++)
-		memset(temp_surface->getBuffer() + y * temp_surface->getPitchInPixels(), transcolor, 128);
+	for (int y = 0; y < height; y++)
+		memset(temp_surface->getBuffer() + y * temp_surface->getPitchInPixels(),
+		       CONCHARS_TRANSCOLOR, width);
 
-	// paste the patch into the linear byte bufer
 	const DCanvas* canvas = temp_surface->getDefaultCanvas();
-	canvas->DrawPatch(W_CachePatch("CONCHARS"), 0, 0);
+	canvas->DrawPatch(patch, 0, 0);
 
-	ConChars = new byte[256*8*8*2];
-	byte* dest = ConChars;
-
-	for (int y = 0; y < 16; y++)
+	for (int i = 0; i < glyph_count; i++)
 	{
-		for (int x = 0; x < 16; x++)
-		{
-			const byte* source = temp_surface->getBuffer() + x * 8 + (y * 8 * temp_surface->getPitch());
-			for (int z = 0; z < 8; z++)
-			{
-				for (int a = 0; a < 8; a++)
-				{
-					const byte val = source[a];
-					if (val == transcolor)
-					{
-						dest[a] = 0x00;
-						dest[a + 8] = 0xff;
-					}
-					else
-					{
-						dest[a] = val;
-						dest[a + 8] = 0x00;
-					}
-				}
+		byte* dest = ConChars + i * CONCHARS_GLYPH_BYTES;
+		const byte* source = temp_surface->getBuffer() +
+		                     (i % cols) * CONCHARS_GLYPH_DIM +
+		                     (i / cols) * CONCHARS_GLYPH_DIM * temp_surface->getPitch();
 
-				dest += 16;
-				source += temp_surface->getPitch();
+		for (int z = 0; z < CONCHARS_GLYPH_DIM; z++)
+		{
+			for (int a = 0; a < CONCHARS_GLYPH_DIM; a++)
+			{
+				const byte val = source[a];
+				if (val == CONCHARS_TRANSCOLOR)
+				{
+					dest[a] = 0x00;
+					dest[a + 8] = 0xff;
+				}
+				else
+				{
+					dest[a] = val;
+					dest[a + 8] = 0x00;
+				}
 			}
+
+			dest += 16;
+			source += temp_surface->getPitch();
 		}
 	}
 
 	temp_surface->unlock();
 	I_FreeSurface(temp_surface);
+	return true;
+}
+
+//
+// C_InitConCharsFont
+//
+// Builds the console font by layering every CONCHARS lump in load order. Each
+// sheet only replaces the characters it actually spans, so a PWAD sheet that
+// stops at ASCII keeps the glyphs an earlier sheet supplied above it.
+//
+void C_InitConCharsFont()
+{
+	ConChars = new byte[CONCHARS_COUNT * CONCHARS_GLYPH_BYTES];
+
+	// characters that no sheet supplies stay fully transparent
+	for (int i = 0; i < CONCHARS_COUNT * CONCHARS_GLYPH_DIM; i++)
+	{
+		memset(ConChars + i * 16, 0x00, 8);
+		memset(ConChars + i * 16 + 8, 0xff, 8);
+	}
+
+	int sheets = 0;
+	for (int lumpnum = W_FindLump("CONCHARS", -1); lumpnum != -1;
+	     lumpnum = W_FindLump("CONCHARS", lumpnum))
+	{
+		if (C_BlendConCharsSheet(lumpnum))
+		{
+			sheets++;
+			continue;
+		}
+
+		const int filenum = W_GetLumpFile(lumpnum);
+		const char* filename = filenum >= 0 && filenum < static_cast<int>(wadfiles.size())
+		                           ? wadfiles[filenum].getBasename().c_str()
+		                           : "an unknown file";
+
+		PrintFmt(PRINT_WARNING,
+		         "CONCHARS in {} is not a grid of 8x8 glyphs, ignoring it.\n",
+		         filename);
+	}
+
+	if (sheets == 0)
+		PrintFmt(PRINT_WARNING,
+		         "No usable CONCHARS lump was found; console text will be blank.\n");
 }
 
 

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -83,8 +83,6 @@ int			ConBottomStep; // Console fall/raise bottom pixels at the end of the tic, 
 int			CursorTicker, ScrollState = 0;
 constate_e	ConsoleState = c_up;
 
-extern byte *ConChars;
-
 bool		KeysShifted;
 bool		KeysCtrl;
 bool		KeysAlt;
@@ -984,7 +982,7 @@ bool C_BlendConCharsSheet(int lumpnum)
 
 	for (ptrdiff_t i = 0; i < glyph_count; i++)
 	{
-		byte* dest = ConChars + (i * CONCHARS_GLYPH_BYTES);
+		byte* dest = ConChars.data() + (i * CONCHARS_GLYPH_BYTES);
 		const byte* source = temp_surface->getBuffer() +
 		                     ((i / cols) * CONCHARS_GLYPH_DIM * pitch) +
 		                     ((i % cols) * CONCHARS_GLYPH_DIM);
@@ -1025,12 +1023,12 @@ bool C_BlendConCharsSheet(int lumpnum)
 //
 void C_InitConCharsFont()
 {
-	ConChars = new byte[CONCHARS_BYTES];
+	ConChars.resize(CONCHARS_BYTES);
 
 	// characters that no sheet supplies stay fully transparent
 	for (ptrdiff_t i = 0; i < CONCHARS_COUNT; i++)
 	{
-		byte* dest = ConChars + (i * CONCHARS_GLYPH_BYTES);
+		byte* dest = ConChars.data() + (i * CONCHARS_GLYPH_BYTES);
 		for (int z = 0; z < CONCHARS_GLYPH_DIM; z++, dest += CONCHARS_ROW_BYTES)
 		{
 			memset(dest, 0x00, CONCHARS_GLYPH_DIM);
@@ -1061,16 +1059,6 @@ void C_InitConCharsFont()
 	if (sheets == 0)
 		PrintFmt(PRINT_WARNING,
 		         "No usable CONCHARS lump was found; console text will be blank.\n");
-}
-
-
-//
-// C_ShutdownConCharsFont
-//
-void C_ShutdownConCharsFont()
-{
-	delete [] ConChars;
-	ConChars = nullptr;
 }
 
 //

--- a/client/src/d_main.cpp
+++ b/client/src/d_main.cpp
@@ -811,8 +811,6 @@ void D_Shutdown()
 
 	HU_Shutdown();
 
-	C_ShutdownConCharsFont();
-
 	C_ShutdownConsoleBackground();
 
 	R_Shutdown();

--- a/client/src/v_text.cpp
+++ b/client/src/v_text.cpp
@@ -54,7 +54,7 @@ static int hu_bigfont_height;
 static int hu_smallfont_height;
 static int hu_digfont_height;
 
-byte *ConChars;
+std::vector<byte> ConChars;
 extern byte *Ranges;
 
 /**
@@ -251,7 +251,7 @@ int V_GetTextColor(std::string_view str)
 void DCanvas::PrintStr(int x, int y, const char* str, int default_color, bool use_color_codes, int scale) const
 {
 	// Don't try and print a string without conchars loaded.
-	if (::ConChars == NULL)
+	if (::ConChars.empty())
 		return;
 
 	const int char_size = 8 * scale;

--- a/client/src/v_text.h
+++ b/client/src/v_text.h
@@ -25,11 +25,16 @@
 #pragma once
 
 #include <stdexcept>
+#include <vector>
 
 #include "v_textcolors.h"	// Ch0wW : Colorized textcodes
 #include "hu_stuff.h"
 #include "r_defs.h"
 #include "w_wad.h"
+
+// The console font: 256 glyphs of 8 rows, each row 8 color bytes followed by 8
+// transparency mask bytes. Built from the CONCHARS lumps by C_InitConCharsFont.
+extern std::vector<byte> ConChars;
 
 struct OGlobalFont
 {

--- a/common/c_console.h
+++ b/common/c_console.h
@@ -46,7 +46,6 @@ void C_InitConsoleBackground();
 void C_ShutdownConsoleBackground();
 
 void C_InitConCharsFont();
-void C_ShutdownConCharsFont();
 
 void C_ClearCommand();
 

--- a/common/w_wad.cpp
+++ b/common/w_wad.cpp
@@ -925,15 +925,35 @@ int W_FindLump (const char *name, int lastlump)
 //
 // W_GetLumpFile
 //
-// Returns the index into wadfiles of the file a lump came from, or -1 if
-// the engine generated the lump instead of reading it.
+// Returns the index into wadfiles of the file a lump came from, or std::nullopt
+// if the engine generated the lump instead of reading it.
 //
-int W_GetLumpFile(unsigned lump)
+std::optional<size_t> W_GetLumpFile(unsigned lump)
 {
 	if (lump >= lumpinfo.size())
 		I_Error("{}: {} >= numlumps", __FUNCTION__, lump);
 
-	return lumpinfo[lump].file;
+	if (lumpinfo[lump].file < 0)
+		return std::nullopt;
+
+	return static_cast<size_t>(lumpinfo[lump].file);
+}
+
+//
+// W_LumpFileName
+//
+// Names the file a lump came from so error messages can point at it. Engine
+// lumps and out of range indices both come back as a placeholder, so callers
+// never have to guard the result.
+//
+std::string_view W_LumpFileName(unsigned lump)
+{
+	const std::optional<size_t> filenum = W_GetLumpFile(lump);
+
+	if (not filenum.has_value() or *filenum >= wadfiles.size())
+		return "an unknown file";
+
+	return wadfiles[*filenum].getBasename();
 }
 
 //
@@ -941,7 +961,9 @@ int W_GetLumpFile(unsigned lump)
 //
 bool W_IsLumpFromPWAD(unsigned lump)
 {
-	return W_GetLumpFile(lump) >= WADFILE_FIRSTPWAD;
+	const std::optional<size_t> filenum = W_GetLumpFile(lump);
+
+	return filenum.has_value() and *filenum >= WADFILE_FIRSTPWAD;
 }
 
 bool W_IsLumpFromPWAD(const char* name, namespace_t namespc)

--- a/common/w_wad.h
+++ b/common/w_wad.h
@@ -24,6 +24,9 @@
 
 #pragma once
 
+#include <optional>
+#include <string_view>
+
 #include "z_zone.h"
 #include "r_defs.h"
 #include "m_resfile.h"
@@ -216,10 +219,15 @@ OLumpName W_GetOLumpName(unsigned lump);
 
 // wadfiles always begins with odamex.wad followed by the IWAD, so every file
 // from here on is a PWAD.
-constexpr int WADFILE_FIRSTPWAD = 2;
+constexpr size_t WADFILE_FIRSTPWAD = 2;
 
-// [RH] Returns file handle for specified lump
-int W_GetLumpFile (unsigned lump);
+// The index into wadfiles of the file a lump came from, or nothing at all when
+// the engine generated the lump instead of reading it.
+std::optional<size_t> W_GetLumpFile(unsigned lump);
+
+// The base name of the file a lump came from, for use in diagnostics. Falls
+// back to a placeholder rather than failing, so it is always printable.
+std::string_view W_LumpFileName(unsigned lump);
 
 // True when a lump was supplied by a PWAD rather than by the IWAD, odamex.wad,
 // or the engine itself.


### PR DESCRIPTION
A bug exposed by [specdest.wad](https://www.doomworld.com/idgames/levels/doom2/Ports/megawads/specdesc), this WAD when loaded had no glyphs in the console. Turns out was because of a CONCHARS lump that was 256x32 instead of 128x128 like Odamex's own CONCHARS lump.

Now we allocate a surface the same size of the CONCHARS lump, and check to see if glyphs can be used based on their relative size. If they can, the glyph is added to the console font -- now patched one glyph at a time since a PWADs CONCHARs lump usually doesn't have Odamex-specific glyphs, so instead of taking a blank one and using it, we check each glyph for emptiness, and if so, simply use what was there before.

The fallback is to always use Odamex's CONCHARS lump if there's an issue with all loaded CONCHARS lumps from loaded PWADs. This ensures a console can't be blank with no glyphs which is an unfortunate failure mode.