### PR TITLE
[FEATURE] Add a predicted waggle

### DIFF
--- a/client/src/cl_main.cpp
+++ b/client/src/cl_main.cpp
@@ -2776,6 +2776,7 @@ void CL_SimulateWorld()
 }
 
 void OnChangedSwitchTexture (line_t *line, int useAgain) {}
+void SV_SendThinkerUpdate(const DThinker* thinker) {}
 void SV_OnActivatedLine(line_t* line, AActor* mo, const int side,
                         const LineActivationType activationType, const bool bossaction)
 {

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -3159,6 +3159,27 @@ void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 			new DGlow2(&::sectors[secnum], start, end, tics, oneShot);
 		break;
 	}
+	case odaproto::svc::ThinkerUpdate::kWaggle: {
+		const odaproto::svc::ThinkerUpdate_Waggle& wmsg = msg->waggle();
+		const int secnum = wmsg.sector();
+
+		if (::numsectors <= 0)
+			break;
+
+		sector_t* sector = &::sectors[secnum];
+		const bool ceiling = wmsg.ceiling();
+
+		// A waggle owns its plane for as long as it runs, so don't stack a
+		// second one on a sector that already has a mover on that plane.
+		if (ceiling ? sector->ceilingdata != nullptr : sector->floordata != nullptr)
+			break;
+
+		if (secnum < ::numsectors)
+			new DWaggle(sector, ceiling, wmsg.original_height(), wmsg.accumulator(),
+			           wmsg.acc_delta(), wmsg.target_scale(), wmsg.scale(),
+			           wmsg.scale_delta(), wmsg.ticker(), wmsg.state());
+		break;
+	}
 	case odaproto::svc::ThinkerUpdate::kPhased: {
 		short secnum = msg->phased().sector();
 		int base = msg->phased().base_level();

--- a/client/src/cl_parse.cpp
+++ b/client/src/cl_parse.cpp
@@ -3166,18 +3166,36 @@ void CL_ThinkerUpdate(const odaproto::svc::ThinkerUpdate* msg)
 		if (::numsectors <= 0)
 			break;
 
-		sector_t* sector = &::sectors[secnum];
-		const bool ceiling = wmsg.ceiling();
+		if (secnum >= 0 and secnum < ::numsectors)
+		{
+			sector_t* sector = &::sectors[secnum];
+			const bool ceiling = wmsg.ceiling();
 
-		// A waggle owns its plane for as long as it runs, so don't stack a
-		// second one on a sector that already has a mover on that plane.
-		if (ceiling ? sector->ceilingdata != nullptr : sector->floordata != nullptr)
-			break;
+			// A waggle owns its plane for as long as it runs, so don't stack a
+			// second one on a sector that already has a mover on that plane.
+			if (ceiling ? sector->ceilingdata != nullptr : sector->floordata != nullptr)
+				break;
 
-		if (secnum < ::numsectors)
-			new DWaggle(sector, ceiling, wmsg.original_height(), wmsg.accumulator(),
-			           wmsg.acc_delta(), wmsg.target_scale(), wmsg.scale(),
-			           wmsg.scale_delta(), wmsg.ticker(), wmsg.state());
+			auto* waggle =
+			    new DWaggle(sector, ceiling, wmsg.original_height(), wmsg.accumulator(),
+			                wmsg.acc_delta(), wmsg.target_scale(), wmsg.scale(),
+			                wmsg.scale_delta(), wmsg.ticker(), wmsg.state());
+
+			const int messageTic = ThisMessageServerTic();
+
+			if (::last_svgametic > 0 and messageTic > 0)
+			{
+				const int64_t staleTics =
+				    static_cast<int64_t>(::last_svgametic) - messageTic;
+
+				// Don't even bother to catch up the waggle if we're about to get timed out
+				if (staleTics > 0 and
+				    staleTics <= OdaMessenger::DEFAULT_CRITICAL_SEQUENCE_TIMEOUT_IN_TICS)
+				{
+					waggle->CatchUp(static_cast<int>(staleTics));
+				}
+			}
+		}
 		break;
 	}
 	case odaproto::svc::ThinkerUpdate::kPhased: {

--- a/client/src/cl_pred.cpp
+++ b/client/src/cl_pred.cpp
@@ -26,6 +26,7 @@
 
 #include "d_player.h"
 #include "p_local.h"
+#include "p_localhistory.h"
 #include "cl_main.h"
 #include "cl_demo.h"
 #include "cl_netgraph.h"
@@ -43,6 +44,12 @@ void P_CalcHeight (player_t& player);
 
 extern odaproto::clc::PlayerInput localcmds[MAXSAVETICS];
 static PlayerSnapshot cl_savedsnaps[MAXSAVETICS];
+
+namespace
+{
+// Last tic the local player stood on a plane this client simulates itself.
+int cl_lastLocalPlaneTic = -1;
+} // namespace
 
 bool predicting;
 
@@ -357,17 +364,49 @@ void CL_PredictWorld(void)
 	if (cl_predictsectors)
 		CL_ResetSectors();
 
+	// A locally simulated plane runs behind the server's copy by however long an
+	// update takes to arrive, so the z the server reports for a player riding one
+	// is for a phase this client has not reached.
+	//
+	// Taking it fights the replay, which drives z from the local plane history -
+	// and while the plane is rising P_ThingHeightClip cannot pull the player
+	// back down, because it decides "was I on the floor" from a z that now sits
+	// above it.
+	// This is what MFO_NOSNAPZ is for: keep the local z and let the replay own it.
+	const sector_t* standingOn = p.mo->floorsector;
+	if (not standingOn and p.mo->subsector)
+		standingOn = p.mo->subsector->sector;
+
+	if (LocalSectorHistory::getInstance().watching(standingOn))
+		cl_lastLocalPlaneTic = gametic;
+
+	// Hold this for as long as the replay still reaches back to a tic where the
+	// player was riding such a plane.
+	if (cl_lastLocalPlaneTic >= p.tic)
+		p.mo->oflags |= MFO_NOSNAPZ;
+
 	// Move the client to the last position received from the sever
 	int snaptime = p.snapshots.getMostRecentTime();
 	PlayerSnapshot snap = p.snapshots.getSnapshot(snaptime);
 	snap.toPlayer(p);
 
+	// Planes the client simulates itself have no server snapshot for
+	// CL_ResetSectors to rewind them to, so borrow them for the replay and give
+	// them back afterwards.
+	LocalSectorHistory& localSectors = LocalSectorHistory::getInstance();
+	localSectors.beginReplay();
+
 	while (++predtic < gametic)
 	{
 		if (cl_predictsectors)
 			CL_PredictSectors(predtic);
+
+		localSectors.restore(predtic);
+
 		CL_PredictLocalPlayer(predtic);
 	}
+
+	localSectors.endReplay();
 
 	// If the player didn't just spawn or teleport, nudge the player from
 	// his position last tic to this new corrected position.  This smooths the
@@ -406,6 +445,8 @@ void CL_ResetWorldPrediction()
 	{
 		savedPlayerSnapshot = PlayerSnapshot{};
 	}
+
+	cl_lastLocalPlaneTic = -1;
 }
 
 VERSION_CONTROL (cl_pred_cpp, "$Id$")

--- a/common/g_level.cpp
+++ b/common/g_level.cpp
@@ -39,6 +39,7 @@
 #include "i_system.h"
 #include "p_acs.h"
 #include "p_local.h"
+#include "p_localhistory.h"
 #include "p_saveg.h"
 #include "p_unlag.h"
 #include "r_data.h"
@@ -970,6 +971,7 @@ void G_InitLevelLocals()
 	::level.detected_gametype = GM_COOP;
 
 	movingsectors.clear();
+	LocalSectorHistory::getInstance().clear();
 }
 
 static void MapinfoHelp()

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -26,6 +26,7 @@
 
 #include "p_local.h"
 #include "p_lnspec.h"
+#include "p_unlag.h"
 #include "s_sound.h"
 #include "r_state.h"
 #include "tables.h"
@@ -1785,34 +1786,35 @@ static constexpr fixed_t FloatBobOffsets[64] = {
     -370728, -405281, -435930, -462381, -484380, -501713, -514215, -521764,
     -524288, -521764, -514214, -501713, -484379, -462381, -435930, -405280,
     -370728, -332605, -291279, -247148, -200637, -152193, -102284, -51389};
-/*
 bool EV_StartPlaneWaggle(int tag, line_t* line, int height, int speed, int offset,
-                             int timer, bool ceiling)
+                         int timer, bool ceiling)
 {
-	int sectorIndex;
-	sector_t* sector;
-	bool retCode;
+	bool retCode = false;
+	int sectorIndex = -1;
 
-	retCode = false;
-	sectorIndex = -1;
 	while ((sectorIndex = P_FindSectorFromTagOrLine(tag, line, sectorIndex)) >= 0)
 	{
-		sector = &sectors[sectorIndex];
+		auto* sector = &sectors[sectorIndex];
+
 		if (ceiling ? P_CeilingActive(sector) : P_FloorActive(sector))
 		{ // Already busy with another thinker
 			continue;
 		}
-		retCode = true;
-		new DWaggle(sector, height, speed, offset, timer, ceiling);
 
-		if (ceiling)
-		{
-			P_AddMovingCeiling(sector);
-		}
-		else
-		{
-			P_AddMovingFloor(sector);
-		}
+		retCode = true;
+
+		// Deliberately not registered with P_AddMovingFloor/P_AddMovingCeiling:
+		// clients run this thinker themselves, so the sector must stay out of
+		// the per-tic moving sector update stream.
+		//
+		// However, unlag is a separate concern, so lets reconcile waggle
+		// for hitscans.
+		const auto* waggle = new DWaggle(sector, height, speed, offset, timer, ceiling);
+		Unlag::getInstance().registerSector(sector);
+
+		// Announce the waggle once, clients that already started their own
+		// copy ignore the message.
+		SV_SendThinkerUpdate(waggle);
 	}
 
 	return retCode;
@@ -1833,8 +1835,7 @@ void DWaggle::Serialize(FArchive& arc)
 		    << m_ScaleDelta
 			<< m_Ticker
 			<< m_State
-			<< m_Ceiling
-			<< m_StartTic;
+			<< m_Ceiling;
 	}
 	else
 	{
@@ -1846,14 +1847,8 @@ void DWaggle::Serialize(FArchive& arc)
 			>> m_ScaleDelta
 			>> m_Ticker
 			>> m_State
-			>> m_Ceiling
-			>> m_StartTic;
+			>> m_Ceiling;
 	}
-}
-
-DWaggle::DWaggle()
-{
-
 }
 
 DWaggle::DWaggle(sector_t* sector, int height, int speed, int offset, int timer,
@@ -1862,35 +1857,55 @@ DWaggle::DWaggle(sector_t* sector, int height, int speed, int offset, int timer,
 	if (ceiling)
 	{
 		sector->ceilingdata = this;
-		m_OriginalHeight = sector->ceilingheight;
+		m_OriginalHeight = P_CeilingHeight(sector);
 	}
 	else
 	{
 		sector->floordata = this;
-		m_OriginalHeight = sector->floorheight;
+		m_OriginalHeight = P_FloorHeight(sector);
 	}
+
 	m_Sector = sector;
 	m_Accumulator = offset * FRACUNIT;
 	m_AccDelta = speed << 10;
 	m_Scale = 0;
 	m_TargetScale = height << 10;
-	m_ScaleDelta = m_TargetScale / (35 + ((3 * 35) * height) / 255);
-	m_Ticker = timer ? timer * 35 : -1;
+	m_ScaleDelta = m_TargetScale / (TICRATE + (((3 * TICRATE) * height) / 255));
+	m_Ticker = timer ? timer * TICRATE : -1;
 	m_State = init;
 	m_Ceiling = ceiling;
-	m_StartTic = ::level.time; // [Blair] Used for client side synchronization
+}
+
+DWaggle::DWaggle(sector_t* sector, bool ceiling, fixed_t originalHeight,
+                 fixed_t accumulator, fixed_t accDelta, fixed_t targetScale,
+                 fixed_t scale, fixed_t scaleDelta, int ticker, int state)
+{
+	if (ceiling)
+		sector->ceilingdata = this;
+	else
+		sector->floordata = this;
+
+	m_Sector = sector;
+	m_OriginalHeight = originalHeight;
+	m_Accumulator = accumulator;
+	m_AccDelta = accDelta;
+	m_TargetScale = targetScale;
+	m_Scale = scale;
+	m_ScaleDelta = scaleDelta;
+	m_Ticker = ticker;
+	m_State = state;
+	m_Ceiling = ceiling;
 }
 
 void DWaggle::RunThink()
 {
+	// Prediction and snapshot simulation both tick sector movers on the client.
+	if (m_LastTic == level.time)
+		return;
+	m_LastTic = level.time;
+
 	switch (m_State)
 	{
-	case finished:
-		Destroy();
-		m_State = destroy;
-	case destroy:
-		return;
-		break;
 	case init:
 		m_State = expand;
 		// fall thru
@@ -1905,15 +1920,12 @@ void DWaggle::RunThink()
 		if ((m_Scale -= m_ScaleDelta) <= 0)
 		{ // Remove
 			if (m_Ceiling)
-			{
 				P_SetCeilingHeight(m_Sector, m_OriginalHeight);
-			}
 			else
-			{
 				P_SetFloorHeight(m_Sector, m_OriginalHeight);
-			}
+
 			P_ChangeSector(m_Sector, DOOM_CRUSH);
-			m_State = finished;
+			Destroy();
 			return;
 		}
 		break;
@@ -1921,40 +1933,23 @@ void DWaggle::RunThink()
 		if (m_Ticker != -1)
 		{
 			if (!--m_Ticker)
-			{
 				m_State = reduce;
-			}
 		}
 		break;
 	}
 
 	m_Accumulator += m_AccDelta;
-	fixed_t changeamount = m_OriginalHeight + FixedMul(FloatBobOffsets[(m_Accumulator >> FRACBITS) & 63], m_Scale);
+
+	const fixed_t height =
+	    m_OriginalHeight +
+	    FixedMul(FloatBobOffsets[(m_Accumulator >> FRACBITS) & 63], m_Scale);
 
 	if (m_Ceiling)
-	{
-		P_SetCeilingHeight(m_Sector, changeamount);
-	}
+		P_SetCeilingHeight(m_Sector, height);
 	else
-	{
-		P_SetFloorHeight(m_Sector, changeamount);
-	}
+		P_SetFloorHeight(m_Sector, height);
+
 	P_ChangeSector(m_Sector, DOOM_CRUSH);
 }
 
-DWaggle::DWaggle(sector_t* sec) : Super(sec) { }
-
-// Clones a DWaggle and returns a pointer to that clone.
-//
-// The caller owns the pointer, and it must be deleted with `delete`.
-DWaggle* DWaggle::Clone(sector_t* sec) const
-{
-	DWaggle* ele = new DWaggle(*this);
-
-	ele->Orphan();
-	ele->m_Sector = sec;
-
-	return ele;
-}
-*/
 VERSION_CONTROL (p_floor_cpp, "$Id$")

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -1897,49 +1897,92 @@ DWaggle::DWaggle(sector_t* sector, bool ceiling, fixed_t originalHeight,
 	m_Ceiling = ceiling;
 }
 
-void DWaggle::RunThink()
+bool DWaggle::AdvanceTics(int tics)
 {
-	// Prediction and snapshot simulation both tick sector movers on the client.
-	if (m_LastTic == level.time)
-		return;
-	m_LastTic = level.time;
-
-	switch (m_State)
+	while (tics > 0)
 	{
-	case init:
-		m_State = expand;
-		// fall thru
-	case expand:
-		if ((m_Scale += m_ScaleDelta) >= m_TargetScale)
+		if (m_State == stable and m_Ticker == -1)
 		{
-			m_Scale = m_TargetScale;
-			m_State = stable;
+			constexpr int64_t period = 64LL << FRACBITS;
+			m_Accumulator +=
+			    static_cast<fixed_t>((static_cast<int64_t>(m_AccDelta) * tics) % period);
+			return true;
 		}
-		break;
-	case reduce:
-		if ((m_Scale -= m_ScaleDelta) <= 0)
-		{ // Remove
-			if (m_Ceiling)
-				P_SetCeilingHeight(m_Sector, m_OriginalHeight);
-			else
-				P_SetFloorHeight(m_Sector, m_OriginalHeight);
 
-			P_ChangeSector(m_Sector, DOOM_CRUSH);
-			Destroy();
-			return;
-		}
-		break;
-	case stable:
-		if (m_Ticker != -1)
+		switch (m_State)
 		{
-			if (!--m_Ticker)
-				m_State = reduce;
+		case init:
+			m_State = expand;
+			// fall thru
+		case expand:
+			m_Scale += m_ScaleDelta;
+			if (m_Scale >= m_TargetScale)
+			{
+				m_Scale = m_TargetScale;
+				m_State = stable;
+			}
+			break;
+		case reduce:
+			m_Scale -= m_ScaleDelta;
+			if (m_Scale <= 0)
+				return false;
+			break;
+		case stable:
+			if (m_Ticker != -1)
+			{
+				m_Ticker--;
+				if (m_Ticker == 0)
+					m_State = reduce;
+			}
+			break;
+		default:
+			break;
 		}
-		break;
+
+		m_Accumulator += m_AccDelta;
+		tics--;
 	}
 
-	m_Accumulator += m_AccDelta;
+	return true;
+}
 
+void DWaggle::Finish()
+{
+	if (m_Ceiling)
+		P_SetCeilingHeight(m_Sector, m_OriginalHeight);
+	else
+		P_SetFloorHeight(m_Sector, m_OriginalHeight);
+
+	P_ChangeSector(m_Sector, DOOM_CRUSH);
+	Destroy();
+}
+
+void DWaggle::CatchUp(int tics)
+{
+	if (tics <= 0)
+		return;
+
+	// Back up waggle state before we run AdvanceTics
+	// Starting late is recoverable, never starting is not.
+	const fixed_t accumulator = m_Accumulator;
+	const fixed_t scale       = m_Scale;
+	const int     ticker      = m_Ticker;
+	const int     state       = m_State;
+
+	if (not AdvanceTics(tics))
+	{
+		m_Accumulator = accumulator;
+		m_Scale       = scale;
+		m_Ticker      = ticker;
+		m_State       = state;
+		return;
+	}
+
+	ApplyHeight();
+}
+
+void DWaggle::ApplyHeight()
+{
 	const fixed_t height =
 	    m_OriginalHeight +
 	    FixedMul(FloatBobOffsets[(m_Accumulator >> FRACBITS) & 63], m_Scale);
@@ -1950,6 +1993,23 @@ void DWaggle::RunThink()
 		P_SetFloorHeight(m_Sector, height);
 
 	P_ChangeSector(m_Sector, DOOM_CRUSH);
+}
+
+void DWaggle::RunThink()
+{
+	// Prediction and snapshot simulation both tick sector movers on the client.
+	// A waggle is already ticked by DThinker::RunThinkers, so ignore the extras.
+	if (m_LastTic == level.time)
+		return;
+	m_LastTic = level.time;
+
+	if (not AdvanceTics(1))
+	{
+		Finish();
+		return;
+	}
+
+	ApplyHeight();
 }
 
 VERSION_CONTROL (p_floor_cpp, "$Id$")

--- a/common/p_floor.cpp
+++ b/common/p_floor.cpp
@@ -26,6 +26,7 @@
 
 #include "p_local.h"
 #include "p_lnspec.h"
+#include "p_localhistory.h"
 #include "p_unlag.h"
 #include "s_sound.h"
 #include "r_state.h"
@@ -1867,6 +1868,11 @@ DWaggle::DWaggle(sector_t* sector, int height, int speed, int offset, int timer,
 	}
 
 	m_Sector = sector;
+
+	// Nothing broadcasts this plane, so prediction has to replay it from a local
+	// history instead of a server snapshot.
+	LocalSectorHistory::getInstance().watch(sector);
+
 	m_Accumulator = offset * FRACUNIT;
 	m_AccDelta = speed << 10;
 	m_Scale = 0;
@@ -1887,6 +1893,8 @@ DWaggle::DWaggle(sector_t* sector, bool ceiling, fixed_t originalHeight,
 		sector->floordata = this;
 
 	m_Sector = sector;
+	LocalSectorHistory::getInstance().watch(sector);
+
 	m_OriginalHeight = originalHeight;
 	m_Accumulator = accumulator;
 	m_AccDelta = accDelta;

--- a/common/p_lnspec.cpp
+++ b/common/p_lnspec.cpp
@@ -60,6 +60,10 @@ bool EV_DoZDoomCeiling(DCeiling::ECeiling type, line_t* line, byte tag, fixed_t 
 // Returns true if the special for line will cause a DMovingFloor or
 // DMovingCeiling object to be created.
 //
+// Floor_Waggle and Ceiling_Waggle are intentionally absent -- their movement is
+// never sent to clients, so clients have to run the special themselves even
+// when cl_predictsectors is off.
+//
 bool P_LineSpecialMovesSector(short special)
 {
 	static bool initialized = false;
@@ -93,7 +97,7 @@ bool P_LineSpecialMovesSector(short special)
 		zdoomspecials[Stairs_BuildUpSync]			= true;		// 32
 		zdoomspecials[Floor_RaiseByValueTimes8]		= true;		// 35
 		zdoomspecials[Floor_LowerByValueTimes8]		= true;		// 36
-		zdoomspecials[Ceiling_Waggle]				= true;		// 38
+		//zdoomspecials[Ceiling_Waggle]				= true;		// 38
 		zdoomspecials[Ceiling_LowerByValue]			= true;		// 40
 		zdoomspecials[Ceiling_RaiseByValue]			= true;		// 41
 		zdoomspecials[Ceiling_CrushAndRaise]		= true;		// 42
@@ -117,7 +121,7 @@ bool P_LineSpecialMovesSector(short special)
 		zdoomspecials[Ceiling_CrushAndRaiseSilentDist] = true;  // 104
 		zdoomspecials[Door_WaitRaise]				= true;		// 105
 		zdoomspecials[Door_WaitClose]				= true;		// 106
-		zdoomspecials[Floor_Waggle]					= true;		// 138
+		//zdoomspecials[Floor_Waggle]					= true;		// 138
 		zdoomspecials[Ceiling_CrushAndRaiseDist]	= true;		// 168
 		zdoomspecials[Generic_Crusher2]				= true;		// 169
 		zdoomspecials[Plat_UpNearestWaitDownStay]	= true;		// 172
@@ -819,15 +823,13 @@ FUNC(LS_Floor_LowerToLowestTxTy)
 FUNC(LS_Floor_Waggle)
 // Floor_Waggle (tag, amplitude, frequency, delay, time)
 {
-	//return EV_StartPlaneWaggle(arg0, ln, arg1, arg2, arg3, arg4, false);
-	return false;
+	return EV_StartPlaneWaggle(arg0, ln, arg1, arg2, arg3, arg4, false);
 }
 
 FUNC(LS_Ceiling_Waggle)
 // Ceiling_Waggle (tag, amplitude, frequency, delay, time)
 {
-	//return EV_StartPlaneWaggle(arg0, ln, arg1, arg2, arg3, arg4, true);
-	return false;
+	return EV_StartPlaneWaggle(arg0, ln, arg1, arg2, arg3, arg4, true);
 }
 
 FUNC(LS_Floor_TransferTrigger)

--- a/common/p_localhistory.cpp
+++ b/common/p_localhistory.cpp
@@ -1,0 +1,146 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 2006-2026 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//   Plane height history for sector movers the client simulates itself.
+//
+//-----------------------------------------------------------------------------
+
+#include "odamex.h"
+
+#include "p_localhistory.h"
+
+#include "doomstat.h"
+#include "p_local.h"
+
+#include <algorithm>
+
+LocalSectorHistory& LocalSectorHistory::getInstance()
+{
+	static LocalSectorHistory instance;
+	return instance;
+}
+
+bool LocalSectorHistory::enabled()
+{
+	return clientside and not serverside;
+}
+
+void LocalSectorHistory::watch(sector_t* sector)
+{
+	if (not sector or not enabled())
+		return;
+
+	for (const auto& record : m_records)
+	{
+		if (record.sector == sector)
+			return;
+	}
+
+	PlaneRecord& record = m_records.emplace_back();
+	record.sector = sector;
+	std::ranges::fill(record.tics, -1);
+}
+
+bool LocalSectorHistory::watching(const sector_t* sector) const
+{
+	if (not sector)
+		return false;
+
+	return std::ranges::any_of(m_records,
+	                           [sector](const PlaneRecord& record)
+	                           { return record.sector == sector; });
+}
+
+void LocalSectorHistory::clear()
+{
+	m_records.clear();
+	m_replaying = false;
+}
+
+void LocalSectorHistory::record(int tic)
+{
+	// A replay installs old heights to check mispredictions --
+	// they must never be mistaken for what actually happened
+	// on this tic.
+	if (m_replaying or tic < 0)
+		return;
+
+	const size_t slot = static_cast<size_t>(tic) % MAX_HISTORY_TICS;
+
+	for (auto& record : m_records)
+	{
+		record.tics[slot] = tic;
+		record.floorheights[slot] = P_FloorHeight(record.sector);
+		record.ceilingheights[slot] = P_CeilingHeight(record.sector);
+	}
+}
+
+void LocalSectorHistory::beginReplay()
+{
+	if (m_records.empty())
+		return;
+
+	for (auto& record : m_records)
+	{
+		record.liveFloor = P_FloorHeight(record.sector);
+		record.liveCeiling = P_CeilingHeight(record.sector);
+	}
+
+	m_replaying = true;
+}
+
+void LocalSectorHistory::restore(int tic)
+{
+	if (not m_replaying or tic < 0)
+		return;
+
+	const size_t slot = static_cast<size_t>(tic) % MAX_HISTORY_TICS;
+
+	for (auto& record : m_records)
+	{
+		// Nothing was recorded for that tic, so leave the plane alone rather than
+		// move it to wherever a much older tic happened to leave it.
+		if (record.tics[slot] != tic)
+			continue;
+
+		P_SetFloorHeight(record.sector, record.floorheights[slot]);
+		P_SetCeilingHeight(record.sector, record.ceilingheights[slot]);
+
+		// Moving the plane is not enough: a thing caches floorz, and only
+		// P_CheckPosition refreshes it - which P_ZMovement is never reached.
+		// A player standing still would keep the stale value and the replay would
+		// not follow the plane at all.
+		// No crunch, just refresh the sector planes.
+		P_ChangeSector(record.sector, false);
+	}
+}
+
+void LocalSectorHistory::endReplay()
+{
+	if (not m_replaying)
+		return;
+
+	for (auto& record : m_records)
+	{
+		P_SetFloorHeight(record.sector, record.liveFloor);
+		P_SetCeilingHeight(record.sector, record.liveCeiling);
+		P_ChangeSector(record.sector, false);
+	}
+
+	m_replaying = false;
+}

--- a/common/p_localhistory.h
+++ b/common/p_localhistory.h
@@ -1,0 +1,94 @@
+// Emacs style mode select   -*- C++ -*-
+//-----------------------------------------------------------------------------
+//
+// $Id$
+//
+// Copyright (C) 2006-2026 by The Odamex Team.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//   Plane height history for sector movers the client simulates itself.
+//
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+#include "doomdef.h"
+#include "m_fixed.h"
+#include "r_defs.h"
+
+#include <array>
+#include <vector>
+
+// Plane height history for sector movers the client simulates itself.
+//
+// A broadcast mover is rewound during prediction by resetting its sector to the
+// most recent SVC_MovingSector* snapshot and re-running the thinker once per
+// replayed tic.
+//
+// A mover that is simulated locally rather than broadcast has no
+// such snapshot, so the replay would run every past tic against the plane's
+// present height - and since the prediction check compares positions for exact
+// equality, anything standing on that plane mispredicts on every tic.
+//
+// Such a mover calls watch() for its sector, the height is recorded once a tic,
+// and prediction hands it back for the tic being replayed.
+class LocalSectorHistory
+{
+  public:
+	static LocalSectorHistory& getInstance();
+
+	static bool enabled();
+
+	// Starts idempotently tracking a sector.
+	void watch(sector_t* sector);
+
+	// Forgets everything. Called when a level is torn down.
+	void clear();
+
+	// Is this sector's plane one we simulate locally?
+	[[nodiscard]] bool watching(const sector_t* sector) const;
+
+	// Stores the current height of every tracked plane under 'tic'. Called once
+	// per tic, after the thinkers have run.
+	void record(int tic);
+
+	// Lends the planes to a prediction replay and takes them back afterwards.
+	// restore() does nothing unless a replay is in progress.
+	void beginReplay();
+	void restore(int tic);
+	void endReplay();
+
+  private:
+	LocalSectorHistory() = default;
+
+	// Has to cover the client's whole prediction window (MAXSAVETICS), which is
+	// not visible from here.
+	static constexpr size_t MAX_HISTORY_TICS = static_cast<size_t>(2 * TICRATE);
+
+	struct PlaneRecord
+	{
+		sector_t* sector = nullptr;
+
+		// Which tic each slot holds, so a gap - a tic the client skipped, or a
+		// sector watched moments ago - reads as empty rather than stale.
+		std::array<int, MAX_HISTORY_TICS> tics{};
+		std::array<fixed_t, MAX_HISTORY_TICS> floorheights{};
+		std::array<fixed_t, MAX_HISTORY_TICS> ceilingheights{};
+
+		fixed_t liveFloor = 0;
+		fixed_t liveCeiling = 0;
+	};
+
+	std::vector<PlaneRecord> m_records;
+	bool m_replaying = false;
+};

--- a/common/p_localhistory.h
+++ b/common/p_localhistory.h
@@ -89,6 +89,6 @@ class LocalSectorHistory
 		fixed_t liveCeiling = 0;
 	};
 
-	std::vector<PlaneRecord> m_records;
+	std::vector<PlaneRecord> m_records{};
 	bool m_replaying = false;
 };

--- a/common/p_setup.cpp
+++ b/common/p_setup.cpp
@@ -1007,8 +1007,6 @@ void P_LoadThings2 (int lump, int position)
 		mt.angle = LESHORT(mt.angle);
 		mt.type = LESHORT(mt.type);
 		mt.flags = MapThingFlags::unsafe_from_int(LESHORT(mt.flags.to_int()));
-
-		P_SpawnMapThing(mt, position);
 	}
 
 	P_SetupThingSlopes(things);

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -1165,6 +1165,12 @@ class DWaggle : public DMover
 
 	void RunThink() override;
 
+	// Runs the waggle forward without moving the plane.
+	// The state a client receives was sampled on an
+	// earlier server tic, so this closes the gap
+	// before the thinker starts ticking locally.
+	void CatchUp(int tics);
+
 	fixed_t m_OriginalHeight = 0;
 	fixed_t m_Accumulator    = 0;
 	fixed_t m_AccDelta       = 0;
@@ -1177,6 +1183,16 @@ class DWaggle : public DMover
 
   private:
 	DWaggle() = default;
+
+	// Advances the state machine, with no side effects on the sector.
+	// Returns false once the waggle has shrunk away.
+	bool AdvanceTics(int tics);
+
+	// Puts the plane back where it started and removes the thinker.
+	void Finish();
+
+	// Moves the plane to whatever the current state says it should be.
+	void ApplyHeight();
 
 	// The client is asked to tick sector movers from more than one place, so
 	// refuse to advance twice in the same tic.

--- a/common/p_spec.h
+++ b/common/p_spec.h
@@ -1131,7 +1131,13 @@ private:
 };
 
 // Waggle
-/*
+//
+// A waggle is deterministic: its plane height depends only on its own state,
+// so both sides simulate it independently instead of broadcasting its state
+// like the other sector mover thinkers.
+//
+// It is deliberately kept out of movingsectors, because a waggle that never
+// finishes would cost a SVC_MovingSector* per player per tic forever.
 class DWaggle : public DMover
 {
 	DECLARE_SERIAL(DWaggle, DMover)
@@ -1141,36 +1147,47 @@ class DWaggle : public DMover
 		init = 0,
 		expand,
 		reduce,
-		stable,
-		finished,
-		destroy,
-		state_size
+		stable
 	};
-	DWaggle(sector_t* sec);
+
 	DWaggle(sector_t* sector, int height, int speed, int offset, int timer,
-	                 bool ceiling);
-	DWaggle* Clone(sector_t* sec) const override;
-	friend void P_SetWaggleDestroy(DWaggle* waggle);
+	        bool ceiling);
+
+	// Rebuilds a waggle that is already running, for a client that joined
+	// mid-waggle and so never saw the line special that started it.
+	DWaggle(sector_t* sector, bool ceiling, fixed_t originalHeight,
+	        fixed_t accumulator, fixed_t accDelta, fixed_t targetScale,
+	        fixed_t scale, fixed_t scaleDelta, int ticker, int state);
+
+	// Don't clone as snapshot processes retick this if copied by P_CopySector,
+	// which depends on Clone().
+	[[nodiscard]] DWaggle* Clone(sector_t*) const override { return nullptr; }
 
 	void RunThink() override;
 
-	fixed_t m_OriginalHeight;
-	fixed_t m_Accumulator;
-	fixed_t m_AccDelta;
-	fixed_t m_TargetScale;
-	fixed_t m_Scale;
-	fixed_t m_ScaleDelta;
-	fixed_t m_StartTic; // [Blair] Client will predict a created (or serialized) waggle based on the start tic.
-	int m_Ticker;
-	int m_State;
-	bool m_Ceiling;
-	DWaggle();
+	fixed_t m_OriginalHeight = 0;
+	fixed_t m_Accumulator    = 0;
+	fixed_t m_AccDelta       = 0;
+	fixed_t m_TargetScale    = 0;
+	fixed_t m_Scale          = 0;
+	fixed_t m_ScaleDelta     = 0;
+	int     m_Ticker         = 0;
+	int     m_State          = init;
+	bool    m_Ceiling        = false;
 
-  protected:
-	friend bool EV_StartPlaneWaggle(int tag, line_t* line, int height, int speed,
-	                                int offset, int timer, bool ceiling);
+  private:
+	DWaggle() = default;
+
+	// The client is asked to tick sector movers from more than one place, so
+	// refuse to advance twice in the same tic.
+	int m_LastTic = -1;
 };
-*/
+
+bool EV_StartPlaneWaggle(int tag, line_t* line, int height, int speed, int offset,
+                         int timer, bool ceiling);
+
+void SV_SendThinkerUpdate(const DThinker* thinker);
+
 //jff 3/15/98 pure texture/type change for better generalized support
 enum EChange
 {

--- a/common/p_tick.cpp
+++ b/common/p_tick.cpp
@@ -25,6 +25,7 @@
 #include "odamex.h"
 
 #include "p_local.h"
+#include "p_localhistory.h"
 #include "c_effect.h"
 #include "p_acs.h"
 #include "c_console.h"
@@ -99,6 +100,10 @@ void P_Ticker (void)
 
 	if (clientside)
 		P_RunEffects(); // [RH] Run particle effects
+
+	// Locally simulated planes have finished moving for this tic, so log where
+	// they ended up for prediction to replay against.
+	LocalSectorHistory::getInstance().record(gametic);
 
 	// for par times
 	level.time++;

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1663,6 +1663,21 @@ odaproto::svc::ThinkerUpdate SVC_ThinkerUpdate(const DThinker* thinker)
 		pmsg->set_base_level(phased->GetBaseLevel());
 		pmsg->set_phase(phased->GetPhase());
 	}
+	else if (thinker->IsA(RUNTIME_CLASS(DWaggle)))
+	{
+		const auto* waggle = static_cast<const DWaggle*>(thinker);
+		odaproto::svc::ThinkerUpdate_Waggle* wmsg = msg.mutable_waggle();
+		wmsg->set_sector(waggle->GetSector() - sectors);
+		wmsg->set_ceiling(waggle->m_Ceiling);
+		wmsg->set_original_height(waggle->m_OriginalHeight);
+		wmsg->set_accumulator(waggle->m_Accumulator);
+		wmsg->set_acc_delta(waggle->m_AccDelta);
+		wmsg->set_target_scale(waggle->m_TargetScale);
+		wmsg->set_scale(waggle->m_Scale);
+		wmsg->set_scale_delta(waggle->m_ScaleDelta);
+		wmsg->set_ticker(waggle->m_Ticker);
+		wmsg->set_state(waggle->m_State);
+	}
 
 	return msg;
 }

--- a/odaproto/server.proto
+++ b/odaproto/server.proto
@@ -763,6 +763,22 @@ message ThinkerUpdate
 		int32 phase = 3;
 	}
 
+	// Waggles are not streamed like the other sector movers, so a client that
+	// joins mid-waggle is handed the whole thinker state and simulates it.
+	message Waggle
+	{
+		int32 sector = 1;
+		bool ceiling = 2;              // If the same sector has a floor and
+		sfixed32 original_height = 3;  // ceiling waggle, 2 will be sent.
+		sfixed32 accumulator = 4;
+		sfixed32 acc_delta = 5;
+		sfixed32 target_scale = 6;
+		sfixed32 scale = 7;
+		sfixed32 scale_delta = 8;
+		sint32 ticker = 9; // -1 means the waggle never stops.
+		int32 state = 10;
+	}
+
 	oneof thinker
 	{
 		Scroller scroller = 1;
@@ -773,6 +789,7 @@ message ThinkerUpdate
 		Glow glow = 6;
 		Glow2 glow2 = 7;
 		Phased phased = 8;
+		Waggle waggle = 9;
 	}
 }
 

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -1955,6 +1955,16 @@ void SV_ThinkerUpdate(client_t* cl)
 	{
 		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(phased));
 	}
+
+	// One of these things is not like the others!
+	// Waggles get no per-tic updates, so this is the only shot a joining
+	// client has to pick up one that is already running.
+	TThinkerIterator<DWaggle> waggleIter;
+	DWaggle* waggle;
+	while ((waggle = waggleIter.Next()))
+	{
+		cl->messenger->Reliable().Write (SVC_ThinkerUpdate(waggle));
+	}
 }
 
 static void SV_ArmInventoryMonitors(player_t& player)
@@ -5120,6 +5130,15 @@ void OnChangedSwitchTexture (line_t *line, int useAgain)
 		client_t *cl = &(player.client);
 
 		cl->messenger->Reliable().Write (SVC_Switch(*line, state, time));
+	}
+}
+
+void SV_SendThinkerUpdate(const DThinker* thinker)
+{
+	for (auto& player : players)
+	{
+		if (player.ingame())
+			player.client.messenger->Reliable().Write (SVC_ThinkerUpdate(thinker));
 	}
 }
 

--- a/tests/unit-tests/src/t_stubs.cpp
+++ b/tests/unit-tests/src/t_stubs.cpp
@@ -180,6 +180,7 @@ FArchive &operator<< (FArchive &arc, UserInfo &info) { return arc; }
 FArchive &operator>> (FArchive &arc, UserInfo &info) { return arc; }
 void SV_OnActivatedLine(line_t* line, AActor* mo, const int side,
     const LineActivationType activationType, const bool bossaction) {}
+void SV_SendThinkerUpdate(const DThinker* thinker) {}
 void UV_SoundAvoidPlayer(const AActor *mo, byte channel, const char *name, byte attenuation) {}
 void OnChangedSwitchTexture (line_t *line, int useAgain) {}
 


### PR DESCRIPTION
I started this years ago but did not finish because registering the servers as `movingsectors` caused the sector to broadcast every tic, flooding the connection with just waggle moving. Because waggle is deterministic, we are able to predict waggle on the client and keep it in lockstep indefinitely.

They are registered with unlagged, but not sector snapshots. Mid-game joiners get a message describing an already-moving waggle mover, and uses `originatorTic` to "catch up" the waggle to the tic currently being predicted by the player. This way, the server and client always see the same waggle state.

The bandwidth for these waggles are low. Attached is a test wad that used to tip over Odamex because of the sheer amount of waggle things transmitting plane position every tic. Now, the map is comparable to Doom 2 MAP01 in bandwidth in.

Also included is a local sector history manager, only used by waggle for now. This is essentially a snapshot manager but for prediction-based local sector plane heights instead of server sent heights. We can use this when we want to predict sector movement based on dead reckoning things based on their start tic -- I tried to generalize this for all specials that move planes and not just waggle, when we want to move towards that.

Also is included is a small fix from the vertex slopes branch, Hexen format maps were spawning things twice, now they only spawn once.

Here's the test WAD and demo:

[waggle8.zip](https://github.com/user-attachments/files/32140059/waggle8.zip)
[waggledemo.zip](https://github.com/user-attachments/files/32140062/waggledemo.zip)
