### PR TITLE
Large messages

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -469,7 +469,7 @@ static void CL_HandleDisconnectCompletionPacket()
 	// confirmation.
 	while (::net_message.BytesLeftToRead() > 0)
 	{
-		const ParseResultType result = CL_ParseCommand();
+		const ParseResultType result = CL_ParseCommand(::net_message);
 
 		switch (result.cmd)
 		{

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -222,12 +222,21 @@ void CL_LargeMessageFragment(const odaproto::LargeMessageFragment* msg)
 	s_receivedLargeMessage.Append(msg->payload().data(), msg->payload().length());
 }
 
+void CL_ParseBuffer(buf_t& buffer);
+
 void CL_LargeMessageEnd(const odaproto::LargeMessageEnd* )
 {
 	if (s_receivedLargeMessage.IsComplete() and not s_receivedLargeMessage.IsEmpty())
 	{
-		CL_ParseCommand(s_receivedLargeMessage.GetBufferRef());
+		CL_ParseBuffer(s_receivedLargeMessage.GetBufferRef());
 		s_receivedLargeMessage.Restart(0);
+	}
+	else
+	{
+		PrintFmt(PRINT_WARNING,
+		        "Incomplete large message!  total: {}, current: {}\n",
+		        s_receivedLargeMessage.TotalSize(),
+		        s_receivedLargeMessage.CurrentSize());
 	}
 }
 
@@ -3741,42 +3750,16 @@ namespace
 		}
 		return svc;
 	}
-}
 
-//
-// CL_ParseCommands
-//
-void CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader)
-{
-	if (optionalHeader)
+	void CL_ParseBuffer(buf_t& buffer)
 	{
-		s_currentHeader = *optionalHeader;
-	}
-
-	while (connected)
-	{
-		if (::net_message.BytesLeftToRead() == 0)
-		{
-			break;
-		}
-
-		// When echoing server gametic back to it, use the tic that comes from the High Priority packet.
-		// This is because the High Priority packet is always live and comes out every tic.  It's totally
-		// possible for the server to go without sending anything Reliable or Best-Effort if things are
-		// all-quiet.
-		if (messenger.GetCurrentReceivedIsHighPriority())
-		{
-			messenger.SetDestinationTic(messenger.GetCurrentReceivedRemoteTic());
-		}
-
-		const size_t          byteStart = ::net_message.BytesRead();
-		const ParseResultType result    = CL_ParseCommand(::net_message);
+		const ParseResultType result = CL_ParseCommand(buffer);
 
 		const parseError_e processResult = result.code == PERR_OK ?
 			CL_ProcessCommand(result) :
 			result.code;
 
-		if (processResult != PERR_OK or ::net_message.overflowed)
+		if (processResult != PERR_OK or buffer.overflowed)
 		{
 			const Protos& protos = CL_GetTicProtos();
 
@@ -3793,7 +3776,7 @@ void CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader)
 			{
 				err = "Could not decode message";
 			}
-			else if (::net_message.overflowed)
+			else if (buffer.overflowed)
 			{
 				err = "Message overflowed";
 			}
@@ -3823,6 +3806,38 @@ void CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader)
 
 			CL_QuitNetGame(NQ_PROTO);
 		}
+	}
+
+}
+
+//
+// CL_ParseCommands
+//
+void CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader)
+{
+	if (optionalHeader)
+	{
+		s_currentHeader = *optionalHeader;
+	}
+
+	while (connected)
+	{
+		if (::net_message.BytesLeftToRead() == 0)
+		{
+			break;
+		}
+
+		// When echoing server gametic back to it, use the tic that comes from the High Priority packet.
+		// This is because the High Priority packet is always live and comes out every tic.  It's totally
+		// possible for the server to go without sending anything Reliable or Best-Effort if things are
+		// all-quiet.
+		if (messenger.GetCurrentReceivedIsHighPriority())
+		{
+			messenger.SetDestinationTic(messenger.GetCurrentReceivedRemoteTic());
+		}
+
+		const size_t byteStart = ::net_message.BytesRead();
+		CL_ParseBuffer(::net_message);
 
 		// Measure length of each message, so we can keep track of bandwidth.
 		if (::net_message.BytesRead() < byteStart)

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -132,6 +132,8 @@ PacketHeaderType s_currentHeader;
 int32_t ThisMessageClientTic() { return s_currentHeader.destinationTic; }
 int32_t ThisMessageServerTic() { return s_currentHeader.originatorTic; }
 
+LargeMessage s_receivedLargeMessage;
+
 /**
  * @brief Unpack a bitfield into an array of booleans.
  */
@@ -208,6 +210,25 @@ void CL_Header(const odaproto::Header* msg)
 	s_currentHeader.destinationTic  = msg->destination_tic();
 	s_currentHeader.reliableSize    = static_cast<uint16_t>(msg->reliable_size());
 	s_currentHeader.flags           = static_cast<uint16_t>(msg->flags());
+}
+
+void CL_LargeMessageStart(const odaproto::LargeMessageStart* msg)
+{
+	s_receivedLargeMessage.Restart(msg->size());
+}
+
+void CL_LargeMessageFragment(const odaproto::LargeMessageFragment* msg)
+{
+	s_receivedLargeMessage.Append(msg->payload().data(), msg->payload().length());
+}
+
+void CL_LargeMessageEnd(const odaproto::LargeMessageEnd* )
+{
+	if (s_receivedLargeMessage.IsComplete() and not s_receivedLargeMessage.IsEmpty())
+	{
+		CL_ParseCommand(s_receivedLargeMessage.GetBufferRef());
+		s_receivedLargeMessage.Restart(0);
+	}
 }
 
 /**
@@ -3559,12 +3580,12 @@ const Protos& CL_GetTicProtos()
 /**
  * @brief Read a server message off the wire.
  */
-ParseResultType CL_ParseCommand()
+ParseResultType CL_ParseCommand(buf_t& buffer)
 {
 	ParseResultType result;
 
 	// What type of message we have.
-	result.cmd = static_cast<msg_t>(MSG_ReadUnVarint());
+	result.cmd = static_cast<msg_t>(buffer.ReadUnVarint());
 
 	if (result.cmd == msg_ack)
 	{
@@ -3576,7 +3597,7 @@ ParseResultType CL_ParseCommand()
 		// proper way of defering ack handling to ProcessCommand.  It's just a lot
 		// easier and less complication overall to say that acks get special handling,
 		// especially as something that has to operate as part of the protocol itself.
-		const int sequence = MSG_ReadLong();
+		const int sequence = buffer.ReadLong();
 		messenger.Acknowledge(sequence);
 		result.code = PERR_OK;
 		return result;
@@ -3584,7 +3605,7 @@ ParseResultType CL_ParseCommand()
 
 	// Turn the message into a protobuf.
 	google::protobuf::Message* msg = nullptr;
-	result.code = MSG_ParseMessage(msg, result.cmd);
+	result.code = MSG_ParseMessage(msg, result.cmd, buffer);
 	result.msg.reset(msg);                      // This does the right thing even if nullptr.
 
 	// Because the result type contains a unique_ptr, which is uncopyable,
@@ -3612,6 +3633,10 @@ parseError_e CL_ProcessCommand(const ParseResultType& parsedCommand)
 		/* clang-format off */
 		SV_MSG(msg_noop, CL_Noop, odaproto::Noop);
 		SV_MSG(msg_header, CL_Header, odaproto::Header);
+
+		SV_MSG(msg_largemessagestart,    CL_LargeMessageStart,    odaproto::LargeMessageStart);
+		SV_MSG(msg_largemessagefragment, CL_LargeMessageFragment, odaproto::LargeMessageFragment);
+		SV_MSG(msg_largemessageend,      CL_LargeMessageEnd,      odaproto::LargeMessageEnd);
 
 		SV_MSG(svc_disconnect, CL_Disconnect, odaproto::svc::Disconnect);
 		SV_MSG(svc_playerinfo, CL_PlayerInfo, odaproto::svc::PlayerInfo);
@@ -3745,7 +3770,7 @@ void CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader)
 		}
 
 		const size_t          byteStart = ::net_message.BytesRead();
-		const ParseResultType result    = CL_ParseCommand();
+		const ParseResultType result    = CL_ParseCommand(::net_message);
 
 		const parseError_e processResult = result.code == PERR_OK ?
 			CL_ProcessCommand(result) :

--- a/client/src/cl_parse.h
+++ b/client/src/cl_parse.h
@@ -49,7 +49,7 @@ struct ParseResultType
 typedef std::vector<Proto> Protos;
 
 const Protos& CL_GetTicProtos();
-ParseResultType CL_ParseCommand();
+ParseResultType CL_ParseCommand(buf_t& buffer);
 parseError_e    CL_ProcessCommand(const ParseResultType& parsedCommand);
 void            CL_ParseCommands(const std::optional<PacketHeaderType>& optionalHeader = std::nullopt);
 

--- a/common/LargeMessage.h
+++ b/common/LargeMessage.h
@@ -60,6 +60,9 @@ class LargeMessage
 		size_t CurrentSize() const { return m_buffer.TellWrite(); }
 
 		[[ nodiscard ]]
+		bool IsEmpty() const { return CurrentSize() == 0; }
+
+		[[ nodiscard ]]
 		bool IsComplete() const { return CurrentSize() == TotalSize(); }
 
 		[[ nodiscard ]]

--- a/common/LargeMessage.h
+++ b/common/LargeMessage.h
@@ -1,3 +1,25 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 2026 by Jim Thoenen.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  Class for reassembling large messages
+//
+//-----------------------------------------------------------------------------
+
 #pragma once
 
 #include "i_net.h"

--- a/common/LargeMessage.h
+++ b/common/LargeMessage.h
@@ -27,7 +27,7 @@
 class LargeMessage
 {
 	public:
-		static const size_t MAX_SIZE { 64u * 1024u };
+		static const size_t MAX_SIZE { 64 << 10 };      // 64 KB:  The absolute largest message payload we allow.
 
 		bool Restart(size_t totalLength)
 		{

--- a/common/LargeMessage.h
+++ b/common/LargeMessage.h
@@ -27,7 +27,7 @@
 class LargeMessage
 {
 	public:
-		static const size_t MAX_SIZE { 64 * 1024 };
+		static const size_t MAX_SIZE { 64u * 1024u };
 
 		bool Restart(size_t totalLength)
 		{

--- a/common/LargeMessage.h
+++ b/common/LargeMessage.h
@@ -31,7 +31,17 @@ class LargeMessage
 			return true;
 		}
 
-		bool IsComplete() const { return m_buffer.TellWrite() == m_buffer.size(); }
+		[[ nodiscard ]]
+		size_t TotalSize() const { return m_buffer.size(); }
+
+		[[ nodiscard ]]
+		size_t CurrentSize() const { return m_buffer.TellWrite(); }
+
+		[[ nodiscard ]]
+		bool IsComplete() const { return CurrentSize() == TotalSize(); }
+
+		[[ nodiscard ]]
+		buf_t& GetBufferRef() { return m_buffer; }
 
 	protected:
 		buf_t m_buffer { MAX_SIZE };

--- a/common/LargeMessage.h
+++ b/common/LargeMessage.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "i_net.h"
+
+class LargeMessage
+{
+	public:
+		static const size_t MAX_SIZE { 64 * 1024 };
+
+		bool Restart(size_t totalLength)
+		{
+			m_buffer.clear();
+
+			if (totalLength <= m_buffer.maxsize())
+			{
+				m_buffer.setcursize(totalLength);
+				return true;
+			}
+			return false;
+		}
+
+		bool Append(const void* data, size_t length)
+		{
+			if (IsComplete())
+				return false;
+
+			if (m_buffer.TellWrite() + length > m_buffer.size())
+				return false;
+
+			m_buffer.WriteChunk(data, length);
+			return true;
+		}
+
+		bool IsComplete() const { return m_buffer.TellWrite() == m_buffer.size(); }
+
+	protected:
+		buf_t m_buffer { MAX_SIZE };
+};

--- a/common/LargeMessageQueue.h
+++ b/common/LargeMessageQueue.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "i_net.h"
+#include "LargeMessage.h"
 #include "MessageQueue.h"
 
 enum class FragmentationStateEnum
@@ -57,6 +58,9 @@ class LargeMessageQueue
 		{
 			m_queue.Write(std::forward<decltype(args)>(args)...);
 		}
+
+		[[ nodiscard ]]
+		size_t GetMessageSize() const { return m_queue.SizeInMessages() != 0 ? m_queue.Front().size() : 0; }
 
 		template <typename IteratorType>
 		[[ nodiscard ]]
@@ -108,6 +112,5 @@ class LargeMessageQueue
 
 	protected:
 
-		static const size_t MAX_LARGE_MESSAGE_SIZE { 64 * 1024 };
-		MessageQueue m_queue { MAX_LARGE_MESSAGE_SIZE };
+		MessageQueue m_queue { LargeMessage::MAX_SIZE };
 };

--- a/common/LargeMessageQueue.h
+++ b/common/LargeMessageQueue.h
@@ -16,42 +16,86 @@
 // GNU General Public License for more details.
 //
 // DESCRIPTION:
-//  Utilities for monitoring changes to player attribute items.
+//  Queue for Large Messages that need to be fragmented and reassembled
 //
 //-----------------------------------------------------------------------------
 
 #pragma once
 
-#include <deque>
-#include <string>
-#include <vector>
-
 #include "i_net.h"
-
-namespace google::protobuf
-{
-	class Message;
-}
+#include "MessageQueue.h"
 
 enum class FragmentationStateEnum
 {
-	NONE,           ///< No large messages are enqueued.
-	START,          ///< This is the first fragment of a new large message.
-	RUNNING,        ///< Fragmentation of a previously-started large message is ongoing.
-	END,            ///< This is the last fragment of a large message.
+	NONE,                   ///< No large messages are enqueued.
+	FIRST_FRAGMENT,         ///< This is the first fragment of a new large message.
+	CONTINUATION_FRAGMENT,  ///< The next fragment in the sequence, but not the last.
+	LAST_FRAGMENT,          ///< This is the last fragment of a large message.
+	ONE_SHOT,               ///< The fragment is the entirety of the message. (both START and END)
+	INVALID_FRAGMENT_SIZE,  ///< An invalid fragmentation was requested.
+	MESSAGE_OVERFLOW,       ///< The fragment overflowed somehow...  Should never happen.
 };
 
 class LargeMessageQueue
 {
 	public:
-		void Write(const google::protobuf::Message& msg);
-		void Write(msg_t id, const std::string& msg);
 
+		// Expose the queue's Write APIs.
+		void Write(auto&&... args)
+		{
+			m_queue.Write(std::forward<decltype(args)>(args)...);
+		}
+
+		template <typename IteratorType>
 		[[ nodiscard ]]
-		FragmentationStateEnum NextFragment(buf_t& o_buffer, size_t maxSize);
+		FragmentationStateEnum NextFragment(size_t maxSize, IteratorType outIter)
+		{
+			if (m_queue.SizeInMessages() == 0)
+				return FragmentationStateEnum::NONE;
+
+			if (maxSize == 0)
+				return FragmentationStateEnum::INVALID_FRAGMENT_SIZE;
+
+			buf_t& bufferRef = m_queue.Front();
+
+			// Did we get an empty message in the queue somehow?  Pop it off and try the next one.
+			if (bufferRef.BytesLeftToRead() == 0)
+			{
+				m_queue.Pop();
+				return NextFragment(maxSize, outIter);
+			}
+
+			const size_t numberOfBytesToExtract = std::min(maxSize, bufferRef.BytesLeftToRead());
+
+			const bool  isAtStartOfMessage = bufferRef.TellRead() == 0;
+			const byte* dataPtr            = bufferRef.ReadChunk(numberOfBytesToExtract);
+			const bool  isAtEndOfMessage   = bufferRef.BytesLeftToRead() == 0;
+
+			// This should never happen due to the above checks.  Still, play it safe.
+			if (dataPtr == nullptr)
+				return FragmentationStateEnum::MESSAGE_OVERFLOW;
+
+			std::copy(dataPtr, dataPtr + numberOfBytesToExtract, outIter);
+
+			if (isAtEndOfMessage)
+			{
+				m_queue.Pop();
+
+				if (isAtStartOfMessage)
+				{
+					return FragmentationStateEnum::ONE_SHOT;
+				}
+				return FragmentationStateEnum::LAST_FRAGMENT;
+			}
+			if (isAtStartOfMessage)
+			{
+				return FragmentationStateEnum::FIRST_FRAGMENT;
+			}
+			return FragmentationStateEnum::CONTINUATION_FRAGMENT;
+		}
 
 	protected:
-		std::deque<buf_t>  m_queue;
-		std::vector<buf_t> m_freeStack;
-		std::string        m_serializationBuffer;
+
+		static const size_t MAX_LARGE_MESSAGE_SIZE { 64 * 1024 };
+		MessageQueue m_queue { MAX_LARGE_MESSAGE_SIZE };
 };

--- a/common/LargeMessageQueue.h
+++ b/common/LargeMessageQueue.h
@@ -59,8 +59,16 @@ class LargeMessageQueue
 			m_queue.Write(std::forward<decltype(args)>(args)...);
 		}
 
+		void Clear()
+		{
+			m_queue.Clear();
+		}
+
 		[[ nodiscard ]]
 		size_t GetMessageSize() const { return m_queue.SizeInMessages() != 0 ? m_queue.Front().size() : 0; }
+
+		[[ nodiscard ]]
+		size_t SizeInBytes() const { return m_queue.SizeInMessages() != 0 ? m_queue.SizeInBytes() - m_queue.Front().TellRead() : 0; }
 
 		template <typename IteratorType>
 		[[ nodiscard ]]

--- a/common/LargeMessageQueue.h
+++ b/common/LargeMessageQueue.h
@@ -1,0 +1,57 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 2026 by Jim Thoenen.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  Utilities for monitoring changes to player attribute items.
+//
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#include <deque>
+#include <string>
+#include <vector>
+
+#include "i_net.h"
+
+namespace google::protobuf
+{
+	class Message;
+}
+
+enum class FragmentationStateEnum
+{
+	NONE,           ///< No large messages are enqueued.
+	START,          ///< This is the first fragment of a new large message.
+	RUNNING,        ///< Fragmentation of a previously-started large message is ongoing.
+	END,            ///< This is the last fragment of a large message.
+};
+
+class LargeMessageQueue
+{
+	public:
+		void Write(const google::protobuf::Message& msg);
+		void Write(msg_t id, const std::string& msg);
+
+		[[ nodiscard ]]
+		FragmentationStateEnum NextFragment(buf_t& o_buffer, size_t maxSize);
+
+	protected:
+		std::deque<buf_t>  m_queue;
+		std::vector<buf_t> m_freeStack;
+		std::string        m_serializationBuffer;
+};

--- a/common/LargeMessageQueue.h
+++ b/common/LargeMessageQueue.h
@@ -36,6 +36,18 @@ enum class FragmentationStateEnum
 	MESSAGE_OVERFLOW,       ///< The fragment overflowed somehow...  Should never happen.
 };
 
+struct FragmentationResultType
+{
+	FragmentationStateEnum state { FragmentationStateEnum::NONE };
+	size_t                 size  { 0 };
+
+	FragmentationResultType(FragmentationStateEnum i_state, size_t i_size) :
+	    state { i_state },
+	    size  { i_size }
+	{
+	}
+};
+
 class LargeMessageQueue
 {
 	public:
@@ -48,13 +60,13 @@ class LargeMessageQueue
 
 		template <typename IteratorType>
 		[[ nodiscard ]]
-		FragmentationStateEnum NextFragment(size_t maxSize, IteratorType outIter)
+		FragmentationResultType NextFragment(size_t maxSize, IteratorType outIter)
 		{
 			if (m_queue.SizeInMessages() == 0)
-				return FragmentationStateEnum::NONE;
+				return FragmentationResultType {FragmentationStateEnum::NONE, 0};
 
 			if (maxSize == 0)
-				return FragmentationStateEnum::INVALID_FRAGMENT_SIZE;
+				return FragmentationResultType {FragmentationStateEnum::INVALID_FRAGMENT_SIZE, 0};
 
 			buf_t& bufferRef = m_queue.Front();
 
@@ -73,7 +85,7 @@ class LargeMessageQueue
 
 			// This should never happen due to the above checks.  Still, play it safe.
 			if (dataPtr == nullptr)
-				return FragmentationStateEnum::MESSAGE_OVERFLOW;
+				return FragmentationResultType {FragmentationStateEnum::MESSAGE_OVERFLOW, 0};
 
 			std::copy(dataPtr, dataPtr + numberOfBytesToExtract, outIter);
 
@@ -83,15 +95,15 @@ class LargeMessageQueue
 
 				if (isAtStartOfMessage)
 				{
-					return FragmentationStateEnum::ONE_SHOT;
+					return FragmentationResultType {FragmentationStateEnum::ONE_SHOT, numberOfBytesToExtract};
 				}
-				return FragmentationStateEnum::LAST_FRAGMENT;
+				return FragmentationResultType {FragmentationStateEnum::LAST_FRAGMENT, numberOfBytesToExtract};
 			}
 			if (isAtStartOfMessage)
 			{
-				return FragmentationStateEnum::FIRST_FRAGMENT;
+				return FragmentationResultType {FragmentationStateEnum::FIRST_FRAGMENT, numberOfBytesToExtract};
 			}
-			return FragmentationStateEnum::CONTINUATION_FRAGMENT;
+			return FragmentationResultType {FragmentationStateEnum::CONTINUATION_FRAGMENT, numberOfBytesToExtract};
 		}
 
 	protected:

--- a/common/MessageQueue.cpp
+++ b/common/MessageQueue.cpp
@@ -44,7 +44,7 @@ buf_t& MessageQueue::Obtain()
 	}
 	else
 	{
-		m_queue.emplace_back(MAX_UDP_PACKET);
+		m_queue.emplace_back(m_maxMessageBufferSize);
 	}
 	return m_queue.back();
 }

--- a/common/MessageQueue.h
+++ b/common/MessageQueue.h
@@ -33,6 +33,11 @@ class MessageQueue
 {
 	public:
 
+		explicit MessageQueue(size_t i_maxMessageBufferSize = MAX_UDP_PACKET) :
+			m_maxMessageBufferSize { i_maxMessageBufferSize }
+		{
+		}
+
 		size_t SizeInBytes()    const { return not m_queue.empty() ? m_totalEnqueuedBytesSansMostRecent + m_queue.back().size() : m_totalEnqueuedBytesSansMostRecent; }
 		size_t SizeInMessages() const { return m_queue.size(); }
 
@@ -44,6 +49,7 @@ class MessageQueue
 
 		// Using messages.
 		const buf_t& Front() const { return m_queue.front(); }
+		buf_t& Front()             { return m_queue.front(); }
 
 		// Popping messages.
 		bool Pop();
@@ -87,4 +93,5 @@ class MessageQueue
 		// "finalized" until the next slot is created.
 		//
 		size_t m_totalEnqueuedBytesSansMostRecent { 0 };
+		size_t m_maxMessageBufferSize { MAX_UDP_PACKET };
 };

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -22,6 +22,8 @@
 #include "OdaMessenger.h"
 
 #include "i_net.h"
+#include "msg_message.h"
+#include "msg_pack.h"
 
 EXTERN_CVAR (log_packetdebug)
 
@@ -376,7 +378,75 @@ MessageResultEnum OdaMessenger::SendStandard(int i_currentTic, const netadr_t& i
 		m_byteBudget               -= static_cast<int>(sendSize);
 	}
 
-	// Okay, done with the "really important" stuff.  Now onto purely best-effort unreliable packets.
+	// Okay, done with the "really important" stuff.  Divide up the remaining budget between best effort
+	// and large message fragments.
+    while (m_outgoingLargeMessageQueue.GetMessageSize() > 0 and m_byteBudget > 0)
+    {
+        const size_t fairSize = std::min(MAX_UDP_SIZE / 2, m_byteBudget / 2);
+
+        // Allow fragments to grow to full size if there are no more best effort messages.
+        const size_t fragmentSize = m_outgoingNonReliableQueue.SizeInBytes() < fairSize ?
+                                    fairSize + (fairSize - m_outgoingNonReliableQueue.SizeInBytes()) :
+                                    fairSize;
+
+        m_outgoingLargeMessageFragment.setcursize(fragmentSize);
+
+        const auto fragmentInfo = m_outgoingLargeMessageQueue.NextFragment(m_outgoingLargeMessageFragment.size(),
+                                                                           m_outgoingLargeMessageFragment.ptr());
+
+        // Please note that we deliberately don't add these reliable messages to the reliable queue because
+        // we don't want to inadvertently wind up in a situation where the fragments are elevated in priority
+        // in a subsequent tic.
+        switch (fragmentInfo.state)
+        {
+            case FragmentationStateEnum::NONE:
+                break;
+
+            case FragmentationStateEnum::FIRST_FRAGMENT:
+                m_scratchpadBuffer.clear();
+                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageStart   (m_outgoingLargeMessageQueue.GetMessageSize()));
+                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+                                                                      fragmentInfo.size));
+                PackAsReliable(m_packet, m_scratchpadBuffer);
+                break;
+
+            case FragmentationStateEnum::CONTINUATION_FRAGMENT:
+                m_scratchpadBuffer.clear();
+                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+                                                                      fragmentInfo.size));
+                PackAsReliable(m_packet, m_scratchpadBuffer);
+                break;
+
+            case FragmentationStateEnum::LAST_FRAGMENT:
+                m_scratchpadBuffer.clear();
+                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+                                                                      fragmentInfo.size));
+                MSG_Pack(m_scratchpadBuffer, odaproto::LargeMessageEnd());
+                PackAsReliable(m_packet, m_scratchpadBuffer);
+                break;
+
+            case FragmentationStateEnum::ONE_SHOT:
+                // This odd case fires if someone puts a small message into the large message queue.
+                // The fragment itself is a whole message, just put it into the packet.
+                PackAsReliable(m_packet, m_outgoingLargeMessageFragment);
+                break;
+
+            case FragmentationStateEnum::INVALID_FRAGMENT_SIZE:
+                break;
+            case FragmentationStateEnum::MESSAGE_OVERFLOW:
+                break;
+        }
+
+		// Now fill out the remaining space with best effort messages.
+		m_outgoingNonReliableQueue.Pack([this](const buf_t& messageBuf) { return PackAsUnreliable(m_packet, messageBuf); });
+
+		const size_t sendSize = m_packet.Send(i_currentTic, m_destinationTic, m_sender, i_dest);
+		m_bytesSentWithReliability += sendSize;
+		m_byteBudget               -= static_cast<int>(sendSize);
+    }
+
+    // We're out of large message fragments or didn't have any to begin with.
+    // Now onto purely best-effort unreliable packets.
 	while (m_outgoingNonReliableQueue.SizeInMessages() > 0 and m_byteBudget > 0)
 	{
 		if (static_cast<int>(m_packet.Size() + m_outgoingNonReliableQueue.Front().size()) > m_byteBudget)

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -207,7 +207,6 @@ MessageResultEnum OdaMessenger::Receive(buf_t& io_rawBuf)
 #endif
 
 	}
-
 	return MessageResultEnum::DEFER;
 }
 

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -381,60 +381,7 @@ MessageResultEnum OdaMessenger::SendStandard(int i_currentTic, const netadr_t& i
 	// and large message fragments.
 	while (m_outgoingLargeMessageQueue.GetMessageSize() > 0 and m_byteBudget > 0)
 	{
-		const size_t fairSize = std::min(MAX_UDP_SIZE / 2, m_byteBudget / 2);
-
-		// Allow fragments to grow to full size if there are no more best effort messages.
-		const size_t fragmentSize = m_outgoingNonReliableQueue.SizeInBytes() < fairSize ?
-		                            fairSize + (fairSize - m_outgoingNonReliableQueue.SizeInBytes()) :
-		                            fairSize;
-
-		m_outgoingLargeMessageFragment.setcursize(fragmentSize);
-
-		const auto fragmentInfo = m_outgoingLargeMessageQueue.NextFragment(m_outgoingLargeMessageFragment.size(),
-		                                                                   m_outgoingLargeMessageFragment.ptr());
-
-		// Please note that we deliberately don't add these reliable messages to the reliable queue because
-		// we don't want to inadvertently wind up in a situation where the fragments are elevated in priority
-		// in a subsequent tic.
-		switch (fragmentInfo.state)
-		{
-			case FragmentationStateEnum::NONE:
-				break;
-
-			case FragmentationStateEnum::FIRST_FRAGMENT:
-				m_scratchpadBuffer.clear();
-				MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageStart   (m_outgoingLargeMessageQueue.GetMessageSize()));
-				MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
-				                                                      fragmentInfo.size));
-				PackAsReliable(m_packet, m_scratchpadBuffer);
-				break;
-
-			case FragmentationStateEnum::CONTINUATION_FRAGMENT:
-				m_scratchpadBuffer.clear();
-				MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
-				                                                      fragmentInfo.size));
-				PackAsReliable(m_packet, m_scratchpadBuffer);
-				break;
-
-			case FragmentationStateEnum::LAST_FRAGMENT:
-				m_scratchpadBuffer.clear();
-				MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
-				                                                      fragmentInfo.size));
-				MSG_Pack(m_scratchpadBuffer, odaproto::LargeMessageEnd());
-				PackAsReliable(m_packet, m_scratchpadBuffer);
-				break;
-
-			case FragmentationStateEnum::ONE_SHOT:
-				// This odd case fires if someone puts a small message into the large message queue.
-				// The fragment itself is a whole message, just put it into the packet.
-				PackAsReliable(m_packet, m_outgoingLargeMessageFragment);
-				break;
-
-			case FragmentationStateEnum::INVALID_FRAGMENT_SIZE:
-				break;
-			case FragmentationStateEnum::MESSAGE_OVERFLOW:
-				break;
-		}
+		SendFragments();
 
 		// Now fill out the remaining space with best effort messages.
 		m_outgoingNonReliableQueue.Pack([this](const buf_t& messageBuf) { return PackAsUnreliable(m_packet, messageBuf); });
@@ -514,6 +461,72 @@ MessageResultEnum OdaMessenger::SendAll(int i_currentTic, const netadr_t& i_dest
 	guard.SendHighPriority();
 	guard.SendRetransmissions();
 	return guard.SendStandard();
+}
+
+size_t OdaMessenger::SendFragments()
+{
+    // 1 KB because there's enough safety margin at the end for us to not have to be concerned about returning
+    // fragments back to the large message queue on account of the Packet class rejecting a large fragment.
+    const size_t fragmentSize = 1024;
+
+    size_t writtenFragmentPortionSize = 0;
+
+    while (writtenFragmentPortionSize < fragmentSize and m_outgoingLargeMessageQueue.GetMessageSize() > 0)
+    {
+        const size_t requestedSize = fragmentSize - writtenFragmentPortionSize;
+        const auto fragmentInfo    = m_outgoingLargeMessageQueue.NextFragment(requestedSize,
+                                                                              m_outgoingLargeMessageFragment.ptr());
+        m_outgoingLargeMessageFragment.setcursize(fragmentInfo.size);
+
+        // Please note that we deliberately don't add these reliable messages to the reliable queue because
+        // we don't want to inadvertently wind up in a situation where the fragments are elevated in priority
+        // in a subsequent tic.
+        switch (fragmentInfo.state)
+        {
+            case FragmentationStateEnum::NONE:
+                PrintFmt(PRINT_WARNING, "No fragment!  requested: {} given: {};  Clearing...\n", requestedSize, fragmentInfo.size);
+                m_outgoingLargeMessageQueue.Clear();
+                break;
+            case FragmentationStateEnum::INVALID_FRAGMENT_SIZE:
+                PrintFmt(PRINT_WARNING, "Invalid fragment size!  requested: {} given: {};  Clearing...\n", requestedSize, fragmentInfo.size);
+                m_outgoingLargeMessageQueue.Clear();
+                break;
+            case FragmentationStateEnum::MESSAGE_OVERFLOW:
+                PrintFmt(PRINT_WARNING, "Fragment message overflow!  requested: {} given: {};  Clearing...\n", requestedSize, fragmentInfo.size);
+                m_outgoingLargeMessageQueue.Clear();
+                break;
+
+            case FragmentationStateEnum::FIRST_FRAGMENT:
+                m_scratchpadBuffer.clear();
+                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageStart   (m_outgoingLargeMessageQueue.GetMessageSize()));
+                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+                                                                      m_outgoingLargeMessageFragment.size()));
+                writtenFragmentPortionSize += PackAsReliable(m_packet, m_scratchpadBuffer);
+                break;
+
+            case FragmentationStateEnum::CONTINUATION_FRAGMENT:
+                m_scratchpadBuffer.clear();
+                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+                                                                      m_outgoingLargeMessageFragment.size()));
+                writtenFragmentPortionSize += PackAsReliable(m_packet, m_scratchpadBuffer);
+                break;
+
+            case FragmentationStateEnum::LAST_FRAGMENT:
+                m_scratchpadBuffer.clear();
+                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+                                                                      m_outgoingLargeMessageFragment.size()));
+                MSG_Pack(m_scratchpadBuffer, odaproto::LargeMessageEnd());
+                writtenFragmentPortionSize += PackAsReliable(m_packet, m_scratchpadBuffer);
+                break;
+
+            case FragmentationStateEnum::ONE_SHOT:
+                // This odd case fires if someone puts a small message into the large message queue.
+                // The fragment itself is a whole message, just put it into the packet.
+                writtenFragmentPortionSize += PackAsReliable(m_packet, m_outgoingLargeMessageFragment);
+                break;
+            }
+        }
+    return writtenFragmentPortionSize;
 }
 
 size_t OdaMessenger::SendRetransmissions(int i_currentTic, const netadr_t& i_dest)

--- a/common/OdaMessenger.cpp
+++ b/common/OdaMessenger.cpp
@@ -380,62 +380,62 @@ MessageResultEnum OdaMessenger::SendStandard(int i_currentTic, const netadr_t& i
 
 	// Okay, done with the "really important" stuff.  Divide up the remaining budget between best effort
 	// and large message fragments.
-    while (m_outgoingLargeMessageQueue.GetMessageSize() > 0 and m_byteBudget > 0)
-    {
-        const size_t fairSize = std::min(MAX_UDP_SIZE / 2, m_byteBudget / 2);
+	while (m_outgoingLargeMessageQueue.GetMessageSize() > 0 and m_byteBudget > 0)
+	{
+		const size_t fairSize = std::min(MAX_UDP_SIZE / 2, m_byteBudget / 2);
 
-        // Allow fragments to grow to full size if there are no more best effort messages.
-        const size_t fragmentSize = m_outgoingNonReliableQueue.SizeInBytes() < fairSize ?
-                                    fairSize + (fairSize - m_outgoingNonReliableQueue.SizeInBytes()) :
-                                    fairSize;
+		// Allow fragments to grow to full size if there are no more best effort messages.
+		const size_t fragmentSize = m_outgoingNonReliableQueue.SizeInBytes() < fairSize ?
+		                            fairSize + (fairSize - m_outgoingNonReliableQueue.SizeInBytes()) :
+		                            fairSize;
 
-        m_outgoingLargeMessageFragment.setcursize(fragmentSize);
+		m_outgoingLargeMessageFragment.setcursize(fragmentSize);
 
-        const auto fragmentInfo = m_outgoingLargeMessageQueue.NextFragment(m_outgoingLargeMessageFragment.size(),
-                                                                           m_outgoingLargeMessageFragment.ptr());
+		const auto fragmentInfo = m_outgoingLargeMessageQueue.NextFragment(m_outgoingLargeMessageFragment.size(),
+		                                                                   m_outgoingLargeMessageFragment.ptr());
 
-        // Please note that we deliberately don't add these reliable messages to the reliable queue because
-        // we don't want to inadvertently wind up in a situation where the fragments are elevated in priority
-        // in a subsequent tic.
-        switch (fragmentInfo.state)
-        {
-            case FragmentationStateEnum::NONE:
-                break;
+		// Please note that we deliberately don't add these reliable messages to the reliable queue because
+		// we don't want to inadvertently wind up in a situation where the fragments are elevated in priority
+		// in a subsequent tic.
+		switch (fragmentInfo.state)
+		{
+			case FragmentationStateEnum::NONE:
+				break;
 
-            case FragmentationStateEnum::FIRST_FRAGMENT:
-                m_scratchpadBuffer.clear();
-                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageStart   (m_outgoingLargeMessageQueue.GetMessageSize()));
-                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
-                                                                      fragmentInfo.size));
-                PackAsReliable(m_packet, m_scratchpadBuffer);
-                break;
+			case FragmentationStateEnum::FIRST_FRAGMENT:
+				m_scratchpadBuffer.clear();
+				MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageStart   (m_outgoingLargeMessageQueue.GetMessageSize()));
+				MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+				                                                      fragmentInfo.size));
+				PackAsReliable(m_packet, m_scratchpadBuffer);
+				break;
 
-            case FragmentationStateEnum::CONTINUATION_FRAGMENT:
-                m_scratchpadBuffer.clear();
-                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
-                                                                      fragmentInfo.size));
-                PackAsReliable(m_packet, m_scratchpadBuffer);
-                break;
+			case FragmentationStateEnum::CONTINUATION_FRAGMENT:
+				m_scratchpadBuffer.clear();
+				MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+				                                                      fragmentInfo.size));
+				PackAsReliable(m_packet, m_scratchpadBuffer);
+				break;
 
-            case FragmentationStateEnum::LAST_FRAGMENT:
-                m_scratchpadBuffer.clear();
-                MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
-                                                                      fragmentInfo.size));
-                MSG_Pack(m_scratchpadBuffer, odaproto::LargeMessageEnd());
-                PackAsReliable(m_packet, m_scratchpadBuffer);
-                break;
+			case FragmentationStateEnum::LAST_FRAGMENT:
+				m_scratchpadBuffer.clear();
+				MSG_Pack(m_scratchpadBuffer, MSG_LargeMessageFragment(m_outgoingLargeMessageFragment.ptr(),
+				                                                      fragmentInfo.size));
+				MSG_Pack(m_scratchpadBuffer, odaproto::LargeMessageEnd());
+				PackAsReliable(m_packet, m_scratchpadBuffer);
+				break;
 
-            case FragmentationStateEnum::ONE_SHOT:
-                // This odd case fires if someone puts a small message into the large message queue.
-                // The fragment itself is a whole message, just put it into the packet.
-                PackAsReliable(m_packet, m_outgoingLargeMessageFragment);
-                break;
+			case FragmentationStateEnum::ONE_SHOT:
+				// This odd case fires if someone puts a small message into the large message queue.
+				// The fragment itself is a whole message, just put it into the packet.
+				PackAsReliable(m_packet, m_outgoingLargeMessageFragment);
+				break;
 
-            case FragmentationStateEnum::INVALID_FRAGMENT_SIZE:
-                break;
-            case FragmentationStateEnum::MESSAGE_OVERFLOW:
-                break;
-        }
+			case FragmentationStateEnum::INVALID_FRAGMENT_SIZE:
+				break;
+			case FragmentationStateEnum::MESSAGE_OVERFLOW:
+				break;
+		}
 
 		// Now fill out the remaining space with best effort messages.
 		m_outgoingNonReliableQueue.Pack([this](const buf_t& messageBuf) { return PackAsUnreliable(m_packet, messageBuf); });
@@ -443,10 +443,10 @@ MessageResultEnum OdaMessenger::SendStandard(int i_currentTic, const netadr_t& i
 		const size_t sendSize = m_packet.Send(i_currentTic, m_destinationTic, m_sender, i_dest);
 		m_bytesSentWithReliability += sendSize;
 		m_byteBudget               -= static_cast<int>(sendSize);
-    }
+	}
 
-    // We're out of large message fragments or didn't have any to begin with.
-    // Now onto purely best-effort unreliable packets.
+	// We're out of large message fragments or didn't have any to begin with.
+	// Now onto purely best-effort unreliable packets.
 	while (m_outgoingNonReliableQueue.SizeInMessages() > 0 and m_byteBudget > 0)
 	{
 		if (static_cast<int>(m_packet.Size() + m_outgoingNonReliableQueue.Front().size()) > m_byteBudget)

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -25,7 +25,9 @@
 #include <memory_resource>
 #include <utility>
 
+#include "LargeMessageQueue.h"
 #include "MessageQueue.h"
+
 #include "Packet.h"
 #include "SequenceReceiver.h"
 #include "SequenceSender.h"
@@ -284,9 +286,10 @@ class OdaMessenger
 		PacketHeaderType m_receivedHeader;
 
 		// Send buffers
-		MessageQueue m_outgoingReliableQueue;
-		MessageQueue m_outgoingNonReliableQueue;
-		MessageQueue m_outgoingHighNonReliableQueue;
+		MessageQueue        m_outgoingReliableQueue;
+		MessageQueue        m_outgoingNonReliableQueue;
+		MessageQueue        m_outgoingHighNonReliableQueue;
+		LargeMessageQueue   m_outgoingLargeMessageQueue;
 
 		buf_t            m_immediateReceiveBuffer{ MAX_UDP_PACKET };
 		PacketHeaderType m_immediateReceiveHeader;

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -218,9 +218,10 @@ class OdaMessenger
 
 		/// Return the requested message queue.  Use these queues to Obtain new messages into which to pack
 		/// new outgoing data.
-		MessageQueue& Reliable() { return m_outgoingReliableQueue; }
-		MessageQueue& BestEffort() { return m_outgoingNonReliableQueue; }
-		MessageQueue& HighPriority() { return m_outgoingHighNonReliableQueue; }
+		MessageQueue&      Reliable() { return m_outgoingReliableQueue; }
+		MessageQueue&      BestEffort() { return m_outgoingNonReliableQueue; }
+		MessageQueue&      HighPriority() { return m_outgoingHighNonReliableQueue; }
+		LargeMessageQueue& LargeMessage() { return m_outgoingLargeMessageQueue; }
 
 		/// Discard all outgoing data that has yet to be sent.
 		void Clear()
@@ -228,6 +229,7 @@ class OdaMessenger
 			m_outgoingReliableQueue.Clear();
 			m_outgoingNonReliableQueue.Clear();
 			m_outgoingHighNonReliableQueue.Clear();
+			m_outgoingLargeMessageQueue.Clear();
 		}
 
 		bool RecordingIsEnabled() const { return m_recordingIsEnabled; }
@@ -258,7 +260,8 @@ class OdaMessenger
 		int GetNonContiguousRetransmitPackets() const { return m_noncontiguousRetransmitCount; }
 		size_t GetOutgoingSizeInBytes() const         { return m_outgoingReliableQueue.SizeInBytes()
 		                                                     + m_outgoingNonReliableQueue.SizeInBytes()
-		                                                     + m_outgoingHighNonReliableQueue.SizeInBytes(); }
+		                                                     + m_outgoingHighNonReliableQueue.SizeInBytes()
+		                                                     + m_outgoingLargeMessageQueue.SizeInBytes(); }
 		int GetPendingAckCount() const       { return m_sender.GetPendingAckCount(); }
 		int GetReliableOverloadCount() const { return m_reliableOverloadCount; }
 		int GetTicBudget() const             { return m_perTicBudget; }
@@ -290,9 +293,12 @@ class OdaMessenger
 		MessageQueue        m_outgoingNonReliableQueue;
 		MessageQueue        m_outgoingHighNonReliableQueue;
 		LargeMessageQueue   m_outgoingLargeMessageQueue;
+		buf_t               m_outgoingLargeMessageFragment { MAX_UDP_PACKET };
 
 		buf_t            m_immediateReceiveBuffer{ MAX_UDP_PACKET };
 		PacketHeaderType m_immediateReceiveHeader;
+
+		buf_t m_scratchpadBuffer { MAX_UDP_PACKET };
 
 		int m_maxPacketsPerRetransmission   { DEFAULT_RETRANSMISSIONS_PER_TIC };
 		int m_retransmitDelayInTics         { 0 };

--- a/common/OdaMessenger.h
+++ b/common/OdaMessenger.h
@@ -279,6 +279,7 @@ class OdaMessenger
 		void ManageBudget(int i_currentTic);
 
 		int SendOldPacket(const SequenceQueueEntryType& queueEntry, const netadr_t& i_dest);
+		size_t SendFragments();
 
 		SequenceSender   m_sender;
 		SequenceReceiver m_receiver;

--- a/common/i_net.cpp
+++ b/common/i_net.cpp
@@ -875,6 +875,9 @@ static void InitNetMessageFormats()
 	// Server Messages.
 	MSG_INFO(msg_noop);
 	MSG_INFO(msg_header);
+    MSG_INFO(msg_largemessagestart);
+    MSG_INFO(msg_largemessagefragment);
+    MSG_INFO(msg_largemessageend);
 
 	MSG_INFO(svc_disconnect);
 	MSG_INFO(svc_playerinfo);

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -623,7 +623,7 @@ public:
 			// Read part of the variant.
 			b = ReadByte();
 			if (overflowed)
-				return -1;
+				return 0;
 
 			// Shove the first seven bits into our output variable.
 			out |= static_cast<unsigned int>(b & 0x7F) << offset;
@@ -640,7 +640,7 @@ public:
 			{
 				// Our variant int is too big - overflow us.
 				overflowed = true;
-				return -1;
+				return 0;
 			}
 		}
 	}

--- a/common/i_net.h
+++ b/common/i_net.h
@@ -208,6 +208,9 @@ enum msg_t
 	msg_noop,
 	msg_ack,
 	msg_header,
+	msg_largemessagestart,
+	msg_largemessagefragment,
+	msg_largemessageend,
 
 	clc_netdemocap,         // netdemos - NullPoint
 	clc_netdemostop,        // netdemos - NullPoint

--- a/common/msg_map.cpp
+++ b/common/msg_map.cpp
@@ -61,6 +61,10 @@ static void InitMap()
 	MapProto(msg_noop,   odaproto::Noop::descriptor());
 	MapProto(msg_header, odaproto::Header::descriptor());
 
+	MapProto(msg_largemessagestart,    odaproto::LargeMessageStart::descriptor());
+	MapProto(msg_largemessagefragment, odaproto::LargeMessageFragment::descriptor());
+	MapProto(msg_largemessageend,      odaproto::LargeMessageEnd::descriptor());
+
 	MapProto(svc_disconnect, odaproto::svc::Disconnect::descriptor());
 	MapProto(svc_playerinfo, odaproto::svc::PlayerInfo::descriptor());
 	MapProto(svc_moveplayer, odaproto::svc::MovePlayer::descriptor());

--- a/common/msg_message.cpp
+++ b/common/msg_message.cpp
@@ -36,3 +36,21 @@ odaproto::Header MSG_Header(const PacketHeaderType& i_header)
 
 	return msg;
 }
+
+odaproto::LargeMessageStart MSG_LargeMessageStart(size_t i_size)
+{
+	odaproto::LargeMessageStart msg;
+
+	msg.set_size(i_size);
+
+	return msg;
+}
+
+odaproto::LargeMessageFragment MSG_LargeMessageFragment(const void* i_data, size_t i_size)
+{
+	odaproto::LargeMessageFragment msg;
+
+	msg.set_payload(i_data, i_size);
+
+	return msg;
+}

--- a/common/msg_message.h
+++ b/common/msg_message.h
@@ -27,3 +27,6 @@
 struct PacketHeaderType;
 
 odaproto::Header MSG_Header(const PacketHeaderType& i_header);
+
+odaproto::LargeMessageStart     MSG_LargeMessageStart(size_t i_size);
+odaproto::LargeMessageFragment  MSG_LargeMessageFragment(const void* i_data, size_t i_size);

--- a/common/msg_parse.cpp
+++ b/common/msg_parse.cpp
@@ -32,14 +32,14 @@ parseError_e MSG_ParseMessage(google::protobuf::Message*& out, const msg_t cmd, 
 	google::protobuf::MessageFactory* factory =
 	    google::protobuf::MessageFactory::generated_factory();
 	const google::protobuf::Descriptor* desc = MSG_ResolveHeader(cmd);
-	if (desc == NULL)
+	if (desc == nullptr)
 	{
 		return PERR_UNKNOWN_HEADER;
 	}
 
 	// Can we get the mssage prototype from the descriptor?
 	const google::protobuf::Message* defmsg = factory->GetPrototype(desc);
-	if (defmsg == NULL)
+	if (defmsg == nullptr)
 	{
 		return PERR_UNKNOWN_MESSAGE;
 	}
@@ -49,7 +49,7 @@ parseError_e MSG_ParseMessage(google::protobuf::Message*& out, const msg_t cmd, 
 
 	// Allocated with "new" - can't be null, and we own it.
 	google::protobuf::Message* msg = defmsg->New();
-	if (!msg->ParseFromArray(data, size))
+	if (not msg->ParseFromArray(data, size))
 	{
 		return PERR_BAD_DECODE;
 	}

--- a/common/msg_parse.cpp
+++ b/common/msg_parse.cpp
@@ -26,7 +26,7 @@
 
 #include "msg_map.h"
 
-parseError_e MSG_ParseMessage(google::protobuf::Message*& out, const msg_t cmd)
+parseError_e MSG_ParseMessage(google::protobuf::Message*& out, const msg_t cmd, buf_t& buffer)
 {
 	// A message factory + Descriptor gives us the proper message.
 	google::protobuf::MessageFactory* factory =
@@ -44,12 +44,12 @@ parseError_e MSG_ParseMessage(google::protobuf::Message*& out, const msg_t cmd)
 		return PERR_UNKNOWN_MESSAGE;
 	}
 
-	const size_t size   = MSG_ReadUnVarint();
-	const void*  buffer = MSG_ReadChunk(size);
+	const size_t size = buffer.ReadUnVarint();
+	const void*  data = buffer.ReadChunk(size);
 
 	// Allocated with "new" - can't be null, and we own it.
 	google::protobuf::Message* msg = defmsg->New();
-	if (!msg->ParseFromArray(buffer, size))
+	if (!msg->ParseFromArray(data, size))
 	{
 		return PERR_BAD_DECODE;
 	}

--- a/common/msg_parse.h
+++ b/common/msg_parse.h
@@ -48,4 +48,4 @@ namespace google
  * @param cmd Command to parse out.
  * @return Error condition, or OK (0) if successful.
  */
-parseError_e MSG_ParseMessage(google::protobuf::Message*& out, const msg_t cmd);
+parseError_e MSG_ParseMessage(google::protobuf::Message*& out, const msg_t cmd, buf_t& buffer);

--- a/odaproto/common.proto
+++ b/odaproto/common.proto
@@ -135,3 +135,17 @@ message MapThing
 	uint32          special = 8;        // Hexen
 	repeated uint32 args    = 9;        // Hexen
 }
+
+message LargeMessageStart
+{
+	uint32 size = 1;
+}
+
+message LargeMessageFragment
+{
+	bytes payload = 1;
+}
+
+message LargeMessageEnd
+{
+}

--- a/odaproto/common.proto
+++ b/odaproto/common.proto
@@ -136,16 +136,19 @@ message MapThing
 	repeated uint32 args    = 9;        // Hexen
 }
 
+// msg_largemessagestart
 message LargeMessageStart
 {
 	uint32 size = 1;
 }
 
+// msg_largemessagefragment
 message LargeMessageFragment
 {
 	bytes payload = 1;
 }
 
+// msg_largemessageend
 message LargeMessageEnd
 {
 }

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -4620,8 +4620,7 @@ parseError_e SV_ParseCommandSVC(const msg_t cmd, player_t& player, buf_t& buffer
 
 void SV_AcknowledgePacket(player_t &player, buf_t& buffer)
 {
-	int sequence = buffer.ReadLong();
-
+	const int sequence = buffer.ReadLong();
 	const bool isFresh = player.client.messenger->Acknowledge(sequence);
 
 	if (sequence == 0 and isFresh)

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -2367,7 +2367,7 @@ void SV_ConnectClient()
 	{
 		google::protobuf::Message* userInfoMsg = nullptr;
 
-		if (MSG_ParseMessage(userInfoMsg, clc_userinfo) != PERR_OK)
+		if (MSG_ParseMessage(userInfoMsg, clc_userinfo, ::net_message) != PERR_OK)
 			return;
 
 		std::unique_ptr<google::protobuf::Message> msgPtr(userInfoMsg);
@@ -4482,10 +4482,10 @@ void SV_SendRequestedMobjUpdate(player_t& player, const odaproto::clc::SendMobjU
 // SV_ParseCommands
 //
 
-parseError_e SV_ParseCommandSVC(const msg_t cmd, player_t& player)
+parseError_e SV_ParseCommandSVC(const msg_t cmd, player_t& player, buf_t& buffer)
 {
 	google::protobuf::Message* msgPtrRaw = nullptr;
-	const parseError_e result = MSG_ParseMessage(msgPtrRaw, cmd);
+	const parseError_e result = MSG_ParseMessage(msgPtrRaw, cmd, buffer);
 
 	std::unique_ptr<google::protobuf::Message> msgPtr(msgPtrRaw);
 
@@ -4613,9 +4613,9 @@ parseError_e SV_ParseCommandSVC(const msg_t cmd, player_t& player)
 	return result;
 }
 
-void SV_AcknowledgePacket(player_t &player)
+void SV_AcknowledgePacket(player_t &player, buf_t& buffer)
 {
-	int sequence = MSG_ReadLong();
+	int sequence = buffer.ReadLong();
 
 	const bool isFresh = player.client.messenger->Acknowledge(sequence);
 
@@ -4646,13 +4646,13 @@ void SV_ParseCommands(player_t &player)
 				// Ack is a special case that's intentionally lower level and must be serviced before anything
 				// at the higher-level protocol layer.
 				case msg_ack:
-					SV_AcknowledgePacket(player);
+					SV_AcknowledgePacket(player, ::net_message);
 					break;
 
 				default:
 					// It's important to allow the clc_ enum to have priority
 					// over svc_ if we have both types of messages.
-					switch (SV_ParseCommandSVC(cmd, player))
+					switch (SV_ParseCommandSVC(cmd, player, ::net_message))
 					{
 						case PERR_OK:
 							continue;

--- a/server/src/sv_maplist.cpp
+++ b/server/src/sv_maplist.cpp
@@ -555,10 +555,7 @@ void SV_MaplistUpdate(player_t &player, maplist_status_t status) {
 	maplist_qrows_t maplist;
 	Maplist::instance().query(maplist);
 
-	odaproto::svc::MaplistUpdate update = SVC_MaplistUpdate(MAPLIST_OUTDATED, &maplist);
-
-	// FIXME:  Does this need to be fragmented?  Could this be too large??
-	cl->messenger->Reliable().Write (update);
+	cl->messenger->LargeMessage().Write (SVC_MaplistUpdate(MAPLIST_OUTDATED, &maplist));
 
 	// Update the timeout to ensure the player doesn't abuse the server
 	Maplist::instance().set_timeout(player.id);

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -9,6 +9,15 @@ struct LargeMessageQueueFixture : testing::Test
     LargeMessageQueue m_queue;
 };
 
+TEST_F(LargeMessageQueueFixture, EmptyQueue)
+{
+    std::array<char, 5> fragment;
+
+    const FragmentationResultType result = m_queue.NextFragment(fragment.size(), fragment.begin());
+    EXPECT_EQ(FragmentationStateEnum::NONE,     result.state);
+    EXPECT_EQ(0,                                result.size);
+}
+
 TEST_F(LargeMessageQueueFixture, BasicSingleMessage)
 {
     m_queue.Write(svc_print, "HelloWorld");

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -9,6 +9,11 @@ struct LargeMessageQueueFixture : testing::Test
     LargeMessageQueue m_queue;
 };
 
+namespace
+{
+    size_t KB(auto value) { return value << 10; }
+}
+
 TEST_F(LargeMessageQueueFixture, EmptyQueue)
 {
     std::array<char, 5> fragment{};
@@ -58,7 +63,7 @@ TEST_F(LargeMessageQueueFixture, BasicSingleMessage)
 
 TEST_F(LargeMessageQueueFixture, GiantMessage)
 {
-    std::string bigBoy(63u * 1024u, '_');
+    std::string bigBoy(KB(63), '_');
 
     char crawler = 'a';
     for (auto iter = bigBoy.begin(); iter < bigBoy.end(); iter += 1024)

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -1,0 +1,43 @@
+#include <array>
+
+#include "gtest/gtest.h"
+
+#include "LargeMessageQueue.h"
+
+struct LargeMessageQueueFixture : testing::Test
+{
+    LargeMessageQueue m_queue;
+};
+
+TEST_F(LargeMessageQueueFixture, BasicSingleMessage)
+{
+    m_queue.Write(svc_print, "HelloWorld");
+
+    std::array<char, 5> fragment;
+
+    const FragmentationStateEnum firstResult = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+    // Please note - the queue put the miniheader on the message.
+    EXPECT_EQ(FragmentationStateEnum::FIRST_FRAGMENT,   firstResult);
+    EXPECT_EQ((std::array{char(svc_print), char(10), 'H','e','l'}), fragment);
+
+    const FragmentationStateEnum nextResult = m_queue.NextFragment(1, fragment.begin());
+
+    EXPECT_EQ(FragmentationStateEnum::CONTINUATION_FRAGMENT, nextResult);
+    EXPECT_EQ((std::array{'l', char(10), 'H', 'e','l'}),     fragment);
+
+    const FragmentationStateEnum thirdResult = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+    EXPECT_EQ(FragmentationStateEnum::CONTINUATION_FRAGMENT, thirdResult);
+    EXPECT_EQ((std::array{'o','W','o','r','l'}),             fragment);
+
+    const FragmentationStateEnum lastResult = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+    EXPECT_EQ(FragmentationStateEnum::LAST_FRAGMENT, lastResult);
+    EXPECT_EQ((std::array{'d','W','o','r','l'}),     fragment);
+
+    const FragmentationStateEnum emptyResult = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+    EXPECT_EQ(FragmentationStateEnum::NONE,       emptyResult);
+    EXPECT_EQ((std::array{'d','W','o','r','l'}),  fragment);
+}

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -15,29 +15,34 @@ TEST_F(LargeMessageQueueFixture, BasicSingleMessage)
 
     std::array<char, 5> fragment;
 
-    const FragmentationStateEnum firstResult = m_queue.NextFragment(fragment.size(), fragment.begin());
+    const FragmentationResultType firstResult = m_queue.NextFragment(fragment.size(), fragment.begin());
 
     // Please note - the queue put the miniheader on the message.
-    EXPECT_EQ(FragmentationStateEnum::FIRST_FRAGMENT,   firstResult);
+    EXPECT_EQ(FragmentationStateEnum::FIRST_FRAGMENT,   firstResult.state);
     EXPECT_EQ((std::array{char(svc_print), char(10), 'H','e','l'}), fragment);
+    EXPECT_EQ(5, firstResult.size);
 
-    const FragmentationStateEnum nextResult = m_queue.NextFragment(1, fragment.begin());
+    const FragmentationResultType nextResult = m_queue.NextFragment(1, fragment.begin());
 
-    EXPECT_EQ(FragmentationStateEnum::CONTINUATION_FRAGMENT, nextResult);
+    EXPECT_EQ(FragmentationStateEnum::CONTINUATION_FRAGMENT, nextResult.state);
     EXPECT_EQ((std::array{'l', char(10), 'H', 'e','l'}),     fragment);
+    EXPECT_EQ(1, nextResult.size);
 
-    const FragmentationStateEnum thirdResult = m_queue.NextFragment(fragment.size(), fragment.begin());
+    const FragmentationResultType thirdResult = m_queue.NextFragment(fragment.size(), fragment.begin());
 
-    EXPECT_EQ(FragmentationStateEnum::CONTINUATION_FRAGMENT, thirdResult);
+    EXPECT_EQ(FragmentationStateEnum::CONTINUATION_FRAGMENT, thirdResult.state);
     EXPECT_EQ((std::array{'o','W','o','r','l'}),             fragment);
+    EXPECT_EQ(5, thirdResult.size);
 
-    const FragmentationStateEnum lastResult = m_queue.NextFragment(fragment.size(), fragment.begin());
+    const FragmentationResultType lastResult = m_queue.NextFragment(fragment.size(), fragment.begin());
 
-    EXPECT_EQ(FragmentationStateEnum::LAST_FRAGMENT, lastResult);
+    EXPECT_EQ(FragmentationStateEnum::LAST_FRAGMENT, lastResult.state);
     EXPECT_EQ((std::array{'d','W','o','r','l'}),     fragment);
+    EXPECT_EQ(1, lastResult.size);
 
-    const FragmentationStateEnum emptyResult = m_queue.NextFragment(fragment.size(), fragment.begin());
+    const FragmentationResultType emptyResult = m_queue.NextFragment(fragment.size(), fragment.begin());
 
-    EXPECT_EQ(FragmentationStateEnum::NONE,       emptyResult);
+    EXPECT_EQ(FragmentationStateEnum::NONE,       emptyResult.state);
     EXPECT_EQ((std::array{'d','W','o','r','l'}),  fragment);
+    EXPECT_EQ(0, emptyResult.size);
 }

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -11,7 +11,7 @@ struct LargeMessageQueueFixture : testing::Test
 
 TEST_F(LargeMessageQueueFixture, EmptyQueue)
 {
-    std::array<char, 5> fragment;
+    std::array<char, 5> fragment{};
 
     const FragmentationResultType result = m_queue.NextFragment(fragment.size(), fragment.begin());
     EXPECT_EQ(FragmentationStateEnum::NONE,     result.state);
@@ -22,7 +22,7 @@ TEST_F(LargeMessageQueueFixture, BasicSingleMessage)
 {
     m_queue.Write(svc_print, "HelloWorld");
 
-    std::array<char, 5> fragment;
+    std::array<char, 5> fragment{};
 
     const FragmentationResultType firstResult = m_queue.NextFragment(fragment.size(), fragment.begin());
 
@@ -58,7 +58,7 @@ TEST_F(LargeMessageQueueFixture, BasicSingleMessage)
 
 TEST_F(LargeMessageQueueFixture, GiantMessage)
 {
-    std::string bigBoy(63 * 1024, '_');
+    std::string bigBoy(63u * 1024u, '_');
 
     char crawler = 'a';
     for (auto iter = bigBoy.begin(); iter < bigBoy.end(); iter += 1024)
@@ -175,7 +175,7 @@ TEST_F(LargeMessageQueueFixture, MultiMessage)
     m_queue.Write(svc_print, "HelloWorld");
     m_queue.Write(svc_print, "FooBar");
 
-    std::array<char, 8> fragment;
+    std::array<char, 8> fragment{};
 
     auto result = m_queue.NextFragment(fragment.size(), fragment.begin());
 
@@ -236,7 +236,7 @@ TEST_F(LargeMessageQueueFixture, Reassembly)
     EXPECT_EQ(0,     msg.CurrentSize());
     EXPECT_EQ(false, msg.IsComplete());
 
-    std::array<char, 8> fragment;
+    std::array<char, 8> fragment{};
 
     auto fragmentInfo = m_queue.NextFragment(fragment.size(), fragment.begin());
     EXPECT_EQ(fragmentInfo.state, FragmentationStateEnum::FIRST_FRAGMENT);
@@ -286,6 +286,7 @@ TEST_F(LargeMessageQueueFixture, Reassembly)
     const size_t payloadSize = buffer.ReadUnVarint();
     EXPECT_EQ(41, payloadSize);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     const std::string receivedAdvice (reinterpret_cast<char*>(buffer.ReadChunk(payloadSize)), payloadSize);
     EXPECT_EQ(receivedAdvice, "We can't stop here!  This is BAT COUNTRY!");
 

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -55,3 +55,153 @@ TEST_F(LargeMessageQueueFixture, BasicSingleMessage)
     EXPECT_EQ((std::array{'d','W','o','r','l'}),  fragment);
     EXPECT_EQ(0, emptyResult.size);
 }
+
+TEST_F(LargeMessageQueueFixture, GiantMessage)
+{
+    std::string bigBoy(63 * 1024, '_');
+
+    char crawler = 'a';
+    for (auto iter = bigBoy.begin(); iter < bigBoy.end(); iter += 1024)
+    {
+        std::fill(iter, iter + 1024, crawler);
+        crawler = crawler < 'z' ? crawler + 1 : 'a';
+    }
+
+    m_queue.Write(svc_print, bigBoy);
+
+    // The first fragment has the mini-header.  Deal with that first so that we can have
+    // a nice orderly test of the subsequent big chunks.
+
+    buf_t firstFragment{16};
+
+    const auto firstResult = m_queue.NextFragment(firstFragment.maxsize(), firstFragment.ptr());
+
+    EXPECT_EQ(firstResult.size,  16);
+    EXPECT_EQ(firstResult.state, FragmentationStateEnum::FIRST_FRAGMENT);
+
+    firstFragment.setcursize(firstResult.size);
+
+    EXPECT_EQ(firstFragment.ReadUnVarint(), svc_print);
+    EXPECT_EQ(firstFragment.ReadUnVarint(), 63 * 1024);
+
+    const size_t firstRunOfPayload = firstFragment.BytesLeftToRead();
+    EXPECT_GT(firstRunOfPayload, 0);
+
+    for (int i = 0; i < firstRunOfPayload; ++i)
+    {
+        EXPECT_EQ(firstFragment.ReadByte(), 'a');
+    }
+
+    auto testBigFragment = [&] (size_t size, char fillChar, FragmentationStateEnum state)
+    {
+        std::string fragment(size, '_');
+        const std::string expectedValue(size, fillChar);
+
+        const auto result = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+        EXPECT_EQ(result.state, state);
+        EXPECT_EQ(result.size,  size);
+        EXPECT_EQ(fragment,     expectedValue);
+    };
+
+    testBigFragment(1024 - firstRunOfPayload, 'a', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'b', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'c', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'd', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'e', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'f', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'g', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'h', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'i', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'j', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'k', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'l', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'm', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'n', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'o', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'p', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'q', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'r', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 's', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 't', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'u', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'v', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'w', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'x', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'y', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'z', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'a', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'b', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'c', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'd', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'e', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'f', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'g', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'h', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'i', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'j', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'k', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'l', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'm', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'n', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'o', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'p', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'q', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'r', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 's', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 't', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'u', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'v', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'w', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'x', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'y', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'z', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'a', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'b', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'c', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'd', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'e', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'f', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'g', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'h', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'i', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'j', FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    testBigFragment(1024 , 'k', FragmentationStateEnum::LAST_FRAGMENT);
+
+}
+
+TEST_F(LargeMessageQueueFixture, MultiMessage)
+{
+    m_queue.Write(svc_print, "HelloWorld");
+    m_queue.Write(svc_print, "FooBar");
+
+    std::array<char, 8> fragment;
+
+    auto result = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+    EXPECT_EQ(result.size, 8);
+    EXPECT_EQ(result.state, FragmentationStateEnum::FIRST_FRAGMENT);
+    EXPECT_EQ(fragment[0], svc_print);
+    EXPECT_EQ(fragment[1], 10);
+    EXPECT_EQ((std::string{fragment.begin() + 2, fragment.end()}), "HelloW");
+
+    result = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+    EXPECT_EQ(result.size, 4);
+    EXPECT_EQ(result.state, FragmentationStateEnum::LAST_FRAGMENT);
+    EXPECT_EQ((std::string{fragment.begin(), fragment.begin() + result.size}), "orld");
+
+    result = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+    EXPECT_EQ(result.size, 8);
+    EXPECT_EQ(result.state, FragmentationStateEnum::ONE_SHOT);
+    EXPECT_EQ(fragment[0], svc_print);
+    EXPECT_EQ(fragment[1], 6);
+    EXPECT_EQ((std::string{fragment.begin() + 2, fragment.begin() + result.size}), "FooBar");
+
+    result = m_queue.NextFragment(fragment.size(), fragment.begin());
+
+    EXPECT_EQ(result.size, 0);
+    EXPECT_EQ(result.state, FragmentationStateEnum::NONE);
+}
+

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -205,6 +205,21 @@ TEST_F(LargeMessageQueueFixture, MultiMessage)
     EXPECT_EQ(result.state, FragmentationStateEnum::NONE);
 }
 
+TEST_F(LargeMessageQueueFixture, DefaultLargeMessage)
+{
+    LargeMessage msg;
+    EXPECT_EQ(0,    msg.TotalSize());
+    EXPECT_EQ(0,    msg.CurrentSize());
+    EXPECT_EQ(true, msg.IsComplete());
+
+    auto someData = std::to_array("Hey there.");
+
+    EXPECT_EQ(false, msg.Append(someData.data(), someData.size()));
+    EXPECT_EQ(0,     msg.TotalSize());
+    EXPECT_EQ(0,     msg.CurrentSize());
+    EXPECT_EQ(true,  msg.IsComplete());
+}
+
 TEST_F(LargeMessageQueueFixture, Reassembly)
 {
     const std::string greatAdvice = "We can't stop here!  This is BAT COUNTRY!";
@@ -273,4 +288,11 @@ TEST_F(LargeMessageQueueFixture, Reassembly)
 
     const std::string receivedAdvice (reinterpret_cast<char*>(buffer.ReadChunk(payloadSize)), buffer.BytesLeftToRead());
     EXPECT_EQ(receivedAdvice, "We can't stop here!  This is BAT COUNTRY!");
+
+    // Now, test adding more data than we should.
+
+    EXPECT_EQ(false, msg.Append(fragment.data(), fragmentInfo.size));
+    EXPECT_EQ(43,    msg.TotalSize());
+    EXPECT_EQ(43,    msg.CurrentSize());
+    EXPECT_EQ(true,  msg.IsComplete());
 }

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -205,3 +205,72 @@ TEST_F(LargeMessageQueueFixture, MultiMessage)
     EXPECT_EQ(result.state, FragmentationStateEnum::NONE);
 }
 
+TEST_F(LargeMessageQueueFixture, Reassembly)
+{
+    const std::string greatAdvice = "We can't stop here!  This is BAT COUNTRY!";
+    m_queue.Write(svc_print, greatAdvice);
+
+    LargeMessage msg;
+
+    const size_t totalSize = m_queue.GetMessageSize();
+    EXPECT_EQ(totalSize, greatAdvice.size() + 2);       // +2 for the mini header.
+
+    EXPECT_EQ(true, msg.Restart(totalSize));
+
+    EXPECT_EQ(43,    msg.TotalSize());
+    EXPECT_EQ(0,     msg.CurrentSize());
+    EXPECT_EQ(false, msg.IsComplete());
+
+    std::array<char, 8> fragment;
+
+    auto fragmentInfo = m_queue.NextFragment(fragment.size(), fragment.begin());
+    EXPECT_EQ(fragmentInfo.state, FragmentationStateEnum::FIRST_FRAGMENT);
+    EXPECT_EQ(true,  msg.Append(fragment.data(), fragmentInfo.size));
+    EXPECT_EQ(43,    msg.TotalSize());
+    EXPECT_EQ(8,     msg.CurrentSize());
+    EXPECT_EQ(false, msg.IsComplete());
+
+    fragmentInfo = m_queue.NextFragment(fragment.size(), fragment.begin());
+    EXPECT_EQ(fragmentInfo.state, FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    EXPECT_EQ(true,  msg.Append(fragment.data(), fragmentInfo.size));
+    EXPECT_EQ(43,    msg.TotalSize());
+    EXPECT_EQ(16,    msg.CurrentSize());
+    EXPECT_EQ(false, msg.IsComplete());
+
+    fragmentInfo = m_queue.NextFragment(fragment.size(), fragment.begin());
+    EXPECT_EQ(fragmentInfo.state, FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    EXPECT_EQ(true,  msg.Append(fragment.data(), fragmentInfo.size));
+    EXPECT_EQ(43,    msg.TotalSize());
+    EXPECT_EQ(24,    msg.CurrentSize());
+    EXPECT_EQ(false, msg.IsComplete());
+
+    fragmentInfo = m_queue.NextFragment(fragment.size(), fragment.begin());
+    EXPECT_EQ(fragmentInfo.state, FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    EXPECT_EQ(true,  msg.Append(fragment.data(), fragmentInfo.size));
+    EXPECT_EQ(43,    msg.TotalSize());
+    EXPECT_EQ(32,    msg.CurrentSize());
+    EXPECT_EQ(false, msg.IsComplete());
+
+    fragmentInfo = m_queue.NextFragment(fragment.size(), fragment.begin());
+    EXPECT_EQ(fragmentInfo.state, FragmentationStateEnum::CONTINUATION_FRAGMENT);
+    EXPECT_EQ(true,  msg.Append(fragment.data(), fragmentInfo.size));
+    EXPECT_EQ(43,    msg.TotalSize());
+    EXPECT_EQ(40,    msg.CurrentSize());
+    EXPECT_EQ(false, msg.IsComplete());
+
+    fragmentInfo = m_queue.NextFragment(fragment.size(), fragment.begin());
+    EXPECT_EQ(fragmentInfo.state, FragmentationStateEnum::LAST_FRAGMENT);
+    EXPECT_EQ(true,  msg.Append(fragment.data(), fragmentInfo.size));
+    EXPECT_EQ(43,    msg.TotalSize());
+    EXPECT_EQ(43,    msg.CurrentSize());
+    EXPECT_EQ(true,  msg.IsComplete());
+
+    auto& buffer = msg.GetBufferRef();
+    EXPECT_EQ(svc_print, buffer.ReadUnVarint());
+
+    const size_t payloadSize = buffer.ReadUnVarint();
+    EXPECT_EQ(41, payloadSize);
+
+    const std::string receivedAdvice (reinterpret_cast<char*>(buffer.ReadChunk(payloadSize)), buffer.BytesLeftToRead());
+    EXPECT_EQ(receivedAdvice, "We can't stop here!  This is BAT COUNTRY!");
+}

--- a/tests/unit-tests/test/t_LargeMessageQueue.cpp
+++ b/tests/unit-tests/test/t_LargeMessageQueue.cpp
@@ -87,7 +87,7 @@ TEST_F(LargeMessageQueueFixture, GiantMessage)
     const size_t firstRunOfPayload = firstFragment.BytesLeftToRead();
     EXPECT_GT(firstRunOfPayload, 0);
 
-    for (int i = 0; i < firstRunOfPayload; ++i)
+    for (size_t i = 0; i < firstRunOfPayload; ++i)
     {
         EXPECT_EQ(firstFragment.ReadByte(), 'a');
     }
@@ -286,7 +286,7 @@ TEST_F(LargeMessageQueueFixture, Reassembly)
     const size_t payloadSize = buffer.ReadUnVarint();
     EXPECT_EQ(41, payloadSize);
 
-    const std::string receivedAdvice (reinterpret_cast<char*>(buffer.ReadChunk(payloadSize)), buffer.BytesLeftToRead());
+    const std::string receivedAdvice (reinterpret_cast<char*>(buffer.ReadChunk(payloadSize)), payloadSize);
     EXPECT_EQ(receivedAdvice, "We can't stop here!  This is BAT COUNTRY!");
 
     // Now, test adding more data than we should.


### PR DESCRIPTION
This PR adds a new message queue to the OdaMessenger:  `LargeMessage`, which allows for individual messages up to 64 KB.  Messages added to this queue are broken up into 1 KB fragments (or smaller, based on budgeting and sequencing) that are sent in reliable packets, at a slightly lower priority than natively reliable messages.

It also adds a utility for reassembling the fragments into the complete message.  Currently only the client instantiates this utility, only the server sends large messages, and the server will reject any client that sends any of the lower-level proto messages pertaining to fragmented large messages.

As of this PR, only the `MaplistUpdate` proto message is sent via `LargeMessage`, but there are several other messages that could be good candidates for this as well - potentially `MidPrint`, `Print`, or any other message that has arbitrary-length strings.

Thanks to @electricbrass for testing with exceedingly large maplists!