### PR TITLE
[FEATURE] All the slopes!

### DIFF
--- a/client/src/am_map.cpp
+++ b/client/src/am_map.cpp
@@ -1477,13 +1477,13 @@ void AM_drawWalls()
 					else
 						AM_drawMline(&l, gameinfo.currentAutomapColors.WallColor);
 				}
-				else if (line.backsector->floorheight !=
-				         line.frontsector->floorheight)
+				else if (P_FloorHeight(line.backsector) !=
+				         P_FloorHeight(line.frontsector))
 				{
 					AM_drawMline(&l, gameinfo.currentAutomapColors.FDWallColor); // floor level change
 				}
-				else if (line.backsector->ceilingheight !=
-				         line.frontsector->ceilingheight)
+				else if (P_CeilingHeight(line.backsector) !=
+				         P_CeilingHeight(line.frontsector))
 				{
 					AM_drawMline(&l, gameinfo.currentAutomapColors.CDWallColor); // ceiling level change
 				}

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -2970,7 +2970,7 @@ void CL_ExecuteLineSpecial(const odaproto::svc::ExecuteLineSpecial* msg)
 	if (linenum != -1 && linenum >= ::numlines)
 		return;
 
-	line_t* line = NULL;
+	line_t* line = nullptr;
 	if (linenum != -1)
 		line = &::lines[linenum];
 

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -146,7 +146,7 @@ void UnpackBoolArray(std::span<bool> bools, uint32_t in)
 /**
  * @brief Common code for activating a line.
  */
-void ActivateLine(AActor* mo, line_s* line, byte side,
+void ActivateLine(AActor* mo, line_t* line, byte side,
                          LineActivationType activationType, const bool bossaction,
                          byte special = 0, int arg0 = 0, int arg1 = 0, int arg2 = 0,
                          int arg3 = 0, int arg4 = 0)
@@ -2970,7 +2970,7 @@ void CL_ExecuteLineSpecial(const odaproto::svc::ExecuteLineSpecial* msg)
 	if (linenum != -1 && linenum >= ::numlines)
 		return;
 
-	line_s* line = NULL;
+	line_t* line = NULL;
 	if (linenum != -1)
 		line = &::lines[linenum];
 

--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -236,7 +236,7 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 
 	// Gate r_fakingunderwater to only apply to heightsecs with
 	// possible deep water, since it applies to every heightsec in frame.
-	bool underwater = (r_fakingunderwater && s->floorheight > sec->floorheight) ||
+	bool underwater = (r_fakingunderwater && P_FloorHeight(s) >P_FloorHeight(sec)) ||
 		(heightsec && viewz <= P_FloorHeight(viewx, viewy, heightsec));
 	bool doorunderwater = false;
 	int diffTex = (s->MoreFlags & SECF_CLIPFAKEPLANES);
@@ -305,7 +305,7 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 	// sectors at the same time.
 
 	if (back && !r_fakingunderwater && curline->frontsector->heightsec == NULL &&
-		s->floorheight > sec->floorheight)
+		P_FloorHeight(s) > P_FloorHeight(sec))
 	{
 		fixed_t fcz1 = P_CeilingHeight(curline->v1->x, curline->v1->y, frontsector);
 		fixed_t fcz2 = P_CeilingHeight(curline->v2->x, curline->v2->y, frontsector);

--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -236,7 +236,7 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 
 	// Gate r_fakingunderwater to only apply to heightsecs with
 	// possible deep water, since it applies to every heightsec in frame.
-	bool underwater = (r_fakingunderwater && P_FloorHeight(s) >P_FloorHeight(sec)) ||
+	const bool underwater = (r_fakingunderwater && P_FloorHeight(s) >P_FloorHeight(sec)) ||
 		(heightsec && viewz <= P_FloorHeight(viewx, viewy, heightsec));
 	bool doorunderwater = false;
 	int diffTex = (s->MoreFlags & SECF_CLIPFAKEPLANES);

--- a/client/src/r_bsp.cpp
+++ b/client/src/r_bsp.cpp
@@ -236,8 +236,8 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 
 	// Gate r_fakingunderwater to only apply to heightsecs with
 	// possible deep water, since it applies to every heightsec in frame.
-	const bool underwater = (r_fakingunderwater && P_FloorHeight(s) >P_FloorHeight(sec)) ||
-		(heightsec && viewz <= P_FloorHeight(viewx, viewy, heightsec));
+	const bool underwater = (r_fakingunderwater and P_FloorHeight(s) >P_FloorHeight(sec)) or
+		(heightsec and viewz <= P_FloorHeight(viewx, viewy, heightsec));
 	bool doorunderwater = false;
 	int diffTex = (s->MoreFlags & SECF_CLIPFAKEPLANES);
 

--- a/client/src/r_segs.cpp
+++ b/client/src/r_segs.cpp
@@ -660,9 +660,9 @@ void R_RenderMaskedSegRange(drawseg_t* ds, int x1, int x2)
 
 	// find texture positioning
 	if (curline->linedef->flags & ML_DONTPEGBOTTOM)
-		dcol.texturemid = std::max(P_FloorHeight(frontsector), P_FloorHeight(backsector)) + R_TexInvScaleY(textureheight[texnum], texnum);
+		dcol.texturemid = std::max(frontsector->floortexz, backsector->floortexz) + R_TexInvScaleY(textureheight[texnum], texnum);
 	else
-		dcol.texturemid = std::min(P_CeilingHeight(frontsector), P_CeilingHeight(backsector));
+		dcol.texturemid = std::min(frontsector->ceilingtexz, backsector->ceilingtexz);
 
 	dcol.texturemid = R_TexScaleY(dcol.texturemid - viewz, texnum) + curline->sidedef->rowoffset;
 
@@ -895,12 +895,12 @@ void R_StoreWallRange(int start, int stop)
 		{
 			// bottom of texture at bottom
 			const fixed_t texheight = R_TexInvScaleY(textureheight[midtexture], midtexture);
-			rw_midtexturemid = P_FloorHeight(frontsector) - viewz + texheight;
+			rw_midtexturemid = frontsector->floortexz - viewz + texheight;
 		}
 		else
 		{
 			// top of texture at top
-			const fixed_t fc = P_CeilingHeight(frontsector);
+			const fixed_t fc = frontsector->ceilingtexz;
 			rw_midtexturemid = fc - viewz;
 		}
 
@@ -1019,14 +1019,14 @@ void R_StoreWallRange(int start, int stop)
 			if (linedef->flags & ML_DONTPEGTOP)
 			{
 				// top of texture at top
-				const fixed_t fc = P_CeilingHeight(frontsector);
+				const fixed_t fc = frontsector->ceilingtexz;
 				rw_toptexturemid = fc - viewz;
 			}
 			else
 			{
 				// bottom of texture
 				const fixed_t texheight = R_TexInvScaleY(textureheight[toptexture], toptexture);
-				rw_toptexturemid = P_CeilingHeight(backsector) - viewz + texheight;
+				rw_toptexturemid = backsector->ceilingtexz - viewz + texheight;
 			}
 		}
 
@@ -1038,13 +1038,13 @@ void R_StoreWallRange(int start, int stop)
 			if (linedef->flags & ML_DONTPEGBOTTOM)
 			{
 				// bottom of texture at bottom, top of texture at top
-				const fixed_t fc = P_CeilingHeight(frontsector);
+				const fixed_t fc = frontsector->ceilingtexz;
 				rw_bottomtexturemid = fc - viewz;
 			}
 			else
 			{
 				// top of texture at top
-				const fixed_t bf = P_FloorHeight(backsector);
+				const fixed_t bf = backsector->floortexz;
 				rw_bottomtexturemid = bf - viewz;
 			}
 		}

--- a/common/g_mapinfo.cpp
+++ b/common/g_mapinfo.cpp
@@ -913,7 +913,7 @@ void MIType_Pages(OScanner& os, bool doEquals, std::array<OLumpName, N>& out)
 }
 
 // Sets the skill levels a spawn filter applies to
-void MIType_SpawnFilter(OScanner& os, bool newStyleMapInfo, int& out)
+void MIType_SpawnFilter(OScanner& os, bool newStyleMapInfo, MapThingFlags& out)
 {
 	ParseMapInfoHelper<std::string>(os, newStyleMapInfo);
 
@@ -924,14 +924,14 @@ void MIType_SpawnFilter(OScanner& os, bool newStyleMapInfo, int& out)
 		{
 			case 1:
 			case 2:
-				out |= 1;
+				out |= MTF_EASY;
 				break;
 			case 3:
-				out |= 2;
+				out |= MTF_MEDIUM;
 				break;
 			case 4:
 			case 5:
-				out |= 4;
+				out |= MTF_HARD;
 				break;
 			default:
 				return;
@@ -940,11 +940,11 @@ void MIType_SpawnFilter(OScanner& os, bool newStyleMapInfo, int& out)
 	else
 	{
 		if (os.compareTokenNoCase("baby") || os.compareTokenNoCase("easy"))
-			out |= 1;
+			out |= MTF_EASY;
 		else if (os.compareTokenNoCase("normal"))
-			out |= 2;
+			out |= MTF_MEDIUM;
 		else if (os.compareTokenNoCase("hard") || os.compareTokenNoCase("nightmare"))
-			out |= 4;
+			out |= MTF_HARD;
 	}
 }
 

--- a/common/g_skill.h
+++ b/common/g_skill.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "c_cvars.h"
+#include "doomdata.h"
 #include "doomtype.h"
 #include "flags.h"
 #include "olumpname.h"
@@ -71,7 +72,7 @@ struct SkillInfo
 	int respawn_counter           = 0;
 	int respawn_limit             = 0;		// not implemented
 	float aggressiveness          = 1.0f;	// not implemented
-	int spawn_filter              = 0;
+	MapThingFlags spawn_filter    = MapThingFlags::none_set();
 	bool spawn_multi              = false;
 	bool instant_reaction         = false;
 	int ACS_return                = limits::MAXINT;

--- a/common/p_ceiling.cpp
+++ b/common/p_ceiling.cpp
@@ -303,23 +303,18 @@ DCeiling::DCeiling (sector_t *sec, fixed_t speed1, fixed_t speed2, int silent)
 }
 
 DCeiling::DCeiling(sector_t* sec, line_t* line, int silent, int speed)
-    : DMovingCeiling(sec), m_Status(init)
+	: DMovingCeiling{sec}, m_Type{silent ? genSilentCrusher : genCrusher},
+	  m_BottomHeight{P_FloorHeight(sec) + 8_fx},
+	  m_TopHeight{P_CeilingHeight(sec)},
+	  m_Crush{DOOM_CRUSH}, m_Silent{silent ? 2 : 1},
+	  m_Direction{-1}, m_Texture{sec->ceilingpic},
+	  m_NewSpecial{sec->special}, m_NewFlags{sec->flags},
+	  m_NewDamageRate{static_cast<int16_t>(sec->damageamount)},
+	  m_NewLeakRate{static_cast<byte>(sec->leakrate)},
+	  m_NewDmgInterval{static_cast<byte>(sec->damageinterval)},
+	  m_Tag{sec->tag},
 {
-	m_Type = silent ? genSilentCrusher : genCrusher;
-	m_Crush = DOOM_CRUSH;
-	m_CrushMode = crushDoom;
-	m_Direction = -1;
 	m_Sector = sec;
-	m_Texture = sec->ceilingpic;
-	m_NewSpecial = sec->special;
-	m_NewDamageRate = sec->damageamount;
-	m_NewDmgInterval = sec->damageinterval;
-	m_NewLeakRate = sec->leakrate;
-	m_NewFlags = sec->flags;
-	m_Tag = sec->tag;
-	m_Silent = m_Type == genSilentCrusher ? 2 : 1;
-	m_TopHeight = sec->ceilingtexz;
-	m_BottomHeight = sec->floortexz + (8 * FRACUNIT);
 
 	// setup ceiling motion speed
 	switch (speed)
@@ -381,7 +376,7 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int speed,
 	}
 
 	// set destination target height
-	targheight = sec->ceilingtexz;
+	targheight = P_CeilingHeight(sec);
 	switch (target)
 	{
 	case CtoHnC:
@@ -399,25 +394,25 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int speed,
 		targheight = P_FindHighestFloorSurrounding(sec);
 		break;
 	case CtoF:
-		targheight = sec->floortexz;
+		targheight = P_FloorHeight(sec);
 		break;
 	case CbyST:
 		targheight =
-		    (sec->ceilingtexz >> FRACBITS) +
-		             m_Direction * (P_FindShortestUpperAround(sec) >> FRACBITS);
+			FIXED2INT(P_CeilingHeight(sec)) +
+			(m_Direction * FIXED2INT(P_FindShortestUpperAround(sec)));
 		if (targheight > 32000)     // jff 3/13/98 prevent overflow
 			targheight = 32000; // wraparound in ceiling height
 		if (targheight < -32000)
 			targheight = -32000;
-		targheight <<= FRACBITS;
+		targheight = INT2FIXED(targheight);
 		break;
 	case Cby24:
 		targheight =
-		    sec->ceilingtexz + m_Direction * 24 * FRACUNIT;
+		    P_CeilingHeight(sec) + (m_Direction * 24_fx); // NOLINT(readability-magic-numbers) - by 24 moves by 24
 		break;
 	case Cby32:
 		targheight =
-		   sec->ceilingtexz + m_Direction * 32 * FRACUNIT;
+		   P_CeilingHeight(sec) + (m_Direction * 32_fx);
 		break;
 	default:
 		break;
@@ -734,13 +729,13 @@ bool P_SpawnZDoomCeiling(DCeiling::ECeiling type, line_t* line, int tag, fixed_t
 		// Don't make noise for instant movement ceilings
 		if (ceiling->m_Direction < 0)
 		{
-			if (ceiling->m_Speed >= sec->ceilingtexz - ceiling->m_BottomHeight)
+			if (ceiling->m_Speed >= P_CeilingHeight(sec) - ceiling->m_BottomHeight)
 				if (silent & 4)
 					ceiling->m_Silent = 2;
 		}
 		else
 		{
-			if (ceiling->m_Speed >= ceiling->m_TopHeight - sec->ceilingtexz)
+			if (ceiling->m_Speed >= ceiling->m_TopHeight - P_CeilingHeight(sec))
 				if (silent & 4)
 					ceiling->m_Silent = 2;
 		}

--- a/common/p_ceiling.cpp
+++ b/common/p_ceiling.cpp
@@ -318,8 +318,8 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int silent, int speed)
 	m_NewFlags = sec->flags;
 	m_Tag = sec->tag;
 	m_Silent = m_Type == genSilentCrusher ? 2 : 1;
-	m_TopHeight = sec->ceilingheight;
-	m_BottomHeight = sec->floorheight + (8 * FRACUNIT);
+	m_TopHeight = sec->ceilingtexz;
+	m_BottomHeight = sec->floortexz + (8 * FRACUNIT);
 
 	// setup ceiling motion speed
 	switch (speed)
@@ -381,7 +381,7 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int speed,
 	}
 
 	// set destination target height
-	targheight = sec->ceilingheight;
+	targheight = sec->ceilingtexz;
 	switch (target)
 	{
 	case CtoHnC:
@@ -399,11 +399,11 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int speed,
 		targheight = P_FindHighestFloorSurrounding(sec);
 		break;
 	case CtoF:
-		targheight = sec->floorheight;
+		targheight = sec->floortexz;
 		break;
 	case CbyST:
 		targheight =
-		    (sec->ceilingheight >> FRACBITS) +
+		    (sec->ceilingtexz >> FRACBITS) +
 		             m_Direction * (P_FindShortestUpperAround(sec) >> FRACBITS);
 		if (targheight > 32000)     // jff 3/13/98 prevent overflow
 			targheight = 32000; // wraparound in ceiling height
@@ -413,11 +413,11 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int speed,
 		break;
 	case Cby24:
 		targheight =
-		    sec->ceilingheight + m_Direction * 24 * FRACUNIT;
+		    sec->ceilingtexz + m_Direction * 24 * FRACUNIT;
 		break;
 	case Cby32:
 		targheight =
-		   sec->ceilingheight + m_Direction * 32 * FRACUNIT;
+		   sec->ceilingtexz + m_Direction * 32 * FRACUNIT;
 		break;
 	default:
 		break;
@@ -734,13 +734,13 @@ bool P_SpawnZDoomCeiling(DCeiling::ECeiling type, line_t* line, int tag, fixed_t
 		// Don't make noise for instant movement ceilings
 		if (ceiling->m_Direction < 0)
 		{
-			if (ceiling->m_Speed >= sec->ceilingheight - ceiling->m_BottomHeight)
+			if (ceiling->m_Speed >= sec->ceilingtexz - ceiling->m_BottomHeight)
 				if (silent & 4)
 					ceiling->m_Silent = 2;
 		}
 		else
 		{
-			if (ceiling->m_Speed >= ceiling->m_TopHeight - sec->ceilingheight)
+			if (ceiling->m_Speed >= ceiling->m_TopHeight - sec->ceilingtexz)
 				if (silent & 4)
 					ceiling->m_Silent = 2;
 		}

--- a/common/p_ceiling.cpp
+++ b/common/p_ceiling.cpp
@@ -312,7 +312,7 @@ DCeiling::DCeiling(sector_t* sec, line_t* line, int silent, int speed)
 	  m_NewDamageRate{static_cast<int16_t>(sec->damageamount)},
 	  m_NewLeakRate{static_cast<byte>(sec->leakrate)},
 	  m_NewDmgInterval{static_cast<byte>(sec->damageinterval)},
-	  m_Tag{sec->tag},
+	  m_Tag{sec->tag}
 {
 	m_Sector = sec;
 

--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -195,7 +195,7 @@ void DDoor::RunThink ()
 			default:
 				break;
 			}
-			if (m_LightTag && m_TopHeight - m_Sector->floortexz)
+			if (m_LightTag && m_TopHeight - P_FloorHeight(m_Sector))
             {
 				EV_LightTurnOnPartway(m_LightTag, 0);
             }
@@ -479,26 +479,26 @@ DDoor::DDoor(sector_t* sec, line_t* ln, int delay, int kind, int trigger, int sp
 	{
 	case OdCDoor:
 		m_Status = opening;
-		m_TopHeight = P_FindLowestCeilingSurrounding(sec) - (4 * FRACUNIT);
-		if (m_TopHeight != sec->ceilingtexz)
+		m_TopHeight = P_FindLowestCeilingSurrounding(sec) - 4_fx;
+		if (m_TopHeight != P_CeilingHeight(sec))
 			PlayDoorSound();
 		m_Type = speed >= SpeedFast ? genBlazeRaise : genRaise;
 		break;
 	case ODoor:
 		m_Status = opening;
-		m_TopHeight = P_FindLowestCeilingSurrounding(sec) - 4 * FRACUNIT;
-		if (m_TopHeight != sec->ceilingtexz)
+		m_TopHeight = P_FindLowestCeilingSurrounding(sec) - 4_fx;
+		if (m_TopHeight != P_CeilingHeight(sec))
 			PlayDoorSound();
 		m_Type = speed >= SpeedFast ? genBlazeOpen : genOpen;
 		break;
 	case CdODoor:
-		m_TopHeight = sec->ceilingtexz;
+		m_TopHeight = P_CeilingHeight(sec);
 		m_Status = closing;
 		PlayDoorSound();
 		m_Type = speed >= SpeedFast ? genBlazeCdO : genCdO;
 		break;
 	case CDoor:
-		m_TopHeight = P_FindLowestCeilingSurrounding(sec) - 4 * FRACUNIT;
+		m_TopHeight = P_FindLowestCeilingSurrounding(sec) - 4_fx;
 		m_Status = closing;
 		PlayDoorSound();
 		m_Type = speed >= SpeedFast ? genBlazeClose : genClose;

--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -195,7 +195,7 @@ void DDoor::RunThink ()
 			default:
 				break;
 			}
-			if (m_LightTag && m_TopHeight - P_FloorHeight(m_Sector))
+			if (m_LightTag and m_TopHeight - P_FloorHeight(m_Sector))
             {
 				EV_LightTurnOnPartway(m_LightTag, 0);
             }

--- a/common/p_doors.cpp
+++ b/common/p_doors.cpp
@@ -195,7 +195,7 @@ void DDoor::RunThink ()
 			default:
 				break;
 			}
-			if (m_LightTag && m_TopHeight - m_Sector->floorheight)
+			if (m_LightTag && m_TopHeight - m_Sector->floortexz)
             {
 				EV_LightTurnOnPartway(m_LightTag, 0);
             }
@@ -480,19 +480,19 @@ DDoor::DDoor(sector_t* sec, line_t* ln, int delay, int kind, int trigger, int sp
 	case OdCDoor:
 		m_Status = opening;
 		m_TopHeight = P_FindLowestCeilingSurrounding(sec) - (4 * FRACUNIT);
-		if (m_TopHeight != sec->ceilingheight)
+		if (m_TopHeight != sec->ceilingtexz)
 			PlayDoorSound();
 		m_Type = speed >= SpeedFast ? genBlazeRaise : genRaise;
 		break;
 	case ODoor:
 		m_Status = opening;
 		m_TopHeight = P_FindLowestCeilingSurrounding(sec) - 4 * FRACUNIT;
-		if (m_TopHeight != sec->ceilingheight)
+		if (m_TopHeight != sec->ceilingtexz)
 			PlayDoorSound();
 		m_Type = speed >= SpeedFast ? genBlazeOpen : genOpen;
 		break;
 	case CdODoor:
-		m_TopHeight = sec->ceilingheight;
+		m_TopHeight = sec->ceilingtexz;
 		m_Status = closing;
 		PlayDoorSound();
 		m_Type = speed >= SpeedFast ? genBlazeCdO : genCdO;

--- a/common/p_enemy.cpp
+++ b/common/p_enemy.cpp
@@ -731,8 +731,8 @@ bool PIT_AvoidDropoff(const line_t& line, const fixed_t floorz, fixed_t& dropoff
 	    tmbbox[BOXTOP] > line.bbox[BOXBOTTOM] && // Linedef must be contacted
 	    tmbbox[BOXBOTTOM] < line.bbox[BOXTOP] && P_BoxOnLineSide(tmbbox, &line) == -1)
 	{
-		const fixed_t front = line.frontsector->floorheight;
-		const fixed_t back = line.backsector->floorheight;
+		const fixed_t front = P_FloorHeight(line.frontsector);
+		const fixed_t back = P_FloorHeight(line.backsector);
 		angle_t angle;
 
 		// The monster must contact one of the two floors,

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -566,24 +566,24 @@ DFloor::DFloor(sector_t* sec, const line_t* line, int speed,
 		m_FloorDestHeight = P_FindLowestCeilingSurrounding(sec);
 		break;
 	case FtoC:
-		m_FloorDestHeight = sec->ceilingtexz;
+		m_FloorDestHeight = P_CeilingHeight(sec);
 		break;
 	case FbyST:
 		m_FloorDestHeight =
-		    (sec->floortexz >> FRACBITS) +
-		    m_Direction * (P_FindShortestTextureAround(sec) >> FRACBITS);
+			FIXED2INT(P_FloorHeight(sec)) +
+			(m_Direction * FIXED2INT((P_FindShortestTextureAround(sec))));
 		if (m_FloorDestHeight > 32000)      // jff 3/13/98 prevent overflow
 			m_FloorDestHeight = 32000; // wraparound in floor height
 		if (m_FloorDestHeight < -32000)
 			m_FloorDestHeight = -32000;
-		m_FloorDestHeight <<= FRACBITS;
+		m_FloorDestHeight = INT2FIXED(m_FloorDestHeight);
 		break;
 	case Fby24:
 		m_FloorDestHeight =
-		    sec->floortexz + m_Direction * 24 * FRACUNIT;
+		    P_FloorHeight(sec) + (m_Direction * 24_fx); // NOLINT(readability-magic-numbers) - by 24 moves by 24
 		break;
 	case Fby32:
-		m_FloorDestHeight = sec->floortexz + m_Direction * 32 * FRACUNIT;
+		m_FloorDestHeight = P_FloorHeight(sec) + (m_Direction * 32_fx);
 		break;
 	}
 
@@ -1115,11 +1115,11 @@ bool EV_DoGenStairs(line_t& line)
 	const uint32_t value = static_cast<uint32_t>(line.special) - GenStairsBase;
 
 	// parse the bit fields in the line's special type
-	const int Igno = (value & StairIgnore) >> StairIgnoreShift;
-	const int Dirn = (value & StairDirection) >> StairDirectionShift;
-	const int Step = (value & StairStep) >> StairStepShift;
-	const int Sped = (value & StairSpeed) >> StairSpeedShift;
-	const int Trig = (value & TriggerType) >> TriggerTypeShift;
+	const auto Igno = (value & StairIgnore) >> StairIgnoreShift;
+	const auto Dirn = (value & StairDirection) >> StairDirectionShift;
+	const auto Step = (value & StairStep) >> StairStepShift;
+	const auto Sped = (value & StairSpeed) >> StairSpeedShift;
+	const auto Trig = (value & TriggerType) >> TriggerTypeShift;
 
 	const auto helper = [&](sector_t* sec, int secnum) -> bool
 	{
@@ -1132,7 +1132,7 @@ bool EV_DoGenStairs(line_t& line)
 		fixed_t floorheight = P_FloorHeight(sec);
 
 		// new floor thinker
-		DFloor* floor = new DFloor(sec);
+		auto* floor = new DFloor(sec);
 		P_AddMovingFloor(sec);
 
 		floor->m_Direction = Dirn ? 1 : -1;
@@ -1161,6 +1161,7 @@ bool EV_DoGenStairs(line_t& line)
 		fixed_t stairsize;
 		switch (Step)
 		{
+		default:
 		case StepSize4:
 			stairsize = 4 * FRACUNIT;
 			break;
@@ -1176,7 +1177,7 @@ bool EV_DoGenStairs(line_t& line)
 		}
 
 		const fixed_t speed = floor->m_Speed;
-		int height = sec->floortexz + floor->m_Direction * stairsize;
+		int height = P_FloorHeight(sec) + (floor->m_Direction * stairsize);
 		floor->m_FloorDestHeight = height;
 		const int texture = sec->floorpic;
 		floor->m_Crush = NO_CRUSH;

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -566,11 +566,11 @@ DFloor::DFloor(sector_t* sec, const line_t* line, int speed,
 		m_FloorDestHeight = P_FindLowestCeilingSurrounding(sec);
 		break;
 	case FtoC:
-		m_FloorDestHeight = sec->ceilingheight;
+		m_FloorDestHeight = sec->ceilingtexz;
 		break;
 	case FbyST:
 		m_FloorDestHeight =
-		    (sec->floorheight >> FRACBITS) +
+		    (sec->floortexz >> FRACBITS) +
 		    m_Direction * (P_FindShortestTextureAround(sec) >> FRACBITS);
 		if (m_FloorDestHeight > 32000)      // jff 3/13/98 prevent overflow
 			m_FloorDestHeight = 32000; // wraparound in floor height
@@ -580,10 +580,10 @@ DFloor::DFloor(sector_t* sec, const line_t* line, int speed,
 		break;
 	case Fby24:
 		m_FloorDestHeight =
-		    sec->floorheight + m_Direction * 24 * FRACUNIT;
+		    sec->floortexz + m_Direction * 24 * FRACUNIT;
 		break;
 	case Fby32:
-		m_FloorDestHeight = sec->floorheight + m_Direction * 32 * FRACUNIT;
+		m_FloorDestHeight = sec->floortexz + m_Direction * 32 * FRACUNIT;
 		break;
 	}
 
@@ -1176,7 +1176,7 @@ bool EV_DoGenStairs(line_t& line)
 		}
 
 		const fixed_t speed = floor->m_Speed;
-		int height = sec->floorheight + floor->m_Direction * stairsize;
+		int height = sec->floortexz + floor->m_Direction * stairsize;
 		floor->m_FloorDestHeight = height;
 		const int texture = sec->floorpic;
 		floor->m_Crush = NO_CRUSH;

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -2769,7 +2769,7 @@ std::array<lnSpecFunc, 283> LineSpecials =
 	LS_Light_Flicker,
 	LS_Light_Strobe,
 	LS_Light_Stop,
-	LS_NOP,		// 118 Plane_Copy (handled elsewhere/not supported)
+	LS_NOP,		// 118 Plane_Copy (handled elsewhere)
     LS_Thing_Damage,
 	LS_Radius_Quake,
 	LS_NOP,		// 123 Set_LineIdentification (handled elsewhere)

--- a/common/p_lnspec.h
+++ b/common/p_lnspec.h
@@ -799,10 +799,10 @@ typedef struct
 	short args[5];
 } xlat_t;
 
-struct line_s;
+struct line_t;
 class AActor;
 
-typedef bool (*lnSpecFunc)(struct line_s	*line,
+typedef bool (*lnSpecFunc)(struct line_t	*line,
 						   class AActor		*activator,
 						   int				arg1,
 						   int				arg2,

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -4170,8 +4170,7 @@ fixed_t P_FloorHeight(const sector_t *sector)
 	if (!sector)
 		return limits::MAXFIXED;
 
-	const plane_t *plane = &sector->floorplane;
-	return P_PlaneZ(plane->texx, plane->texy, plane);
+	return sector->floorheight;
 }
 
 //
@@ -4207,8 +4206,7 @@ fixed_t P_CeilingHeight(const sector_t *sector)
 	if (!sector)
 		return limits::MAXFIXED;
 
-	const plane_t *plane = &sector->ceilingplane;
-	return P_PlaneZ(plane->texx, plane->texy, plane);
+	return sector->ceilingheight;
 }
 
 //
@@ -4320,8 +4318,7 @@ void P_SetCeilingHeight(sector_t *sector, fixed_t value)
 	if (!sector)
 		return;
 
-	plane_t *plane = &sector->ceilingplane;
-	fixed_t oldvalue = P_PlaneZ(plane->texx, plane->texy, plane);
+	fixed_t oldvalue = sector->ceilingheight;
 
 	P_ChangeCeilingHeight(sector, value - oldvalue);
 }
@@ -4331,8 +4328,7 @@ void P_SetFloorHeight(sector_t *sector, fixed_t value)
 	if (!sector)
 		return;
 
-	plane_t *plane = &sector->floorplane;
-	fixed_t oldvalue = P_PlaneZ(plane->texx, plane->texy, plane);
+	fixed_t oldvalue = sector->floorheight;
 
 	P_ChangeFloorHeight(sector, value - oldvalue);
 }

--- a/common/p_map.cpp
+++ b/common/p_map.cpp
@@ -4170,7 +4170,7 @@ fixed_t P_FloorHeight(const sector_t *sector)
 	if (!sector)
 		return limits::MAXFIXED;
 
-	return sector->floorheight;
+	return sector->floortexz;
 }
 
 //
@@ -4206,7 +4206,7 @@ fixed_t P_CeilingHeight(const sector_t *sector)
 	if (!sector)
 		return limits::MAXFIXED;
 
-	return sector->ceilingheight;
+	return sector->ceilingtexz;
 }
 
 //
@@ -4297,7 +4297,7 @@ void P_ChangeCeilingHeight(sector_t *sector, fixed_t amount)
 
 	// The sector's ceilingheight variable is still used for (among other things)
 	// calculating wall texture offsets
-	sector->ceilingheight += amount;
+	sector->ceilingtexz += amount;
 }
 
 void P_ChangeFloorHeight(sector_t *sector, fixed_t amount)
@@ -4310,7 +4310,7 @@ void P_ChangeFloorHeight(sector_t *sector, fixed_t amount)
 
 	// The sector's floorheight variable is still used for (among other things)
 	// calculating wall texture offsets
-	sector->floorheight += amount;
+	sector->floortexz += amount;
 }
 
 void P_SetCeilingHeight(sector_t *sector, fixed_t value)
@@ -4318,9 +4318,7 @@ void P_SetCeilingHeight(sector_t *sector, fixed_t value)
 	if (!sector)
 		return;
 
-	fixed_t oldvalue = sector->ceilingheight;
-
-	P_ChangeCeilingHeight(sector, value - oldvalue);
+	P_ChangeCeilingHeight(sector, value - sector->ceilingtexz);
 }
 
 void P_SetFloorHeight(sector_t *sector, fixed_t value)
@@ -4328,9 +4326,7 @@ void P_SetFloorHeight(sector_t *sector, fixed_t value)
 	if (!sector)
 		return;
 
-	fixed_t oldvalue = sector->floorheight;
-
-	P_ChangeFloorHeight(sector, value - oldvalue);
+	P_ChangeFloorHeight(sector, value - sector->floortexz);
 }
 
 //
@@ -4448,8 +4444,8 @@ void P_CopySector(sector_t *dest, sector_t *src)
 	if (!dest || !src)
 		return;
 
-	dest->floorheight			= src->floorheight;
-	dest->ceilingheight			= src->ceilingheight;
+	dest->floortexz			= src->floortexz;
+	dest->ceilingtexz			= src->ceilingtexz;
 	dest->floorpic				= src->floorpic;
 	dest->ceilingpic			= src->ceilingpic;
 	dest->lightlevel			= src->lightlevel;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -1039,7 +1039,7 @@ void P_MoveActor(AActor *mo)
 		sector_t *hsec = mo->subsector->sector->heightsec;
 		if (hsec && hsec->waterzone && !mo->subsector->sector->waterzone)
 		{
-			if (mo->z < hsec->floorheight)
+			if (mo->z < P_FloorHeight(hsec))
 			{
 				fixed_t floorheight = P_FloorHeight(mo->x, mo->y, hsec);
 				if (mo->z < floorheight)
@@ -1057,7 +1057,7 @@ void P_MoveActor(AActor *mo)
 					mo->waterlevel = 3;
 				}
 			}
-			else if (mo->z + mo->height > hsec->ceilingheight)
+			else if (mo->z + mo->height > P_CeilingHeight(hsec))
 			{
 				mo->waterlevel = 3;
 			}
@@ -1844,7 +1844,7 @@ static void P_ApplyXYFriction(AActor* mo)
 	     mo->oflags & MFO_FALLING) &&
 	    (mo->momx > FRACUNIT / 4 || mo->momx < -FRACUNIT / 4 || mo->momy > FRACUNIT / 4 ||
 	     mo->momy < -FRACUNIT / 4) &&
-	    mo->floorz != mo->subsector->sector->floorheight)
+	    mo->floorz != P_FloorHeight(mo->subsector->sector))
 		return; // do not stop sliding if halfway off a step with some momentum
 
 	// keep corpses sliding if halfway off a step with some momentum
@@ -2364,7 +2364,7 @@ static void P_ApplyBouncyPhysics(AActor *mo)
 		{
 			if (ceilingline && ceilingline->backsector &&
 			    R_IsSkyFlat(ceilingline->backsector->ceilingpic) &&
-			    mo->z > ceilingline->backsector->ceilingheight)
+			    mo->z > P_CeilingHeight(ceilingline->backsector))
 				mo->Destroy();
 			else
 				P_ExplodeMissile(mo);

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3689,8 +3689,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 		return;
 
 	// check for appropriate skill level
-	// TODO: change type of spawn_filter to MapThingFlags after merging with type-safe mapinfo PR
-	if (!(mthing.flags & combo(MapThingFlags::unsafe_from_int(static_cast<int16_t>(G_GetCurrentSkill().spawn_filter)))))
+	if (!(mthing.flags & combo(G_GetCurrentSkill().spawn_filter)))
 		return;
 
 	if (isSpringPad)

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3713,7 +3713,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 		return;
 
 	// check for appropriate skill level
-	if (!(mthing.flags & combo(G_GetCurrentSkill().spawn_filter)))
+	if (not (mthing.flags & combo(G_GetCurrentSkill().spawn_filter)))
 		return;
 
 	if (isSpringPad)

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3616,7 +3616,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 		mthing.type == PO_SPAWN_TYPE ||
 		mthing.type == PO_SPAWNCRUSH_TYPE))
 	{
-		polyspawns_t *polyspawn = new polyspawns_t;
+		auto* polyspawn = new polyspawns_t;
 		polyspawn->next = polyspawns;
 		polyspawn->x = mthing.x << FRACBITS;
 		polyspawn->y = mthing.y << FRACBITS;
@@ -3858,7 +3858,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 		return;
 	}
 
-	AActor* mobj = new AActor(x, y, z, info->type);
+	auto* mobj = new AActor(x, y, z, info->type);
 
 	if (type == MT_HORDESPAWN)
 	{
@@ -3884,7 +3884,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 
 	// [RH] Set the thing's special
 	mobj->special = mthing.special;
-	std::copy(std::begin(mthing.args), std::end(mthing.args), mobj->args.begin());
+	std::ranges::copy(mthing.args, mobj->args.begin());
 
 	// [RH] If it's an ambient sound, activate it
 	if (type == MT_AMBIENT)
@@ -3909,7 +3909,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 		mobj->tics = 1 + (P_Random(mobj) % mobj->tics);
 
 	if (type != MT_SPARK)
-		mobj->angle = ANG45 * (mthing.angle/45);
+		mobj->angle = ANG(mthing.angle);
 
 	if (mthing.flags & MTF_AMBUSH)
 		mobj->flags |= MF_AMBUSH;

--- a/common/p_mobj.cpp
+++ b/common/p_mobj.cpp
@@ -3909,7 +3909,7 @@ void P_SpawnMapThing (mapthing2_t& mthing, int position)
 		mobj->tics = 1 + (P_Random(mobj) % mobj->tics);
 
 	if (type != MT_SPARK)
-		mobj->angle = ANG(mthing.angle);
+		mobj->angle = ANG45 * (mthing.angle / 45);
 
 	if (mthing.flags & MTF_AMBUSH)
 		mobj->flags |= MF_AMBUSH;

--- a/common/p_pillar.cpp
+++ b/common/p_pillar.cpp
@@ -237,13 +237,13 @@ bool EV_DoZDoomPillar(DPillar::EPillar type, line_t* line, int tag, fixed_t spee
 	{
 		sector_t* sec = &sectors[secnum];
 
-		if (P_FloorActive(sec) || P_CeilingActive(sec))
+		if (P_FloorActive(sec) or P_CeilingActive(sec))
 			continue;
 
-		if (type == DPillar::pillarBuild && P_FloorHeight(sec) == P_CeilingHeight(sec))
+		if (type == DPillar::pillarBuild and P_FloorHeight(sec) == P_CeilingHeight(sec))
 			continue;
 
-		if (type == DPillar::pillarOpen && P_FloorHeight(sec) != P_CeilingHeight(sec))
+		if (type == DPillar::pillarOpen and P_FloorHeight(sec) != P_CeilingHeight(sec))
 			continue;
 
 		rtn = true;

--- a/common/p_pillar.cpp
+++ b/common/p_pillar.cpp
@@ -240,10 +240,10 @@ bool EV_DoZDoomPillar(DPillar::EPillar type, line_t* line, int tag, fixed_t spee
 		if (P_FloorActive(sec) || P_CeilingActive(sec))
 			continue;
 
-		if (type == DPillar::pillarBuild && sec->floorheight == sec->ceilingheight)
+		if (type == DPillar::pillarBuild && sec->floortexz == sec->ceilingtexz)
 			continue;
 
-		if (type == DPillar::pillarOpen && sec->floorheight != sec->ceilingheight)
+		if (type == DPillar::pillarOpen && sec->floortexz != sec->ceilingtexz)
 			continue;
 
 		rtn = true;

--- a/common/p_pillar.cpp
+++ b/common/p_pillar.cpp
@@ -240,10 +240,10 @@ bool EV_DoZDoomPillar(DPillar::EPillar type, line_t* line, int tag, fixed_t spee
 		if (P_FloorActive(sec) || P_CeilingActive(sec))
 			continue;
 
-		if (type == DPillar::pillarBuild && sec->floortexz == sec->ceilingtexz)
+		if (type == DPillar::pillarBuild && P_FloorHeight(sec) == P_CeilingHeight(sec))
 			continue;
 
-		if (type == DPillar::pillarOpen && sec->floortexz != sec->ceilingtexz)
+		if (type == DPillar::pillarOpen && P_FloorHeight(sec) != P_CeilingHeight(sec))
 			continue;
 
 		rtn = true;

--- a/common/p_plats.cpp
+++ b/common/p_plats.cpp
@@ -395,32 +395,32 @@ DPlat::DPlat(sector_t* sec, int target, int delay, int speed, int trigger)
 	m_Status = DPlat::down;
 	m_Height = 0;
 	m_Lip = 0;
-	m_High = sec->floorheight;
+	m_High = sec->floortexz;
 
 	// setup the target destination height
 	switch (target)
 	{
 	case F2LnF:
 		m_Low = P_FindLowestFloorSurrounding(sec);
-		if (m_Low > sec->floorheight)
-			m_Low = sec->floorheight;
+		if (m_Low > sec->floortexz)
+			m_Low = sec->floortexz;
 		break;
 	case F2NnF:
 		m_Low = P_FindNextLowestFloor(sec);
 		break;
 	case F2LnC:
 		m_Low = P_FindLowestCeilingSurrounding(sec);
-		if (m_Low > sec->floorheight)
-			m_Low = sec->floorheight;
+		if (m_Low > sec->floortexz)
+			m_Low = sec->floortexz;
 		break;
 	case LnF2HnF:
 		m_Type = genPerpetual;
 		m_Low = P_FindLowestFloorSurrounding(sec);
-		if (m_Low > sec->floorheight)
-			m_Low = sec->floorheight;
+		if (m_Low > sec->floortexz)
+			m_Low = sec->floortexz;
 		m_High = P_FindHighestFloorSurrounding(sec);
-		if (m_High < sec->floorheight)
-			m_High = sec->floorheight;
+		if (m_High < sec->floortexz)
+			m_High = sec->floortexz;
 		m_Status = P_Random() & 1 ? DPlat::down : DPlat::up;
 		break;
 	default:

--- a/common/p_plats.cpp
+++ b/common/p_plats.cpp
@@ -388,39 +388,26 @@ DPlat::DPlat(sector_t *sec, DPlat::EPlatType type, fixed_t height,
 }
 
 DPlat::DPlat(sector_t* sec, int target, int delay, int speed, int trigger)
-    : DMovingFloor(sec), m_Status(init)
+	: DMovingFloor{sec}, m_High{P_FloorHeight(sec)},
+	  m_Status{DPlat::down}, m_Type{genLift}
 {
-	m_Crush = false;
-	m_Type = genLift;
-	m_Status = DPlat::down;
-	m_Height = 0;
-	m_Lip = 0;
-	m_High = sec->floortexz;
 
 	// setup the target destination height
 	switch (target)
 	{
 	case F2LnF:
-		m_Low = P_FindLowestFloorSurrounding(sec);
-		if (m_Low > sec->floortexz)
-			m_Low = sec->floortexz;
+		m_Low = std::min(P_FindLowestFloorSurrounding(sec), P_FloorHeight(sec));
 		break;
 	case F2NnF:
 		m_Low = P_FindNextLowestFloor(sec);
 		break;
 	case F2LnC:
-		m_Low = P_FindLowestCeilingSurrounding(sec);
-		if (m_Low > sec->floortexz)
-			m_Low = sec->floortexz;
+		m_Low = std::min(P_FindLowestCeilingSurrounding(sec), P_FloorHeight(sec));
 		break;
 	case LnF2HnF:
 		m_Type = genPerpetual;
-		m_Low = P_FindLowestFloorSurrounding(sec);
-		if (m_Low > sec->floortexz)
-			m_Low = sec->floortexz;
-		m_High = P_FindHighestFloorSurrounding(sec);
-		if (m_High < sec->floortexz)
-			m_High = sec->floortexz;
+		m_Low = std::min(P_FindLowestFloorSurrounding(sec), P_FloorHeight(sec));
+		m_High = std::max(P_FindHighestFloorSurrounding(sec), P_FloorHeight(sec));
 		m_Status = P_Random() & 1 ? DPlat::down : DPlat::up;
 		break;
 	default:

--- a/common/p_saveg.cpp
+++ b/common/p_saveg.cpp
@@ -77,8 +77,8 @@ void P_SerializeWorld (FArchive &arc)
 		// do sectors
 		for (sector_t& sec : R_GetSectors())
 		{
-			arc << sec.floorheight
-				<< sec.ceilingheight
+			arc << sec.floortexz
+				<< sec.ceilingtexz
 				<< sec.floorplane.a
 				<< sec.floorplane.b
 				<< sec.floorplane.c
@@ -173,8 +173,8 @@ void P_SerializeWorld (FArchive &arc)
 			AActor* SkyboxCeiling;
 			AActor* SkyboxFloor;
 
-			arc >> sec.floorheight
-				>> sec.ceilingheight
+			arc >> sec.floortexz
+				>> sec.ceilingtexz
 				>> sec.floorplane.a
 				>> sec.floorplane.b
 				>> sec.floorplane.c

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -73,7 +73,7 @@ void P_SpawnCompatibleSectorSpecial(sector_t* sector);
 namespace {
 void P_SetupLevelFloorPlane(sector_t *sector);
 void P_SetupLevelCeilingPlane(sector_t *sector);
-void P_SetupSlopes();
+void P_SetupLineSlopes();
 }
 
 void P_InvertPlane(plane_t *plane);
@@ -1628,7 +1628,7 @@ void P_SetupPlane(sector_t* sec, line_t* line, bool floor)
 	srcplane->texy = refvert->y;
 }
 
-void P_SetupSlopes()
+void P_SetupLineSlopes()
 {
 	for (line_t& line : R_GetLines())
 	{
@@ -1654,6 +1654,82 @@ void P_SetupSlopes()
 				P_SetupPlane(line.frontsector, &line, false);
 			else if (align_side == 2)
 				P_SetupPlane(line.backsector, &line, false);
+		}
+	}
+}
+
+void P_CopyPlane(int tag, sector_t& dest, bool copyCeiling)
+{
+	const int secnum = P_FindSectorFromTag(tag, -1);
+	if (secnum == -1)
+		return;
+
+	const sector_t& source = R_GetSectors()[secnum];
+
+	if (copyCeiling)
+		dest.ceilingplane = source.ceilingplane;
+	else
+		dest.floorplane = source.floorplane;
+};
+
+void P_CopyPlane(int tag, fixed_t x, fixed_t y, bool copyCeiling)
+{
+	sector_t& dest = *P_PointInSubsector(x, y)->sector;
+	P_CopyPlane(tag, dest, copyCeiling);
+}
+
+void P_CopySlopes()
+{
+	for (line_t& line : R_GetLines())
+	{
+		if (not (map_format.getZDoom() && line.special == Plane_Copy))
+			continue;
+
+		line.special = 0;
+		if (line.args[0])
+			P_CopyPlane(line.args[0], *line.frontsector, false);
+		if (line.args[1])
+			P_CopyPlane(line.args[1], *line.frontsector, true);
+
+		if (not line.backsector)
+			continue;
+
+		if (line.args[2])
+			P_CopyPlane(line.args[2], *line.backsector, false);
+		if (line.args[3])
+			P_CopyPlane(line.args[3], *line.backsector, true);
+
+		static constexpr int floor_mask = 0b11;
+		static constexpr int ceiling_mask = 0b1100;
+		enum
+		{
+			FloorFrontToBack = 0b01,
+			FloorBackToFront = 0b10,
+			CeilFrontToBack  = 0b0100,
+			CeilBackToFront  = 0b1000,
+		};
+
+		// other cases are intentionally ignored
+		// NOLINTNEXTLINE(bugprone-switch-missing-default-case)
+		switch (line.args[4] & floor_mask)
+		{
+			case FloorFrontToBack:
+				line.backsector->floorplane = line.frontsector->floorplane;
+				break;
+			case FloorBackToFront:
+				line.frontsector->floorplane = line.backsector->floorplane;
+				break;
+		}
+
+		// NOLINTNEXTLINE(bugprone-switch-missing-default-case)
+		switch (line.args[4] & ceiling_mask)
+		{
+			case CeilFrontToBack:
+				line.backsector->ceilingplane = line.frontsector->ceilingplane;
+				break;
+			case CeilBackToFront:
+				line.frontsector->ceilingplane = line.backsector->ceilingplane;
+				break;
 		}
 	}
 }
@@ -1871,7 +1947,7 @@ void P_SetupLevel (const char *lumpname, int position)
 	if (!demoplayback)
 		P_RemoveSlimeTrails();
 
-	P_SetupSlopes();
+	P_SetupLineSlopes();
 
     po_NumPolyobjs = 0;
 
@@ -1889,6 +1965,8 @@ void P_SetupLevel (const char *lumpname, int position)
 	// SkyViewpoint / stack point has spawned.
 	P_ResolveSkyPickers();
 	P_ResolveStackLinks();
+
+	P_CopySlopes();
 
 	if (!HasBehavior)
 		P_TranslateTeleportThings(); // [RH] Assign teleport destination TIDs

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1544,7 +1544,6 @@ void P_SetupLevelFloorPlane(sector_t *sector)
 	sector->floorplane.a = sector->floorplane.b = 0;
 	sector->floorplane.c = sector->floorplane.invc = FRACUNIT;
 	sector->floorplane.d = -sector->floorheight;
-	sector->floorplane.texx = sector->floorplane.texy = 0;
 	sector->floorplane.sector = sector;
 }
 
@@ -1556,7 +1555,6 @@ void P_SetupLevelCeilingPlane(sector_t *sector)
 	sector->ceilingplane.a = sector->ceilingplane.b = 0;
 	sector->ceilingplane.c = sector->ceilingplane.invc = -FRACUNIT;
 	sector->ceilingplane.d = sector->ceilingheight;
-	sector->ceilingplane.texx = sector->ceilingplane.texy = 0;
 	sector->ceilingplane.sector = sector;
 }
 
@@ -1628,8 +1626,6 @@ void P_SetupPlane(sector_t* sec, line_t* line, bool floor)
 	srcplane->c = FLOAT2FIXED(cross.z);
 	srcplane->invc = FLOAT2FIXED(1.f/cross.z);
 	srcplane->d = -FixedMul(srcplane->a, line->v1->x) - FixedMul(srcplane->b, line->v1->y) - FixedMul(srcplane->c, destheight);
-	srcplane->texx = refvert->x;
-	srcplane->texy = refvert->y;
 }
 
 void P_SetupLineSlopes()
@@ -1787,9 +1783,6 @@ void P_SlopeLineToPoint (const int lineid, const fixed_t x, const fixed_t y, con
 			(cross.y * FIXED2DOUBLE(y)) +
 			(cross.z * FIXED2DOUBLE(z))
 		);
-		// TODO: verify that this is correct
-		plane.texx = line.v1->x;
-		plane.texy = line.v1->y;
 	}
 }
 
@@ -1829,9 +1822,6 @@ void P_SetSlope(plane_t& plane, const int xyang_deg, const int zang_deg,
 		(norm.y * FIXED2DOUBLE(y)) +
 		(norm.z * FIXED2DOUBLE(z))
 	);
-	// TODO: verify that this is correct
-	plane.texx = x;
-	plane.texy = y;
 }
 
 void P_VavoomSlope(sector_t& sec, const int id, fixed_t x, fixed_t y, fixed_t z, const bool floor)
@@ -1882,9 +1872,6 @@ void P_VavoomSlope(sector_t& sec, const int id, fixed_t x, fixed_t y, fixed_t z,
 			(cross.y * FIXED2DOUBLE(y)) +
 			(cross.z * FIXED2DOUBLE(z))
 		);
-		// TODO: verify that this is correct
-		plane.texx = x;
-		plane.texy = y;
 
 		return;
 	}
@@ -2014,8 +2001,6 @@ void P_SetupVertexSlopes(std::span<MapThing> things)
 				(cross.y * FIXED2DOUBLE(vertexes[vi3].y)) +
 				(cross.z * vt3.z)
 			);
-			plane.texx = vertexes[vi3].x;
-			plane.texy = vertexes[vi3].y;
 		}
 	}
 }

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -331,8 +331,8 @@ void P_LoadSectors (int lump)
 	sector_t* ss = sectors;
 	for (int i = 0; i < numsectors; i++, ss++, ms++)
 	{
-		ss->floorheight = LESHORT(ms->floorheight)<<FRACBITS;
-		ss->ceilingheight = LESHORT(ms->ceilingheight)<<FRACBITS;
+		ss->floortexz = LESHORT(ms->floorheight)<<FRACBITS;
+		ss->ceilingtexz = LESHORT(ms->ceilingheight)<<FRACBITS;
 		ss->floorpic = static_cast<short>(R_FlatNumForName(ms->floorpic));
 		ss->ceilingpic = static_cast<short>(R_FlatNumForName(ms->ceilingpic));
 		ss->lightlevel = LESHORT(ms->lightlevel);
@@ -1543,7 +1543,7 @@ void P_SetupLevelFloorPlane(sector_t *sector)
 
 	sector->floorplane.a = sector->floorplane.b = 0;
 	sector->floorplane.c = sector->floorplane.invc = FRACUNIT;
-	sector->floorplane.d = -sector->floorheight;
+	sector->floorplane.d = -sector->floortexz;
 	sector->floorplane.sector = sector;
 }
 
@@ -1554,7 +1554,7 @@ void P_SetupLevelCeilingPlane(sector_t *sector)
 
 	sector->ceilingplane.a = sector->ceilingplane.b = 0;
 	sector->ceilingplane.c = sector->ceilingplane.invc = -FRACUNIT;
-	sector->ceilingplane.d = sector->ceilingheight;
+	sector->ceilingplane.d = sector->ceilingtexz;
 	sector->ceilingplane.sector = sector;
 }
 
@@ -1602,8 +1602,8 @@ void P_SetupPlane(sector_t* sec, line_t* line, bool floor)
 
 	const sector_t* refsec = line->frontsector == sec ? line->backsector : line->frontsector;
 	plane_t* srcplane = floor ? &sec->floorplane : &sec->ceilingplane;
-	const fixed_t srcheight = floor ? sec->floorheight : sec->ceilingheight;
-	const fixed_t destheight = floor ? refsec->floorheight : refsec->ceilingheight;
+	const fixed_t srcheight = floor ? sec->floortexz : sec->ceilingtexz;
+	const fixed_t destheight = floor ? refsec->floortexz : refsec->ceilingtexz;
 
 	v3float_t p, v1, v2, cross;
 	M_SetVec3f(&p, line->v1->x, line->v1->y, destheight);

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -2015,6 +2015,7 @@ void P_SetupThingSlopes(std::span<MapThing> things)
 		// 3rd separate internal type, and when doing that it
 		// checks the spawn map a single time per-mapthing in P_LoadThings(2)
 		// though their spawn map stores slightly different information
+		// we will need to do the 3rd separate type when we add UDMF support anyways
 		if (spawn_map.contains(mt.type))
 			continue;
 

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1826,7 +1826,7 @@ void P_SetSlope(plane_t& plane, const int xyang_deg, const int zang_deg,
 
 void P_VavoomSlope(sector_t& sec, const int id, fixed_t x, fixed_t y, fixed_t z, const bool floor)
 {
-	for (line_t* line : sec.getLines())
+	for (const line_t* line : sec.getLines())
 	{
 		if (line->args[0] != id)
 			continue;

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -2157,8 +2157,6 @@ void P_SetupLevel (const char *lumpname, int position)
 		}
 	}
 
-	// To use the correct nodes for
-
 	// Initial height of PointOfView will be set by player think.
 	consoleplayer().viewz = 1;
 

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -2023,7 +2023,7 @@ void P_SetupThingSlopes(std::span<MapThing> things)
 
 		const fixed_t x = INT2FIXED(mt.x);
 		const fixed_t y = INT2FIXED(mt.y);
-		sector_t& sec = *R_PointInSubsector(x, y)->sector;
+		sector_t& sec = *P_PointInSubsector(x, y)->sector;
 		plane_t* plane;
 		bool floor;
 		if (mt.type & 1)

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -74,6 +74,7 @@ namespace {
 void P_SetupLevelFloorPlane(sector_t *sector);
 void P_SetupLevelCeilingPlane(sector_t *sector);
 void P_SetupLineSlopes();
+void P_SetupThingSlopes(std::span<MapThing> things);
 }
 
 void P_InvertPlane(plane_t *plane);
@@ -908,6 +909,7 @@ void P_LoadThings2 (int lump, int position)
 	auto* data = W_CacheLumpNum<mapthing2_t>(lump, PU_STATIC);
 	const auto guard = nonstd::make_scope_exit([&]{ Z_Free(data); });
 	size_t count = W_LumpLength(lump) / sizeof(mapthing2_t);
+	auto things = std::span{data, count};
 
 	P_HordeClearSpawns();
 	playerstarts.clear();
@@ -916,13 +918,12 @@ void P_LoadThings2 (int lump, int position)
 	for (int iTeam = 0; iTeam < NUMTEAMS; iTeam++)
 		GetTeamInfo(static_cast<team_t>(iTeam))->Starts.clear();
 
-	for (size_t i = 0; i < count; i++)
+	for (auto& mt : things)
 	{
 		// [RH] At this point, monsters unique to Doom II were weeded out
 		//		if the IWAD wasn't for Doom II. R_SpawnMapThing() can now
 		//		handle these and more cases better, so we just pass it
 		//		everything and let it decide what to do with them.
-		mapthing2_t& mt = data[i];
 
 		mt.thingid = LESHORT(mt.thingid);
 		mt.x = LESHORT(mt.x);
@@ -939,9 +940,12 @@ void P_LoadThings2 (int lump, int position)
 			Freecam::setStartPosition(mt.x << FRACBITS, mt.y << FRACBITS, ONFLOORZ, ANG45 * (mt.angle / 45));
 		}
 		#endif
-
-		P_SpawnMapThing(mt, position);
 	}
+
+	P_SetupThingSlopes(things);
+
+	for (auto& mt : things)
+		P_SpawnMapThing(mt, position);
 
 	// Sort by player number if starts are not in order
 	std::ranges::sort(playerstarts, [](const mapthing2_t& p1, const mapthing2_t& p2){
@@ -1658,7 +1662,7 @@ void P_SetupLineSlopes()
 	}
 }
 
-void P_CopyPlane(int tag, sector_t& dest, bool copyCeiling)
+void P_CopyPlane(const int tag, sector_t& dest, const bool floor)
 {
 	const int secnum = P_FindSectorFromTag(tag, -1);
 	if (secnum == -1)
@@ -1666,38 +1670,38 @@ void P_CopyPlane(int tag, sector_t& dest, bool copyCeiling)
 
 	const sector_t& source = R_GetSectors()[secnum];
 
-	if (copyCeiling)
-		dest.ceilingplane = source.ceilingplane;
-	else
+	if (floor)
 		dest.floorplane = source.floorplane;
+	else
+		dest.ceilingplane = source.ceilingplane;
 };
 
-void P_CopyPlane(int tag, fixed_t x, fixed_t y, bool copyCeiling)
+void P_CopyPlane(const int tag, const fixed_t x, const fixed_t y, const bool floor)
 {
 	sector_t& dest = *P_PointInSubsector(x, y)->sector;
-	P_CopyPlane(tag, dest, copyCeiling);
+	P_CopyPlane(tag, dest, floor);
 }
 
 void P_CopySlopes()
 {
 	for (line_t& line : R_GetLines())
 	{
-		if (not (map_format.getZDoom() && line.special == Plane_Copy))
+		if (not (map_format.getZDoom() and line.special == Plane_Copy))
 			continue;
 
 		line.special = 0;
 		if (line.args[0])
-			P_CopyPlane(line.args[0], *line.frontsector, false);
+			P_CopyPlane(line.args[0], *line.frontsector, true);
 		if (line.args[1])
-			P_CopyPlane(line.args[1], *line.frontsector, true);
+			P_CopyPlane(line.args[1], *line.frontsector, false);
 
 		if (not line.backsector)
 			continue;
 
 		if (line.args[2])
-			P_CopyPlane(line.args[2], *line.backsector, false);
+			P_CopyPlane(line.args[2], *line.backsector, true);
 		if (line.args[3])
-			P_CopyPlane(line.args[3], *line.backsector, true);
+			P_CopyPlane(line.args[3], *line.backsector, false);
 
 		static constexpr int floor_mask = 0b11;
 		static constexpr int ceiling_mask = 0b1100;
@@ -1730,6 +1734,345 @@ void P_CopySlopes()
 			case CeilBackToFront:
 				line.frontsector->ceilingplane = line.backsector->ceilingplane;
 				break;
+		}
+	}
+}
+
+void P_SlopeLineToPoint (const int lineid, const fixed_t x, const fixed_t y, const fixed_t z, const bool floor)
+{
+	int linenum = -1;
+	while ((linenum = P_FindLineFromID(lineid, linenum)) != -1)
+	{
+		const line_t& line = R_GetLines()[linenum];
+		sector_t* sec = P_PointOnLineSide(x, y, &line) == 0 ? line.frontsector : line.backsector;
+
+		if (sec == nullptr)
+			continue;
+
+		plane_t& plane = floor ? sec->floorplane : sec->ceilingplane;
+
+		v3double_t p;
+		p.x = FIXED2DOUBLE(line.v1->x);
+		p.y = FIXED2DOUBLE(line.v1->y);
+		p.z = P_PlaneZ(FIXED2DOUBLE(line.v1->x), FIXED2DOUBLE(line.v1->y), &plane);
+
+		v3double_t v1;
+		v1.x = FIXED2DOUBLE(line.dx);
+		v1.y = FIXED2DOUBLE(line.dy);
+		v1.y = P_PlaneZ(FIXED2DOUBLE(line.v2->x), FIXED2DOUBLE(line.v2->y), &plane) - p.y;
+
+		v3double_t v2;
+		v2.x = FIXED2DOUBLE(x - line.v1->x);
+		v2.y = FIXED2DOUBLE(y - line.v1->y);
+		v2.y = FIXED2DOUBLE(z) - p.y;
+
+		v3double_t cross;
+		M_CrossProductVec3(&cross, &v1, &v2);
+		M_NormalizeVec3(&cross, &cross);
+
+		// Fix backward normals
+		if ((cross.y < 0 and floor) or (cross.y > 0 and not floor))
+		{
+			cross.x = -cross.x;
+			cross.y = -cross.y;
+			cross.z = -cross.z;
+		}
+
+		plane.a = DOUBLE2FIXED(cross.x);
+		plane.b = DOUBLE2FIXED(cross.y);
+		plane.c = DOUBLE2FIXED(cross.z);
+		plane.invc = DOUBLE2FIXED(1.0 / cross.z);
+		plane.d = -DOUBLE2FIXED(
+			(cross.x * FIXED2DOUBLE(x)) +
+			(cross.y * FIXED2DOUBLE(y)) +
+			(cross.z * FIXED2DOUBLE(z))
+		);
+		// TODO: verify that this is correct
+		plane.texx = line.v1->x;
+		plane.texy = line.v1->y;
+	}
+}
+
+void P_SetSlope(plane_t& plane, const int xyang_deg, const int zang_deg,
+                const fixed_t x, const fixed_t y, const fixed_t z, const bool floor)
+{
+	angle_t zang;
+	if (zang_deg >= 180) // NOLINT(readability-magic-numbers) - I think 180 degrees is obvious
+		zang = ANG180 - ANG(1);
+	else if (zang_deg <= 0)
+		zang = ANG(1);
+	else
+		zang = ANG(zang_deg);
+
+	if (not floor)
+		zang += ANG180;
+
+	zang >>= ANGLETOFINESHIFT;
+
+	const angle_t xyang = ANG(xyang_deg) >> ANGLETOFINESHIFT;
+
+	v3double_t norm;
+	norm.x = FIXED2DOUBLE(finecosine[zang]) *
+	         FIXED2DOUBLE(finecosine[xyang]);
+	norm.y = FIXED2DOUBLE(finecosine[zang]) *
+	         FIXED2DOUBLE(finesine[xyang]);
+	norm.z = FIXED2DOUBLE(finesine[zang]);
+
+	M_NormalizeVec3(&norm, &norm);
+
+	plane.a = DOUBLE2FIXED(norm.x);
+	plane.b = DOUBLE2FIXED(norm.y);
+	plane.c = DOUBLE2FIXED(norm.z);
+	plane.invc = DOUBLE2FIXED(1.0 / norm.z);
+	plane.d = -DOUBLE2FIXED(
+		(norm.x * FIXED2DOUBLE(x)) +
+		(norm.y * FIXED2DOUBLE(y)) +
+		(norm.z * FIXED2DOUBLE(z))
+	);
+	// TODO: verify that this is correct
+	plane.texx = x;
+	plane.texy = y;
+}
+
+void P_VavoomSlope(sector_t& sec, const int id, fixed_t x, fixed_t y, fixed_t z, const bool floor)
+{
+	for (line_t* line : sec.getLines())
+	{
+		if (line->args[0] != id)
+			continue;
+
+		const fixed_t height = floor ?  P_FloorHeight(&sec) : P_CeilingHeight(&sec);
+
+		v3double_t v1;
+		v1.x = FIXED2DOUBLE(x - line->v2->x);
+		v1.y = FIXED2DOUBLE(y - line->v2->y);
+		v1.z = FIXED2DOUBLE(z - height);
+
+		v3double_t v2;
+		v2.x = FIXED2DOUBLE(x - line->v1->x);
+		v2.y = FIXED2DOUBLE(y - line->v1->y);
+		v2.z = FIXED2DOUBLE(z - height);
+
+		v3double_t cross;
+		M_CrossProductVec3(&cross, &v1, &v2);
+
+		const auto length = M_LengthVec3(cross);
+		if (length == 0.0)
+		{
+			PrintFmt(PRINT_WARNING, "Slope thing at ({},{}) is directly on target line\n", FIXED2INT(x), FIXED2INT(y));
+			return;
+		}
+
+		M_NormalizeVec3(&cross, &cross);
+
+		if ((cross.z < 0 and floor) or (cross.z > 0 and not floor))
+		{
+			cross.x = -cross.x;
+			cross.y = -cross.y;
+			cross.z = -cross.z;
+		}
+
+		plane_t& plane = floor ? sec.floorplane : sec.ceilingplane;
+		plane.a = DOUBLE2FIXED(cross.x);
+		plane.b = DOUBLE2FIXED(cross.y);
+		plane.c = DOUBLE2FIXED(cross.z);
+		plane.invc = DOUBLE2FIXED(1.0 / cross.z);
+		plane.d = -DOUBLE2FIXED(
+			(cross.x * FIXED2DOUBLE(x)) +
+			(cross.y * FIXED2DOUBLE(y)) +
+			(cross.z * FIXED2DOUBLE(z))
+		);
+		// TODO: verify that this is correct
+		plane.texx = x;
+		plane.texy = y;
+
+		return;
+	}
+}
+
+enum
+{
+	Slope_VavoomFloor           = 1500,
+	Slope_VavoomCeiling         = 1501,
+	Slope_VavoomVertexFloor     = 1504,
+	Slope_VavoomVertexCeiling   = 1505,
+	Slope_SlopeFloorPointLine   = 9500,
+	Slope_SlopeCeilingPointLine = 9501,
+	Slope_SetFloorSlope         = 9502,
+	Slope_SetCeilingSlope       = 9503,
+	Slope_CopyFloorPlane        = 9510,
+	Slope_CopyCeilingPlane      = 9511,
+};
+
+void P_SetupVertexSlopes(std::span<MapThing> things)
+{
+	std::array<std::unordered_map<ptrdiff_t, double>, 2> vt_heights;
+	static constexpr auto floor_idx = 0;
+	static constexpr auto ceil_idx = 1;
+
+	for (auto& mt : things)
+	{
+		if (spawn_map.contains(mt.type))
+			continue;
+
+		if (mt.type != Slope_VavoomVertexCeiling and mt.type != Slope_VavoomVertexFloor)
+			continue;
+
+		for (int i = 0; i < numvertexes; i++)
+		{
+			if (vertexes[i].x == INT2FIXED(mt.x) and vertexes[i].y == INT2FIXED(mt.y))
+			{
+				if (mt.type == Slope_VavoomVertexCeiling)
+					vt_heights[ceil_idx][i] = mt.z;
+				else
+					vt_heights[floor_idx][i] = mt.z;
+			}
+		}
+
+		mt.type = 0;
+	}
+
+	// don't bother iterating over all sectors if there's nothing to do
+	if (vt_heights[0].empty() and vt_heights[1].empty())
+		return;
+
+	for (auto& sec : R_GetSectors())
+	{
+		if (sec.getLines().size() != 3)
+			continue;
+
+		const auto vi1 = sec.getLines()[0]->v1 - vertexes;
+		const auto vi2 = sec.getLines()[0]->v2 - vertexes;
+		const auto vi3 =
+			(sec.getLines()[1]->v1 == sec.getLines()[0]->v1 or sec.getLines()[1]->v1 == sec.getLines()[0]->v2) ?
+				sec.getLines()[1]->v2 - vertexes :
+				sec.getLines()[1]->v1 - vertexes;
+
+		v3double_t vt1;
+		vt1.x = FIXED2DOUBLE(vertexes[vi1].x);
+		vt1.y = FIXED2DOUBLE(vertexes[vi1].y);
+
+		v3double_t vt2;
+		vt2.x = FIXED2DOUBLE(vertexes[vi2].x);
+		vt2.y = FIXED2DOUBLE(vertexes[vi2].y);
+
+		v3double_t vt3;
+		vt3.x = FIXED2DOUBLE(vertexes[vi3].x);
+		vt3.y = FIXED2DOUBLE(vertexes[vi3].y);
+
+		for (int i = 0; i < 2; i++)
+		{
+			const bool floor = i == floor_idx;
+			const auto h1 = vt_heights[i].find(vi1);
+			const auto h2 = vt_heights[i].find(vi2);
+			const auto h3 = vt_heights[i].find(vi3);
+
+			if (h1 == vt_heights[i].end() and h2 == vt_heights[i].end() and h3 == vt_heights[i].end())
+				continue;
+
+			const auto sector_height = floor ? FIXED2DOUBLE(P_FloorHeight(&sec)) : FIXED2DOUBLE(P_CeilingHeight(&sec));
+			vt1.z = h1 != vt_heights[i].end() ? h1->second : sector_height;
+			vt2.z = h2 != vt_heights[i].end() ? h2->second : sector_height;
+			vt3.z = h3 != vt_heights[i].end() ? h3->second : sector_height;
+
+			v3double_t vec1;
+			v3double_t vec2;
+			if (P_PointOnLineSide(vertexes[vi3].x, vertexes[vi3].y, sec.getLines()[0]) == 0)
+			{
+				M_SubVec3(&vec1, &vt2, &vt3);
+				M_SubVec3(&vec2, &vt1, &vt3);
+			}
+			else
+			{
+				M_SubVec3(&vec1, &vt1, &vt3);
+				M_SubVec3(&vec2, &vt2, &vt3);
+			}
+
+			v3double_t cross;
+			M_CrossProductVec3(&cross, &vec1, &vec2);
+
+			const auto length = M_LengthVec3(cross);
+			if (length == 0.0)
+				continue;
+
+			M_NormalizeVec3(&cross, &cross);
+
+			if ((cross.z < 0 and floor) or (cross.z > 0 and not floor))
+			{
+				cross.x = -cross.x;
+				cross.y = -cross.y;
+				cross.z = -cross.z;
+			}
+
+			plane_t& plane = floor ? sec.floorplane : sec.ceilingplane;
+			plane.a = DOUBLE2FIXED(cross.x);
+			plane.b = DOUBLE2FIXED(cross.y);
+			plane.c = DOUBLE2FIXED(cross.z);
+			plane.invc = DOUBLE2FIXED(1.0/cross.z);
+			plane.d = -DOUBLE2FIXED(
+				(cross.x * FIXED2DOUBLE(vertexes[vi3].x)) +
+				(cross.y * FIXED2DOUBLE(vertexes[vi3].y)) +
+				(cross.z * vt3.z)
+			);
+			plane.texx = vertexes[vi3].x;
+			plane.texy = vertexes[vi3].y;
+		}
+	}
+}
+
+void P_SetupThingSlopes(std::span<MapThing> things)
+{
+	for (auto& mt : things)
+	{
+		// TODO: we really need a better way of handling this
+		// so we don't have to keep calling .contains all over
+		// modern zdoom converts doom and hexen mapthings to a
+		// 3rd separate internal type, and when doing that it
+		// checks the spawn map a single time per-mapthing in P_LoadThings(2)
+		// though their spawn map stores slightly different information
+		if (spawn_map.contains(mt.type))
+			continue;
+
+		if (not ((mt.type >= Slope_SlopeFloorPointLine and mt.type <= Slope_SetCeilingSlope) or (mt.type == Slope_VavoomFloor) or (mt.type == Slope_VavoomCeiling)))
+			continue;
+
+		const fixed_t x = INT2FIXED(mt.x);
+		const fixed_t y = INT2FIXED(mt.y);
+		sector_t& sec = *R_PointInSubsector(x, y)->sector;
+		plane_t* plane;
+		bool floor;
+		if (mt.type & 1)
+		{
+			plane = &sec.ceilingplane;
+			floor = false;
+		}
+		else
+		{
+			plane = &sec.floorplane;
+			floor = true;
+		}
+
+		if (mt.type <= Slope_VavoomCeiling)
+			P_VavoomSlope(sec, mt.thingid, x, y, INT2FIXED(mt.z), floor);
+		else if (mt.type <= Slope_SlopeCeilingPointLine)
+			P_SlopeLineToPoint(mt.args[0], x, y, P_PlaneZ(x, y, plane) + INT2FIXED(mt.z), floor);
+		else
+			P_SetSlope(*plane, mt.angle, mt.args[0], x, y, P_PlaneZ(x, y, plane) + INT2FIXED(mt.z), floor);
+
+		mt.type = 0;
+	}
+	P_SetupVertexSlopes(things);
+
+	for (auto& mt : things)
+	{
+		if (spawn_map.contains(mt.type))
+			continue;
+
+		if (mt.type == Slope_CopyFloorPlane or
+			mt.type == Slope_CopyCeilingPlane)
+		{
+			P_CopyPlane(mt.args[0], INT2FIXED(mt.x), INT2FIXED(mt.y), mt.type == Slope_CopyFloorPlane);
+			mt.type = 0;
 		}
 	}
 }

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1755,19 +1755,19 @@ void P_SlopeLineToPoint (const int lineid, const fixed_t x, const fixed_t y, con
 		v3double_t v1;
 		v1.x = FIXED2DOUBLE(line.dx);
 		v1.y = FIXED2DOUBLE(line.dy);
-		v1.y = P_PlaneZ(FIXED2DOUBLE(line.v2->x), FIXED2DOUBLE(line.v2->y), &plane) - p.y;
+		v1.z = P_PlaneZ(FIXED2DOUBLE(line.v2->x), FIXED2DOUBLE(line.v2->y), &plane) - p.z;
 
 		v3double_t v2;
 		v2.x = FIXED2DOUBLE(x - line.v1->x);
 		v2.y = FIXED2DOUBLE(y - line.v1->y);
-		v2.y = FIXED2DOUBLE(z) - p.y;
+		v2.z = FIXED2DOUBLE(z) - p.z;
 
 		v3double_t cross;
 		M_CrossProductVec3(&cross, &v1, &v2);
 		M_NormalizeVec3(&cross, &cross);
 
 		// Fix backward normals
-		if ((cross.y < 0 and floor) or (cross.y > 0 and not floor))
+		if ((cross.z < 0 and floor) or (cross.z > 0 and not floor))
 		{
 			cross.x = -cross.x;
 			cross.y = -cross.y;

--- a/common/p_setup.h
+++ b/common/p_setup.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // $Id$
@@ -27,8 +27,7 @@
 
 #include "doomdata.h"
 
-struct line_s;
-using line_t = line_s;
+struct line_t;
 
 // NOT called by W_Ticker. Fixme.
 //

--- a/common/p_snapshot.h
+++ b/common/p_snapshot.h
@@ -32,8 +32,7 @@
 class AActor;
 class player_t;
 struct sector_t;
-struct line_s;
-typedef line_s line_t;
+struct line_t;
 
 class PlayerSnapshotManager;
 

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2605,7 +2605,7 @@ void DScroller::RunThink ()
 	if (m_Control != -1)
 	{	// compute scroll amounts based on a sector's height changes
 		sector_t *sector = &sectors[m_Control];
-		fixed_t height = sector->ceilingtexz + sector->floortexz;
+		const fixed_t height = P_CeilingHeight(sector) + P_FloorHeight(sector);
 
 		fixed_t delta = height - m_LastHeight;
 		m_LastHeight = height;
@@ -2694,20 +2694,15 @@ void DScroller::RunThink ()
 // accel: non-zero if this is an accelerative effect
 //
 
-DScroller::DScroller (EScrollType type, fixed_t dx, fixed_t dy,
-					  int control, int affectee, int accel)
+DScroller::DScroller(EScrollType type, fixed_t dx, fixed_t dy,
+                     int control, int affectee, int accel)
+	: m_Type{type}, m_dx{dx}, m_dy{dy}, m_Control{control}, m_Accel{accel}
 {
-	s_scrollers.push_back(this);
-	m_Type = type;
-	m_dx = dx;
-	m_dy = dy;
-        m_vdx = 0;
-        m_vdy = 0;
-        m_Accel = accel;
-	if ((m_Control = control) != -1)
+	s_scrollers.push_back(this); // FIXME: incomplete object escapes constructor
+	if (control != -1)
 	{
 		sector_t *sector = &sectors[control];
-		fixed_t height = sector->ceilingtexz + sector->floortexz;
+		const fixed_t height = P_CeilingHeight(sector) + P_FloorHeight(sector);
 
 		m_LastHeight = height;
 	}
@@ -2722,28 +2717,29 @@ DScroller::DScroller (EScrollType type, fixed_t dx, fixed_t dy,
 //
 // killough 5/25/98: cleaned up arithmetic to avoid drift due to roundoff
 
-DScroller::DScroller (fixed_t dx, fixed_t dy, const line_t *l,
-					 int control, int accel)
+DScroller::DScroller(fixed_t dx, fixed_t dy, const line_t *l,
+                     int control, int accel)
+	: m_Control{control}, m_Accel{accel}
 {
-	s_scrollers.push_back(this);
-	fixed_t x = abs(l->dx), y = abs(l->dy), d;
+	s_scrollers.push_back(this); // FIXME: incomplete object escapes contructors
+	fixed_t x = abs(l->dx);
+	fixed_t y = abs(l->dy);
 	if (y > x)
-		d = x, x = y, y = d;
-	d = FixedDiv (x, finesine[(tantoangle[FixedDiv(y,x) >> DBITS] + ANG90)
-						  >> ANGLETOFINESHIFT]);
+	{
+		std::swap(x, y);
+	}
+	const fixed_t d = FixedDiv (x, finesine[(tantoangle[FixedDiv(y,x) >> DBITS] + ANG90)
+	                                    >> ANGLETOFINESHIFT]);
 	x = -FixedDiv (FixedMul(dy, l->dy) + FixedMul(dx, l->dx), d);
 	y = -FixedDiv (FixedMul(dx, l->dy) - FixedMul(dy, l->dx), d);
 
-	m_Type = sc_side;
 	m_dx = x;
 	m_dy = y;
-	m_vdx = m_vdy = 0;
-	m_Accel = accel;
 
-	if ((m_Control = control) != -1)
+	if (control != -1)
 	{
 		sector_t *sector = &sectors[control];
-		fixed_t height = sector->ceilingtexz + sector->floortexz;
+		const fixed_t height = P_CeilingHeight(sector) + P_FloorHeight(sector);
 
 		m_LastHeight = height;
 	}

--- a/common/p_spec.cpp
+++ b/common/p_spec.cpp
@@ -2605,7 +2605,7 @@ void DScroller::RunThink ()
 	if (m_Control != -1)
 	{	// compute scroll amounts based on a sector's height changes
 		sector_t *sector = &sectors[m_Control];
-		fixed_t height = sector->ceilingheight + sector->floorheight;
+		fixed_t height = sector->ceilingtexz + sector->floortexz;
 
 		fixed_t delta = height - m_LastHeight;
 		m_LastHeight = height;
@@ -2707,7 +2707,7 @@ DScroller::DScroller (EScrollType type, fixed_t dx, fixed_t dy,
 	if ((m_Control = control) != -1)
 	{
 		sector_t *sector = &sectors[control];
-		fixed_t height = sector->ceilingheight + sector->floorheight;
+		fixed_t height = sector->ceilingtexz + sector->floortexz;
 
 		m_LastHeight = height;
 	}
@@ -2743,7 +2743,7 @@ DScroller::DScroller (fixed_t dx, fixed_t dy, const line_t *l,
 	if ((m_Control = control) != -1)
 	{
 		sector_t *sector = &sectors[control];
-		fixed_t height = sector->ceilingheight + sector->floorheight;
+		fixed_t height = sector->ceilingtexz + sector->floortexz;
 
 		m_LastHeight = height;
 	}

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -180,8 +180,11 @@ class DSectorEffect;
 struct sector_t
 {
 	// FIXME: set the real default values instead of 0 for everything. this was just to replace memsetting the struct for now
-	fixed_t 	floorheight = 0;
-	fixed_t 	ceilingheight = 0;
+	// these were previously the vanilla floorheight/ceilingheight
+	// now with slopes their primary purpose is for aligning textures
+	// with height instead obtained from P_FloorHeight/P_CeilingHeight
+	fixed_t 	floortexz = 0;
+	fixed_t 	ceilingtexz = 0;
 	short		floorpic = 0;
 	short		ceilingpic = 0;
 	short		lightlevel = 0;

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -86,14 +86,13 @@ extern int MaxDrawSegs;
 // Note: transformed values not buffered locally,
 //	like some DOOM-alikes ("wt", "WebView") did.
 //
-struct vertex_s
+struct vertex_t
 {
 	fixed_t x, y;
 };
-typedef vertex_s vertex_t;
 
 // Forward of LineDefs, for Sectors.
-struct line_s;
+struct line_t;
 struct sector_t;
 
 //
@@ -166,7 +165,7 @@ enum SideDefPropChanges
 // Plane
 //
 // Stores the coefficients for the variable that defines a plane (sloping sector)
-struct plane_s
+struct plane_t
 {
 	// Planes are defined by the equation ax + by + cz + d = 0
 	fixed_t		a, b, c, d;
@@ -174,7 +173,6 @@ struct plane_s
 	fixed_t		texx, texy;
 	sector_t	*sector;
 };
-typedef plane_s plane_t;
 
 struct dyncolormap_t;
 
@@ -262,8 +260,8 @@ struct sector_t
 	msecnode_t *touching_thinglist = nullptr;				// phares 3/14/98
 
 	int linecount = 0;
-	line_s **lines = nullptr;		// [linecount] size
-	std::span<line_s*> getLines() { return std::span(lines, linecount); }
+	line_t **lines = nullptr;		// [linecount] size
+	std::span<line_t*> getLines() { return std::span(lines, linecount); }
 
 	float gravity = 0.0f;		// [RH] Sector gravity (1.0 is normal)
 	int damageamount = 0;
@@ -296,7 +294,7 @@ struct sector_t
 //
 // The SideDef.
 //
-struct side_s
+struct side_t
 {
     // add this to the calculated texture column
     fixed_t	textureoffset;
@@ -319,23 +317,22 @@ struct side_s
 	short		tag;
 	int SidedefChanges;
 };
-typedef side_s side_t;
 
 
 //
 // Move clipping aid for LineDefs.
 //
-typedef enum
+enum slopetype_t
 {
 	ST_HORIZONTAL,
 	ST_VERTICAL,
 	ST_POSITIVE,
 	ST_NEGATIVE
-} slopetype_t;
+};
 
 #define R_NOSIDE (static_cast<unsigned short>(-1))
 
-struct line_s
+struct line_t
 {
     // Vertices, from v1 to v2.
     vertex_t*	v1;
@@ -379,7 +376,6 @@ struct line_s
 	bool PropertiesChanged;
 	bool SidedefChanged;
 };
-typedef line_s line_t;
 
 // phares 3/14/98
 //
@@ -434,7 +430,7 @@ struct seg_t
 };
 
 // ===== Polyobj data =====
-typedef struct FPolyObj
+struct polyobj_t
 {
 	int			numsegs;
 	seg_t		**segs;
@@ -449,14 +445,14 @@ typedef struct FPolyObj
 	int			seqType;
 	fixed_t		size;			// polyobj size (area of POLY_AREAUNIT == size of FRACUNIT)
 	DThinker	*specialdata;	// pointer to a thinker, if the poly is moving
-} polyobj_t;
+};
 
-typedef struct polyblock_s
+struct polyblock_t
 {
 	polyobj_t *polyobj;
-	polyblock_s *prev;
-	polyblock_s *next;
-} polyblock_t;
+	polyblock_t *prev;
+	polyblock_t *next;
+};
 
 //
 // A SubSector.
@@ -480,7 +476,7 @@ struct subsector_t
 // Indicate a leaf.
 #define NF_SUBSECTOR	0x80000000
 
-struct node_s
+struct node_t
 {
 	// Partition line.
 	fixed_t			x;
@@ -490,7 +486,6 @@ struct node_s
 	fixed_t			bbox[2][4];		// Bounding box for each child.
 	unsigned int	children[2];	// If NF_SUBSECTOR its a subsector.
 };
-typedef node_s node_t;
 
 
 

--- a/common/r_defs.h
+++ b/common/r_defs.h
@@ -170,7 +170,6 @@ struct plane_t
 	// Planes are defined by the equation ax + by + cz + d = 0
 	fixed_t		a, b, c, d;
 	fixed_t		invc;		// pre-calculated 1/c, used to solve for z value
-	fixed_t		texx, texy;
 	sector_t	*sector;
 };
 

--- a/common/util.h
+++ b/common/util.h
@@ -77,7 +77,7 @@ public:
 	constexpr SafeBool(const Bool auto b) noexcept : m_value(b) {};
 	[[nodiscard]] constexpr bool to_bool() const noexcept { return m_value; }
 	[[nodiscard]] constexpr explicit operator bool () const noexcept { return m_value; }
-    [[nodiscard]] constexpr bool operator==(const SafeBool other) const { return m_value == other.m_value; }
+    [[nodiscard]] constexpr bool operator==(const SafeBool other) const noexcept { return m_value == other.m_value; }
 };
 
 // Helper for use of std::visit with lambdas


### PR DESCRIPTION
Resolves #1952

This adds support for all of the remaining ways of creating slopes, other than those that require UDMF (which should be super easy to build on top of this once we have support for it). 

I don't feel like describing them here, just go read the ZDoom wiki page: https://zdoom.org/wiki/Slope
It's everything except:
- Plane_Align (we already had this)
- UDMF plane equations
- UDMF vertex heights
- Eternity Engine's Doom format specials for Plane_Copy (these are only supported by UZDoom for it's half-working Eternity compat mode and I don't expect we'll be running EE maps anytime soon)
- Eternity Engine's Doom format specials for Plane_Align (we have the ZDoom version of those, which are completely identical except for the special number, also same reasoning as Plane_Copy)

I did not add them to the UDB config because they are already there, inherited from the ZDoom config