### PR TITLE
[BUGFIX] Cherry pick psprites (demo recording) fix on stable

### DIFF
--- a/client/src/r_things.cpp
+++ b/client/src/r_things.cpp
@@ -717,22 +717,26 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 {
 	vissprite_t 		avis;
 
+	const state_t* st = psp->state();
+	if (!st)
+		return;
+
 	// decide which patch to use
-	auto it = sprites.find(psp->state->sprite);
+	auto it = sprites.find(st->sprite);
 #ifdef RANGECHECK
 	if (it == sprites.end()) {
-		DPrintFmt("R_DrawPSprite: invalid sprite number {}\n", psp->state->sprite);
+		DPrintFmt("R_DrawPSprite: invalid sprite number {}\n", st->sprite);
 		return;
 	}
 #endif
 	const spritedef_t* sprdef = &it->second;
 #ifdef RANGECHECK
-	if ( (psp->state->frame & FF_FRAMEMASK) >= sprdef->numframes) {
-		DPrintFmt("R_DrawPSprite: invalid sprite frame {} : {}\n", psp->state->sprite, psp->state->frame);
+	if ( (st->frame & FF_FRAMEMASK) >= sprdef->numframes) {
+		DPrintFmt("R_DrawPSprite: invalid sprite frame {} : {}\n", st->sprite, st->frame);
 		return;
 	}
 #endif
-	const spriteframe_t* sprframe = &sprdef->spriteframes[ psp->state->frame & FF_FRAMEMASK ];
+	const spriteframe_t* sprframe = &sprdef->spriteframes[ st->frame & FF_FRAMEMASK ];
 
 	const int32_t lump = sprframe->lump[0];
 	const bool flip = sprframe->flip[0];
@@ -804,7 +808,7 @@ void R_DrawPSprite(pspdef_t* psp, unsigned flags)
 		// fixed color
 		vis->colormap = fixedcolormap;
 	}
-	else if (psp->state->frame & FF_FULLBRIGHT)
+	else if (st->frame & FF_FULLBRIGHT)
 	{
 		// full bright
 		vis->colormap = basecolormap;	// [RH] use basecolormap
@@ -896,7 +900,7 @@ void R_DrawPlayerSprites()
 			 i<NUMPSPRITES;
 			 i++,psp++)
 		{
-			if (psp->state)
+			if (psp->statenum != S_NULL)
 				R_DrawPSprite (psp, 0);
 		}
 

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -1662,6 +1662,7 @@ FArchive &operator<< (FArchive &arc, pspdef_t &def)
 
 FArchive &operator>> (FArchive &arc, pspdef_t &def)
 {
+	//NOLINTNEXTLINE(misc-const-correctness) - false positive
 	state_t* state = nullptr;
 	arc >> state >> def.tics >> def.sx >> def.sy;
 	def.statenum = state ? static_cast<statenum_t>(state->statenum) : S_NULL;

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -87,7 +87,7 @@ weaponstate_t P_GetWeaponState(const player_t& player)
 {
 	const state_t* st = player.psprites[player.psprnum].state();
 
-	if (st == NULL)
+	if (st == nullptr)
 		return unknownstate;
 
 	if (st->action == A_WeaponReady)
@@ -195,7 +195,7 @@ void P_SetPspriteRef(player_t& player, pspdef_t& psp, int32_t stnum)
 
 		psp.statenum = static_cast<statenum_t>(stnum);
 
-		state_t* st = &it->second;
+		const state_t* st = &it->second;
 		psp.tics = st->tics;		// could be 0
 
 		if (st->misc1)
@@ -886,7 +886,7 @@ void A_WeaponJump(AActor* mo)
 		return;
 
 	if (P_Random(mo) < st->args[1])
-		P_SetPspriteRef(player, psp, (statenum_t)st->args[0]);
+		P_SetPspriteRef(player, psp, static_cast<statenum_t>(st->args[0]));
 }
 
 
@@ -915,7 +915,7 @@ void A_CheckAmmo(AActor* mo)
 		amount = weaponinfo[player.readyweapon].ammopershot;
 
 	if (player.ammo[type] < amount)
-		P_SetPspriteRef(player, psp, (statenum_t)st->args[0]);
+		P_SetPspriteRef(player, psp, static_cast<statenum_t>(st->args[0]));
 }
 
 
@@ -974,7 +974,7 @@ void A_RefireTo(AActor* mo)
 	    (player.pendingweapon == wp_nochange && player.health))
 	{
 		player.refire++;
-		P_SetPspriteRef(player, psp, (statenum_t)st->args[0]);
+		P_SetPspriteRef(player, psp, static_cast<statenum_t>(st->args[0]));
 	}
 	else
 	{
@@ -1000,7 +1000,7 @@ void A_GunFlashTo(AActor* mo)
 	if (!st->args[1])
 		P_SetMobjState(player.mo, S_PLAY_ATK2);
 
-	P_SetPsprite(player, ps_flash, (statenum_t)st->args[0]);
+	P_SetPsprite(player, ps_flash, static_cast<statenum_t>(st->args[0]));
 }
 
 //
@@ -1662,7 +1662,7 @@ FArchive &operator<< (FArchive &arc, pspdef_t &def)
 
 FArchive &operator>> (FArchive &arc, pspdef_t &def)
 {
-	state_t* state = NULL;
+	state_t* state = nullptr;
 	arc >> state >> def.tics >> def.sx >> def.sy;
 	def.statenum = state ? static_cast<statenum_t>(state->statenum) : S_NULL;
 	return arc;

--- a/common/p_pspr.cpp
+++ b/common/p_pspr.cpp
@@ -85,16 +85,16 @@ fixed_t P_BulletSlope(AActor* mo);
 //
 weaponstate_t P_GetWeaponState(const player_t& player)
 {
-	const pspdef_t& psp = player.psprites[player.psprnum];
+	const state_t* st = player.psprites[player.psprnum].state();
 
-	if (psp.state == NULL)
+	if (st == NULL)
 		return unknownstate;
 
-	if (psp.state->action == A_WeaponReady)
+	if (st->action == A_WeaponReady)
 		return readystate;
-	if (psp.state->action == A_Lower)
+	if (st->action == A_Lower)
 		return downstate;
-	if (psp.state->action == A_Raise)
+	if (st->action == A_Raise)
 		return upstate;
 
 	// must be in one of the many attack states...
@@ -114,9 +114,11 @@ fixed_t P_CalculateWeaponBobX(player_t& player, float scale_amount)
 
 	const weaponstate_t weaponstate = P_GetWeaponState(player);
 
+	const state_t* st = psp.state();
+
 	fixed_t center_sx = FRACUNIT;
-	if (weaponstate != readystate && psp.state && psp.state->misc1)
-		center_sx = psp.state->misc1 << FRACBITS;
+	if (weaponstate != readystate && st && st->misc1)
+		center_sx = st->misc1 << FRACBITS;
 
 	if (weaponstate == readystate)
 	{
@@ -150,9 +152,11 @@ fixed_t P_CalculateWeaponBobY(player_t& player, float scale_amount)
 	if (weaponstate == upstate || weaponstate == downstate)
 		return psp.sy;
 
+	const state_t* st = psp.state();
+
 	fixed_t center_sy = WEAPONTOP;
-	if (weaponstate != readystate && psp.state && psp.state->misc1)
-		center_sy = psp.state->misc2 << FRACBITS;
+	if (weaponstate != readystate && st && st->misc1)
+		center_sy = st->misc2 << FRACBITS;
 
 	if (weaponstate == readystate)
 	{
@@ -181,7 +185,7 @@ void P_SetPspriteRef(player_t& player, pspdef_t& psp, int32_t stnum)
 		if (!stnum)
 		{
 			// object removed itself
-			psp.state = nullptr;
+			psp.statenum = S_NULL;
 			break;
 		}
 
@@ -189,32 +193,35 @@ void P_SetPspriteRef(player_t& player, pspdef_t& psp, int32_t stnum)
 		if (it == states.end())
 			return;
 
-		psp.state = &it->second;
-		psp.tics = psp.state->tics;		// could be 0
+		psp.statenum = static_cast<statenum_t>(stnum);
 
-		if (psp.state->misc1)
+		state_t* st = &it->second;
+		psp.tics = st->tics;		// could be 0
+
+		if (st->misc1)
 		{
 			// coordinate set
-			psp.sx = psp.state->misc1 << FRACBITS;
-			psp.sy = psp.state->misc2 << FRACBITS;
+			psp.sx = st->misc1 << FRACBITS;
+			psp.sy = st->misc2 << FRACBITS;
 		}
 
 		// Call action routine.
 		// Modified handling.
-		if (psp.state->action)
+		if (st->action)
 		{
 			if (!player.spectator && player.mo != NULL)
 			{
 				// [CMB] calculate psprnum here using the present psp and length of psprites
 				player.psprnum = &psp - player.psprites;
-				psp.state->action(player.mo);
+				st->action(player.mo);
 			}
 
-			if (!psp.state)
+			st = psp.state();
+			if (!st)
 				break;
 		}
 
-		stnum = psp.state->nextstate;
+		stnum = st->nextstate;
 
 	} while (!psp.tics);
 	// an initial state of 0 could cycle through
@@ -519,7 +526,7 @@ void A_WeaponReady(AActor* mo)
 	if (player.mo->state == &states[S_PLAY_ATK1] || player.mo->state == &states[S_PLAY_ATK2])
 		P_SetMobjState(player.mo, S_PLAY);
 
-	if (player.readyweapon == wp_chainsaw && psp->state == &states[S_SAW])
+	if (player.readyweapon == wp_chainsaw && psp->statenum == S_SAW)
 		A_FireSound(player, "weapons/sawidle");
 
 	// check for change -  if player is dead, put the weapon away
@@ -874,11 +881,12 @@ void A_WeaponJump(AActor* mo)
 	player_t& player = *mo->player;
 	pspdef_t& psp = player.psprites[player.psprnum];
 
-	if (!psp.state)
+	const state_t* st = psp.state();
+	if (!st)
 		return;
 
-	if (P_Random(mo) < psp.state->args[1])
-		P_SetPspriteRef(player, psp, (statenum_t)psp.state->args[0]);
+	if (P_Random(mo) < st->args[1])
+		P_SetPspriteRef(player, psp, (statenum_t)st->args[0]);
 }
 
 
@@ -896,17 +904,18 @@ void A_CheckAmmo(AActor* mo)
 	player_t& player = *mo->player;
 	pspdef_t& psp = player.psprites[player.psprnum];
 
+	const state_t* st = psp.state();
 	const ammotype_t type = weaponinfo[player.readyweapon].ammotype;
-	if (!psp.state || type == am_noammo)
+	if (!st || type == am_noammo)
 		return;
 
-	if (psp.state->args[1] != 0)
-		amount = psp.state->args[1];
+	if (st->args[1] != 0)
+		amount = st->args[1];
 	else
 		amount = weaponinfo[player.readyweapon].ammopershot;
 
 	if (player.ammo[type] < amount)
-		P_SetPspriteRef(player, psp, (statenum_t)psp.state->args[0]);
+		P_SetPspriteRef(player, psp, (statenum_t)st->args[0]);
 }
 
 
@@ -926,14 +935,15 @@ void A_ConsumeAmmo(AActor* mo)
 		return;
 
 	// don't do dumb things, kids
+	const state_t* st = psp.state();
 	const ammotype_t type = weaponinfo[player.readyweapon].ammotype;
-	if (!psp.state || type == am_noammo)
+	if (!st || type == am_noammo)
 		return;
 
 	// use the weapon's ammo-per-shot amount if zero.
 	// to subtract zero ammo, don't call this function. ;)
-	if (psp.state->args[0] != 0)
-		amount = psp.state->args[0];
+	if (st->args[0] != 0)
+		amount = st->args[0];
 	else
 		amount = weaponinfo[player.readyweapon].ammopershot;
 
@@ -955,15 +965,16 @@ void A_RefireTo(AActor* mo)
 	player_t& player = *mo->player;
 	pspdef_t& psp = player.psprites[player.psprnum];
 
-	if (!psp.state)
+	const state_t* st = psp.state();
+	if (!st)
 		return;
 
-	if ((psp.state->args[1] || P_CheckAmmo(player)) &&
+	if ((st->args[1] || P_CheckAmmo(player)) &&
 	    (player.cmd.buttons & BT_ATTACK) &&
 	    (player.pendingweapon == wp_nochange && player.health))
 	{
 		player.refire++;
-		P_SetPspriteRef(player, psp, (statenum_t)psp.state->args[0]);
+		P_SetPspriteRef(player, psp, (statenum_t)st->args[0]);
 	}
 	else
 	{
@@ -982,13 +993,14 @@ void A_GunFlashTo(AActor* mo)
 	player_t& player = *mo->player;
 	const pspdef_t& psp = player.psprites[player.psprnum];
 
-	if (!psp.state)
+	const state_t* st = psp.state();
+	if (!st)
 		return;
 
-	if (!psp.state->args[1])
+	if (!st->args[1])
 		P_SetMobjState(player.mo, S_PLAY_ATK2);
 
-	P_SetPsprite(player, ps_flash, (statenum_t)psp.state->args[0]);
+	P_SetPsprite(player, ps_flash, (statenum_t)st->args[0]);
 }
 
 //
@@ -1007,14 +1019,15 @@ void A_WeaponProjectile(AActor* mo)
 	player_t* player = mo->player;
 	pspdef_t* psp = &player->psprites[player->psprnum];
 
-	if (!psp->state || !psp->state->args[0])
+	const state_t* st = psp->state();
+	if (!st || !st->args[0])
 		return;
 
-	type = psp->state->args[0] - 1;
-	angle = psp->state->args[1];
-	pitch = psp->state->args[2];
-	spawnofs_xy = psp->state->args[3];
-	spawnofs_z = psp->state->args[4];
+	type = st->args[0] - 1;
+	angle = st->args[1];
+	pitch = st->args[2];
+	spawnofs_xy = st->args[3];
+	spawnofs_z = st->args[4];
 
 	if (!CheckIfDehActorDefined((mobjtype_t)type))
 	{
@@ -1042,14 +1055,15 @@ void A_WeaponBulletAttack(AActor* mo)
 	player_t* player = mo->player;
 	pspdef_t* psp = &player->psprites[player->psprnum];
 
-	if (!psp->state)
+	const state_t* st = psp->state();
+	if (!st)
 		return;
 
-	hspread    = psp->state->args[0];
-	vspread    = psp->state->args[1];
-	numbullets = psp->state->args[2];
-	damagebase = psp->state->args[3];
-	damagemod  = psp->state->args[4];
+	hspread    = st->args[0];
+	vspread    = st->args[1];
+	numbullets = st->args[2];
+	damagebase = st->args[3];
+	damagemod  = st->args[4];
 
 	Unlag::getInstance().reconcile(player->id);
 
@@ -1085,14 +1099,15 @@ void A_WeaponMeleeAttack(AActor* mo)
 	player_t* player = mo->player;
 	pspdef_t* psp = &player->psprites[player->psprnum];
 
-	if (!psp->state)
+	const state_t* st = psp->state();
+	if (!st)
 		return;
 
-	damagebase = psp->state->args[0];
-	damagemod = psp->state->args[1];
-	zerkfactor = psp->state->args[2];
-	hitsound = psp->state->args[3];
-	range = psp->state->args[4];
+	damagebase = st->args[0];
+	damagemod = st->args[1];
+	zerkfactor = st->args[2];
+	hitsound = st->args[3];
+	range = st->args[4];
 
 	const char* snd;
 
@@ -1156,10 +1171,11 @@ void A_WeaponSound(AActor *mo)
 	const player_t* player = mo->player;
 	const pspdef_t& psp = player->psprites[player->psprnum];
 
-	if (!psp.state)
+	const state_t* st = psp.state();
+	if (!st)
 		return;
 
-	const int sndmap = psp.state->args[0];
+	const int sndmap = st->args[0];
 	const char* snd = nullptr;
 
 	auto soundIt = SoundMap.find(sndmap);
@@ -1169,7 +1185,7 @@ void A_WeaponSound(AActor *mo)
 		snd = soundIt->second.c_str();
 
 	UV_SoundAvoidPlayer(player->mo, CHAN_WEAPON, snd,
-	                    (psp.state->args[1] ? ATTN_NONE : ATTN_NORM));
+	                    (st->args[1] ? ATTN_NONE : ATTN_NORM));
 }
 
 
@@ -1454,7 +1470,7 @@ void A_FireCGun(AActor* mo)
 	DecreaseAmmo(player);
 
 	// [CMB] this is expecting to calculate a very specific state based on the pointer arithmetic
-	P_SetPsprite(player, ps_flash, weaponinfo[player.readyweapon].flashstate + psp.state->statenum - states[S_CHAIN1].statenum);
+	P_SetPsprite(player, ps_flash, weaponinfo[player.readyweapon].flashstate + psp.statenum - states[S_CHAIN1].statenum);
 
 	const spreadtype_t accuracy = player.refire ? SPREAD_NORMAL : SPREAD_NONE;
 	P_FireHitscan(player, 1, accuracy);
@@ -1556,7 +1572,7 @@ void P_SetupPsprites(player_t& player)
 {
 	// remove all psprites
 	for (int i = 0; i < NUMPSPRITES; i++)
-		player.psprites[i].state = NULL;
+		player.psprites[i].statenum = S_NULL;
 
 	// spawn the gun
 	player.pendingweapon = player.readyweapon;
@@ -1575,7 +1591,8 @@ void P_MovePsprites(player_t& player)
 		pspdef_t* psp = &player.psprites[i];
 
 		// a null state means not active
-		if (psp->state)
+		const state_t* st = psp->state();
+		if (st)
 		{
 			// drop tic count and possibly change state
 			// a -1 tic count never changes
@@ -1585,7 +1602,7 @@ void P_MovePsprites(player_t& player)
 				psp->tics--;
 
 				if (psp->tics == 0)
-					P_SetPsprite(player, i, psp->state->nextstate);
+					P_SetPsprite(player, i, st->nextstate);
 			}
 		}
 	}
@@ -1640,12 +1657,15 @@ void A_ForceWeaponFire(AActor* mo, weapontype_t weapon, int tic)
 
 FArchive &operator<< (FArchive &arc, pspdef_t &def)
 {
-	return arc << def.state << def.tics << def.sx << def.sy;
+	return arc << def.state() << def.tics << def.sx << def.sy;
 }
 
 FArchive &operator>> (FArchive &arc, pspdef_t &def)
 {
-	return arc >> def.state >> def.tics >> def.sx >> def.sy;
+	state_t* state = NULL;
+	arc >> state >> def.tics >> def.sx >> def.sy;
+	def.statenum = state ? static_cast<statenum_t>(state->statenum) : S_NULL;
+	return arc;
 }
 
 VERSION_CONTROL (p_pspr_cpp, "$Id$")

--- a/common/p_pspr.h
+++ b/common/p_pspr.h
@@ -77,13 +77,13 @@ struct pspdef_t
 	fixed_t 	sx;
 	fixed_t 	sy;
 
-	state_t* state() const
+	[[nodiscard]] state_t* state() const
 	{
 		if (statenum == S_NULL)
-			return NULL;
+			return nullptr;
 
-		DoomObjectContainer<state_t, int32_t>::iterator it = states.find(statenum);
-		return it != states.end() ? &it->second : NULL;
+		const auto it = states.find(statenum);
+		return it != states.end() ? &it->second : nullptr;
 	}
 };
 

--- a/common/p_pspr.h
+++ b/common/p_pspr.h
@@ -71,11 +71,20 @@ inline FArchive &operator>> (FArchive &arc, psprnum_t &out)
 
 struct pspdef_t
 {
-	state_t*	state;	// a NULL state means not active
+	statenum_t	statenum;	// S_NULL means not active
 	int 		tics;
 
 	fixed_t 	sx;
 	fixed_t 	sy;
+
+	state_t* state() const
+	{
+		if (statenum == S_NULL)
+			return NULL;
+
+		DoomObjectContainer<state_t, int32_t>::iterator it = states.find(statenum);
+		return it != states.end() ? &it->second : NULL;
+	}
 };
 
 FArchive &operator<< (FArchive &, pspdef_t &);

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -1457,7 +1457,7 @@ player_s::player_s() :
 	// Can't put this in initializer list?
 	attacker = AActor::AActorPtr();
 
-	pspdef_t zeropsp = { NULL, 0, 0, 0 };
+	pspdef_t zeropsp = { S_NULL, 0, 0, 0 };
 	ArrayInit(psprites, zeropsp);
 	ArrayInit(oldvelocity, 0);
 	ArrayInit(prefcolor, 0);

--- a/common/p_user.cpp
+++ b/common/p_user.cpp
@@ -1457,7 +1457,7 @@ player_s::player_s() :
 	// Can't put this in initializer list?
 	attacker = AActor::AActorPtr();
 
-	pspdef_t zeropsp = { S_NULL, 0, 0, 0 };
+	const pspdef_t zeropsp = { S_NULL, 0, 0, 0 };
 	ArrayInit(psprites, zeropsp);
 	ArrayInit(oldvelocity, 0);
 	ArrayInit(prefcolor, 0);

--- a/common/svc_message.cpp
+++ b/common/svc_message.cpp
@@ -1047,10 +1047,8 @@ odaproto::svc::PlayerState SVC_PlayerState(const player_t& player)
 
 	for (int i = 0; i < NUMPSPRITES; i++)
 	{
-		const pspdef_t* psp = &player.psprites[i];
-		const int32_t state = psp->state ? psp->state->statenum : 0;
 		odaproto::Player_Psp* plpsp = pl->add_psprites();
-		plpsp->set_statenum(state);
+		plpsp->set_statenum(player.psprites[i].statenum);
 	}
 
 	for (int i = 0; i < NUMPOWERS; i++)


### PR DESCRIPTION
Fixes #1975 

Recording a demo when a player becomes a spectator during the previous round causes a null psprite crash the next round. This is fixed in protobreak already (#1901), we're just backporting it to stable.