### PR TITLE
Enforce consistent operator spellings in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -75,3 +75,6 @@ CheckOptions:
   # allow array members to be uninitialized
   - key: cppcoreguidelines-pro-type-member-init.IgnoreArrays
     value: true
+  # enforce consistent operator style
+  - key: readability-operators-representation.BinaryOperators
+    value: and;or;not;&;|;^;~;&=;|=;^=;!=


### PR DESCRIPTION
Right now we have a mix of spellings for the boolean operators. I think it would be best if we kept it consistent, and it turns out clang-tidy has a check for this enabled already, it just doesn't do anything without saying exactly which spellings you want. It seems like we're heading in the direction of using the keyword versions instead of the symbols, and I at least have been convinced of the benefits of `not` over `!`, but please say if you believe we should set this differently.