### PR TITLE
Fix intermittent server crash due to messenger corruption

### DIFF
--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3639,7 +3639,10 @@ static SortedMobjPartitionsType SV_SortMobjsForPlayer(player_t& player, int part
 	return partitions;
 }
 
-static void SV_WriteMonitoredInventoryChanges(player_t& player)
+namespace
+{
+
+void SV_WriteMonitoredInventoryChanges(player_t& player)
 {
 	const bool pendingWeaponWasChanged = player.pendingweaponMonitor.EvaluateAsChanged();
 	const bool readyWeaponWasChanged   = player.readyweaponMonitor.EvaluateAsChanged();
@@ -3835,6 +3838,7 @@ void SV_WriteCommands(void)
 	}
 }
 
+}
 
 void SV_PlayerTriedToCheat(player_t &player)
 {

--- a/server/src/sv_main.cpp
+++ b/server/src/sv_main.cpp
@@ -3639,7 +3639,7 @@ static SortedMobjPartitionsType SV_SortMobjsForPlayer(player_t& player, int part
 	return partitions;
 }
 
-static void SV_SendMonitoredInventoryChanges(player_t& player)
+static void SV_WriteMonitoredInventoryChanges(player_t& player)
 {
 	const bool pendingWeaponWasChanged = player.pendingweaponMonitor.EvaluateAsChanged();
 	const bool readyWeaponWasChanged   = player.readyweaponMonitor.EvaluateAsChanged();
@@ -3712,8 +3712,6 @@ void SV_WriteCommandsForPlayer(player_t& player)
 		player.playerInfoIsRequested = false;
 		SV_SendPlayerInfo(player);
 	}
-	SV_SendMonitoredInventoryChanges(player);
-	SV_ArmInventoryMonitors(player);
 
 	// [SL] Send client info about player he is spying on
 	player_t& target = idplayer(player.spying);
@@ -3805,6 +3803,14 @@ void SV_WriteCommands(void)
 	// they can be reconciled later for unlagging
 	Unlag::getInstance().recordPlayerPositions();
 	Unlag::getInstance().recordSectorPositions();
+
+	// Do any last minute broadcasting here, because any attempt to do so from the
+	// worker threads can and eventually will corrupt another player's messenger.
+	for (player_t& player : players)
+	{
+		SV_WriteMonitoredInventoryChanges(player);
+		SV_ArmInventoryMonitors(player);
+	}
 
 	// Palm off the job of writing the player messages onto the worker threads.
 	std::vector<std::future<void> > futures;

--- a/server/src/sv_main.h
+++ b/server/src/sv_main.h
@@ -118,7 +118,6 @@ void SV_TeamPrintFmt(int level, int who, fmt::format_string<ARGS...> format, ARG
 void SV_CheckTimeouts (void);
 void SV_ConnectClient(void);
 void SV_ConnectClient2(player_t& player);
-void SV_WriteCommands(void);
 MessageResultEnum SV_SendPacket(player_t &pl);
 void SV_DisplayTics();
 void SV_RunTics();


### PR DESCRIPTION
This PR addresses a crash caused by a messenger's reliable queue being corrupted.  The corruption is due to the queue being accessed and modified from more than one thread simultaneously.

The fix is to move the Broadcast-generating operation out of the threaded workload and into the main thread before the threaded workloads start.  A subsequent PR will adjust the organization and documentation of the sender functions to alert the developer as to the critical constraints that must be honored in the threaded workload.

Please note that I've been unsuccessful at duplicating the crash locally, which isn't hugely surprising given that the timing has to work out just right to hit the condition where the concurrent accesses happen.